### PR TITLE
fix(forms-web-app): change cookie expiry from 100 to 1 year

### DIFF
--- a/packages/forms-web-app/src/controllers/cookies.js
+++ b/packages/forms-web-app/src/controllers/cookies.js
@@ -48,7 +48,7 @@ exports.postCookies = (req, res) => {
 
   res.cookie(cookieConfig.COOKIE_POLICY_KEY, JSON.stringify(updatedCookiePolicy), {
     encode: String,
-    expires: new Date(Date.now() + 36500 * 24 * 60 * 60 * 1000),
+    expires: new Date(Date.now() + 365 * 24 * 60 * 60 * 1000),
     secure: appConfig.isProduction,
   });
 

--- a/packages/forms-web-app/src/lib/client-side/cookie/cookie-jar.js
+++ b/packages/forms-web-app/src/lib/client-side/cookie/cookie-jar.js
@@ -2,7 +2,7 @@
 
 // https://www.quirksmode.org/js/cookies.html
 
-const createCookie = (document, name, value, days = 36500) => {
+const createCookie = (document, name, value, days = 365) => {
   let expires = '';
   if (typeof days === 'number') {
     const date = new Date();

--- a/packages/forms-web-app/tests/unit/controllers/cookies.test.js
+++ b/packages/forms-web-app/tests/unit/controllers/cookies.test.js
@@ -90,7 +90,7 @@ describe('controllers/cookies', () => {
             ...cookieConfig.DEFAULT_COOKIE_POLICY,
             usage,
           }),
-          { encode: String, expires: new Date('2120-10-25T00:00:00.000Z'), secure }
+          { encode: String, expires: new Date('2021-11-18T00:00:00.000Z'), secure }
         );
       };
 

--- a/packages/forms-web-app/tests/unit/lib/client-side/cookie/cookie-jar.test.js
+++ b/packages/forms-web-app/tests/unit/lib/client-side/cookie/cookie-jar.test.js
@@ -47,7 +47,7 @@ describe('lib/client-side/cookie/cookie-jar', () => {
       createCookie(document, fakeName, fakeValue);
 
       expect(document.cookie).toEqual(
-        `${fakeName}=${fakeValue}; expires=Fri, 25 Oct 2120 00:00:00 GMT; path=/`
+        `${fakeName}=${fakeValue}; expires=Thu, 18 Nov 2021 00:00:00 GMT; path=/`
       );
     });
 


### PR DESCRIPTION
## Ticket Number
<!-- Add the number from the Jira board -->
AS-1459

## Description of change
change cookie expiry from 100 to 1 year

## Checklist
<!-- Put an `x` in all the boxes that apply: -->
- [ ] Requires infrastructure changes
- [ ] If adding or remove environment variables (e.g. in `docker-compose.yaml`) then I have updated the appropriate Helm chart
- [ ] I have updated the documentation accordingly
- [x] My commit history in this PR is linear
- [x] New features have tests
- [ ] Breaking change (team conversation required)

## Important

Please do not merge from `master` (please only [rebase](https://github.com/foundry4/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
