### PR TITLE
fix(forms-web-app): remove gray colour from bottom of generated appeal PDF

### DIFF
--- a/packages/forms-web-app/src/views/appellant-submission/submission-information.njk
+++ b/packages/forms-web-app/src/views/appellant-submission/submission-information.njk
@@ -7,6 +7,7 @@
 
 {% block head %}
   <style>{{ css | safe }}</style>
+  <style>.govuk-template { background-color: #FFFFFF; }</style>
 {% endblock %}
 
 {% block pageTitle %}
@@ -21,7 +22,6 @@
 
 {% block bodyStart %}
 {% endblock %}
-
 
 {% block bodyEnd %}
 {% endblock %}
@@ -48,11 +48,11 @@
         rows: [
           {
             key: {
-            text: "Local planning department"
-          },
+              text: "Local planning department"
+            },
             value: {
-            text: summaryField(appealLPD, { 'data-cy': "local-planning-department" })
-          }
+              text: summaryField(appealLPD, { 'data-cy': "local-planning-department" })
+            }
           }
         ]
       }) }}
@@ -64,11 +64,11 @@
         rows: [
           {
             key: {
-            text: "Was the original planning application made in your name?"
-          },
+              text: "Was the original planning application made in your name?"
+            },
             value: {
-            text: boolToSentenceCaseField(appeal.aboutYouSection.yourDetails.isOriginalApplicant, { 'data-cy': "who-are-you" })
-          }
+              text: boolToSentenceCaseField(appeal.aboutYouSection.yourDetails.isOriginalApplicant, { 'data-cy': "who-are-you" })
+            }
           },
           appeal.aboutYouSection.yourDetails.isOriginalApplicant === false and {
             key: {
@@ -83,16 +83,16 @@
             text: "Your name"
           },
             value: {
-            text: summaryField(appeal.aboutYouSection.yourDetails.name, { 'data-cy': "appellant-name" })
-          }
+              text: summaryField(appeal.aboutYouSection.yourDetails.name, { 'data-cy': "appellant-name" })
+            }
           },
           {
             key: {
-            text: "Your email"
-          },
+              text: "Your email"
+            },
             value: {
-            text: summaryField(appeal.aboutYouSection.yourDetails.email, { 'data-cy': "appellant-email" })
-          }
+              text: summaryField(appeal.aboutYouSection.yourDetails.email, { 'data-cy': "appellant-email" })
+            }
           }
         ]
       }) }}
@@ -104,27 +104,27 @@
         rows: [
           {
             key: {
-            text: "Planning application number"
-          },
+              text: "Planning application number"
+            },
             value: {
-            text: summaryField(appeal.requiredDocumentsSection.applicationNumber, { 'data-cy': "application-number" })
-          }
+              text: summaryField(appeal.requiredDocumentsSection.applicationNumber, { 'data-cy': "application-number" })
+            }
           },
           {
             key: {
-            text: "Planning application form"
-          },
+              text: "Planning application form"
+            },
             value: {
-            text: summaryField(appeal.requiredDocumentsSection.originalApplication.uploadedFile.name, { 'data-cy': "upload-application" })
-          }
+              text: summaryField(appeal.requiredDocumentsSection.originalApplication.uploadedFile.name, { 'data-cy': "upload-application" })
+            }
           },
           {
             key: {
-            text: "Decision letter"
-          },
+              text: "Decision letter"
+            },
             value: {
-            text: summaryField(appeal.requiredDocumentsSection.decisionLetter.uploadedFile.name, { 'data-cy': "upload-decision" })
-          }
+              text: summaryField(appeal.requiredDocumentsSection.decisionLetter.uploadedFile.name, { 'data-cy': "upload-decision" })
+            }
           }
         ]
       }) }}
@@ -134,22 +134,21 @@
       {{ govukSummaryList({
         classes: "govuk-summary-list govuk-!-margin-bottom-9",
         rows: [
-
           {
             key: {
             text: "Your appeal statement"
           },
             value: {
-            text: summaryField(appeal.yourAppealSection.appealStatement.uploadedFile.name, { 'data-cy': "appeal-statement" })
-          }
+              text: summaryField(appeal.yourAppealSection.appealStatement.uploadedFile.name, { 'data-cy': "appeal-statement" })
+            }
           },
           {
             key: {
             text: "Documents to support your appeal"
           },
             value: {
-            text: multifileUploadToList(appeal.yourAppealSection.otherDocuments.uploadedFiles, { 'data-cy': "supporting-documents" })
-          }
+              text: multifileUploadToList(appeal.yourAppealSection.otherDocuments.uploadedFiles, { 'data-cy': "supporting-documents" })
+            }
           }
         ]
       }) }}
@@ -161,39 +160,39 @@
         rows: [
           {
             key: {
-            text: "Address of the appeal site"
-          },
+              text: "Address of the appeal site"
+            },
             value: {
-            text: summaryField(appeal | appealSiteAddressToArray | join("\n") | nl2br | safe, { 'data-cy': "site-location" })
-          }
+              text: summaryField(appeal | appealSiteAddressToArray | join("\n") | nl2br | safe, { 'data-cy': "site-location" })
+            }
           },
           {
             key: {
-            text: "Do you own the whole appeal site?"
-          },
+              text: "Do you own the whole appeal site?"
+            },
             value: {
-            text: boolToSentenceCaseField(appeal.appealSiteSection.siteOwnership.ownsWholeSite, { 'data-cy': "site-ownership" })
-          }
+              text: boolToSentenceCaseField(appeal.appealSiteSection.siteOwnership.ownsWholeSite, { 'data-cy': "site-ownership" })
+            }
           },
           {
             key: {
-            text: "Can the Inspector see the whole of the appeal site from a public road?"
-          },
+              text: "Can the Inspector see the whole of the appeal site from a public road?"
+            },
             value: {
-            text: boolToSentenceCaseField(appeal.appealSiteSection.siteAccess.canInspectorSeeWholeSiteFromPublicRoad, { 'data-cy': "site-access" })
-            if appeal.appealSiteSection.siteAccess.canInspectorSeeWholeSiteFromPublicRoad
-            else summaryField(appeal.appealSiteSection.siteAccess.howIsSiteAccessRestricted, { 'data-cy': "site-access" })
-          }
+              text: boolToSentenceCaseField(appeal.appealSiteSection.siteAccess.canInspectorSeeWholeSiteFromPublicRoad, { 'data-cy': "site-access" })
+              if appeal.appealSiteSection.siteAccess.canInspectorSeeWholeSiteFromPublicRoad
+              else summaryField(appeal.appealSiteSection.siteAccess.howIsSiteAccessRestricted, { 'data-cy': "site-access" })
+            }
           },
           {
             key: {
-            text: "Any health and safety issues?"
-          },
+              text: "Any health and safety issues?"
+            },
             value: {
-            text: summaryField(appeal.appealSiteSection.healthAndSafety.healthAndSafetyIssues, { 'data-cy': "site-access-safety" })
-            if appeal.appealSiteSection.healthAndSafety.hasIssues
-            else boolToSentenceCaseField(appeal.appealSiteSection.healthAndSafety.hasIssues, { 'data-cy': "site-access-safety" })
-          }
+              text: summaryField(appeal.appealSiteSection.healthAndSafety.healthAndSafetyIssues, { 'data-cy': "site-access-safety" })
+              if appeal.appealSiteSection.healthAndSafety.hasIssues
+              else boolToSentenceCaseField(appeal.appealSiteSection.healthAndSafety.hasIssues, { 'data-cy': "site-access-safety" })
+            }
           }
 
         ]


### PR DESCRIPTION


## Ticket Number
<!-- Add the number from the Jira board -->
AS-1768

## Description of change
remove gray colour from bottom of generated appeal PDF

## Checklist
<!-- Put an `x` in all the boxes that apply: -->
- [ ] Requires infrastructure changes
- [ ] If adding or remove environment variables (e.g. in `docker-compose.yaml`) then I have updated the appropriate Helm chart
- [ ] I have updated the documentation accordingly
- [x] My commit history in this PR is linear
- [ ] New features have tests
- [ ] Breaking change (team conversation required)

## Important

Please do not merge from `master` (please only [rebase](https://github.com/foundry4/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
