### PR TITLE
fix(lpa): remove dependency on deprecated req.params fn

### DIFF
--- a/packages/appeals-service-api/src/controllers/local-planning-authorities.js
+++ b/packages/appeals-service-api/src/controllers/local-planning-authorities.js
@@ -11,7 +11,7 @@ const LPASchema = require('../schemas/lpa');
 
 module.exports = {
   async get(req, res, next) {
-    const id = req.param('id');
+    const { id } = req.params;
 
     req.log.info({ id }, 'Retrieving LPA');
 
@@ -30,7 +30,7 @@ module.exports = {
   },
 
   async list(req, res) {
-    const name = req.param('name');
+    const { name } = req.query;
 
     const filter = {};
     if (name) {

--- a/packages/appeals-service-api/tests/unit/controllers/local-planning-authorities.test.js
+++ b/packages/appeals-service-api/tests/unit/controllers/local-planning-authorities.test.js
@@ -1,6 +1,5 @@
 jest.mock('../../../src/schemas/lpa');
 
-const { when } = require('jest-when');
 const LPA = require('../../../src/schemas/lpa');
 const lpas = require('../../../src/controllers/local-planning-authorities');
 
@@ -14,7 +13,8 @@ describe('LPAs controller test', () => {
         debug: jest.fn(),
         trace: jest.fn(),
       },
-      param: jest.fn(),
+      params: {},
+      query: {},
     };
     res = {
       status: jest.fn(),
@@ -27,7 +27,9 @@ describe('LPAs controller test', () => {
   describe('#get', () => {
     it('should trigger next if there is no LPA found', async () => {
       const id = 'someInvalidId';
-      when(req.param).calledWith('id').mockReturnValue(id);
+      req.params = {
+        id,
+      };
 
       LPA.find.mockResolvedValue();
 
@@ -46,7 +48,9 @@ describe('LPAs controller test', () => {
     it('should return the LPA if one found', async () => {
       const id = 'someValidId';
       const target = 'some-data';
-      when(req.param).calledWith('id').mockReturnValue(id);
+      req.params = {
+        id,
+      };
 
       LPA.findOne.mockResolvedValue(target);
 
@@ -80,7 +84,9 @@ describe('LPAs controller test', () => {
 
     it('should return filtered LPAs if filter applied', async () => {
       const filter = 'some-filter';
-      when(req.param).calledWith('name').mockReturnValue(filter);
+      req.query = {
+        name: filter,
+      };
       const data = ['some-filtered-array'];
       LPA.find.mockResolvedValue(data);
 


### PR DESCRIPTION
## Ticket Number
<!-- Add the number from the Jira board -->
N/A

## Description of change
<!-- Please describe the change -->
Remove use of `req.param` function in the local planning authority controller which is now deprecated by Express.

## Checklist
<!-- Put an `x` in all the boxes that apply: -->
- [ ] Requires infrastructure changes
- [ ] If adding or remove environment variables (e.g. in `docker-compose.yaml`) then I have updated the appropriate Helm chart
- [ ] I have updated the documentation accordingly
- [ ] My commit history in this PR is linear
- [ ] New features have tests
- [ ] Breaking change (team conversation required)

## Important

Please do not merge from `master` (please only [rebase](https://github.com/foundry4/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
