### PR TITLE
fix(forms-web-app): ensure third party cookies are removed

### DIFF
--- a/e2e-tests/cypress/integration/cookie-consent-save-preferences/cookie-consent-save-preferences.js
+++ b/e2e-tests/cypress/integration/cookie-consent-save-preferences/cookie-consent-save-preferences.js
@@ -47,6 +47,7 @@ Then('any existing third party cookies have been deleted', () => {
 
 Then('the not necessary cookie is active from that point onwards', () => {
   cy.confirmUsageCookieHasBeenMarkedAsActive();
+  cy.confirmHasGoogleAnalyticsCookies();
 });
 
 Then('the user should not see the cookie banner', () => {

--- a/e2e-tests/cypress/support/cookies/confirmHasGoogleAnalyticsCookies.js
+++ b/e2e-tests/cypress/support/cookies/confirmHasGoogleAnalyticsCookies.js
@@ -1,0 +1,6 @@
+import { findCookieObjectByName } from '../../integration/cookies/cookies';
+import cookieConfig from '../../../../packages/forms-web-app/src/lib/client-side/cookie/cookie-config';
+
+module.exports = () => {
+  cy.getCookie('_ga').should('exist');
+};

--- a/e2e-tests/cypress/support/cookies/cookies-commands.js
+++ b/e2e-tests/cypress/support/cookies/cookies-commands.js
@@ -61,6 +61,11 @@ Cypress.Commands.add(
 );
 
 Cypress.Commands.add(
+  'confirmHasGoogleAnalyticsCookies',
+  require('./confirmHasGoogleAnalyticsCookies'),
+);
+
+Cypress.Commands.add(
   'confirmCookieFlashMessageContent',
   require('./confirmCookieFlashMessageContent'),
 );

--- a/packages/forms-web-app/src/app.js
+++ b/packages/forms-web-app/src/app.js
@@ -19,6 +19,7 @@ const addKeyValuePair = require('./lib/add-key-value-pair');
 const renderTemplateFilter = require('./lib/render-template-filter');
 const flashMessageCleanupMiddleware = require('./middleware/flash-message-cleanup');
 const flashMessageToNunjucks = require('./middleware/flash-message-to-nunjucks');
+const removeUnwantedCookiesMiddelware = require('./middleware/remove-unwanted-cookies');
 require('express-async-errors');
 
 const config = require('./config');
@@ -98,6 +99,7 @@ app.use(express.json());
 app.use(express.urlencoded({ extended: false }));
 app.use(cookieParser());
 app.use(session(sessionConfig()));
+app.use(removeUnwantedCookiesMiddelware);
 app.use('/public', express.static(path.join(__dirname, 'public')));
 app.use(
   '/assets',

--- a/packages/forms-web-app/src/controllers/cookies.js
+++ b/packages/forms-web-app/src/controllers/cookies.js
@@ -3,6 +3,7 @@ const appConfig = require('../config');
 const cookieConfig = require('../lib/client-side/cookie/cookie-config');
 const getPreviousPagePath = require('../lib/get-previous-page-path');
 const { addFlashMessage } = require('../lib/flash-message');
+const { removeUnwantedCookies } = require('../lib/remove-unwanted-cookies');
 
 const getExistingCookiePolicy = (req) => {
   let cookiePolicy = {};
@@ -66,6 +67,10 @@ exports.postCookies = (req, res) => {
       },
     },
   });
+
+  if (body['usage-cookies'] === 'off') {
+    removeUnwantedCookies(req, res);
+  }
 
   res.redirect(`/${VIEW.COOKIES}`);
 };

--- a/packages/forms-web-app/src/lib/remove-unwanted-cookies.js
+++ b/packages/forms-web-app/src/lib/remove-unwanted-cookies.js
@@ -1,0 +1,13 @@
+const cookieConfig = require('./client-side/cookie/cookie-config');
+
+const defaultKeepMeCookies = ['connect.sid', cookieConfig.COOKIE_POLICY_KEY];
+
+const removeUnwantedCookies = (req, res, keepTheseCookies = defaultKeepMeCookies) =>
+  Object.keys(req.cookies)
+    .filter((cookieName) => keepTheseCookies.includes(cookieName) === false)
+    .forEach((cookieName) => res.clearCookie(cookieName));
+
+module.exports = {
+  defaultKeepMeCookies,
+  removeUnwantedCookies,
+};

--- a/packages/forms-web-app/src/middleware/remove-unwanted-cookies.js
+++ b/packages/forms-web-app/src/middleware/remove-unwanted-cookies.js
@@ -1,0 +1,39 @@
+const { removeUnwantedCookies } = require('../lib/remove-unwanted-cookies');
+const cookieConfig = require('../lib/client-side/cookie/cookie-config');
+
+/**
+ * Middleware to ensure any unwanted third party cookies are removed if the user has chosen not
+ * to accept the usage policy.
+ *
+ * @param req
+ * @param res
+ * @param next
+ * @returns {*}
+ */
+module.exports = (req, res, next) => {
+  if (!req.cookies) {
+    return next();
+  }
+
+  if (typeof req.cookies[cookieConfig.COOKIE_POLICY_KEY] === 'undefined') {
+    removeUnwantedCookies(req, res);
+    return next();
+  }
+
+  let activeCookiePolicy;
+  try {
+    activeCookiePolicy = JSON.parse(req.cookies[cookieConfig.COOKIE_POLICY_KEY]);
+  } catch (e) {
+    // something went wrong decoding the cookie policy JSON, so lets wipe it and start again
+    removeUnwantedCookies(req, res, ['connect.sid']);
+    req.log.warn(e, 'Erasing all cookies due to JSON decoding error in the stored cookie policy.');
+    return next();
+  }
+
+  if (activeCookiePolicy.usage) {
+    return next();
+  }
+
+  removeUnwantedCookies(req, res);
+  return next();
+};

--- a/packages/forms-web-app/tests/unit/controllers/cookies.test.js
+++ b/packages/forms-web-app/tests/unit/controllers/cookies.test.js
@@ -5,8 +5,10 @@ const getPreviousPagePath = require('../../../src/lib/get-previous-page-path');
 const { VIEW } = require('../../../src/lib/views');
 const { mockReq, mockRes } = require('../mocks');
 const { addFlashMessage } = require('../../../src/lib/flash-message');
+const { removeUnwantedCookies } = require('../../../src/lib/remove-unwanted-cookies');
 
 jest.mock('../../../src/config');
+jest.mock('../../../src/lib/remove-unwanted-cookies');
 jest.mock('../../../src/lib/flash-message');
 jest.mock('../../../src/lib/get-previous-page-path');
 
@@ -121,8 +123,11 @@ describe('controllers/cookies', () => {
               previous_page_path: fakePreviousPage,
             },
           }),
+          runExtraAssertions: () => {
+            resCookieCallTest(false, false);
+            expect(removeUnwantedCookies).toHaveBeenCalledWith(req, res);
+          },
           expectedPreviousPagePath: fakePreviousPage,
-          runExtraAssertions: () => resCookieCallTest(false, false),
         },
         {
           description: 'Not in production, enable usage cookies',
@@ -136,7 +141,10 @@ describe('controllers/cookies', () => {
             },
           }),
           expectedPreviousPagePath: '/',
-          runExtraAssertions: () => resCookieCallTest(true, false),
+          runExtraAssertions: () => {
+            resCookieCallTest(true, false);
+            expect(removeUnwantedCookies).not.toHaveBeenCalled();
+          },
         },
         {
           description: 'In production, disable usage cookies',
@@ -150,7 +158,10 @@ describe('controllers/cookies', () => {
             },
           }),
           expectedPreviousPagePath: '/',
-          runExtraAssertions: () => resCookieCallTest(false, true),
+          runExtraAssertions: () => {
+            resCookieCallTest(false, true);
+            expect(removeUnwantedCookies).toHaveBeenCalledWith(req, res);
+          },
         },
         {
           description: 'In production,  enable usage cookies',
@@ -164,8 +175,11 @@ describe('controllers/cookies', () => {
               previous_page_path: fakePreviousPage,
             },
           }),
+          runExtraAssertions: () => {
+            resCookieCallTest(true, true);
+            expect(removeUnwantedCookies).not.toHaveBeenCalled();
+          },
           expectedPreviousPagePath: fakePreviousPage,
-          runExtraAssertions: () => resCookieCallTest(true, true),
         },
       ].forEach(
         ({ description, before, setupReq, expectedPreviousPagePath, runExtraAssertions }) => {
@@ -187,7 +201,7 @@ describe('controllers/cookies', () => {
 
             expect(res.redirect).toHaveBeenCalledWith(`/${VIEW.COOKIES}`);
 
-            runExtraAssertions();
+            runExtraAssertions(req, res);
           });
         }
       );

--- a/packages/forms-web-app/tests/unit/lib/remove-unwanted-cookies.test.js
+++ b/packages/forms-web-app/tests/unit/lib/remove-unwanted-cookies.test.js
@@ -1,0 +1,171 @@
+const {
+  defaultKeepMeCookies,
+  removeUnwantedCookies,
+} = require('../../../src/lib/remove-unwanted-cookies');
+const { mockReq, mockRes } = require('../mocks');
+const cookieConfig = require('../../../src/lib/client-side/cookie/cookie-config');
+
+describe('lib/remove-unwanted-cookies', () => {
+  describe('defaultKeepMeCookies', () => {
+    it('should have the expected cookie names', () => {
+      expect(defaultKeepMeCookies).toEqual(['connect.sid', cookieConfig.COOKIE_POLICY_KEY]);
+    });
+  });
+
+  describe('removeUnwantedCookies', () => {
+    const fakeSessionId = 'abc-xyz-123';
+
+    [
+      {
+        title: 'no existing cookies',
+        given: {
+          req: mockReq(),
+          res: mockRes(),
+          keepTheseCookies: undefined,
+        },
+        expected: (res) => {
+          expect(res.clearCookie).not.toHaveBeenCalled();
+        },
+      },
+      {
+        title: 'retains session cookie',
+        given: {
+          req: {
+            ...mockReq(),
+            cookies: {
+              'connect.sid': fakeSessionId,
+            },
+          },
+          res: mockRes(),
+          keepTheseCookies: undefined,
+        },
+        expected: (res) => {
+          expect(res.clearCookie).not.toHaveBeenCalled();
+        },
+      },
+      {
+        title: 'can force session cookie removal if explicitly excluded in keepTheseCookies',
+        given: {
+          req: {
+            ...mockReq(),
+            cookies: {
+              'connect.sid': fakeSessionId,
+            },
+          },
+          res: mockRes(),
+          keepTheseCookies: [],
+        },
+        expected: (res) => {
+          expect(res.clearCookie).toHaveBeenCalledTimes(1);
+          expect(res.clearCookie).toHaveBeenCalledWith('connect.sid');
+        },
+      },
+      {
+        title: `retains ${[cookieConfig.COOKIE_POLICY_KEY]}`,
+        given: {
+          req: {
+            ...mockReq(),
+            cookies: {
+              [cookieConfig.COOKIE_POLICY_KEY]: { a: 'b' },
+            },
+          },
+          res: mockRes(),
+          keepTheseCookies: undefined,
+        },
+        expected: (res) => {
+          expect(res.clearCookie).not.toHaveBeenCalled();
+        },
+      },
+      {
+        title: `can force ${[
+          cookieConfig.COOKIE_POLICY_KEY,
+        ]} removal if explicitly excluded in keepTheseCookies`,
+        given: {
+          req: {
+            ...mockReq(),
+            cookies: {
+              [cookieConfig.COOKIE_POLICY_KEY]: { a: 'b' },
+            },
+          },
+          res: mockRes(),
+          keepTheseCookies: [],
+        },
+        expected: (res) => {
+          expect(res.clearCookie).toHaveBeenCalledTimes(1);
+          expect(res.clearCookie).toHaveBeenCalledWith(cookieConfig.COOKIE_POLICY_KEY);
+        },
+      },
+      {
+        title: `removes and retains expected with defaults`,
+        given: {
+          req: {
+            ...mockReq(),
+            cookies: {
+              'connect.sid': fakeSessionId,
+              [cookieConfig.COOKIE_POLICY_KEY]: { a: 'b' },
+              'some-unwanted-cookie': 'i am unwanted :(',
+            },
+          },
+          res: mockRes(),
+          keepTheseCookies: undefined,
+        },
+        expected: (res) => {
+          expect(res.clearCookie).toHaveBeenCalledTimes(1);
+          expect(res.clearCookie).toHaveBeenCalledWith('some-unwanted-cookie');
+        },
+      },
+      {
+        title: `removes and retains expected with custom keepTheseCookies`,
+        given: {
+          req: {
+            ...mockReq(),
+            cookies: {
+              'connect.sid': fakeSessionId,
+              [cookieConfig.COOKIE_POLICY_KEY]: { a: 'b' },
+              'some-unwanted-cookie': 'i am unwanted :(',
+            },
+          },
+          res: mockRes(),
+          keepTheseCookies: ['some-unwanted-cookie'],
+        },
+        expected: (res) => {
+          expect(res.clearCookie).toHaveBeenCalledTimes(2);
+          expect(res.clearCookie).toHaveBeenCalledWith('connect.sid');
+          expect(res.clearCookie).toHaveBeenCalledWith(cookieConfig.COOKIE_POLICY_KEY);
+        },
+      },
+      {
+        title: `removes and retains expected with real world looking setup`,
+        given: {
+          req: {
+            ...mockReq(),
+            cookies: {
+              'connect.sid':
+                's%3Avh3SpX2LGpPS77Do2F0WVt4Gz3FaKP7t.CBnhpm4ua8zP4kXqnXjBC%2BH9%2FOlW%2BNPnuR155nAxvAE',
+              _ga_TZBWMVPTHV: 'GS1.1.1615458372.1.1.1615458496.0',
+              [cookieConfig.COOKIE_POLICY_KEY]: {
+                essential: true,
+                settings: false,
+                usage: false,
+                campaigns: false,
+              },
+              _ga: 'GA1.1.1786687680.1615458372',
+            },
+          },
+          res: mockRes(),
+          keepTheseCookies: undefined,
+        },
+        expected: (res) => {
+          expect(res.clearCookie).toHaveBeenCalledTimes(2);
+          expect(res.clearCookie).toHaveBeenCalledWith('_ga_TZBWMVPTHV');
+          expect(res.clearCookie).toHaveBeenCalledWith('_ga');
+        },
+      },
+    ].forEach(({ title, given: { req, res, keepTheseCookies }, expected }) => {
+      it(`should retain the expected cookies - ${title}`, () => {
+        removeUnwantedCookies(req, res, keepTheseCookies);
+        expected(res);
+      });
+    });
+  });
+});

--- a/packages/forms-web-app/tests/unit/middleware/remove-unwanted-cookies.test.js
+++ b/packages/forms-web-app/tests/unit/middleware/remove-unwanted-cookies.test.js
@@ -1,0 +1,80 @@
+const { mockReq, mockRes } = require('../mocks');
+const removeUnwantedCookiesMiddelware = require('../../../src/middleware/remove-unwanted-cookies');
+const { removeUnwantedCookies } = require('../../../src/lib/remove-unwanted-cookies');
+const cookieConfig = require('../../../src/lib/client-side/cookie/cookie-config');
+
+jest.mock('../../../src/lib/remove-unwanted-cookies');
+
+describe('middleware/remove-unwanted-cookies', () => {
+  [
+    {
+      title: 'req.cookies is undefined',
+      given: () => {
+        const r = mockReq();
+        delete r.cookies;
+        return r;
+      },
+      expected: (req, res, next) => {
+        expect(removeUnwantedCookies).not.toHaveBeenCalled();
+        expect(next).toHaveBeenCalled();
+      },
+    },
+    {
+      title: 'req.cookies is set but the interesting key does not exist',
+      given: () => mockReq(),
+      expected: (req, res, next) => {
+        expect(removeUnwantedCookies).toHaveBeenCalledWith(req, res);
+        expect(next).toHaveBeenCalled();
+      },
+    },
+    {
+      title: 'req.cookies[cookieConfig.COOKIE_POLICY_KEY] is set but the value is not JSON',
+      given: () => ({
+        ...mockReq(),
+        cookies: {
+          [cookieConfig.COOKIE_POLICY_KEY]: 'this is not JSON!',
+        },
+      }),
+      expected: (req, res, next) => {
+        expect(removeUnwantedCookies).toHaveBeenCalledWith(req, res, ['connect.sid']);
+        expect(next).toHaveBeenCalled();
+      },
+    },
+    {
+      title: 'req.cookies[cookieConfig.COOKIE_POLICY_KEY] is set and usage is enabled',
+      given: () => ({
+        ...mockReq(),
+        cookies: {
+          [cookieConfig.COOKIE_POLICY_KEY]: JSON.stringify({ usage: true }),
+        },
+      }),
+      expected: (req, res, next) => {
+        expect(removeUnwantedCookies).not.toHaveBeenCalled();
+        expect(next).toHaveBeenCalled();
+      },
+    },
+    {
+      title: 'req.cookies[cookieConfig.COOKIE_POLICY_KEY] is set and usage is disabled',
+      given: () => ({
+        ...mockReq(),
+        cookies: {
+          [cookieConfig.COOKIE_POLICY_KEY]: JSON.stringify({ usage: false }),
+        },
+      }),
+      expected: (req, res, next) => {
+        expect(removeUnwantedCookies).toHaveBeenCalledWith(req, res);
+        expect(next).toHaveBeenCalled();
+      },
+    },
+  ].forEach(({ title, given, expected }) => {
+    it(title, async () => {
+      const next = jest.fn();
+      const req = given();
+      const res = mockRes();
+
+      await removeUnwantedCookiesMiddelware(req, res, next);
+
+      expected(req, res, next);
+    });
+  });
+});

--- a/packages/forms-web-app/tests/unit/mocks.js
+++ b/packages/forms-web-app/tests/unit/mocks.js
@@ -6,6 +6,7 @@ const { APPEAL_DOCUMENT } = require('../../src/lib/empty-appeal');
 const { empty: emptyAppeal } = APPEAL_DOCUMENT;
 
 const mockReq = (appeal = emptyAppeal) => ({
+  cookies: {},
   log: logger,
   params: {},
   session: {
@@ -14,6 +15,7 @@ const mockReq = (appeal = emptyAppeal) => ({
 });
 
 const mockRes = () => ({
+  clearCookie: jest.fn(),
   cookie: jest.fn(),
   locals: jest.fn(),
   redirect: jest.fn(),


### PR DESCRIPTION
ensure third party cookies are removed when setting usage to inactive

## Ticket Number
<!-- Add the number from the Jira board -->
AS-1318

## Description of change
Remove any `_ga` cookies when toggling third party cookie usage to 'off'.

## Checklist
<!-- Put an `x` in all the boxes that apply: -->
- [ ] Requires infrastructure changes
- [ ] If adding or remove environment variables (e.g. in `docker-compose.yaml`) then I have updated the appropriate Helm chart
- [ ] I have updated the documentation accordingly
- [x] My commit history in this PR is linear
- [x] New features have tests
- [ ] Breaking change (team conversation required)

## Important

Please do not merge from `master` (please only [rebase](https://github.com/foundry4/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
