### PR TITLE
feat(forms-web-app): adds non-JS cookie consent banner

### DIFF
--- a/e2e-tests/cypress/integration/cookies-consent-bar-without-javascript-enabled.feature
+++ b/e2e-tests/cypress/integration/cookies-consent-bar-without-javascript-enabled.feature
@@ -1,4 +1,3 @@
-@wip
 Feature: Cookie consent bar - no JS
 
   As a PO on the appeals service
@@ -11,8 +10,8 @@ Feature: Cookie consent bar - no JS
     When the user navigates through the service
     Then the cookie banner remains visible
 
-#  @as-98 @as-98-2
-#  Scenario: Cookie banner links to cookie settings page
-#    Given a user visits the site with JavaScript disabled
-#    When the user views the cookie preferences page
-#    Then the cookies page is presented
+  @as-98 @as-98-2
+  Scenario: Cookie banner links to cookie settings page
+    Given a user visits the site with JavaScript disabled
+    When the user views the cookie preferences page
+    Then the cookies page is presented

--- a/e2e-tests/cypress/integration/cookies-consent-bar-without-javascript-enabled/cookies-consent-bar-without-javascript-enabled.js
+++ b/e2e-tests/cypress/integration/cookies-consent-bar-without-javascript-enabled/cookies-consent-bar-without-javascript-enabled.js
@@ -11,7 +11,7 @@ When('the user navigates through the service', () => {
 });
 
 When('the user views the cookie preferences page', () => {
-  cy.goToHelpCookiesPage();
+  cy.viewCookiePageUsingCookieConsentBannerLink();
 });
 
 Then('the cookies page is presented', () => {

--- a/e2e-tests/cypress/support/cookies/commands.js
+++ b/e2e-tests/cypress/support/cookies/commands.js
@@ -24,3 +24,8 @@ Cypress.Commands.add(
 );
 
 Cypress.Commands.add('confirmCookiePolicy', require('./confirmCookiePolicy'));
+
+Cypress.Commands.add(
+  'viewCookiePageUsingCookieConsentBannerLink',
+  require('./viewCookiePageUsingCookieConsentBannerLink'),
+);

--- a/e2e-tests/cypress/support/cookies/viewCookiePageUsingCookieConsentBannerLink.js
+++ b/e2e-tests/cypress/support/cookies/viewCookiePageUsingCookieConsentBannerLink.js
@@ -1,4 +1,4 @@
 module.exports = () => {
-  cy.visit('/cookies');
+  cy.get('[data-cy="cookie-banner-view-cookies"]').click();
   cy.wait(Cypress.env('demoDelay'));
 };

--- a/packages/forms-web-app/src/views/macros/cookie-banner.njk
+++ b/packages/forms-web-app/src/views/macros/cookie-banner.njk
@@ -29,7 +29,8 @@
             type: "submit",
             name: "cookie_banner",
             value: "accept",
-            attributes: { "data-cy": "cookie-banner-accept-analytics-cookies" }
+            attributes: { "data-cy": "cookie-banner-accept-analytics-cookies" },
+            classes: "govuk-!-display-none"
           },
           {
             text: "Reject analytics cookies",

--- a/packages/forms-web-app/tests/unit/views/macros/__snapshots__/cookie-banner.njk.test.js.snap
+++ b/packages/forms-web-app/tests/unit/views/macros/__snapshots__/cookie-banner.njk.test.js.snap
@@ -34,7 +34,7 @@ exports[`views/macros/cookie-banner should allow setting a custom cookiePagePath
       <div class=\\"govuk-button-group\\">
         
           
-            <button value=\\"accept\\" type=\\"submit\\" name=\\"cookie_banner\\" class=\\"govuk-button\\" data-module=\\"govuk-button\\" data-cy=\\"cookie-banner-accept-analytics-cookies\\">
+            <button value=\\"accept\\" type=\\"submit\\" name=\\"cookie_banner\\" class=\\"govuk-button govuk-!-display-none\\" data-module=\\"govuk-button\\" data-cy=\\"cookie-banner-accept-analytics-cookies\\">
               Accept analytics cookies
             </button>
           
@@ -93,7 +93,7 @@ exports[`views/macros/cookie-banner should allow setting a custom serviceName 1`
       <div class=\\"govuk-button-group\\">
         
           
-            <button value=\\"accept\\" type=\\"submit\\" name=\\"cookie_banner\\" class=\\"govuk-button\\" data-module=\\"govuk-button\\" data-cy=\\"cookie-banner-accept-analytics-cookies\\">
+            <button value=\\"accept\\" type=\\"submit\\" name=\\"cookie_banner\\" class=\\"govuk-button govuk-!-display-none\\" data-module=\\"govuk-button\\" data-cy=\\"cookie-banner-accept-analytics-cookies\\">
               Accept analytics cookies
             </button>
           
@@ -152,7 +152,7 @@ exports[`views/macros/cookie-banner should allow setting all custom attributes 1
       <div class=\\"govuk-button-group\\">
         
           
-            <button value=\\"accept\\" type=\\"submit\\" name=\\"cookie_banner\\" class=\\"govuk-button\\" data-module=\\"govuk-button\\" data-cy=\\"cookie-banner-accept-analytics-cookies\\">
+            <button value=\\"accept\\" type=\\"submit\\" name=\\"cookie_banner\\" class=\\"govuk-button govuk-!-display-none\\" data-module=\\"govuk-button\\" data-cy=\\"cookie-banner-accept-analytics-cookies\\">
               Accept analytics cookies
             </button>
           
@@ -211,7 +211,7 @@ exports[`views/macros/cookie-banner should have sensible default attributes 1`] 
       <div class=\\"govuk-button-group\\">
         
           
-            <button value=\\"accept\\" type=\\"submit\\" name=\\"cookie_banner\\" class=\\"govuk-button\\" data-module=\\"govuk-button\\" data-cy=\\"cookie-banner-accept-analytics-cookies\\">
+            <button value=\\"accept\\" type=\\"submit\\" name=\\"cookie_banner\\" class=\\"govuk-button govuk-!-display-none\\" data-module=\\"govuk-button\\" data-cy=\\"cookie-banner-accept-analytics-cookies\\">
               Accept analytics cookies
             </button>
           


### PR DESCRIPTION
## Ticket Number
<!-- Add the number from the Jira board -->
AS-98

## Description of change
adds non-JS cookie consent banner

All of this functionality was in a standalone PR: https://github.com/Planning-Inspectorate/appeal-planning-decision/pull/597

That PR was not merged, but used as a starting point for https://github.com/Planning-Inspectorate/appeal-planning-decision/pull/604/files

PR 604 *has* been merged.

PR 597 should have been incorporated into those later changes, however there have been several changes to master since then that make for a messy / conflicting history.

These changes are a small set of bug fixes and FF / glue fixes to ensure the e2e behave as expected. 

Please speak to me if unsure.

## Checklist
<!-- Put an `x` in all the boxes that apply: -->
- [ ] Requires infrastructure changes
- [ ] If adding or remove environment variables (e.g. in `docker-compose.yaml`) then I have updated the appropriate Helm chart
- [ ] I have updated the documentation accordingly
- [x] My commit history in this PR is linear
- [x] New features have tests
- [ ] Breaking change (team conversation required)

## Important

Please do not merge from `master` (please only [rebase](https://github.com/foundry4/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
