### PR TITLE
chore: specify versions for the public Helm charts

### DIFF
--- a/.github/workflows/infra-environments.yml
+++ b/.github/workflows/infra-environments.yml
@@ -166,7 +166,6 @@ jobs:
         if: github.ref == matrix.branch
         uses: ./.github/actions/kubectl-helm
         env:
-          CERT_MANAGER_VERSION: 1.0.3
           CLUSTER: ${{ matrix.environment }}
           CLUSTER_LB_IP_ADDRESS: ${{ steps.tf_output.outputs.cluster_lb_ip_address }}
           CLUSTER_LB_IP_NAME: ${{ steps.tf_output.outputs.cluster_lb_ip_name }}


### PR DESCRIPTION
## Ticket Number
<!-- Add the number from the Jira board -->
AS-1296

## Description of change
<!-- Please describe the change -->
Specified the versions of public Helm charts. Noticed this wasn't being set when AKV2K8S wouldn't deploy last week because they changed major versions.

## Checklist
<!-- Put an `x` in all the boxes that apply: -->
- [x] Requires infrastructure changes
- [ ] If adding or remove environment variables (e.g. in `docker-compose.yaml`) then I have updated the appropriate Helm chart
- [ ] I have updated the documentation accordingly
- [ ] My commit history in this PR is linear
- [ ] New features have tests
- [ ] Breaking change (team conversation required)

## Important

Please do not merge from `master` (please only [rebase](https://github.com/foundry4/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
