### PR TITLE
fix(add-document): remove the maxBodyLength limitation

### DIFF
--- a/packages/horizon-add-document/handler.js
+++ b/packages/horizon-add-document/handler.js
@@ -87,6 +87,8 @@ module.exports = async (event, context) => {
 
     const { data } = await axios.post('/horizon', input, {
       baseURL: config.horizon.url,
+      /* Needs to be infinity as Horizon doesn't support multipart uploads */
+      maxBodyLength: Infinity,
     });
 
     return {

--- a/packages/horizon-add-document/handler.spec.js
+++ b/packages/horizon-add-document/handler.spec.js
@@ -121,6 +121,7 @@ describe('handler', () => {
       },
       {
         baseURL: process.env.HORIZON_URL,
+        maxBodyLength: Infinity,
       }
     );
 


### PR DESCRIPTION


## Ticket Number
<!-- Add the number from the Jira board -->
AS-1604

## Description of change
<!-- Please describe the change -->
Remove `maxBodyLength` limitation. This is required to allow file uploads via the HTTP body, which is how Horizon requires them

## Checklist
<!-- Put an `x` in all the boxes that apply: -->
- [ ] Requires infrastructure changes
- [ ] If adding or remove environment variables (e.g. in `docker-compose.yaml`) then I have updated the appropriate Helm chart
- [ ] I have updated the documentation accordingly
- [ ] My commit history in this PR is linear
- [ ] New features have tests
- [ ] Breaking change (team conversation required)

## Important

Please do not merge from `master` (please only [rebase](https://github.com/foundry4/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
