### PR TITLE
Subtask/as 1536 upload delete endpoints

### DIFF
--- a/packages/lpa-questionnaire-web-app/src/controllers/files.js
+++ b/packages/lpa-questionnaire-web-app/src/controllers/files.js
@@ -1,0 +1,88 @@
+const { deleteDocument } = require('../lib/documents-api-wrapper');
+
+exports.uploadFile = async (req, res) => {
+  const { body } = req;
+  const { errors = {}, errorSummary = [], files = {} } = body;
+
+  if (!files.documents || !files.documents.length) {
+    res.status(500);
+    return;
+  }
+
+  // even though multi file upload handles multiple files, it uploads files one at a time.
+  const { name: fileName } = files.documents[0];
+
+  if (Object.keys(errors).length > 0) {
+    res.json({
+      error: {
+        message: errors?.['files.documents[0]']?.msg,
+        summary: errorSummary.map((error) => ({
+          ...error,
+          url: '#documents',
+        })),
+      },
+      file: {
+        filename: fileName,
+        originalname: fileName,
+      },
+    });
+    return;
+  }
+
+  // only push valid files to uploadedFiles
+  if (!req.session.uploadedFiles) {
+    req.session.uploadedFiles = [files.documents[0]];
+  } else {
+    req.session.uploadedFiles.push(files.documents[0]);
+  }
+
+  res.status(200).json({
+    success: {
+      messageText: fileName,
+      messageHtml: fileName,
+    },
+    file: {
+      filename: fileName,
+      originalname: fileName,
+    },
+  });
+};
+
+exports.deleteFile = async (req, res) => {
+  if (!req.session) {
+    res.status(500).send('No session data found');
+    return;
+  }
+
+  const {
+    body: { delete: deleteId = '' },
+  } = req;
+
+  if (!deleteId) {
+    res.status(400).send('Delete required');
+    return;
+  }
+
+  const file = req.session.uploadedFiles?.find((upload) => upload.name === deleteId);
+
+  if (!file) {
+    // try to delete file from doc store. if that fails, doc must be missing
+    try {
+      await deleteDocument(deleteId);
+    } catch (err) {
+      req.log.error({ err }, 'Error from documents service');
+      res.status(404).send('File not found');
+      return;
+    }
+  } else {
+    req.session.uploadedFiles = req.session.uploadedFiles.filter(
+      (upload) => upload.name !== deleteId
+    );
+  }
+
+  res.status(200).json({
+    success: {
+      messageText: `${deleteId} deleted`,
+    },
+  });
+};

--- a/packages/lpa-questionnaire-web-app/src/lib/documents-api-wrapper.js
+++ b/packages/lpa-questionnaire-web-app/src/lib/documents-api-wrapper.js
@@ -6,8 +6,8 @@ const uuid = require('uuid');
 const config = require('../config');
 const parentLogger = require('./logger');
 
-exports.createDocument = async (appeal, formData) => {
-  const path = `/api/v1/${appeal.id}`;
+exports.createDocument = async (appealReply, formData) => {
+  const path = `/api/v1/${appealReply.id}`;
 
   const correlationId = uuid.v4();
   const url = `${config.documents.url}${path}`;
@@ -52,6 +52,46 @@ exports.createDocument = async (appeal, formData) => {
     logger.warn({ response }, msg);
     throw new Error(msg);
   }
+
+  return response;
+};
+
+exports.deleteDocument = async (id) => {
+  const path = `/api/v1/${id}`;
+
+  const correlationId = uuid.v4();
+  const url = `${config.documents.url}${path}`;
+
+  const logger = parentLogger.child({
+    correlationId,
+    service: 'Document Service API',
+  });
+
+  let apiResponse;
+  try {
+    apiResponse = await fetch(url, {
+      method: 'DELETE',
+      headers: {
+        'X-Correlation-ID': correlationId,
+      },
+    });
+  } catch (e) {
+    logger.error(e);
+    throw new Error(e.toString());
+  }
+
+  if (!apiResponse.ok) {
+    logger.debug(apiResponse, 'Documents API Response not OK');
+    throw new Error(apiResponse.statusText);
+  }
+
+  const ok = (await apiResponse.status) === 202;
+
+  if (!ok) {
+    throw new Error(apiResponse.statusText);
+  }
+
+  const response = await apiResponse.json();
 
   return response;
 };

--- a/packages/lpa-questionnaire-web-app/src/middleware/clear-uploaded-files.js
+++ b/packages/lpa-questionnaire-web-app/src/middleware/clear-uploaded-files.js
@@ -1,0 +1,16 @@
+/**
+ * Middleware to clear uploaded files session to prepare it for fresh uploads
+ *
+ * @param req
+ * @param res
+ * @param next
+ */
+module.exports = async (req, res, next) => {
+  if (!req.session) {
+    return next();
+  }
+
+  req.session.uploadedFiles = [];
+
+  return next();
+};

--- a/packages/lpa-questionnaire-web-app/src/middleware/req-files-to-req-body-files.js
+++ b/packages/lpa-questionnaire-web-app/src/middleware/req-files-to-req-body-files.js
@@ -21,21 +21,13 @@ module.exports = (filesPropertyPath) => (req, res, next) => {
     return next();
   }
 
-  try {
-    req.body.files = {
-      ...req.body.files,
-      // Ensure we are always working with an array. Single files would otherwise be an object.
-      [filesPropertyPath]: Array.isArray(req.files[filesPropertyPath])
-        ? req.files[filesPropertyPath]
-        : [req.files[filesPropertyPath]],
-    };
-  } catch (err) {
-    // this feels like it should never happen, as nothing in the try block throws. This is a precaution.
-    /* istanbul ignore next */
-    req.log.debug({ err, filesPropertyPath }, 'Error extracting req.files[filesPropertyPath]');
-    /* istanbul ignore next */
-    req.body.files = [];
-  }
+  req.body.files = {
+    ...req.body.files,
+    // Ensure we are always working with an array. Single files would otherwise be an object.
+    [filesPropertyPath]: Array.isArray(req.files[filesPropertyPath])
+      ? req.files[filesPropertyPath]
+      : [req.files[filesPropertyPath]],
+  };
 
   return next();
 };

--- a/packages/lpa-questionnaire-web-app/src/routes/files.js
+++ b/packages/lpa-questionnaire-web-app/src/routes/files.js
@@ -1,0 +1,17 @@
+const express = require('express');
+const filesController = require('../controllers/files');
+const reqFilesToReqBodyFilesMiddleware = require('../middleware/req-files-to-req-body-files');
+const fileValidationRules = require('../validators/files');
+const { validationErrorHandler } = require('../validators/validation-error-handler');
+
+const router = express.Router();
+
+router.post(
+  '/upload',
+  [reqFilesToReqBodyFilesMiddleware('documents'), fileValidationRules()],
+  validationErrorHandler,
+  filesController.uploadFile
+);
+router.post('/delete', filesController.deleteFile);
+
+module.exports = router;

--- a/packages/lpa-questionnaire-web-app/src/routes/home.js
+++ b/packages/lpa-questionnaire-web-app/src/routes/home.js
@@ -4,6 +4,6 @@ const indexController = require('../controllers');
 const router = express.Router();
 
 /* GET home page. */
-router.get('/:id/', indexController.getIndex);
+router.get('/:id((?!(upload|delete)\\w+))', indexController.getIndex);
 
 module.exports = router;

--- a/packages/lpa-questionnaire-web-app/src/routes/index.js
+++ b/packages/lpa-questionnaire-web-app/src/routes/index.js
@@ -3,6 +3,7 @@ const express = require('express');
 const router = express.Router();
 
 const homeRouter = require('./home');
+const filesRouter = require('./files');
 const taskListRouter = require('./task-list');
 const accuracySubmissionRouter = require('./accuracy-submission');
 const otherAppealsRouter = require('./other-appeals');
@@ -11,6 +12,7 @@ const extraConditionsRouter = require('./extra-conditions');
 const uploadPlansRouter = require('./upload-plans');
 
 router.use(homeRouter);
+router.use(filesRouter);
 router.use(taskListRouter);
 router.use(accuracySubmissionRouter);
 router.use(otherAppealsRouter);

--- a/packages/lpa-questionnaire-web-app/src/routes/upload-plans.js
+++ b/packages/lpa-questionnaire-web-app/src/routes/upload-plans.js
@@ -2,12 +2,13 @@ const express = require('express');
 const uploadPlansController = require('../controllers/upload-plans');
 const fetchExistingAppealReplyMiddleware = require('../middleware/fetch-existing-appeal-reply');
 const fetchAppealMiddleware = require('../middleware/fetch-appeal');
+const clearUploadedFilesMiddleware = require('../middleware/clear-uploaded-files');
 
 const router = express.Router();
 
 router.get(
   '/:id/plans',
-  [fetchAppealMiddleware, fetchExistingAppealReplyMiddleware],
+  [fetchAppealMiddleware, fetchExistingAppealReplyMiddleware, clearUploadedFilesMiddleware],
   uploadPlansController.getUploadPlans
 );
 

--- a/packages/lpa-questionnaire-web-app/src/validators/files.js
+++ b/packages/lpa-questionnaire-web-app/src/validators/files.js
@@ -1,0 +1,8 @@
+const { checkSchema } = require('express-validator');
+const fileSchema = require('./schemas/files');
+
+const rules = () => {
+  return [checkSchema(fileSchema)];
+};
+
+module.exports = rules;

--- a/packages/lpa-questionnaire-web-app/src/validators/schemas/files.js
+++ b/packages/lpa-questionnaire-web-app/src/validators/schemas/files.js
@@ -1,0 +1,38 @@
+const config = require('../../config');
+const validateFileSize = require('../custom/file-size');
+const validMimeType = require('../custom/mime-type');
+const {
+  MIME_TYPE_DOC,
+  MIME_TYPE_DOCX,
+  MIME_TYPE_PDF,
+  MIME_TYPE_JPEG,
+  MIME_TYPE_TIF,
+  MIME_TYPE_PNG,
+} = require('../../lib/mime-types');
+
+module.exports = {
+  'files.documents.*': {
+    custom: {
+      options: (value) => {
+        const { name, mimetype, size } = value;
+
+        validMimeType(
+          mimetype,
+          [
+            MIME_TYPE_DOC,
+            MIME_TYPE_DOCX,
+            MIME_TYPE_PDF,
+            MIME_TYPE_JPEG,
+            MIME_TYPE_TIF,
+            MIME_TYPE_PNG,
+          ],
+          `${name} is the wrong file type: The file must be a DOC, DOCX, PDF, TIF, JPG or PNG`
+        );
+
+        validateFileSize(size, config.fileUpload.pins.maxFileSize, name);
+
+        return true;
+      },
+    },
+  },
+};

--- a/packages/lpa-questionnaire-web-app/src/views/upload-plans.njk
+++ b/packages/lpa-questionnaire-web-app/src/views/upload-plans.njk
@@ -42,13 +42,14 @@
 
         {% set uploadHtml %}
           {{ govukFileUpload({
-            id: 'plans',
-            name: 'plans',
+            id: 'documents',
+            name: 'documents',
             classes: 'moj-multi-file-upload__input',
             label: {
               text: 'Upload a file',
               classes: 'govuk-label--m'
             },
+            attributes: { multiple: '' },
             errorMessage: errorMessage
           }) }}
 

--- a/packages/lpa-questionnaire-web-app/tests/unit/controllers/files.test.js
+++ b/packages/lpa-questionnaire-web-app/tests/unit/controllers/files.test.js
@@ -1,0 +1,242 @@
+const filesController = require('../../../src/controllers/files');
+const { deleteDocument } = require('../../../src/lib/documents-api-wrapper');
+const { mockReq, mockRes } = require('../mocks');
+
+jest.mock('../../../src/lib/logger');
+jest.mock('../../../src/lib/documents-api-wrapper');
+
+describe('controllers/files', () => {
+  describe('uploadFile', () => {
+    [
+      {
+        title: 'should return status 500 if no files provided',
+        given: () => ({
+          ...mockReq(),
+          body: {},
+        }),
+        expected: (_, res) => {
+          expect(res.status).toHaveBeenCalledWith(500);
+        },
+      },
+      {
+        title: 'should return status 500 if no files provided with wrong name',
+        given: () => ({
+          ...mockReq(),
+          body: {
+            'mock-name': [],
+          },
+        }),
+        expected: (_, res) => {
+          expect(res.status).toHaveBeenCalledWith(500);
+        },
+      },
+      {
+        title: 'should return error if validator fails',
+        given: () => ({
+          ...mockReq(),
+          body: {
+            files: {
+              documents: [
+                {
+                  name: 'mock-file',
+                },
+              ],
+            },
+            errors: {
+              'files.documents[0]': {
+                msg: 'some error',
+              },
+            },
+            errorSummary: [
+              {
+                text: 'some error',
+                url: '#mock-url',
+              },
+            ],
+          },
+        }),
+        expected: (_, res) => {
+          expect(res.json).toHaveBeenCalledWith({
+            error: {
+              message: 'some error',
+              summary: [
+                {
+                  text: 'some error',
+                  url: '#documents',
+                },
+              ],
+            },
+            file: {
+              filename: 'mock-file',
+              originalname: 'mock-file',
+            },
+          });
+        },
+      },
+      {
+        title: 'should add file to uploaded files if all valid',
+        given: () => ({
+          ...mockReq(),
+          body: {
+            files: {
+              documents: [
+                {
+                  name: 'mock-file',
+                },
+              ],
+            },
+          },
+        }),
+        expected: (req, res) => {
+          expect(req.session.uploadedFiles).toEqual([{ name: 'mock-file' }]);
+          expect(res.status).toHaveBeenCalledWith(200);
+          expect(res.json).toHaveBeenCalledWith({
+            success: {
+              messageText: 'mock-file',
+              messageHtml: 'mock-file',
+            },
+            file: {
+              filename: 'mock-file',
+              originalname: 'mock-file',
+            },
+          });
+        },
+      },
+      {
+        title: 'should append doc if valid and other documents exist',
+        given: () => ({
+          ...mockReq(),
+          body: {
+            files: {
+              documents: [{ name: 'mock-file' }],
+            },
+          },
+          session: {
+            uploadedFiles: [{ name: 'another-file' }],
+          },
+        }),
+        expected: (req, res) => {
+          expect(req.session.uploadedFiles).toEqual([
+            { name: 'another-file' },
+            { name: 'mock-file' },
+          ]);
+          expect(res.status).toHaveBeenCalledWith(200);
+          expect(res.json).toHaveBeenCalledWith({
+            success: {
+              messageText: 'mock-file',
+              messageHtml: 'mock-file',
+            },
+            file: {
+              filename: 'mock-file',
+              originalname: 'mock-file',
+            },
+          });
+        },
+      },
+    ].forEach(({ title, given, expected }) => {
+      it(title, async () => {
+        const req = given();
+        const res = mockRes();
+
+        await filesController.uploadFile(req, res);
+
+        expected(req, res);
+      });
+    });
+  });
+
+  describe('deleteFile', () => {
+    [
+      {
+        title: 'should return status 500 if no session found',
+        given: () => ({
+          ...mockReq(),
+          session: null,
+        }),
+        expected: (_, res) => {
+          expect(res.status).toHaveBeenCalledWith(500);
+          expect(res.send).toHaveBeenCalledWith('No session data found');
+        },
+      },
+      {
+        title: 'should return status 400 if no delete ID provided',
+        given: () => ({
+          ...mockReq(),
+          body: {},
+        }),
+        expected: (_, res) => {
+          expect(res.status).toHaveBeenCalledWith(400);
+          expect(res.send).toHaveBeenCalledWith('Delete required');
+        },
+      },
+      {
+        title: 'should call delete service if not in uploadedFiles and if successful, return 200',
+        given: () => ({
+          ...mockReq(),
+          body: {
+            delete: 'mock-file',
+          },
+        }),
+        deleteMock: () => 'ok',
+        expected: (req, res) => {
+          expect(deleteDocument).toHaveBeenCalledWith('mock-file');
+          expect(res.status).toHaveBeenCalledWith(200);
+          expect(res.json).toHaveBeenCalledWith({
+            success: {
+              messageText: 'mock-file deleted',
+            },
+          });
+        },
+      },
+      {
+        title: 'should call delete service if not in uploadedFiles and and if error, return 404',
+        given: () => ({
+          ...mockReq(),
+          body: {
+            delete: 'mock-file',
+          },
+        }),
+        deleteMock: () => {
+          throw new Error('Not found');
+        },
+        expected: (req, res) => {
+          expect(deleteDocument).toHaveBeenCalledWith('mock-file');
+          expect(res.status).toHaveBeenCalledWith(404);
+          expect(res.send).toHaveBeenCalledWith('File not found');
+        },
+      },
+      {
+        title: 'should return status 200 and remove file if file is in uploaded files',
+        given: () => ({
+          ...mockReq(),
+          body: {
+            delete: 'mock-file',
+          },
+          session: {
+            uploadedFiles: [{ name: 'mock-file' }],
+          },
+        }),
+        expected: (req, res) => {
+          expect(req.session.uploadedFiles).toEqual([]);
+          expect(res.status).toHaveBeenCalledWith(200);
+          expect(res.json).toHaveBeenCalledWith({
+            success: {
+              messageText: 'mock-file deleted',
+            },
+          });
+        },
+      },
+    ].forEach(({ title, given, expected, deleteMock }) => {
+      it(title, async () => {
+        const req = given();
+        const res = mockRes();
+
+        deleteDocument.mockImplementation(deleteMock || (() => {}));
+
+        await filesController.deleteFile(req, res);
+
+        expected(req, res);
+      });
+    });
+  });
+});

--- a/packages/lpa-questionnaire-web-app/tests/unit/lib/documents-api-wrapper.test.js
+++ b/packages/lpa-questionnaire-web-app/tests/unit/lib/documents-api-wrapper.test.js
@@ -1,5 +1,5 @@
 const fetch = require('node-fetch');
-const { createDocument } = require('../../../src/lib/documents-api-wrapper');
+const { createDocument, deleteDocument } = require('../../../src/lib/documents-api-wrapper');
 
 const mockLogger = jest.fn();
 
@@ -82,6 +82,41 @@ describe('lib/documents-api-wrapper', () => {
         applicationId: 123,
         id: '123-abc-456-xyz',
         name: 'tmp-2-1607684291243',
+      });
+    });
+  });
+
+  describe('createDocument', () => {
+    let mockDocument;
+
+    beforeEach(() => {
+      mockDocument = { id: 123 };
+    });
+
+    it('should throw if fetch fails', async () => {
+      fetch.mockReject(new Error('fake error message'));
+      expect(deleteDocument(mockDocument)).rejects.toThrow('fake error message');
+    });
+
+    it('should throw if the remote API response is not ok', () => {
+      fetch.mockResponse('fake response body', { status: 400 });
+      expect(deleteDocument(mockDocument)).rejects.toThrow('Bad Request');
+    });
+
+    it('should throw if the response code is anything other than a 202', async () => {
+      fetch.mockResponse('a response body', { status: 204 });
+      expect(deleteDocument(mockDocument)).rejects.toThrow('No Content');
+    });
+
+    it('should return the expected response if the fetch status is 202', async () => {
+      fetch.mockResponse(
+        JSON.stringify({
+          deletedId: 123,
+        }),
+        { status: 202 }
+      );
+      expect(await deleteDocument(mockDocument)).toEqual({
+        deletedId: 123,
       });
     });
   });

--- a/packages/lpa-questionnaire-web-app/tests/unit/middleware/clear-uploaded-files.test.js
+++ b/packages/lpa-questionnaire-web-app/tests/unit/middleware/clear-uploaded-files.test.js
@@ -1,0 +1,31 @@
+const clearUploadedFilesMiddleware = require('../../../src/middleware/clear-uploaded-files');
+const { mockReq, mockRes } = require('../mocks');
+
+describe('middleware/clear-uploaded-files', () => {
+  let req;
+  let next;
+
+  beforeEach(() => {
+    req = mockReq();
+    next = jest.fn();
+
+    jest.resetAllMocks();
+  });
+
+  it('should call next immediately if no session', () => {
+    req.session = null;
+
+    clearUploadedFilesMiddleware(req, mockRes, next);
+
+    expect(next).toHaveBeenCalled();
+  });
+
+  it('should clear uploaded files if not empty', () => {
+    req.session.uploadedFiles = ['some file'];
+
+    clearUploadedFilesMiddleware(req, mockRes, next);
+
+    expect(next).toHaveBeenCalled();
+    expect(req.session.uploadedFiles).toEqual([]);
+  });
+});

--- a/packages/lpa-questionnaire-web-app/tests/unit/mocks.js
+++ b/packages/lpa-questionnaire-web-app/tests/unit/mocks.js
@@ -17,6 +17,9 @@ const mockRes = () => {
   const res = {};
   res.redirect = jest.fn();
   res.render = jest.fn();
+  res.status = jest.fn().mockReturnValue(res);
+  res.json = jest.fn().mockReturnValue(res);
+  res.send = jest.fn().mockReturnValue(res);
   return res;
 };
 

--- a/packages/lpa-questionnaire-web-app/tests/unit/routes/home.test.js
+++ b/packages/lpa-questionnaire-web-app/tests/unit/routes/home.test.js
@@ -12,6 +12,6 @@ describe('routes/index', () => {
   });
 
   it('should define the expected routes', () => {
-    expect(get).toHaveBeenCalledWith('/:id/', indexController.getIndex);
+    expect(get).toHaveBeenCalledWith('/:id((?!(upload|delete)\\w+))', indexController.getIndex);
   });
 });

--- a/packages/lpa-questionnaire-web-app/tests/unit/routes/index.test.js
+++ b/packages/lpa-questionnaire-web-app/tests/unit/routes/index.test.js
@@ -11,6 +11,6 @@ describe('routes/index', () => {
   });
 
   it('should define the expected routes', () => {
-    expect(use.mock.calls.length).toBe(7);
+    expect(use.mock.calls.length).toBe(8);
   });
 });

--- a/packages/lpa-questionnaire-web-app/tests/unit/routes/upload-plans.test.js
+++ b/packages/lpa-questionnaire-web-app/tests/unit/routes/upload-plans.test.js
@@ -2,6 +2,7 @@ const { get } = require('./router-mock');
 const uploadPlansController = require('../../../src/controllers/upload-plans');
 const fetchExistingAppealReplyMiddleware = require('../../../src/middleware/fetch-existing-appeal-reply');
 const fetchAppealMiddleware = require('../../../src/middleware/fetch-appeal');
+const clearUploadedFilesMiddleware = require('../../../src/middleware/clear-uploaded-files');
 
 describe('routes/placeholder', () => {
   beforeEach(() => {
@@ -16,7 +17,7 @@ describe('routes/placeholder', () => {
   it('should define the expected routes', () => {
     expect(get).toHaveBeenCalledWith(
       '/:id/plans',
-      [fetchAppealMiddleware, fetchExistingAppealReplyMiddleware],
+      [fetchAppealMiddleware, fetchExistingAppealReplyMiddleware, clearUploadedFilesMiddleware],
       uploadPlansController.getUploadPlans
     );
   });

--- a/packages/lpa-questionnaire-web-app/tests/unit/validators/files.test.js
+++ b/packages/lpa-questionnaire-web-app/tests/unit/validators/files.test.js
@@ -1,0 +1,124 @@
+const { validationResult } = require('express-validator');
+const { testExpressValidatorMiddleware } = require('./validation-middleware-helper');
+const rules = require('../../../src/validators/files');
+const { MIME_TYPE_JPEG } = require('../../../src/lib/mime-types');
+const config = require('../../../src/config');
+
+describe('validators/files', () => {
+  describe('rules', () => {
+    it('has a rule for `files.documents.*`', () => {
+      const rule = rules()[0][0].builder.build();
+
+      expect(rule.fields).toEqual(['files.documents.*']);
+      expect(rule.optional).toBeFalsy();
+      expect(rule.stack).toHaveLength(1);
+      expect(rule.stack[0].validator.name).toEqual('options');
+      expect(rule.stack[0].validator.negated).toBeFalsy();
+    });
+
+    it('should have the expected number of configured rules', () => {
+      expect(rules().length).toEqual(1);
+    });
+  });
+
+  describe('validator', () => {
+    [
+      {
+        title: 'undefined / empty - pass ',
+        given: () => ({
+          body: {},
+        }),
+        expected: (result) => {
+          expect(result.errors).toHaveLength(0);
+        },
+      },
+      {
+        title: 'files key is empty - pass',
+        given: () => ({
+          body: {
+            files: [],
+          },
+        }),
+        expected: (result) => {
+          expect(result.errors).toHaveLength(0);
+        },
+      },
+      {
+        title: 'files path is not matched - pass',
+        given: () => ({
+          body: {
+            files: {
+              'something-else': [],
+            },
+          },
+        }),
+        expected: (result) => {
+          expect(result.errors).toHaveLength(0);
+        },
+      },
+      {
+        title: 'files path is matched but mime type is wrong - fail',
+        given: () => ({
+          body: {
+            files: {
+              documents: [
+                {
+                  mimetype: 'bad',
+                },
+              ],
+            },
+          },
+        }),
+        expected: (result) => {
+          expect(result.errors).toHaveLength(1);
+        },
+      },
+      {
+        title: 'files path is matched but file size is too big - fail',
+        given: () => ({
+          body: {
+            files: {
+              documents: [
+                {
+                  mimetype: MIME_TYPE_JPEG,
+                  size: config.fileUpload.pins.maxFileSize + 1,
+                },
+              ],
+            },
+          },
+        }),
+        expected: (result) => {
+          expect(result.errors).toHaveLength(1);
+        },
+      },
+      {
+        title: 'valid file - pass',
+        given: () => ({
+          body: {
+            documents: 'x',
+          },
+          files: {
+            documents: [
+              {
+                mimetype: MIME_TYPE_JPEG,
+                size: config.fileUpload.pins.maxFileSize - 1,
+              },
+            ],
+          },
+        }),
+        expected: (result) => {
+          expect(result.errors).toHaveLength(0);
+        },
+      },
+    ].forEach(({ title, given, expected }) => {
+      it(`should return the expected validation outcome - ${title}`, async () => {
+        const mockReq = given();
+        const mockRes = jest.fn();
+
+        await testExpressValidatorMiddleware(mockReq, mockRes, rules());
+        const result = validationResult(mockReq);
+        expected(result);
+      });
+    });
+  });
+});

--- a/packages/lpa-questionnaire-web-app/tests/unit/validators/schemas/files.test.js
+++ b/packages/lpa-questionnaire-web-app/tests/unit/validators/schemas/files.test.js
@@ -1,0 +1,55 @@
+const schema = require('../../../../src/validators/schemas/files');
+const validateFileSize = require('../../../../src/validators/custom/file-size');
+const validMimeType = require('../../../../src/validators/custom/mime-type');
+const {
+  MIME_TYPE_DOC,
+  MIME_TYPE_DOCX,
+  MIME_TYPE_PDF,
+  MIME_TYPE_JPEG,
+  MIME_TYPE_TIF,
+  MIME_TYPE_PNG,
+} = require('../../../../src/lib/mime-types');
+const config = require('../../../../src/config');
+
+jest.mock('../../../../src/validators/custom/file-size');
+jest.mock('../../../../src/validators/custom/mime-type');
+jest.mock('../../../../src/config');
+
+describe('validators/schemas/files', () => {
+  it('has a defined custom schema object', () => {
+    expect(schema['files.documents.*'].custom.options).toBeDefined();
+  });
+
+  describe(`schema['files.documents.*'].custom.options`, () => {
+    let fn;
+
+    beforeEach(() => {
+      fn = schema['files.documents.*'].custom.options;
+    });
+
+    it('should call the validMimeType validator', () => {
+      fn({ mimetype: MIME_TYPE_PNG, name: 'pingu.penguin' });
+      expect(validMimeType).toHaveBeenCalledWith(
+        MIME_TYPE_PNG,
+        [
+          MIME_TYPE_DOC,
+          MIME_TYPE_DOCX,
+          MIME_TYPE_PDF,
+          MIME_TYPE_JPEG,
+          MIME_TYPE_TIF,
+          MIME_TYPE_PNG,
+        ],
+        'pingu.penguin is the wrong file type: The file must be a DOC, DOCX, PDF, TIF, JPG or PNG'
+      );
+    });
+
+    it('should call the validateFileSize validator', () => {
+      fn({ mimetype: MIME_TYPE_JPEG, name: 'pingu.penguin', size: 12345 });
+      expect(validateFileSize).toHaveBeenCalledWith(
+        12345,
+        config.fileUpload.pins.maxFileSize,
+        'pingu.penguin'
+      );
+    });
+  });
+});


### PR DESCRIPTION
## Ticket Number
<!-- Add the number from the Jira board -->
AS-1536

## Description of change
- Added delete endpoint to documents wrapper
- added upload and delete endpoints
- updated home endpoint to ignore upload and delete for ID purposes
- added `uploadedFiles` to session to allow temporary file storage
- added middleware to clear `uploadedFiles` session on get for docs pages (successful upload will also clear)

## Checklist
<!-- Put an `x` in all the boxes that apply: -->
- [ ] Requires infrastructure changes
- [ ] If adding or remove environment variables (e.g. in `docker-compose.yaml`) then I have updated the appropriate Helm chart
- [ ] I have updated the documentation accordingly
- [X] My commit history in this PR is linear
- [X] New features have tests
- [ ] Breaking change (team conversation required)

## Important

Please do not merge from `master` (please only [rebase](https://github.com/foundry4/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
