### PR TITLE
feat(keyvault): configure k8s to be able to read from pins internal key vault

### DIFF
--- a/charts/app/templates/keyVault.yaml
+++ b/charts/app/templates/keyVault.yaml
@@ -1,11 +1,16 @@
-{{- $keyVaultName := .Values.keyVault.name -}}
-{{- $secrets := .Values.keyVault.secrets }}
-{{- range $item := .Values.keyVault.envSpecific.secrets }}
+{{- /* Combine the key vault configs into one list */}}
+{{ $keyVaults := list .Values.keyVault .Values.pinsKeyVault }}
+
+{{- range $keyVault := $keyVaults }}
+
+{{- $keyVaultName := $keyVault.name -}}
+{{- $secrets := $keyVault.secrets }}
+{{- range $item := $keyVault.envSpecific.secrets }}
 {{- $secrets = append $secrets $item }}
 {{- end }}
 
-{{- $multiValueSecrets := .Values.keyVault.multiValueSecrets }}
-{{- range $item := .Values.keyVault.envSpecific.multiValueSecrets }}
+{{- $multiValueSecrets := $keyVault.multiValueSecrets }}
+{{- range $item := $keyVault.envSpecific.multiValueSecrets }}
 {{- $multiValueSecrets = append $multiValueSecrets $item }}
 {{- end }}
 
@@ -43,4 +48,5 @@ spec:
   output:
     secret:
       name: akv-{{ . }}
+{{- end }}
 {{- end }}

--- a/charts/app/values.yaml
+++ b/charts/app/values.yaml
@@ -205,6 +205,14 @@ keyVault:
     secrets: []
     multiValueSecrets: []
 
+pinsKeyVault:
+  name: odtkeyvault
+  secrets: []
+  multiValueSecrets: []
+  envSpecific:
+    secrets: []
+    multiValueSecrets: []
+
 ### Third-party services
 gotenberg:
   replicaCount: 1

--- a/infrastructure/environments/kubernetes.tf
+++ b/infrastructure/environments/kubernetes.tf
@@ -116,6 +116,18 @@ resource "azurerm_key_vault_access_policy" "k8s" {
   ]
 }
 
+resource "azurerm_key_vault_access_policy" "k8s_pins" {
+  key_vault_id = var.pins_key_vault
+  object_id = azurerm_kubernetes_cluster.k8s.kubelet_identity.0.object_id
+  tenant_id = azurerm_kubernetes_cluster.k8s.identity.0.tenant_id
+
+  secret_permissions = [
+    "get"
+  ]
+
+  provider = azurerm.pins-main
+}
+
 resource "azurerm_public_ip" "k8s" {
   name = format(local.name_format, "k8s")
   location = azurerm_resource_group.k8s.location

--- a/releases/dev/app.yml
+++ b/releases/dev/app.yml
@@ -69,6 +69,11 @@ spec:
         multiValueSecrets:
         - http-basic
 
+    pinsKeyVault:
+      envSpecific:
+        secrets:
+          - notify-preprod
+
     ingress:
       hosts:
         fwa:

--- a/releases/preprod/app.yml
+++ b/releases/preprod/app.yml
@@ -69,6 +69,11 @@ spec:
         multiValueSecrets:
         - http-basic
 
+    pinsKeyVault:
+      envSpecific:
+        secrets:
+          - notify-preprod
+
     ingress:
       hosts:
         fwa:


### PR DESCRIPTION
## Ticket Number
<!-- Add the number from the Jira board -->
AS-1483

## Description of change
<!-- Please describe the change -->
Configure import of secrets of PINS Key Vault. This is used so that PINS staff can inject tokens (eg, Notify) into the cluster without ever having to distribute in an insecure manner

## Checklist
<!-- Put an `x` in all the boxes that apply: -->
- [x] Requires infrastructure changes
- [x] If adding or remove environment variables (e.g. in `docker-compose.yaml`) then I have updated the appropriate Helm chart
- [x] I have updated the documentation accordingly
- [ ] My commit history in this PR is linear
- [ ] New features have tests
- [ ] Breaking change (team conversation required)

## Important

Please do not merge from `master` (please only [rebase](https://github.com/foundry4/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
