### PR TITLE
fix(document-types): add document types into horizon documents

### DIFF
--- a/packages/horizon-add-document/handler.js
+++ b/packages/horizon-add-document/handler.js
@@ -15,7 +15,7 @@ const config = {
   },
 };
 
-async function parseFile(containerClient, documentId, applicationId) {
+async function parseFile(containerClient, documentId, applicationId, documentType) {
   debug('Getting document', { applicationId, documentId });
 
   const { data } = await axios.get(`/api/v1/${applicationId}/${documentId}`, {
@@ -38,7 +38,7 @@ async function parseFile(containerClient, documentId, applicationId) {
     // The order of this object is important
     'a:HorizonAPIDocument': {
       'a:Content': fileData,
-      'a:DocumentType': 'Initial Documents',
+      'a:DocumentType': documentType,
       'a:Filename': data.name,
       'a:IsPublished': 'true',
       'a:Metadata': {
@@ -48,6 +48,13 @@ async function parseFile(containerClient, documentId, applicationId) {
               '__i:type': 'a:StringAttributeValue',
               'a:Name': 'Document:Involvement',
               'a:Value': 'Appellant',
+            },
+          },
+          {
+            'a:AttributeValue': {
+              '__i:type': 'a:StringAttributeValue',
+              'a:Name': 'Document:Document Group Type',
+              'a:Value': 'Initial Documents',
             },
           },
           {
@@ -76,7 +83,7 @@ debug({ config });
 module.exports = async (event, context) => {
   try {
     const { body } = event;
-    const { caseReference, applicationId, documentId } = body;
+    const { caseReference, applicationId, documentId, documentType } = body;
 
     debug('Connecting to Blob Storage');
 
@@ -94,7 +101,7 @@ module.exports = async (event, context) => {
         documents: [
           { '__xmlns:a': 'http://schemas.datacontract.org/2004/07/Horizon.Business' },
           { '__xmlns:i': 'http://www.w3.org/2001/XMLSchema-instance' },
-          await parseFile(containerClient, documentId, applicationId),
+          await parseFile(containerClient, documentId, applicationId, documentType),
         ],
       },
     };

--- a/packages/horizon-add-document/handler.spec.js
+++ b/packages/horizon-add-document/handler.spec.js
@@ -51,6 +51,7 @@ describe('handler', () => {
     const caseReference = '1234567890';
     const applicationId = 'some-app-id';
     const documentId = 'some-document-id';
+    const documentType = 'some-doc-type';
     const docServiceOutput = {
       blobStorageLocation: 'blob-storage-location',
       name: 'some-file-name',
@@ -65,6 +66,7 @@ describe('handler', () => {
       caseReference,
       applicationId,
       documentId,
+      documentType,
     };
 
     BlobServiceClient.fromConnectionString.mockReturnValue(blobServiceClient);
@@ -101,7 +103,7 @@ describe('handler', () => {
             {
               'a:HorizonAPIDocument': {
                 'a:Content': blobBuffer.toString('base64'),
-                'a:DocumentType': 'Initial Documents',
+                'a:DocumentType': documentType,
                 'a:Filename': docServiceOutput.name,
                 'a:IsPublished': 'true',
                 'a:Metadata': {
@@ -111,6 +113,13 @@ describe('handler', () => {
                         '__i:type': 'a:StringAttributeValue',
                         'a:Name': 'Document:Involvement',
                         'a:Value': 'Appellant',
+                      },
+                    },
+                    {
+                      'a:AttributeValue': {
+                        '__i:type': 'a:StringAttributeValue',
+                        'a:Name': 'Document:Document Group Type',
+                        'a:Value': 'Initial Documents',
                       },
                     },
                     {

--- a/packages/horizon-householder-appeal-publish/handler.spec.js
+++ b/packages/horizon-householder-appeal-publish/handler.spec.js
@@ -1706,15 +1706,28 @@ describe('handler', () => {
       );
 
       [
-        event.body.appeal.yourAppealSection.appealStatement.uploadedFile.id,
-        event.body.appeal.requiredDocumentsSection.originalApplication.uploadedFile.id,
-        event.body.appeal.requiredDocumentsSection.decisionLetter.uploadedFile.id,
-        event.body.appeal.appealSubmission.appealPDFStatement.uploadedFile.id,
-      ].forEach((documentId) => {
+        {
+          id: event.body?.appeal?.yourAppealSection?.appealStatement?.uploadedFile?.id,
+          type: 'Appellant Grounds of Appeal',
+        },
+        {
+          id: event.body?.appeal?.requiredDocumentsSection?.originalApplication?.uploadedFile?.id,
+          type: 'Appellant Initial Documents',
+        },
+        {
+          id: event.body?.appeal?.requiredDocumentsSection?.decisionLetter?.uploadedFile?.id,
+          type: 'LPA Decision Notice',
+        },
+        {
+          id: event.body?.appeal?.appealSubmission?.appealPDFStatement?.uploadedFile?.id,
+          type: 'Appellant Initial Documents',
+        },
+      ].forEach(({ id: documentId, type: documentType }) => {
         expect(axios.post).toBeCalledWith(
           '/async-function/horizon-add-document',
           {
             documentId,
+            documentType,
             caseReference: horizonCaseId,
             applicationId: appealId,
           },
@@ -2053,16 +2066,32 @@ describe('handler', () => {
       );
 
       [
-        event.body.appeal.yourAppealSection.appealStatement.uploadedFile.id,
-        event.body.appeal.requiredDocumentsSection.originalApplication.uploadedFile.id,
-        event.body.appeal.requiredDocumentsSection.decisionLetter.uploadedFile.id,
-        event.body.appeal.yourAppealSection.otherDocuments.uploadedFiles[0].id,
-        event.body.appeal.appealSubmission.appealPDFStatement.uploadedFile.id,
-      ].forEach((documentId) => {
+        {
+          id: event.body?.appeal?.yourAppealSection?.appealStatement?.uploadedFile?.id,
+          type: 'Appellant Grounds of Appeal',
+        },
+        {
+          id: event.body?.appeal?.requiredDocumentsSection?.originalApplication?.uploadedFile?.id,
+          type: 'Appellant Initial Documents',
+        },
+        {
+          id: event.body?.appeal?.requiredDocumentsSection?.decisionLetter?.uploadedFile?.id,
+          type: 'LPA Decision Notice',
+        },
+        {
+          id: event.body?.appeal?.appealSubmission?.appealPDFStatement?.uploadedFile?.id,
+          type: 'Appellant Initial Documents',
+        },
+        {
+          id: event.body.appeal.yourAppealSection.otherDocuments.uploadedFiles[0].id,
+          type: 'Appellant Grounds of Appeal',
+        },
+      ].forEach(({ id: documentId, type: documentType }) => {
         expect(axios.post).toBeCalledWith(
           '/async-function/horizon-add-document',
           {
             documentId,
+            documentType,
             caseReference: horizonCaseId,
             applicationId: appealId,
           },
@@ -2404,17 +2433,36 @@ describe('handler', () => {
       );
 
       [
-        event.body.appeal.yourAppealSection.appealStatement.uploadedFile.id,
-        event.body.appeal.requiredDocumentsSection.originalApplication.uploadedFile.id,
-        event.body.appeal.requiredDocumentsSection.decisionLetter.uploadedFile.id,
-        event.body.appeal.yourAppealSection.otherDocuments.uploadedFiles[0].id,
-        event.body.appeal.yourAppealSection.otherDocuments.uploadedFiles[1].id,
-        event.body.appeal.appealSubmission.appealPDFStatement.uploadedFile.id,
-      ].forEach((documentId) => {
+        {
+          id: event.body?.appeal?.yourAppealSection?.appealStatement?.uploadedFile?.id,
+          type: 'Appellant Grounds of Appeal',
+        },
+        {
+          id: event.body?.appeal?.requiredDocumentsSection?.originalApplication?.uploadedFile?.id,
+          type: 'Appellant Initial Documents',
+        },
+        {
+          id: event.body?.appeal?.requiredDocumentsSection?.decisionLetter?.uploadedFile?.id,
+          type: 'LPA Decision Notice',
+        },
+        {
+          id: event.body?.appeal?.appealSubmission?.appealPDFStatement?.uploadedFile?.id,
+          type: 'Appellant Initial Documents',
+        },
+        {
+          id: event.body.appeal.yourAppealSection.otherDocuments.uploadedFiles[0].id,
+          type: 'Appellant Grounds of Appeal',
+        },
+        {
+          id: event.body.appeal.yourAppealSection.otherDocuments.uploadedFiles[1].id,
+          type: 'Appellant Grounds of Appeal',
+        },
+      ].forEach(({ id: documentId, type: documentType }) => {
         expect(axios.post).toBeCalledWith(
           '/async-function/horizon-add-document',
           {
             documentId,
+            documentType,
             caseReference: horizonCaseId,
             applicationId: appealId,
           },
@@ -2540,7 +2588,6 @@ describe('handler', () => {
         },
       };
 
-      console.log(event.body.appeal);
       expect(await handler(event, context)).toEqual({
         id: horizonFullCaseId.split('/').slice(-1).pop(),
       });
@@ -2750,17 +2797,36 @@ describe('handler', () => {
       );
 
       [
-        event.body.appeal.yourAppealSection.appealStatement.uploadedFile.id,
-        event.body.appeal.requiredDocumentsSection.originalApplication.uploadedFile.id,
-        event.body.appeal.requiredDocumentsSection.decisionLetter.uploadedFile.id,
-        event.body.appeal.yourAppealSection.otherDocuments.uploadedFiles[0].id,
-        event.body.appeal.yourAppealSection.otherDocuments.uploadedFiles[1].id,
-        event.body.appeal.appealSubmission.appealPDFStatement.uploadedFile.id,
-      ].forEach((documentId) => {
+        {
+          id: event.body?.appeal?.yourAppealSection?.appealStatement?.uploadedFile?.id,
+          type: 'Appellant Grounds of Appeal',
+        },
+        {
+          id: event.body?.appeal?.requiredDocumentsSection?.originalApplication?.uploadedFile?.id,
+          type: 'Appellant Initial Documents',
+        },
+        {
+          id: event.body?.appeal?.requiredDocumentsSection?.decisionLetter?.uploadedFile?.id,
+          type: 'LPA Decision Notice',
+        },
+        {
+          id: event.body?.appeal?.appealSubmission?.appealPDFStatement?.uploadedFile?.id,
+          type: 'Appellant Initial Documents',
+        },
+        {
+          id: event.body.appeal.yourAppealSection.otherDocuments.uploadedFiles[0].id,
+          type: 'Appellant Grounds of Appeal',
+        },
+        {
+          id: event.body.appeal.yourAppealSection.otherDocuments.uploadedFiles[1].id,
+          type: 'Appellant Grounds of Appeal',
+        },
+      ].forEach(({ id: documentId, type: documentType }) => {
         expect(axios.post).toBeCalledWith(
           '/async-function/horizon-add-document',
           {
             documentId,
+            documentType,
             caseReference: horizonCaseId,
             applicationId: appealId,
           },
@@ -3096,17 +3162,36 @@ describe('handler', () => {
       );
 
       [
-        event.body.appeal.yourAppealSection.appealStatement.uploadedFile.id,
-        event.body.appeal.requiredDocumentsSection.originalApplication.uploadedFile.id,
-        event.body.appeal.requiredDocumentsSection.decisionLetter.uploadedFile.id,
-        event.body.appeal.yourAppealSection.otherDocuments.uploadedFiles[0].id,
-        event.body.appeal.yourAppealSection.otherDocuments.uploadedFiles[1].id,
-        event.body.appeal.appealSubmission.appealPDFStatement.uploadedFile.id,
-      ].forEach((documentId) => {
+        {
+          id: event.body?.appeal?.yourAppealSection?.appealStatement?.uploadedFile?.id,
+          type: 'Appellant Grounds of Appeal',
+        },
+        {
+          id: event.body?.appeal?.requiredDocumentsSection?.originalApplication?.uploadedFile?.id,
+          type: 'Appellant Initial Documents',
+        },
+        {
+          id: event.body?.appeal?.requiredDocumentsSection?.decisionLetter?.uploadedFile?.id,
+          type: 'LPA Decision Notice',
+        },
+        {
+          id: event.body?.appeal?.appealSubmission?.appealPDFStatement?.uploadedFile?.id,
+          type: 'Appellant Initial Documents',
+        },
+        {
+          id: event.body.appeal.yourAppealSection.otherDocuments.uploadedFiles[0].id,
+          type: 'Appellant Grounds of Appeal',
+        },
+        {
+          id: event.body.appeal.yourAppealSection.otherDocuments.uploadedFiles[1].id,
+          type: 'Appellant Grounds of Appeal',
+        },
+      ].forEach(({ id: documentId, type: documentType }) => {
         expect(axios.post).toBeCalledWith(
           '/async-function/horizon-add-document',
           {
             documentId,
+            documentType,
             caseReference: horizonCaseId,
             applicationId: appealId,
           },
@@ -3445,17 +3530,36 @@ describe('handler', () => {
       );
 
       [
-        event.body.appeal.yourAppealSection.appealStatement.uploadedFile.id,
-        event.body.appeal.requiredDocumentsSection.originalApplication.uploadedFile.id,
-        event.body.appeal.requiredDocumentsSection.decisionLetter.uploadedFile.id,
-        event.body.appeal.yourAppealSection.otherDocuments.uploadedFiles[0].id,
-        event.body.appeal.yourAppealSection.otherDocuments.uploadedFiles[1].id,
-        event.body.appeal.appealSubmission.appealPDFStatement.uploadedFile.id,
-      ].forEach((documentId) => {
+        {
+          id: event.body?.appeal?.yourAppealSection?.appealStatement?.uploadedFile?.id,
+          type: 'Appellant Grounds of Appeal',
+        },
+        {
+          id: event.body?.appeal?.requiredDocumentsSection?.originalApplication?.uploadedFile?.id,
+          type: 'Appellant Initial Documents',
+        },
+        {
+          id: event.body?.appeal?.requiredDocumentsSection?.decisionLetter?.uploadedFile?.id,
+          type: 'LPA Decision Notice',
+        },
+        {
+          id: event.body?.appeal?.appealSubmission?.appealPDFStatement?.uploadedFile?.id,
+          type: 'Appellant Initial Documents',
+        },
+        {
+          id: event.body.appeal.yourAppealSection.otherDocuments.uploadedFiles[0].id,
+          type: 'Appellant Grounds of Appeal',
+        },
+        {
+          id: event.body.appeal.yourAppealSection.otherDocuments.uploadedFiles[1].id,
+          type: 'Appellant Grounds of Appeal',
+        },
+      ].forEach(({ id: documentId, type: documentType }) => {
         expect(axios.post).toBeCalledWith(
           '/async-function/horizon-add-document',
           {
             documentId,
+            documentType,
             caseReference: horizonCaseId,
             applicationId: appealId,
           },
@@ -3794,17 +3898,36 @@ describe('handler', () => {
       );
 
       [
-        event.body.appeal.yourAppealSection.appealStatement.uploadedFile.id,
-        event.body.appeal.requiredDocumentsSection.originalApplication.uploadedFile.id,
-        event.body.appeal.requiredDocumentsSection.decisionLetter.uploadedFile.id,
-        event.body.appeal.yourAppealSection.otherDocuments.uploadedFiles[0].id,
-        event.body.appeal.yourAppealSection.otherDocuments.uploadedFiles[1].id,
-        event.body.appeal.appealSubmission.appealPDFStatement.uploadedFile.id,
-      ].forEach((documentId) => {
+        {
+          id: event.body?.appeal?.yourAppealSection?.appealStatement?.uploadedFile?.id,
+          type: 'Appellant Grounds of Appeal',
+        },
+        {
+          id: event.body?.appeal?.requiredDocumentsSection?.originalApplication?.uploadedFile?.id,
+          type: 'Appellant Initial Documents',
+        },
+        {
+          id: event.body?.appeal?.requiredDocumentsSection?.decisionLetter?.uploadedFile?.id,
+          type: 'LPA Decision Notice',
+        },
+        {
+          id: event.body?.appeal?.appealSubmission?.appealPDFStatement?.uploadedFile?.id,
+          type: 'Appellant Initial Documents',
+        },
+        {
+          id: event.body.appeal.yourAppealSection.otherDocuments.uploadedFiles[0].id,
+          type: 'Appellant Grounds of Appeal',
+        },
+        {
+          id: event.body.appeal.yourAppealSection.otherDocuments.uploadedFiles[1].id,
+          type: 'Appellant Grounds of Appeal',
+        },
+      ].forEach(({ id: documentId, type: documentType }) => {
         expect(axios.post).toBeCalledWith(
           '/async-function/horizon-add-document',
           {
             documentId,
+            documentType,
             caseReference: horizonCaseId,
             applicationId: appealId,
           },


### PR DESCRIPTION
## Ticket Number
<!-- Add the number from the Jira board -->
AS-1561

## Description of change
<!-- Please describe the change -->
Add `documentType` field to add document function and implement it in the householder appeal publish function

## Checklist
<!-- Put an `x` in all the boxes that apply: -->
- [ ] Requires infrastructure changes
- [ ] If adding or remove environment variables (e.g. in `docker-compose.yaml`) then I have updated the appropriate Helm chart
- [ ] I have updated the documentation accordingly
- [ ] My commit history in this PR is linear
- [ ] New features have tests
- [ ] Breaking change (team conversation required)

## Important

Please do not merge from `master` (please only [rebase](https://github.com/foundry4/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
