### PR TITLE
ci(execution of e2e tests on merge to master): documentation job alre…

### DIFF
--- a/.github/workflows/e2e-tests-on-PR.yml
+++ b/.github/workflows/e2e-tests-on-PR.yml
@@ -9,9 +9,6 @@ env:
   LPA_CYPRESS_REPORTS: ./lpa-submissions-e2e-tests/cypress/cucumber-report
 
 on:
-  push:
-    branches:
-      - master
   pull_request:
     branches:
       - master
@@ -176,4 +173,3 @@ jobs:
         with:
           name: screenshots-pins
           path: ${{ env.CYPRESS_SCREENSHOTS }}
-


### PR DESCRIPTION
…ady runs these tests

## Ticket Number
AS-1781

## Description of change
we already run the e2e tests before merges->master are permitted
on merge to master we already run the e2e tests as part of the documentation job
kicking off the e2e tests on merge to master is a waste of resource and causing bottlenecks


## Checklist
<!-- Put an `x` in all the boxes that apply: -->
- [ ] Requires infrastructure changes
- [ ] If adding or remove environment variables (e.g. in `docker-compose.yaml`) then I have updated the appropriate Helm chart
- [ ] I have updated the documentation accordingly
- [ ] My commit history in this PR is linear
- [ ] New features have tests
- [ ] Breaking change (team conversation required)

## Important

Please do not merge from `master` (please only [rebase](https://github.com/foundry4/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
