### PR TITLE
fix(forms-web-app): change decision-date handling to return input errors

### DIFF
--- a/packages/forms-web-app/src/controllers/eligibility/decision-date.js
+++ b/packages/forms-web-app/src/controllers/eligibility/decision-date.js
@@ -19,7 +19,11 @@ exports.getDecisionDate = (req, res) => {
   const decisionDate = isValid(appealDecisionDate) ? appealDecisionDate : null;
 
   res.render(VIEW.ELIGIBILITY.DECISION_DATE, {
-    decisionDate,
+    decisionDate: decisionDate && {
+      day: `0${decisionDate.getDate()}`.slice(-2),
+      month: `0${decisionDate.getMonth() + 1}`.slice(-2),
+      year: decisionDate.getFullYear(),
+    },
   });
 };
 
@@ -30,11 +34,12 @@ exports.postDecisionDate = async (req, res) => {
   const { errors = {}, errorSummary = [] } = body;
 
   if (Object.keys(errors).length > 0) {
-    const appealDecisionDate = parseISO(appeal.decisionDate);
-    const decisionDate = isValid(appealDecisionDate) ? appealDecisionDate : null;
-
     res.render(VIEW.ELIGIBILITY.DECISION_DATE, {
-      decisionDate,
+      decisionDate: {
+        day: body['decision-date-day'],
+        month: body['decision-date-month'],
+        year: body['decision-date-year'],
+      },
       errors,
       errorSummary,
     });

--- a/packages/forms-web-app/src/views/eligibility/decision-date.njk
+++ b/packages/forms-web-app/src/views/eligibility/decision-date.njk
@@ -45,18 +45,18 @@
             {
               classes: "govuk-input--width-2 govuk-input--error" if errors['decision-date'] or errors['decision-date-day'] else "govuk-input--width-2",
               name: "day",
-              value: decisionDate and ("0" + decisionDate.getDate()).slice(-2)
+              value: decisionDate.day
             },
             {
               classes: "govuk-input--width-2 govuk-input--error" if errors['decision-date'] or errors['decision-date-month'] else "govuk-input--width-2",
               name: "month",
-              value: decisionDate and ("0" + (decisionDate.getMonth() + 1)).slice(-2)
+              value: decisionDate.month
 
             },
             {
               classes: "govuk-input--width-4 govuk-input--error" if errors['decision-date'] or errors['decision-date-year'] else "govuk-input--width-4",
               name: "year",
-              value: decisionDate and decisionDate.getFullYear()
+              value: decisionDate.year
             }
           ]
         } ) }}

--- a/packages/forms-web-app/tests/unit/controllers/eligibility/decision-date.test.js
+++ b/packages/forms-web-app/tests/unit/controllers/eligibility/decision-date.test.js
@@ -62,7 +62,11 @@ describe('controllers/eligibility/decision-date', () => {
       decisionDateController.getDecisionDate(mockRequest, res);
 
       expect(res.render).toHaveBeenCalledWith(VIEW.ELIGIBILITY.DECISION_DATE, {
-        decisionDate: parseISO(decisionDate),
+        decisionDate: {
+          day: '01',
+          month: '01',
+          year: 2000,
+        },
       });
     });
   });
@@ -99,12 +103,14 @@ describe('controllers/eligibility/decision-date', () => {
         },
       };
 
-      mockRequest.session.appeal.decisionDate = '';
-
       await decisionDateController.postDecisionDate(mockRequest, res);
 
       expect(res.render).toHaveBeenCalledWith(VIEW.ELIGIBILITY.DECISION_DATE, {
-        decisionDate: null,
+        decisionDate: {
+          day: undefined,
+          month: undefined,
+          year: undefined,
+        },
         errorSummary: [],
         errors: {
           'decision-date-year': {
@@ -113,12 +119,17 @@ describe('controllers/eligibility/decision-date', () => {
         },
       });
 
-      mockRequest.session.appeal.decisionDate = '2000-01-01T12:00:00.000Z';
+      mockRequest.body['decision-date-day'] = '01';
+      mockRequest.body['decision-date-month'] = '01';
 
       await decisionDateController.postDecisionDate(mockRequest, res);
 
       expect(res.render).toHaveBeenCalledWith(VIEW.ELIGIBILITY.DECISION_DATE, {
-        decisionDate: parseISO(appeal.decisionDate),
+        decisionDate: {
+          day: '01',
+          month: '01',
+          year: undefined,
+        },
         errorSummary: [],
         errors: {
           'decision-date-year': {
@@ -198,6 +209,9 @@ describe('controllers/eligibility/decision-date', () => {
       ...req,
       body: {
         'decision-date': '1-1-2020',
+        'decision-date-day': '1',
+        'decision-date-month': '1',
+        'decision-date-year': '2020',
         errors: { a: 'b' },
         errorSummary: [{ text: 'There were errors here', href: '#' }],
       },
@@ -209,7 +223,11 @@ describe('controllers/eligibility/decision-date', () => {
 
     expect(res.redirect).not.toHaveBeenCalled();
     expect(res.render).toHaveBeenCalledWith(VIEW.ELIGIBILITY.DECISION_DATE, {
-      decisionDate: parseISO(appeal.decisionDate),
+      decisionDate: {
+        day: '1',
+        month: '1',
+        year: '2020',
+      },
       errorSummary: [{ text: 'There were errors here', href: '#' }],
       errors: { a: 'b' },
     });


### PR DESCRIPTION
## Ticket Number
<!-- Add the number from the Jira board -->
AS-1440

## Description of change
Changed handling of decision date to return errors on input entry. Previously only did this on a valid date, however with expansion of error handling of this field it needs to be able to handle more use cases.

## Checklist
<!-- Put an `x` in all the boxes that apply: -->
- [ ] Requires infrastructure changes
- [ ] If adding or remove environment variables (e.g. in `docker-compose.yaml`) then I have updated the appropriate Helm chart
- [ ] I have updated the documentation accordingly
- [X] My commit history in this PR is linear
- [X] New features have tests
- [ ] Breaking change (team conversation required)

## Important

Please do not merge from `master` (please only [rebase](https://github.com/foundry4/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
