### PR TITLE
Subtask/as 1304 add status validator

### DIFF
--- a/lpa-submissions-e2e-tests/cypress/integration/appealsDevelopmentPlan/appealsDevelopmentPlanSteps.js
+++ b/lpa-submissions-e2e-tests/cypress/integration/appealsDevelopmentPlan/appealsDevelopmentPlanSteps.js
@@ -56,6 +56,7 @@ When(`there is not a Development plan document or Neighbourhood plan`, () => {
 
 When(`details are provided about the plan {string}`, (plan_details) => {
   cy.inputDevelopmentPlanDetails().type(plan_details);
+  cy.clickSaveAndContinue();
 });
 
 When(`no details are given about the plan`, () => {

--- a/packages/lpa-questionnaire-web-app/src/services/task-status/development-plan.js
+++ b/packages/lpa-questionnaire-web-app/src/services/task-status/development-plan.js
@@ -1,0 +1,15 @@
+const { COMPLETED, NOT_STARTED } = require('./task-statuses');
+
+module.exports = (appealReply) => {
+  if (!appealReply) return null;
+
+  const task = appealReply.optionalDocumentsSection?.developmentOrNeighbourhood;
+  let completion;
+
+  if (task && typeof task.hasPlanSubmitted === 'boolean') {
+    completion =
+      (!task.hasPlanSubmitted || (task.hasPlanSubmitted && task.planChanges)) && COMPLETED;
+  }
+
+  return completion || NOT_STARTED;
+};

--- a/packages/lpa-questionnaire-web-app/src/services/task.service.js
+++ b/packages/lpa-questionnaire-web-app/src/services/task.service.js
@@ -2,6 +2,7 @@ const TASK_STATUS = require('./task-status/task-statuses');
 const accuracySubmissionCompletion = require('./task-status/accuracy-submission');
 const otherAppealsCompletion = require('./task-status/other-appeals');
 const extraConditionsCompletion = require('./task-status/extra-conditions');
+const developmentPlanCompletion = require('./task-status/development-plan');
 
 function statusTemp() {
   // TODO: these will be replaces when we have checks for status of each step
@@ -105,7 +106,7 @@ const SECTIONS = [
       {
         taskId: 'developmentOrNeighbourhood',
         href: '/development-plan',
-        rule: statusTemp,
+        rule: developmentPlanCompletion,
       },
     ],
   },

--- a/packages/lpa-questionnaire-web-app/tests/unit/services/task-status/development-plan.test.js
+++ b/packages/lpa-questionnaire-web-app/tests/unit/services/task-status/development-plan.test.js
@@ -1,0 +1,60 @@
+const { NOT_STARTED, COMPLETED } = require('../../../../src/services/task-status/task-statuses');
+const developmentPlanCompletion = require('../../../../src/services/task-status/development-plan');
+
+describe('services/task.service/task-status/other-appeals', () => {
+  it('should return null if no appeal reply passed', () => {
+    expect(developmentPlanCompletion()).toBeNull();
+  });
+
+  it('should return not started if not set', () => {
+    const mockAppealReply = {
+      optionalDocumentsSection: {
+        developmentOrNeighbourhood: {
+          hasPlanSubmitted: null,
+          planChanges: '',
+        },
+      },
+    };
+
+    expect(developmentPlanCompletion(mockAppealReply)).toEqual(NOT_STARTED);
+  });
+
+  it('should return completed if answer is no', () => {
+    const mockAppealReply = {
+      optionalDocumentsSection: {
+        developmentOrNeighbourhood: {
+          hasPlanSubmitted: false,
+          planChanges: '',
+        },
+      },
+    };
+
+    expect(developmentPlanCompletion(mockAppealReply)).toEqual(COMPLETED);
+  });
+
+  it('should return completed if answer is yes and text is passed.', () => {
+    const mockAppealReply = {
+      optionalDocumentsSection: {
+        developmentOrNeighbourhood: {
+          hasPlanSubmitted: true,
+          planChanges: 'some-text',
+        },
+      },
+    };
+
+    expect(developmentPlanCompletion(mockAppealReply)).toEqual(COMPLETED);
+  });
+
+  it('should return not started if answer is yes and no text is passed', () => {
+    const mockAppealReply = {
+      optionalDocumentsSection: {
+        developmentOrNeighbourhood: {
+          hasPlanSubmitted: null,
+          planChanges: '',
+        },
+      },
+    };
+
+    expect(developmentPlanCompletion(mockAppealReply)).toEqual(NOT_STARTED);
+  });
+});


### PR DESCRIPTION
## Ticket Number
AS-1304

## Description of change
add task status for development plan page

## Checklist
<!-- Put an `x` in all the boxes that apply: -->
- [ ] Requires infrastructure changes
- [ ] If adding or remove environment variables (e.g. in `docker-compose.yaml`) then I have updated the appropriate Helm chart
- [ ] I have updated the documentation accordingly
- [x] My commit history in this PR is linear
- [x] New features have tests
- [ ] Breaking change (team conversation required)

## Important

Please do not merge from `master` (please only [rebase](https://github.com/foundry4/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
