### PR TITLE
fix(horizon): make the horizon gateway subnet a configurable parameter

### DIFF
--- a/infrastructure/clusters/dev.tfvars
+++ b/infrastructure/clusters/dev.tfvars
@@ -5,6 +5,7 @@ horizon_enabled = true
 horizon_gateway_subnets_secret = "horizon-gateway-subnets-preprod"
 horizon_gateway_ip_secret = "horizon-gateway-ip-preprod"
 horizon_shared_key_secret = "horizon-gateway-shared-key-preprod"
+network_subnet_range = "10.32.0.0/16"
 
 k8s_min_nodes = 3
 k8s_max_nodes = 5

--- a/infrastructure/clusters/preprod.tfvars
+++ b/infrastructure/clusters/preprod.tfvars
@@ -5,6 +5,7 @@ horizon_enabled = true
 horizon_gateway_subnets_secret = "horizon-gateway-subnets-preprod"
 horizon_gateway_ip_secret = "horizon-gateway-ip-preprod"
 horizon_shared_key_secret = "horizon-gateway-shared-key-preprod"
+network_subnet_range = "10.31.0.0/16"
 
 k8s_min_nodes = 3
 k8s_max_nodes = 5

--- a/infrastructure/clusters/prod.tfvars
+++ b/infrastructure/clusters/prod.tfvars
@@ -2,6 +2,7 @@ pins_key_vault_subscription_id = "cbd9712b-34c8-4c94-9633-37ffc0f54f9d"
 pins_key_vault = "/subscriptions/cbd9712b-34c8-4c94-9633-37ffc0f54f9d/resourceGroups/ODT-KEY-VAULT/providers/Microsoft.KeyVault/vaults/odtkeyvault"
 
 horizon_enabled = false
+network_subnet_range = "10.30.0.0/16"
 
 k8s_min_nodes = 3
 k8s_max_nodes = 5

--- a/infrastructure/environments/README.md
+++ b/infrastructure/environments/README.md
@@ -47,6 +47,7 @@ No requirements.
 | mongodb\_max\_throughput | Max throughput of the MongoDB database - set in increments of 100 between 400 and 100,000 | `number` | `400` | no |
 | mongodb\_multi\_write\_locations | Enable multiple write locations | `bool` | `false` | no |
 | mongodb\_primary\_zone\_redundancy | Enable redundancy in the primary zone | `bool` | `false` | no |
+| network\_subnet\_range | Network subnet range. This must be unique across all clusters and end `/16` | `string` | n/a | yes |
 | pins\_key\_vault | ID of the PINS Key Vault - used to securely share secrets with this infrastructure | `string` | `null` | no |
 | pins\_key\_vault\_subscription\_id | Subscription ID for the Key Vault | `string` | `null` | no |
 | prefix | Resource prefix | `string` | `"pins"` | no |

--- a/infrastructure/environments/horizon.tf
+++ b/infrastructure/environments/horizon.tf
@@ -29,7 +29,7 @@ resource "azurerm_subnet" "horizon" {
   name = "GatewaySubnet"
   resource_group_name = azurerm_resource_group.network.name
   virtual_network_name = azurerm_virtual_network.network.name
-  address_prefixes = ["10.30.255.0/27"]
+  address_prefixes = [ cidrsubnet(var.network_subnet_range, 11, 2040) ]
 }
 
 resource "azurerm_virtual_network_gateway" "horizon" {

--- a/infrastructure/environments/networks.tf
+++ b/infrastructure/environments/networks.tf
@@ -13,14 +13,14 @@ resource "azurerm_virtual_network" "network" {
   name = format(local.name_format, "network")
   location = azurerm_resource_group.network.location
   resource_group_name = azurerm_resource_group.network.name
-  address_space = ["10.30.0.0/16"]
+  address_space = [ var.network_subnet_range ]
 }
 
 resource "azurerm_subnet" "network" {
   name = format(local.name_format, "network")
   resource_group_name = azurerm_resource_group.network.name
   virtual_network_name = azurerm_virtual_network.network.name
-  address_prefixes = ["10.30.1.0/24"]
+  address_prefixes = [ cidrsubnet(var.network_subnet_range, 8, 1) ]
 
   service_endpoints = [
     "Microsoft.AzureCosmosDB",

--- a/infrastructure/environments/variables.tf
+++ b/infrastructure/environments/variables.tf
@@ -217,6 +217,14 @@ variable "mongodb_primary_zone_redundancy" {
 }
 
 /*
+  Network
+ */
+variable "network_subnet_range" {
+  description = "Network subnet range. This must be unique across all clusters and end `/16`"
+  type = string
+}
+
+/*
   Storage
  */
 


### PR DESCRIPTION
This is required to avoid having a conflict with the connections on the PINS side

## Ticket Number
<!-- Add the number from the Jira board -->
AS-1309

## Description of change
<!-- Please describe the change -->
Prevents the subnets causing conflicts when connected to the Horizon VPN gateway

## Checklist
<!-- Put an `x` in all the boxes that apply: -->
- [ ] Requires infrastructure changes
- [ ] If adding or remove environment variables (e.g. in `docker-compose.yaml`) then I have updated the appropriate Helm chart
- [ ] I have updated the documentation accordingly
- [ ] My commit history in this PR is linear
- [ ] New features have tests
- [ ] Breaking change (team conversation required)

## Important

Please do not merge from `master` (please only [rebase](https://github.com/foundry4/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
