### PR TITLE
test: provide easy scripts for sending appeals to horizon via cypress

### DIFF
--- a/e2e-tests/cypress.json
+++ b/e2e-tests/cypress.json
@@ -6,6 +6,7 @@
   "viewportHeight":1600,
   "env": {
     "demoDelay": 0,
+    "QUEUE_VALIDATION_ENABLED": true,
     "HORIZON_HAS_PUBLISHER_HOST": "localhost",
     "HORIZON_HAS_PUBLISHER_PASSWORD": "admin",
     "HORIZON_HAS_PUBLISHER_PORT": 4004,

--- a/e2e-tests/cypress/integration/appeal-submission-to-horizon/appeal-submission-to-horizon.js
+++ b/e2e-tests/cypress/integration/appeal-submission-to-horizon/appeal-submission-to-horizon.js
@@ -1,6 +1,8 @@
 import { Given, When, Then } from 'cypress-cucumber-preprocessor/steps';
 import { matchWhatWeCanFrom, STANDARD_APPEAL } from '../common/standard-appeal';
 
+const queueValidationEnabled = Cypress.env('QUEUE_VALIDATION_ENABLED');
+
 Given('a prospective appellant has provided appeal information', () => {
   cy.provideCompleteAppeal({
     ...STANDARD_APPEAL,
@@ -50,22 +52,27 @@ Then('a case is created for the appellant', () => {
   // /appellant-submission/confirmation
   cy.confirmAppealSubmitted();
 
-  cy.task('getLastFromQueue').then((actualMessage) => {
-    const hardCodedExpectations = require('./ucd-831-ac1.json');
-    const reasonableExpectation = matchWhatWeCanFrom(hardCodedExpectations);
+  if (queueValidationEnabled) {
+    cy.task('getLastFromQueue').then((actualMessage) => {
+      const hardCodedExpectations = require('./ucd-831-ac1.json');
+      const reasonableExpectation = matchWhatWeCanFrom(hardCodedExpectations);
 
-    expect(actualMessage).toEqual(reasonableExpectation);
-  });
+      expect(actualMessage).toEqual(reasonableExpectation);
+    });
+  }
 });
 
 Then('a case is created for the appellant and the agent', () => {
   // /appellant-submission/confirmation
   cy.confirmAppealSubmitted();
 
-  cy.task('getLastFromQueue').then((actualMessage) => {
-    const hardCodedExpectations = require('./as-102-ac1.json');
-    const reasonableExpectation = matchWhatWeCanFrom(hardCodedExpectations);
+  if (queueValidationEnabled) {
+    cy.task('getLastFromQueue').then((actualMessage) => {
+      const hardCodedExpectations = require('./as-102-ac1.json');
+      const reasonableExpectation = matchWhatWeCanFrom(hardCodedExpectations);
 
-    expect(actualMessage).toEqual(reasonableExpectation);
-  });
+      expect(actualMessage).toEqual(reasonableExpectation);
+    });
+  }
+
 });

--- a/e2e-tests/cypress/plugins/queue.js
+++ b/e2e-tests/cypress/plugins/queue.js
@@ -1,6 +1,8 @@
 const container = require('rhea');
 
 module.exports = (config) => {
+  const queueValidationEnabled = config.env.QUEUE_VALIDATION_ENABLED;
+
   const username = config.env.HORIZON_HAS_PUBLISHER_USERNAME;
   const password = config.env.HORIZON_HAS_PUBLISHER_PASSWORD;
   const port = config.env.HORIZON_HAS_PUBLISHER_PORT;
@@ -15,46 +17,62 @@ module.exports = (config) => {
   return {
     listenToQueue: () => {
       return new Promise( (resolve, reject) => {
-        container.on('message', function (context) {
-          const messageFromBuffer = context.message.body.content.toString('utf-8');
-          const message = JSON.parse(messageFromBuffer);
-          received.push(message);
-        });
 
-        container.on('error', function (context) {
-          reject(error);
-        });
+        if (queueValidationEnabled) {
+          container.on('message', function (context) {
+            const messageFromBuffer = context.message.body.content.toString('utf-8');
+            const message = JSON.parse(messageFromBuffer);
+            received.push(message);
+          });
 
-        var connection = container.connect(opts);
+          container.on('error', function (context) {
+            reject(error);
+          });
 
-        connection.open_receiver(queue);
+          var connection = container.connect(opts);
 
-        resolve(null);
+          connection.open_receiver(queue);
+
+          resolve(null);
+        } else {
+          resolve(null);
+        }
+
       });
     },
 
     putOnQueue: (message)=> {
       return new Promise( (resolve, reject) => {
-        container.once('sendable', function (context) {
-          context.sender.send({body: message});
+
+        if (queueValidationEnabled) {
+          container.once('sendable', function (context) {
+            context.sender.send({body: message});
+            resolve(null);
+          });
+
+          container.on('error', function (context) {
+            reject(error);
+          });
+
+          var connection = container.connect(opts);
+
+          connection.open_sender(queue);
+        } else {
           resolve(null);
-        });
+        }
 
-        container.on('error', function (context) {
-          reject(error);
-        });
-
-        var connection = container.connect(opts);
-
-        connection.open_sender(queue);
       });
     },
 
     getLastFromQueue: ()=> {
-      if (!received || !received.length) {
-        return null; // at least surface the failure in the test..
+      if (queueValidationEnabled) {
+        if (!received || !received.length) {
+          return null; // at least surface the failure in the test..
+        }
+        return received[received.length - 1];
+      } else {
+        return "should not be validating against this as queue validation is disabled"
       }
-      return received[received.length - 1];
     }
   }
 }

--- a/e2e-tests/package.json
+++ b/e2e-tests/package.json
@@ -11,7 +11,10 @@
     "test:e2e:smoke": "cypress run -e TAGS='not @wip and @smoketest' --config video=false,baseUrl=$BASEURL",
     "test:e2e:acp": "cypress run -e TAGS='not @wip' --config integrationFolder=cypress/integration-with-acp",
     "test:e2e:demo:acp": "cypress run --headed -b chrome -e TAGS='not @wip',demoDelay=1000 --config integrationFolder=cypress/integration-with-acp",
-    "test:e2e:smoke:acp": "cypress run -e TAGS='not @wip and @smoketest' --config video=false,baseUrl=$BASEURL,integrationFolder=cypress/integration-with-acp"
+    "test:e2e:smoke:acp": "cypress run -e TAGS='not @wip and @smoketest' --config video=false,baseUrl=$BASEURL,integrationFolder=cypress/integration-with-acp",
+
+    "test:e2e:horizon:script": "cypress run --headed -b chrome --env QUEUE_VALIDATION_ENABLED=false --spec='**/*horizon*.feature'"
+
   },
   "author": "",
   "license": "ISC",


### PR DESCRIPTION
## Ticket Number
AS-1215 / AS-190

## Description of change
in e2e-tests
`CYPRESS_BASE_URL=http://<user>:<password>@appeals-dev.planninginspectorate.gov.uk npm run test:e2e:horizon:script`

-> executes our horizon tests but without queue validation; so we can run these against a deployed environment to generate appeals->horizon.

## Checklist
<!-- Put an `x` in all the boxes that apply: -->
- [ ] Requires infrastructure changes
- [ ] If adding or remove environment variables (e.g. in `docker-compose.yaml`) then I have updated the appropriate Helm chart
- [ ] I have updated the documentation accordingly
- [ ] My commit history in this PR is linear
- [ ] New features have tests
- [ ] Breaking change (team conversation required)

## Important

Please do not merge from `master` (please only [rebase](https://github.com/foundry4/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
