### PR TITLE
fix(as-1313): add a default value if first/last name not present

### DIFF
--- a/packages/horizon-create-contact/handler.js
+++ b/packages/horizon-create-contact/handler.js
@@ -11,7 +11,7 @@ module.exports = async (event, context) => {
 
   const { body } = event;
 
-  /* The order of this appears to be important */
+  /* The order of this appears to be important - first and last name's are required by Horizon */
   const contactData = [
     {
       key: 'a:Email',
@@ -19,11 +19,11 @@ module.exports = async (event, context) => {
     },
     {
       key: 'a:FirstName',
-      value: body?.firstName,
+      value: body?.firstName || '<Not provided>',
     },
     {
       key: 'a:LastName',
-      value: body?.lastName,
+      value: body?.lastName || '<Not provided>',
     },
   ];
 

--- a/packages/horizon-create-contact/handler.spec.js
+++ b/packages/horizon-create-contact/handler.spec.js
@@ -20,6 +20,106 @@ describe('handler', () => {
     process.env = envvars;
   });
 
+  it('should simulate a successful call without a first name', async () => {
+    process.env.HORIZON_URL = 'some-horizon-url';
+
+    const body = {
+      firstName: '',
+      lastName: 'Testington',
+    };
+
+    const horizonId = 'abc12';
+
+    axios.post.mockResolvedValue({
+      data: {
+        Envelope: {
+          Body: {
+            AddContactResponse: {
+              AddContactResult: {
+                value: horizonId,
+              },
+            },
+          },
+        },
+      },
+    });
+
+    expect(await handler({ body }, context)).toEqual({
+      id: horizonId,
+    });
+
+    expect(axios.post).toBeCalledWith(`${process.env.HORIZON_URL}/contacts`, {
+      AddContact: {
+        __soap_op: 'http://tempuri.org/IContacts/AddContact',
+        __xmlns: 'http://tempuri.org/',
+        contact: {
+          '__xmlns:a': 'http://schemas.datacontract.org/2004/07/Contacts.API',
+          '__xmlns:i': 'http://www.w3.org/2001/XMLSchema-instance',
+          '__i:type': 'a:HorizonAPIPerson',
+          'a:FirstName': '<Not provided>',
+          'a:LastName': body.lastName,
+          'a:Email': {
+            '__i:nil': 'true',
+          },
+        },
+      },
+    });
+
+    expect(context).toEqual({
+      httpStatus: 200,
+    });
+  });
+
+  it('should simulate a successful call without a last name', async () => {
+    process.env.HORIZON_URL = 'some-horizon-url';
+
+    const body = {
+      firstName: 'Test',
+      lastName: '',
+    };
+
+    const horizonId = 'abc129';
+
+    axios.post.mockResolvedValue({
+      data: {
+        Envelope: {
+          Body: {
+            AddContactResponse: {
+              AddContactResult: {
+                value: horizonId,
+              },
+            },
+          },
+        },
+      },
+    });
+
+    expect(await handler({ body }, context)).toEqual({
+      id: horizonId,
+    });
+
+    expect(axios.post).toBeCalledWith(`${process.env.HORIZON_URL}/contacts`, {
+      AddContact: {
+        __soap_op: 'http://tempuri.org/IContacts/AddContact',
+        __xmlns: 'http://tempuri.org/',
+        contact: {
+          '__xmlns:a': 'http://schemas.datacontract.org/2004/07/Contacts.API',
+          '__xmlns:i': 'http://www.w3.org/2001/XMLSchema-instance',
+          '__i:type': 'a:HorizonAPIPerson',
+          'a:FirstName': body.firstName,
+          'a:LastName': '<Not provided>',
+          'a:Email': {
+            '__i:nil': 'true',
+          },
+        },
+      },
+    });
+
+    expect(context).toEqual({
+      httpStatus: 200,
+    });
+  });
+
   it('should simulate a successful call with no optional data', async () => {
     process.env.HORIZON_URL = 'some-horizon-url';
 


### PR DESCRIPTION
## Ticket Number
<!-- Add the number from the Jira board -->
AS-1313

## Description of change
<!-- Please describe the change -->
Horizon has validation to ensure first and last name's are completed. The form is not (correctly) in the form first name and last name so this is something that we need to generate.

## Checklist
<!-- Put an `x` in all the boxes that apply: -->
- [ ] Requires infrastructure changes
- [ ] If adding or remove environment variables (e.g. in `docker-compose.yaml`) then I have updated the appropriate Helm chart
- [ ] I have updated the documentation accordingly
- [ ] My commit history in this PR is linear
- [ ] New features have tests
- [ ] Breaking change (team conversation required)

## Important

Please do not merge from `master` (please only [rebase](https://github.com/foundry4/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
