### PR TITLE
Subtask/as 1032 submission accuracy status

### DIFF
--- a/packages/lpa-questionnaire-web-app/src/services/task-status/accuracy-submission.js
+++ b/packages/lpa-questionnaire-web-app/src/services/task-status/accuracy-submission.js
@@ -1,0 +1,15 @@
+const { COMPLETED, NOT_STARTED } = require('./task-statuses');
+
+module.exports = (appealReply) => {
+  if (!appealReply) return null;
+
+  const task = appealReply.aboutAppealSection?.submissionAccuracy;
+  let completion;
+
+  if (task && typeof task.accurateSubmission === 'boolean') {
+    completion =
+      (task.accurateSubmission || (!task.accurateSubmission && task.inaccuracyReason)) && COMPLETED;
+  }
+
+  return completion || NOT_STARTED;
+};

--- a/packages/lpa-questionnaire-web-app/src/services/task.service.js
+++ b/packages/lpa-questionnaire-web-app/src/services/task.service.js
@@ -1,4 +1,5 @@
 const TASK_STATUS = require('./task-status/task-statuses');
+const accuracySubmissionCompletion = require('./task-status/accuracy-submission');
 const otherAppealsCompletion = require('./task-status/other-appeals');
 
 function statusTemp() {
@@ -18,7 +19,7 @@ const SECTIONS = [
       {
         taskId: 'submissionAccuracy',
         href: '/accuracy-submission',
-        rule: statusTemp,
+        rule: accuracySubmissionCompletion,
       },
       {
         taskId: 'extraConditions',

--- a/packages/lpa-questionnaire-web-app/tests/unit/services/task-status/accuract-submission.test.js
+++ b/packages/lpa-questionnaire-web-app/tests/unit/services/task-status/accuract-submission.test.js
@@ -1,0 +1,60 @@
+const { NOT_STARTED, COMPLETED } = require('../../../../src/services/task-status/task-statuses');
+const accuracySubmissionCompletion = require('../../../../src/services/task-status/accuracy-submission');
+
+describe('services/task.service/task-status/accuracy-submission', () => {
+  it('should return null if no appeal reply passed', () => {
+    expect(accuracySubmissionCompletion()).toBeNull();
+  });
+
+  it('should return not started if not set', () => {
+    const mockAppealReply = {
+      aboutAppealSection: {
+        submissionAccuracy: {
+          accurateSubmission: null,
+          inaccuracyReason: '',
+        },
+      },
+    };
+
+    expect(accuracySubmissionCompletion(mockAppealReply)).toEqual(NOT_STARTED);
+  });
+
+  it('should return completed if answer is yes', () => {
+    const mockAppealReply = {
+      aboutAppealSection: {
+        submissionAccuracy: {
+          accurateSubmission: true,
+          inaccuracyReason: '',
+        },
+      },
+    };
+
+    expect(accuracySubmissionCompletion(mockAppealReply)).toEqual(COMPLETED);
+  });
+
+  it('should return completed if answer is no and reason is set', () => {
+    const mockAppealReply = {
+      aboutAppealSection: {
+        submissionAccuracy: {
+          accurateSubmission: false,
+          inaccuracyReason: 'mock reason',
+        },
+      },
+    };
+
+    expect(accuracySubmissionCompletion(mockAppealReply)).toEqual(COMPLETED);
+  });
+
+  it('should return not started if answer is no and reason is not set', () => {
+    const mockAppealReply = {
+      aboutAppealSection: {
+        submissionAccuracy: {
+          accurateSubmission: false,
+          inaccuracyReason: '',
+        },
+      },
+    };
+
+    expect(accuracySubmissionCompletion(mockAppealReply)).toEqual(NOT_STARTED);
+  });
+});

--- a/packages/lpa-questionnaire-web-app/tests/unit/services/task.service.test.js
+++ b/packages/lpa-questionnaire-web-app/tests/unit/services/task.service.test.js
@@ -3,14 +3,15 @@ const {
   CANNOT_START_YET,
 } = require('../../../src/services/task-status/task-statuses');
 const { SECTIONS, getTaskStatus } = require('../../../src/services/task.service');
+const appealReply = require('../../../src/lib/empty-appeal-reply');
 
 describe('services/task.service', () => {
   describe('SECTIONS', () => {
     it('should return not started from statusTemp', () => {
-      expect(SECTIONS[0].tasks[0].rule()).toEqual(NOT_STARTED);
+      expect(SECTIONS[3].tasks[0].rule(appealReply)).toEqual(NOT_STARTED);
     });
     it('should return cannot start yet for statusCheckYourAnswer', () => {
-      expect(SECTIONS[SECTIONS.length - 1].tasks[0].rule()).toEqual(CANNOT_START_YET);
+      expect(SECTIONS[SECTIONS.length - 1].tasks[0].rule(appealReply)).toEqual(CANNOT_START_YET);
     });
   });
   describe('getTaskStatus', () => {


### PR DESCRIPTION
## Ticket Number
<!-- Add the number from the Jira board -->
AS-1032

## Description of change
- Added submission accuracy status check for task list and API
- Change Task service test to target different status to ensure continued test coverage

## Checklist
<!-- Put an `x` in all the boxes that apply: -->
- [ ] Requires infrastructure changes
- [ ] If adding or remove environment variables (e.g. in `docker-compose.yaml`) then I have updated the appropriate Helm chart
- [ ] I have updated the documentation accordingly
- [X] My commit history in this PR is linear
- [X] New features have tests
- [ ] Breaking change (team conversation required)

## Important

Please do not merge from `master` (please only [rebase](https://github.com/foundry4/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
