### PR TITLE
fix(forms-web-app): fixed the way errors are handled on the lpa and h…

### DIFF
--- a/e2e-tests/cypress/support/appeal-submission-appeal-site-ownership/answerDidNotToldOtherOwnersAppeal.js
+++ b/e2e-tests/cypress/support/appeal-submission-appeal-site-ownership/answerDidNotToldOtherOwnersAppeal.js
@@ -1,5 +1,4 @@
 module.exports = () => {
-  cy.get('#have-other-owners-been-told-no').click();
-
+  cy.get('input[data-cy="answer-no"]').check();
   cy.wait(Cypress.env('demoDelay'));
 };

--- a/e2e-tests/cypress/support/appeal-submission-appeal-site-ownership/answerDidToldOtherOwnersAppeal.js
+++ b/e2e-tests/cypress/support/appeal-submission-appeal-site-ownership/answerDidToldOtherOwnersAppeal.js
@@ -1,5 +1,5 @@
 module.exports = () => {
-  cy.get('#have-other-owners-been-told-yes').click();
+  cy.get('input[data-cy="answer-yes"]').check();
 
   cy.wait(Cypress.env('demoDelay'));
 };

--- a/e2e-tests/cypress/support/eligibility-local-planning-department/confirmEligibleLocalPlanningDepartment.js
+++ b/e2e-tests/cypress/support/eligibility-local-planning-department/confirmEligibleLocalPlanningDepartment.js
@@ -8,7 +8,7 @@ module.exports = () => {
       }
 
       cy.goToPlanningDepartmentPage();
-      cy.get('input#planning-department-label').should('have.value', firstEligibleLocalPlanningDepartment);
+      cy.get('input#local-planning-department').should('have.value', firstEligibleLocalPlanningDepartment);
       cy.wait(Cypress.env('demoDelay'));
 
       cy.goToCheckYourAnswersPage();

--- a/e2e-tests/cypress/support/eligibility-local-planning-department/confirmIneligibleLocalPlanningDepartment.js
+++ b/e2e-tests/cypress/support/eligibility-local-planning-department/confirmIneligibleLocalPlanningDepartment.js
@@ -8,7 +8,7 @@ module.exports = () => {
       }
 
       cy.goToPlanningDepartmentPage();
-      cy.get('input#planning-department-label').should('have.value', firstIneligibleLocalPlanningDepartment);
+      cy.get('input#local-planning-department').should('have.value', firstIneligibleLocalPlanningDepartment);
       cy.wait(Cypress.env('demoDelay'));
 
       cy.goToCheckYourAnswersPage();

--- a/e2e-tests/cypress/support/eligibility-local-planning-department/confirmPlanningDepartmentSelected.js
+++ b/e2e-tests/cypress/support/eligibility-local-planning-department/confirmPlanningDepartmentSelected.js
@@ -1,6 +1,6 @@
 module.exports = (planningDepartment) => {
   cy.goToPlanningDepartmentPage();
-  cy.get('input#planning-department-label').should('have.value', planningDepartment);
+  cy.get('input#local-planning-department').should('have.value', planningDepartment);
   cy.wait(Cypress.env('demoDelay'));
 
   cy.goToCheckYourAnswersPage();

--- a/e2e-tests/cypress/support/eligibility-local-planning-department/provideEligibleLocalPlanningDepartment.js
+++ b/e2e-tests/cypress/support/eligibility-local-planning-department/provideEligibleLocalPlanningDepartment.js
@@ -6,7 +6,7 @@ module.exports = () => {
       if (eligiblePlanningDepartments.length > 0) {
         firstEligibleLocalPlanningDepartment = eligiblePlanningDepartments[0];
       }
-      cy.get('input#planning-department-label').type(`{selectall}{backspace}${firstEligibleLocalPlanningDepartment}`);
+      cy.get('input#local-planning-department').type(`{selectall}{backspace}${firstEligibleLocalPlanningDepartment}`);
       cy.wait(Cypress.env('demoDelay'));
     })
 }

--- a/e2e-tests/cypress/support/eligibility-local-planning-department/provideIneligibleLocalPlanningDepartment.js
+++ b/e2e-tests/cypress/support/eligibility-local-planning-department/provideIneligibleLocalPlanningDepartment.js
@@ -6,7 +6,7 @@ module.exports = () => {
       if (ineligiblePlanningDepartments.length > 0) {
         firstIneligibleLocalPlanningDepartment = ineligiblePlanningDepartments[0];
       }
-      cy.get('input#planning-department-label').type(`{selectall}{backspace}${firstIneligibleLocalPlanningDepartment}`);
+      cy.get('input#local-planning-department').type(`{selectall}{backspace}${firstIneligibleLocalPlanningDepartment}`);
       cy.wait(Cypress.env('demoDelay'));
     })
 }

--- a/e2e-tests/cypress/support/eligibility-local-planning-department/provideLocalPlanningDepartment.js
+++ b/e2e-tests/cypress/support/eligibility-local-planning-department/provideLocalPlanningDepartment.js
@@ -1,5 +1,5 @@
 module.exports = (text) => {
-  cy.get('input#planning-department-label').type(`{selectall}{backspace}${text}`);
+  cy.get('input#local-planning-department').type(`{selectall}{backspace}${text}`);
 
   cy.wait(Cypress.env('demoDelay'));
 };

--- a/packages/forms-web-app/src/views/appellant-submission/site-access-safety.njk
+++ b/packages/forms-web-app/src/views/appellant-submission/site-access-safety.njk
@@ -105,11 +105,3 @@
   </div>
 
 {% endblock %}
-
-{% block footer %}
-  {{ super() }}
-  <script src="/assets/govuk/all.js"></script>
-  <script>
-    window.GOVUKFrontend.initAll()
-  </script>
-{% endblock %}

--- a/packages/forms-web-app/src/views/appellant-submission/site-access.njk
+++ b/packages/forms-web-app/src/views/appellant-submission/site-access.njk
@@ -88,12 +88,3 @@
   </div>
 
 {% endblock %}
-
-
-{% block footer %}
-  {{ super() }}
-  <script src="/assets/govuk/all.js"></script>
-  <script>
-    window.GOVUKFrontend.initAll()
-  </script>
-{% endblock %}

--- a/packages/forms-web-app/src/views/appellant-submission/site-ownership-certb.njk
+++ b/packages/forms-web-app/src/views/appellant-submission/site-ownership-certb.njk
@@ -2,6 +2,8 @@
 
 {% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
+{% from "govuk/components/warning-text/macro.njk" import govukWarningText %}
+{% from "govuk/components/radios/macro.njk" import govukRadios %}
 
 {% set haveOtherOwnersBeenTold = appeal.appealSiteSection.siteOwnership.haveOtherOwnersBeenTold %}
 
@@ -22,36 +24,51 @@
         }) }}
       {% endif %}
 
+      {% set warningTextHtml %}
+        {{ govukWarningText({
+          text: "If the site has more than one owner, you must tell the other owners that you're appealing.",
+          iconFallbackText: "Warning"
+        }) }}
+      {% endset %}
+
       <form action="" method="post" novalidate>
         <span class="govuk-caption-l"><span class="govuk-visually-hidden">Section. </span>Visiting the appeal site</span>
-        <div class="govuk-form-group">
-          <fieldset class="govuk-fieldset">
-            <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
-              Have you told the other owners that you’re appealing?
-            </legend>
-            <div class="govuk-warning-text">
-              <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
-              <strong class="govuk-warning-text__text">
-                <span class="govuk-warning-text__assistive">Warning</span>
-                If the site has more than one owner, you must tell the other owners that you're appealing.
-              </strong>
-            </div>
-            <div class="govuk-radios govuk-!-padding-bottom-6">
-              <div class="govuk-radios__item">
-                <input class="govuk-radios__input" id="have-other-owners-been-told-yes" name="have-other-owners-been-told" type="radio" value="yes" data-cy="answer-yes" {% if haveOtherOwnersBeenTold %}checked{% endif %}>
-                <label class="govuk-label govuk-radios__label" for="have-other-owners-been-told-yes">
-                  Yes, I have already told the other owners
-                </label>
-              </div>
-              <div class="govuk-radios__item">
-                <input class="govuk-radios__input" id="have-other-owners-been-told-no" name="have-other-owners-been-told" type="radio" value="no" data-cy="answer-no" {% if haveOtherOwnersBeenTold === false %}checked{% endif %}>
-                <label class="govuk-label govuk-radios__label" for="have-other-owners-been-told-no">
-                  No, but I understand that I have to inform them
-                </label>
-              </div>
-            </div>
-          </fieldset>
-        </div>
+
+        {{ govukRadios({
+          idPrefix: "have-other-owners-been-told",
+          name: "have-other-owners-been-told",
+          fieldset: {
+            legend: {
+              text: "Have you told the other owners that you’re appealing?",
+              isPageHeading: true,
+              classes: "govuk-fieldset__legend--l"
+            }
+          },
+          hint: {
+            html: warningTextHtml
+          },
+          items: [
+            {
+              value: "yes",
+              text: "Yes, I have already told the other owners",
+              checked: true if haveOtherOwnersBeenTold,
+              attributes: {
+                "data-cy": "answer-yes"
+              }
+            },
+            {
+              value: "no",
+              text: "No, but I understand that I have to inform them",
+              checked: true if haveOtherOwnersBeenTold === false,
+              attributes: {
+                "data-cy": "answer-no"
+              }
+            }
+          ],
+          errorMessage: errors['have-other-owners-been-told'] and {
+            text: errors['have-other-owners-been-told'].msg
+          }
+        }) }}
 
         {{ govukButton({
           text: "Save and continue",

--- a/packages/forms-web-app/src/views/eligibility/planning-department.njk
+++ b/packages/forms-web-app/src/views/eligibility/planning-department.njk
@@ -49,7 +49,7 @@
   <script src="/assets/accessible-autocomplete.min.js"></script>
   <script>
     accessibleAutocomplete({
-      id: 'planning-department-label',
+      id: 'local-planning-department',
       name: 'local-planning-department',
       showAllValues: true,
       defaultValue:  {{ appealLPD | dump | safe }},

--- a/packages/forms-web-app/src/views/includes/scripts.njk
+++ b/packages/forms-web-app/src/views/includes/scripts.njk
@@ -1,1 +1,5 @@
 <!-- Javascript -->
+<script src="/assets/govuk/all.js"></script>
+<script>
+  window.GOVUKFrontend.initAll()
+</script>


### PR DESCRIPTION
…omeowner notifications pages

## Ticket Number
AS-114

## Description of change
Fixed problem where clicking an error message wasn't focussing on the right input.

## Checklist
<!-- Put an `x` in all the boxes that apply: -->
- [ ] Requires infrastructure changes
- [ ] If adding or remove environment variables (e.g. in `docker-compose.yaml`) then I have updated the appropriate Helm chart
- [ ] I have updated the documentation accordingly
- [x] My commit history in this PR is linear
- [ ] New features have tests
- [ ] Breaking change (team conversation required)

## Important

Please do not merge from `master` (please only [rebase](https://github.com/foundry4/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
