### PR TITLE
fix(forms-web-app): do not display cookie banner on certain pages

### DIFF
--- a/e2e-tests/cypress/integration/appeal-submission-creation-of-submission-information-file.feature
+++ b/e2e-tests/cypress/integration/appeal-submission-creation-of-submission-information-file.feature
@@ -1,12 +1,12 @@
-@wip
 Feature: Appeal Submission - Creation of submission information file
 
   As a Planning Inspectorate case worker
   I want a human readable file containing the appellant’s appeal submission information, at point of submission
   So that I have all the information collected during the appeal submission that was not explicitly passed to Horizon
 
-  @as-101
+  @as-101 @as-1441
   Scenario: Summary of submission
     Given a prospective appellant has provided valid appeal information
     When the appeal is submitted
     Then a submission information file is created
+    And the cookie banner does not exist

--- a/e2e-tests/cypress/integration/appeal-submission-creation-of-submission-information-file/appeal-submission-creation-of-submission-information-file.js
+++ b/e2e-tests/cypress/integration/appeal-submission-creation-of-submission-information-file/appeal-submission-creation-of-submission-information-file.js
@@ -1,5 +1,7 @@
 import { Given, When, Then } from 'cypress-cucumber-preprocessor/steps';
 import { STANDARD_APPEAL } from '../common/standard-appeal';
+import { getTask } from '../common/task';
+import '../common/cookies';
 
 Given('a prospective appellant has provided valid appeal information', () => {
   cy.provideCompleteAppeal(STANDARD_APPEAL);

--- a/e2e-tests/cypress/integration/common/cookies.js
+++ b/e2e-tests/cypress/integration/common/cookies.js
@@ -66,3 +66,7 @@ Then('not necessary cookies are disabled', () => {
       expectCookieIsNotDefined(cookies, 'cookie_preferences_set');
     });
 });
+
+Then('the cookie banner does not exist', () => {
+  cy.confirmCookieConsentBannerDoesNotExist();
+});

--- a/e2e-tests/cypress/integration/cookie-consent-save-preferences.feature
+++ b/e2e-tests/cypress/integration/cookie-consent-save-preferences.feature
@@ -9,7 +9,7 @@ Feature: Cookie Consent - Save Preferences
     Given a user has not previously submitted cookie preferences
     When a user is managing their cookie preference
     Then the not necessary cookies are shown as neither enabled or disabled
-    And the user should not see the cookie banner
+    And the cookie banner does not exist
 
   @as-1214 @as-1214-2
   Scenario: Manage Cookie preference - Disable

--- a/e2e-tests/cypress/integration/cookies-consent-bar-without-javascript-enabled.feature
+++ b/e2e-tests/cypress/integration/cookies-consent-bar-without-javascript-enabled.feature
@@ -15,3 +15,4 @@ Feature: Cookie consent bar - no JS
     Given a user visits the site with JavaScript disabled
     When the user views the cookie preferences page
     Then the cookies page is presented
+    And the cookie banner does not exist

--- a/e2e-tests/cypress/support/appeal-submission-information/submission-information-commands.js
+++ b/e2e-tests/cypress/support/appeal-submission-information/submission-information-commands.js
@@ -1,0 +1,9 @@
+Cypress.Commands.add(
+  'confirmSubmissionInformationDisplayItems',
+  require('./confirmSubmissionInformationDisplayItems'),
+);
+
+Cypress.Commands.add(
+  'navigateToSubmissionInformationPage',
+  require('./navigateToSubmissionInformationPage'),
+);

--- a/e2e-tests/cypress/support/commands.js
+++ b/e2e-tests/cypress/support/commands.js
@@ -6,3 +6,4 @@ require('./commands/navigation-commands');
 require('./commands/eligibility-commands');
 require('./commands/submission-commands');
 require('./commands/guidance-page-commands');
+require('./appeal-submission-information/submission-information-commands');

--- a/e2e-tests/cypress/support/common/assertRadioButtonState.js
+++ b/e2e-tests/cypress/support/common/assertRadioButtonState.js
@@ -1,6 +1,4 @@
 module.exports = (cyTags, { isChecked }) => {
-  console.log('cyTags', { cyTags, isChecked });
-
   const matchAssertion = isChecked ? 'be.checked' : 'not.be.checked';
 
   const interestingTags = Array.isArray(cyTags) ? cyTags : [cyTags];

--- a/e2e-tests/cypress/support/cookies/confirmCookieConsentBannerDoesNotExist.js
+++ b/e2e-tests/cypress/support/cookies/confirmCookieConsentBannerDoesNotExist.js
@@ -1,0 +1,4 @@
+module.exports = () => {
+  cy.get(`[data-cy="cookie-banner"]`).should('not.exist');
+  cy.wait(Cypress.env('demoDelay'));
+};

--- a/e2e-tests/cypress/support/cookies/cookies-commands.js
+++ b/e2e-tests/cypress/support/cookies/cookies-commands.js
@@ -28,6 +28,11 @@ Cypress.Commands.add(
   require('./confirmCookieConsentBannerIsNotVisible'),
 );
 
+Cypress.Commands.add(
+  'confirmCookieConsentBannerDoesNotExist',
+  require('./confirmCookieConsentBannerDoesNotExist'),
+);
+
 Cypress.Commands.add('confirmCookiePolicy', require('./confirmCookiePolicy'));
 
 Cypress.Commands.add(

--- a/packages/forms-web-app/src/controllers/appellant-submission/submission-information.js
+++ b/packages/forms-web-app/src/controllers/appellant-submission/submission-information.js
@@ -23,5 +23,6 @@ exports.getSubmissionInformation = async (req, res) => {
     appealLPD: appealLPD.name,
     appeal,
     css,
+    displayCookieBanner: false,
   });
 };

--- a/packages/forms-web-app/src/controllers/cookies.js
+++ b/packages/forms-web-app/src/controllers/cookies.js
@@ -20,6 +20,7 @@ const getExistingCookiePolicy = (req) => {
 exports.getCookies = (req, res) => {
   res.render(VIEW.COOKIES, {
     cookiePolicy: getExistingCookiePolicy(req),
+    displayCookieBanner: false,
   });
 };
 
@@ -30,6 +31,7 @@ exports.postCookies = (req, res) => {
   if (Object.keys(errors).length > 0) {
     res.render(VIEW.COOKIES, {
       cookiePolicy: getExistingCookiePolicy(req),
+      displayCookieBanner: false,
     });
     return;
   }

--- a/packages/forms-web-app/src/lib/client-side/cookie/cookie-consent.js
+++ b/packages/forms-web-app/src/lib/client-side/cookie/cookie-consent.js
@@ -6,7 +6,6 @@ const { hideSingleDomElementBySelector } = require('./cookie-dom-helpers');
 const { showCookieConsentAcceptedBanner } = require('./cookie-consent-accepted');
 const { showCookieConsentRejectedBanner } = require('./cookie-consent-rejected');
 const { initialiseOptionalJavaScripts } = require('../javascript-requiring-consent');
-const { VIEW } = require('../../views');
 
 const setCookies = (document, cookiePolicy) => {
   eraseCookie(document, cookieConfig.COOKIE_POLICY_KEY);
@@ -60,22 +59,20 @@ const addRejectCookieConsentListener = (document, rejectCookieConsentButton) => 
 };
 
 const cookieConsentHandler = (document) => {
-  if (readCookie(document, cookieConfig.COOKIE_POLICY_KEY) !== null) {
-    hideConsentBanner(document);
-    return;
-  }
-
-  // do not display the cookie banner on the /cookies page
-  if (window.location.pathname === `/${VIEW.COOKIES}`) {
-    hideConsentBanner(document);
-    return;
-  }
-
   const {
     allConsentButtons,
     acceptCookieConsentButton,
     rejectCookieConsentButton,
   } = getConsentButtons(document);
+
+  if (!acceptCookieConsentButton || !rejectCookieConsentButton) {
+    return;
+  }
+
+  if (readCookie(document, cookieConfig.COOKIE_POLICY_KEY) !== null) {
+    hideConsentBanner(document);
+    return;
+  }
 
   addAcceptCookieConsentListener(document, acceptCookieConsentButton);
   addRejectCookieConsentListener(document, rejectCookieConsentButton);

--- a/packages/forms-web-app/src/views/includes/cookie-banner.njk
+++ b/packages/forms-web-app/src/views/includes/cookie-banner.njk
@@ -2,8 +2,12 @@
 {% from "../macros/cookie-banner-accepted.njk" import cookieBannerAccepted %}
 {% from "../macros/cookie-banner-rejected.njk" import cookieBannerRejected %}
 
-<div id="global-cookie-message" role="region" aria-label="cookie banner" data-nosnippet="">
-  {{ cookieBanner() }}
-  {{ cookieBannerAccepted() }}
-  {{ cookieBannerRejected() }}
-</div>
+{% set showCookieBanner = displayCookieBanner | default(true) %}
+
+{%- if showCookieBanner -%}
+  <div id="global-cookie-message" role="region" aria-label="cookie banner" data-nosnippet="">
+    {{ cookieBanner() }}
+    {{ cookieBannerAccepted() }}
+    {{ cookieBannerRejected() }}
+  </div>
+{%- endif -%}

--- a/packages/forms-web-app/tests/unit/controllers/appellant-submission/submission-information.test.js
+++ b/packages/forms-web-app/tests/unit/controllers/appellant-submission/submission-information.test.js
@@ -69,6 +69,7 @@ describe('controllers/appellant-submission/submission-information', () => {
         appealLPD: fakeLpdName,
         appeal: req.session.appeal,
         css,
+        displayCookieBanner: false,
       });
     });
   });

--- a/packages/forms-web-app/tests/unit/controllers/cookies.test.js
+++ b/packages/forms-web-app/tests/unit/controllers/cookies.test.js
@@ -44,6 +44,7 @@ describe('controllers/cookies', () => {
 
       expect(res.render).toHaveBeenCalledWith(VIEW.COOKIES, {
         cookiePolicy: {},
+        displayCookieBanner: false,
       });
     });
 
@@ -52,6 +53,7 @@ describe('controllers/cookies', () => {
 
       expect(res.render).toHaveBeenCalledWith(VIEW.COOKIES, {
         cookiePolicy: undefined,
+        displayCookieBanner: false,
       });
     });
   });
@@ -77,6 +79,7 @@ describe('controllers/cookies', () => {
 
       expect(res.render).toHaveBeenCalledWith(VIEW.COOKIES, {
         cookiePolicy: undefined,
+        displayCookieBanner: false,
       });
 
       expect(res.cookie).not.toHaveBeenCalled();


### PR DESCRIPTION
## Ticket Number
<!-- Add the number from the Jira board -->
AS-1441

## Description of change
Do not display cookie banner on certain pages.

This also un-WIP's the submission information feature, which flagged several sub issues. 

This includes a fix for the issue of JS console errors (which blew up cypress) when the cookie banner was entirely removed from the page. 

## Checklist
<!-- Put an `x` in all the boxes that apply: -->
- [ ] Requires infrastructure changes
- [ ] If adding or remove environment variables (e.g. in `docker-compose.yaml`) then I have updated the appropriate Helm chart
- [ ] I have updated the documentation accordingly
- [x] My commit history in this PR is linear
- [x] New features have tests
- [ ] Breaking change (team conversation required)

## Important

Please do not merge from `master` (please only [rebase](https://github.com/foundry4/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
