### PR TITLE
Monitoring and alerting

### DIFF
--- a/.github/workflows/infra-environments.yml
+++ b/.github/workflows/infra-environments.yml
@@ -113,6 +113,7 @@ jobs:
           -var container_registry_name="${{ steps.tf_common.outputs.container_registry_name }}"
           -var container_registry_rg_name="${{ steps.tf_common.outputs.container_registry_rg_name }}"
           -var-file="${{ steps.vars.outputs.tfvars }}"
+          -var="monitoring_alert_email=${{ secrets.DEVOPS_EMAIL_ADDRESS }}"
           -out tfplan
 
       - name: Unlock resources

--- a/infrastructure/clusters/prod.tfvars
+++ b/infrastructure/clusters/prod.tfvars
@@ -11,3 +11,8 @@ mongodb_auto_failover = true
 mongodb_databases = []
 mongodb_failover_locations = []
 mongodb_multi_write_locations = true
+
+monitoring_ping_urls = [{
+  name = "Forms Web App",
+  url = "http://appeal-planning-decision.planninginspectorate.gov.uk"
+}]

--- a/infrastructure/environments/README.md
+++ b/infrastructure/environments/README.md
@@ -47,6 +47,10 @@ No requirements.
 | mongodb\_max\_throughput | Max throughput of the MongoDB database - set in increments of 100 between 400 and 100,000 | `number` | `400` | no |
 | mongodb\_multi\_write\_locations | Enable multiple write locations | `bool` | `false` | no |
 | mongodb\_primary\_zone\_redundancy | Enable redundancy in the primary zone | `bool` | `false` | no |
+| monitoring\_alert\_email | Email to send alerts to | `string` | `null` | no |
+| monitoring\_ping\_frequency | Interval in seconds between test runs for this ping test | `number` | `300` | no |
+| monitoring\_ping\_locations | A list where to run the tests from - min of 5 location recommended. List available at https://docs.microsoft.com/en-us/azure/azure-monitor/app/monitor-web-app-availability#location-population-tags | `list(string)` | <pre>[<br>  "emea-ru-msa-edge",<br>  "emea-se-sto-edge",<br>  "emea-gb-db3-azr",<br>  "emea-nl-ams-azr",<br>  "us-va-ash-azr"<br>]</pre> | no |
+| monitoring\_ping\_urls | URLs to ping in the monitoring | <pre>list(object({<br>    name = string<br>    url = string<br>  }))</pre> | `[]` | no |
 | network\_subnet\_range | Network subnet range. This must be unique across all clusters and end `/16` | `string` | n/a | yes |
 | pins\_key\_vault | ID of the PINS Key Vault - used to securely share secrets with this infrastructure | `string` | `null` | no |
 | pins\_key\_vault\_subscription\_id | Subscription ID for the Key Vault | `string` | `null` | no |

--- a/infrastructure/environments/key_vault.tf
+++ b/infrastructure/environments/key_vault.tf
@@ -9,6 +9,14 @@ resource "azurerm_resource_group" "key_vault" {
   }
 }
 
+module "key_vault_rg_roles" {
+  source = "../modules/resource-group-aad-roles"
+
+  admin_group_id = azuread_group.admin.id
+  resource_group_id = azurerm_resource_group.key_vault.id
+  user_group_id = azuread_group.user.id
+}
+
 resource "random_integer" "key_vault" {
   max = 9999
   min = 1000

--- a/infrastructure/environments/kubernetes.tf
+++ b/infrastructure/environments/kubernetes.tf
@@ -9,6 +9,14 @@ resource "azurerm_resource_group" "k8s" {
   }
 }
 
+module "k8s_rg_roles" {
+  source = "../modules/resource-group-aad-roles"
+
+  admin_group_id = azuread_group.admin.id
+  resource_group_id = azurerm_resource_group.k8s.id
+  user_group_id = azuread_group.user.id
+}
+
 resource "random_integer" "k8s" {
   max = 9999
   min = 1000

--- a/infrastructure/environments/local.tf
+++ b/infrastructure/environments/local.tf
@@ -6,6 +6,8 @@ locals {
   lock_delete = "CanNotDelete"
   lock_none = null # Doesn't add tag
   lock_readonly = "ReadOnly"
+  monitoring_alert_email_count = var.monitoring_alert_email != null ? 1 : 0 # This should be a PINS email group
+  monitoring_ping_tests_count = length(var.monitoring_ping_urls)
   name_format = join("-", [
     var.prefix,
     local.location,

--- a/infrastructure/environments/message_queue.tf
+++ b/infrastructure/environments/message_queue.tf
@@ -9,6 +9,14 @@ resource "azurerm_resource_group" "message_queue" {
   }
 }
 
+module "message_queue_rg_roles" {
+  source = "../modules/resource-group-aad-roles"
+
+  admin_group_id = azuread_group.admin.id
+  resource_group_id = azurerm_resource_group.message_queue.id
+  user_group_id = azuread_group.user.id
+}
+
 resource "azurerm_servicebus_namespace" "message_queue" {
   name = format(local.name_format, "message-queue")
   location = azurerm_resource_group.message_queue.location

--- a/infrastructure/environments/mongodb.tf
+++ b/infrastructure/environments/mongodb.tf
@@ -9,6 +9,14 @@ resource "azurerm_resource_group" "mongodb" {
   }
 }
 
+module "mongodb_rg_roles" {
+  source = "../modules/resource-group-aad-roles"
+
+  admin_group_id = azuread_group.admin.id
+  resource_group_id = azurerm_resource_group.mongodb.id
+  user_group_id = azuread_group.user.id
+}
+
 resource "random_integer" "mongodb" {
   min = 1000
   max = 9999

--- a/infrastructure/environments/monitoring.tf
+++ b/infrastructure/environments/monitoring.tf
@@ -1,0 +1,127 @@
+resource "azurerm_resource_group" "monitoring" {
+  count = local.monitoring_ping_tests_count
+
+  location = var.location
+  name = format(local.name_format, "monitoring")
+
+  tags = {
+    app = local.app_name
+    env = terraform.workspace
+    lock = local.lock_delete
+  }
+}
+
+module "monitoring_rg_roles" {
+  source = "../modules/resource-group-aad-roles"
+  count = local.monitoring_ping_tests_count
+
+  admin_group_id = azuread_group.admin.id
+  resource_group_id = azurerm_resource_group.monitoring[count.index].id
+  user_group_id = azuread_group.user.id
+}
+
+resource "azurerm_application_insights" "monitoring" {
+  count = local.monitoring_ping_tests_count
+
+  name = format(local.name_format, "monitoring")
+  application_type = "web"
+  location = azurerm_resource_group.monitoring[count.index].location
+  resource_group_name = azurerm_resource_group.monitoring[count.index].name
+}
+
+resource "azurerm_application_insights_web_test" "ping_test" {
+  count = local.monitoring_ping_tests_count
+
+  name = var.monitoring_ping_urls[count.index].name
+  location = azurerm_resource_group.monitoring[count.index].location
+  resource_group_name = azurerm_resource_group.monitoring[count.index].name
+  application_insights_id = azurerm_application_insights.monitoring[count.index].id
+  description = "Perform a ping test for ${var.monitoring_ping_urls[count.index].url}"
+  geo_locations = var.monitoring_ping_locations
+  kind = "ping"
+  frequency = var.monitoring_ping_frequency
+  enabled = true
+
+  configuration = <<XML
+<WebTest
+  Name="${var.monitoring_ping_urls[count.index].name}"
+  Id="ABD48585-0831-40CB-9069-682EA6BB3583"
+  Enabled="True"
+  CssProjectStructure=""
+  CssIteration=""
+  Timeout="0"
+  WorkItemIds=""
+  xmlns="http://microsoft.com/schemas/VisualStudio/TeamTest/2010"
+  Description=""
+  CredentialUserName=""
+  CredentialPassword=""
+  PreAuthenticate="True"
+  Proxy="default"
+  StopOnError="False"
+  RecordedResultFile=""
+  ResultsLocale="">
+  <Items>
+    <Request
+      Method="GET"
+      Guid="a5f10126-e4cd-570d-961c-cea43999a200"
+      Version="1.1"
+      Url="${var.monitoring_ping_urls[count.index].url}"
+      ThinkTime="0"
+      Timeout="${var.monitoring_ping_frequency}"
+      ParseDependentRequests="True"
+      FollowRedirects="True"
+      RecordResult="True"
+      Cache="False"
+      ResponseTimeGoal="0"
+      Encoding="utf-8"
+      ExpectedHttpStatusCode="200"
+      ExpectedResponseUrl=""
+      ReportingName=""
+      IgnoreHttpStatusCode="False" />
+  </Items>
+</WebTest>
+XML
+
+  lifecycle {
+    ignore_changes = [
+      tags
+    ]
+  }
+}
+
+resource "azurerm_monitor_action_group" "monitoring" {
+  count = local.monitoring_ping_tests_count == 1 && local.monitoring_alert_email_count == 1 ? 1 : 0
+
+  name = "Critical alert"
+  resource_group_name = azurerm_resource_group.monitoring[count.index].name
+  short_name = "PINS Alert"
+  enabled = true
+
+  email_receiver {
+    email_address = var.monitoring_alert_email
+    name = "PINS DevOps"
+    use_common_alert_schema = true
+  }
+}
+
+resource "azurerm_monitor_metric_alert" "monitoring" {
+  count = local.monitoring_ping_tests_count == 1 && local.monitoring_alert_email_count == 1 ? 1 : 0
+
+  name = var.monitoring_ping_urls[count.index].name
+  resource_group_name = azurerm_resource_group.monitoring[count.index].name
+  scopes = [
+    azurerm_application_insights_web_test.ping_test[count.index].id,
+    azurerm_application_insights.monitoring[count.index].id
+  ]
+  description = "Alert for errors on ${var.monitoring_ping_urls[count.index].url}"
+
+  application_insights_web_test_location_availability_criteria {
+    web_test_id = azurerm_application_insights_web_test.ping_test[count.index].id
+    component_id = azurerm_application_insights.monitoring[count.index].id
+    failed_location_count = 2
+  }
+
+  action {
+    action_group_id = azurerm_monitor_action_group.monitoring[count.index].id
+  }
+}

--- a/infrastructure/environments/networks.tf
+++ b/infrastructure/environments/networks.tf
@@ -9,6 +9,14 @@ resource "azurerm_resource_group" "network" {
   }
 }
 
+module "network_rg_roles" {
+  source = "../modules/resource-group-aad-roles"
+
+  admin_group_id = azuread_group.admin.id
+  resource_group_id = azurerm_resource_group.network.id
+  user_group_id = azuread_group.user.id
+}
+
 resource "azurerm_virtual_network" "network" {
   name = format(local.name_format, "network")
   location = azurerm_resource_group.network.location

--- a/infrastructure/environments/storage.tf
+++ b/infrastructure/environments/storage.tf
@@ -9,6 +9,14 @@ resource "azurerm_resource_group" "storage" {
   }
 }
 
+module "storage_rg_roles" {
+  source = "../modules/resource-group-aad-roles"
+
+  admin_group_id = azuread_group.admin.id
+  resource_group_id = azurerm_resource_group.storage.id
+  user_group_id = azuread_group.user.id
+}
+
 resource "random_integer" "storage" {
   max = 9999
   min = 1000

--- a/infrastructure/environments/variables.tf
+++ b/infrastructure/environments/variables.tf
@@ -217,6 +217,42 @@ variable "mongodb_primary_zone_redundancy" {
 }
 
 /*
+  Monitoring
+ */
+variable "monitoring_ping_locations" {
+  description = "A list where to run the tests from - min of 5 location recommended. List available at https://docs.microsoft.com/en-us/azure/azure-monitor/app/monitor-web-app-availability#location-population-tags"
+  type = list(string)
+  default = [
+    "emea-ru-msa-edge", // UK South
+    "emea-se-sto-edge", // UK West
+    "emea-gb-db3-azr", // North Europe
+    "emea-nl-ams-azr", // West Europe
+    "us-va-ash-azr" // US East
+  ]
+}
+
+variable "monitoring_ping_frequency" {
+  description = "Interval in seconds between test runs for this ping test"
+  type = number
+  default = 300
+}
+
+variable "monitoring_ping_urls" {
+  description = "URLs to ping in the monitoring"
+  type = list(object({
+    name = string
+    url = string
+  }))
+  default = []
+}
+
+variable "monitoring_alert_email" {
+  description = "Email to send alerts to"
+  type = string
+  default = null
+}
+
+/*
   Network
  */
 variable "network_subnet_range" {

--- a/infrastructure/k8s/rbac/README.md
+++ b/infrastructure/k8s/rbac/README.md
@@ -8,3 +8,7 @@ Defines RBAC roles for the Kubernetes cluster
 There should be one file per group defined. The `admin` group doesn't need
 one as it's set as the Kubernetes admin user, which gives it full access to
 the cluster. 
+
+Files are loaded per folder. Anything in the `common` folder is applied to
+all clusters. It accepts folder names set to the cluster name to apply
+RBAC rules set just to those clusters only.

--- a/infrastructure/k8s/rbac/common/namespaces.yaml
+++ b/infrastructure/k8s/rbac/common/namespaces.yaml
@@ -1,0 +1,31 @@
+# Namespaces Role
+#
+# This allows users to list namespaces. This is a ClusterRole
+# and applies this rule to the whole cluster, not just a specific
+# namespace
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: user-namespaces
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - namespaces
+    verbs:
+      - get
+      - list
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: user-namespaces-binding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: user-namespaces
+subjects:
+  - kind: Group
+    namespace: default
+    name: $GROUP_USER_ID

--- a/infrastructure/k8s/rbac/common/user.yaml
+++ b/infrastructure/k8s/rbac/common/user.yaml
@@ -60,4 +60,3 @@ subjects:
   - kind: Group
     namespace: $RBAC_NAMESPACE
     name: $GROUP_USER_ID
-

--- a/infrastructure/k8s/rbac/dev/openfaas.yaml
+++ b/infrastructure/k8s/rbac/dev/openfaas.yaml
@@ -1,0 +1,36 @@
+# OpenFaaS Role
+#
+# Users are limited in what they can do. They are able to
+# have read access to most things, but have no access to secrets
+# (except listing).
+#
+# This is designed to be given to anyone who is a developer on the
+# application. For the most part, this will enable them to read logs
+# and make sure that things have deployed correctly.
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: openfaas-user-access
+  namespace: openfaas
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - secrets
+    verbs:
+      - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: openfaas-user-group
+  namespace: openfaas
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: openfaas-user-access
+subjects:
+  - kind: Group
+    namespace: openfaas
+    name: $GROUP_USER_ID

--- a/infrastructure/k8s/setup.sh
+++ b/infrastructure/k8s/setup.sh
@@ -29,11 +29,18 @@ add_registry_secret() {
 configure_rbac() {
   echo "Configuring RBAC"
 
-  echo "${DIR}"/../k8s/rbac/*.yaml
+  mkdir -p "${DIR}/../k8s/rbac/${CLUSTER}"
 
   for namespace in ${DEPLOY_NAMESPACE} ${OPENFAAS_NAMESPACES} flux
   do
-    for file in "${DIR}/../k8s/rbac"/*.yaml
+    # Handle spaces in path names
+    OIFS="$IFS"
+    IFS=$'\n'
+
+    COMMON_RBAC=$(find "${DIR}/../k8s/rbac/common" -name "*.yaml" -type f -exec ls {} \;)
+    CLUSTER_RBAC=$(find "${DIR}/../k8s/rbac/${CLUSTER}" -name "*.yaml" -type f -exec ls {} \;)
+
+    for file in ${COMMON_RBAC} ${CLUSTER_RBAC}
     do
       echo "Applying file: ${file}"
       echo "Namespace: ${namespace}"
@@ -42,6 +49,8 @@ configure_rbac() {
 
       envsubst < "${file}" | kubectl apply -f -
     done
+
+    IFS="$OIFS"
   done
 }
 

--- a/infrastructure/modules/resource-group-aad-roles/README.md
+++ b/infrastructure/modules/resource-group-aad-roles/README.md
@@ -1,0 +1,28 @@
+# Resource Group AAD Roles
+
+Provides base ActiveDirectory roles for a resource group
+
+## Requirements
+
+| Name | Version |
+|------|---------|
+| azurerm | >= 2.31.1 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| azurerm | >= 2.31.1 |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| admin\_group\_id | n/a | `any` | n/a | yes |
+| resource\_group\_id | n/a | `any` | n/a | yes |
+| user\_group\_id | n/a | `any` | n/a | yes |
+
+## Outputs
+
+No output.
+

--- a/infrastructure/modules/resource-group-aad-roles/main.tf
+++ b/infrastructure/modules/resource-group-aad-roles/main.tf
@@ -1,0 +1,26 @@
+/**
+ * # Resource Group AAD Roles
+ *
+ * Provides base ActiveDirectory roles for a resource group
+ */
+
+terraform {
+  required_providers {
+    azurerm = {
+      source = "hashicorp/azurerm"
+      version = ">= 2.31.1"
+    }
+  }
+}
+
+resource "azurerm_role_assignment" "admin_logs" {
+  principal_id = var.admin_group_id
+  scope = var.resource_group_id
+  role_definition_name = "Log Analytics Contributor"
+}
+
+resource "azurerm_role_assignment" "user_logs" {
+  principal_id = var.user_group_id
+  scope = var.resource_group_id
+  role_definition_name = "Log Analytics Reader"
+}

--- a/infrastructure/modules/resource-group-aad-roles/variables.tf
+++ b/infrastructure/modules/resource-group-aad-roles/variables.tf
@@ -1,0 +1,3 @@
+variable "admin_group_id" {}
+variable "resource_group_id" {}
+variable "user_group_id" {}


### PR DESCRIPTION
## Ticket Number
<!-- Add the number from the Jira board -->
AS-196

## Description of change
<!-- Please describe the change -->
 - AS-1328 - allow users to view Kubernetes logs in Azure Portal
 - AS-1312 - allow users to view resource monitoring in Azure Portal
 - AS-1329 - allow users to list Kubernetes namespaces
 - AS-1330 - allow users to get secrets in OpenFaaS namespace. Improved OpenFaaS development docs
 - AS-1343 - ping website(s) from Azure Monitor and alert on failures

## Checklist
<!-- Put an `x` in all the boxes that apply: -->
- [x] Requires infrastructure changes
- [ ] If adding or remove environment variables (e.g. in `docker-compose.yaml`) then I have updated the appropriate Helm chart
- [ ] I have updated the documentation accordingly
- [ ] My commit history in this PR is linear
- [ ] New features have tests
- [ ] Breaking change (team conversation required)

## Important

Please do not merge from `master` (please only [rebase](https://github.com/foundry4/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
