### PR TITLE
ci: update semantic-release to use the custom github token

### DIFF
--- a/.github/workflows/appeal-reply-service-api.yml
+++ b/.github/workflows/appeal-reply-service-api.yml
@@ -43,7 +43,7 @@ jobs:
         id: version_number
         with:
           DIR: packages/${{ env.APP_DIR }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.CUSTOM_GITHUB_TOKEN }}
           GET_VERSION: 'true'
 
       - name: Extract variables
@@ -106,5 +106,5 @@ jobs:
         if: ${{ steps.version_number.outputs.new_release_published == 'true' }}
         with:
           DIR: packages/${{ env.APP_DIR }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.CUSTOM_GITHUB_TOKEN }}
           SET_VERSION: 'true'

--- a/.github/workflows/appeals-service-api.yml
+++ b/.github/workflows/appeals-service-api.yml
@@ -43,7 +43,7 @@ jobs:
         id: version_number
         with:
           DIR: packages/${{ env.APP_DIR }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.CUSTOM_GITHUB_TOKEN }}
           GET_VERSION: 'true'
 
       - name: Extract variables
@@ -106,5 +106,5 @@ jobs:
         if: ${{ steps.version_number.outputs.new_release_published == 'true' }}
         with:
           DIR: packages/${{ env.APP_DIR }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.CUSTOM_GITHUB_TOKEN }}
           SET_VERSION: 'true'

--- a/.github/workflows/document-service-api.yml
+++ b/.github/workflows/document-service-api.yml
@@ -43,7 +43,7 @@ jobs:
         id: version_number
         with:
           DIR: packages/${{ env.APP_DIR }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.CUSTOM_GITHUB_TOKEN }}
           GET_VERSION: 'true'
 
       - name: Extract variables
@@ -106,5 +106,5 @@ jobs:
         if: ${{ steps.version_number.outputs.new_release_published == 'true' }}
         with:
           DIR: packages/${{ env.APP_DIR }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.CUSTOM_GITHUB_TOKEN }}
           SET_VERSION: 'true'

--- a/.github/workflows/forms-web-app.yml
+++ b/.github/workflows/forms-web-app.yml
@@ -43,7 +43,7 @@ jobs:
         id: version_number
         with:
           DIR: packages/${{ env.APP_DIR }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.CUSTOM_GITHUB_TOKEN }}
           GET_VERSION: 'true'
 
       - name: Extract variables
@@ -106,5 +106,5 @@ jobs:
         if: ${{ steps.version_number.outputs.new_release_published == 'true' }}
         with:
           DIR: packages/${{ env.APP_DIR }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.CUSTOM_GITHUB_TOKEN }}
           SET_VERSION: 'true'

--- a/.github/workflows/horizon-add-document.yml
+++ b/.github/workflows/horizon-add-document.yml
@@ -46,7 +46,7 @@ jobs:
         id: version_number
         with:
           DIR: packages/${{ env.APP_DIR }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.CUSTOM_GITHUB_TOKEN }}
           GET_VERSION: 'true'
 
       - name: Extract variables
@@ -113,5 +113,5 @@ jobs:
         if: ${{ steps.version_number.outputs.new_release_published == 'true' }}
         with:
           DIR: packages/${{ env.APP_DIR }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.CUSTOM_GITHUB_TOKEN }}
           SET_VERSION: 'true'

--- a/.github/workflows/horizon-create-case.yml
+++ b/.github/workflows/horizon-create-case.yml
@@ -46,7 +46,7 @@ jobs:
         id: version_number
         with:
           DIR: packages/${{ env.APP_DIR }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.CUSTOM_GITHUB_TOKEN }}
           GET_VERSION: 'true'
 
       - name: Extract variables
@@ -113,5 +113,5 @@ jobs:
         if: ${{ steps.version_number.outputs.new_release_published == 'true' }}
         with:
           DIR: packages/${{ env.APP_DIR }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.CUSTOM_GITHUB_TOKEN }}
           SET_VERSION: 'true'

--- a/.github/workflows/horizon-householder-appeal-publish.yml
+++ b/.github/workflows/horizon-householder-appeal-publish.yml
@@ -46,7 +46,7 @@ jobs:
         id: version_number
         with:
           DIR: packages/${{ env.APP_DIR }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.CUSTOM_GITHUB_TOKEN }}
           GET_VERSION: 'true'
 
       - name: Extract variables
@@ -113,5 +113,5 @@ jobs:
         if: ${{ steps.version_number.outputs.new_release_published == 'true' }}
         with:
           DIR: packages/${{ env.APP_DIR }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.CUSTOM_GITHUB_TOKEN }}
           SET_VERSION: 'true'

--- a/.github/workflows/lpa-questionnaire.yml
+++ b/.github/workflows/lpa-questionnaire.yml
@@ -43,7 +43,7 @@ jobs:
         id: version_number
         with:
           DIR: packages/${{ env.APP_DIR }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.CUSTOM_GITHUB_TOKEN }}
           GET_VERSION: 'true'
 
       - name: Extract variables
@@ -106,5 +106,5 @@ jobs:
         if: ${{ steps.version_number.outputs.new_release_published == 'true' }}
         with:
           DIR: packages/${{ env.APP_DIR }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.CUSTOM_GITHUB_TOKEN }}
           SET_VERSION: 'true'


### PR DESCRIPTION
The default github token doesn't have permissions to push changelog and updated
package.json to the master branch

## Ticket Number
<!-- Add the number from the Jira board -->
AS-

## Description of change
<!-- Please describe the change -->

## Checklist
<!-- Put an `x` in all the boxes that apply: -->
- [ ] Requires infrastructure changes
- [ ] If adding or remove environment variables (e.g. in `docker-compose.yaml`) then I have updated the appropriate Helm chart
- [ ] I have updated the documentation accordingly
- [ ] My commit history in this PR is linear
- [ ] New features have tests
- [ ] Breaking change (team conversation required)

## Important

Please do not merge from `master` (please only [rebase](https://github.com/foundry4/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
