### PR TITLE
fix(as-1855): add isListedBuilding to appeals api

### DIFF
--- a/e2e-tests/cypress/fixtures/as-102-ac1.json
+++ b/e2e-tests/cypress/fixtures/as-102-ac1.json
@@ -8,7 +8,8 @@
     "eligibility": {
       "enforcementNotice": false,
       "householderPlanningPermission": true,
-      "isClaimingCosts": false
+      "isClaimingCosts": false,
+      "isListedBuilding": null
     },
     "aboutYouSection": {
       "yourDetails": {

--- a/e2e-tests/cypress/fixtures/expected-appeal-where-an-inspector-does-not-require-site-access.json
+++ b/e2e-tests/cypress/fixtures/expected-appeal-where-an-inspector-does-not-require-site-access.json
@@ -7,7 +7,8 @@
     "eligibility": {
       "enforcementNotice": false,
       "householderPlanningPermission": true,
-      "isClaimingCosts": false
+      "isClaimingCosts": false,
+      "isListedBuilding": null
     },
     "aboutYouSection": {
       "yourDetails": {

--- a/e2e-tests/cypress/fixtures/expected-appeal-where-an-inspector-does-require-site-access.json
+++ b/e2e-tests/cypress/fixtures/expected-appeal-where-an-inspector-does-require-site-access.json
@@ -7,7 +7,8 @@
     "eligibility": {
       "enforcementNotice": false,
       "householderPlanningPermission": true,
-      "isClaimingCosts": false
+      "isClaimingCosts": false,
+      "isListedBuilding": null
     },
     "aboutYouSection": {
       "yourDetails": {

--- a/e2e-tests/cypress/fixtures/expected-appeal-with-certificate-a.json
+++ b/e2e-tests/cypress/fixtures/expected-appeal-with-certificate-a.json
@@ -7,7 +7,8 @@
     "eligibility": {
       "enforcementNotice": false,
       "householderPlanningPermission": true,
-      "isClaimingCosts": false
+      "isClaimingCosts": false,
+      "isListedBuildig": null
     },
     "aboutYouSection": {
       "yourDetails": {

--- a/e2e-tests/cypress/fixtures/expected-appeal-with-many-documents.json
+++ b/e2e-tests/cypress/fixtures/expected-appeal-with-many-documents.json
@@ -11,7 +11,8 @@
     "eligibility": {
       "enforcementNotice": false,
       "householderPlanningPermission": true,
-      "isClaimingCosts": false
+      "isClaimingCosts": false,
+      "isListedBuilding": null
     },
     "aboutYouSection": {
       "yourDetails": {

--- a/e2e-tests/cypress/fixtures/expected-appeal-without-certificate-a-other-owner-informed.json
+++ b/e2e-tests/cypress/fixtures/expected-appeal-without-certificate-a-other-owner-informed.json
@@ -7,7 +7,8 @@
     "eligibility": {
       "enforcementNotice": false,
       "householderPlanningPermission": true,
-      "isClaimingCosts": false
+      "isClaimingCosts": false,
+      "isListedBuilding": null
     },
     "aboutYouSection": {
       "yourDetails": {

--- a/e2e-tests/cypress/fixtures/expected-appeal-without-certificate-a-other-owner-not-informed.json
+++ b/e2e-tests/cypress/fixtures/expected-appeal-without-certificate-a-other-owner-not-informed.json
@@ -7,7 +7,8 @@
     "eligibility": {
       "enforcementNotice": false,
       "householderPlanningPermission": true,
-      "isClaimingCosts": false
+      "isClaimingCosts": false,
+      "isListedBuilding": null
     },
     "aboutYouSection": {
       "yourDetails": {

--- a/e2e-tests/cypress/fixtures/ucd-831-ac1.json
+++ b/e2e-tests/cypress/fixtures/ucd-831-ac1.json
@@ -8,7 +8,8 @@
     "eligibility": {
       "enforcementNotice": false,
       "householderPlanningPermission": true,
-      "isClaimingCosts": false
+      "isClaimingCosts": false,
+      "isListedBuilding": null
     },
     "aboutYouSection": {
       "yourDetails": {

--- a/e2e-tests/cypress/integration/common/standard-appeal.js
+++ b/e2e-tests/cypress/integration/common/standard-appeal.js
@@ -72,7 +72,7 @@ const STANDARD_APPEAL = {
   eligibility: {
     householderPlanningPermission: true,
     eligibleLocalPlanningDepartment: true,
-    listedBuilding: true,
+    isListedBuilding: true,
     isClaimingCosts: false,
   },
   aboutYouSection: {

--- a/e2e-tests/cypress/support/appellant-submission-check-your-answers/provideCompleteAppeal.js
+++ b/e2e-tests/cypress/support/appellant-submission-check-your-answers/provideCompleteAppeal.js
@@ -25,7 +25,7 @@ module.exports = (appeal, overrides = {}) => {
   cy.provideEnforcementNoticeAnswer(appeal.eligibility.enforcementNotice === true);
   cy.clickSaveAndContinue();
 
-  if (appeal.eligibility.listedBuilding) {
+  if (appeal.eligibility.isListedBuilding) {
     cy.stateCaseDoesNotInvolveAListedBuilding();
   } else {
     cy.stateCaseInvolvesListedBuilding();

--- a/e2e-tests/cypress/support/eligibility-listed-building-status/confirmUserCanProceedWithNonListedBuilding.js
+++ b/e2e-tests/cypress/support/eligibility-listed-building-status/confirmUserCanProceedWithNonListedBuilding.js
@@ -10,6 +10,7 @@ module.exports = () => {
   // prove that the entered data is retained during navigation
   // -> use the provided 'back' button
   cy.get('[data-cy="back"]').click();
+
   // -> confirm the expected state of the radio-buttons
   cy.get('#is-your-appeal-about-a-listed-building-2').should('be.checked');
   cy.get('#is-your-appeal-about-a-listed-building').should('not.be.checked');

--- a/packages/appeals-service-api/api/openapi.yaml
+++ b/packages/appeals-service-api/api/openapi.yaml
@@ -306,6 +306,8 @@ components:
           type: boolean
         isClaimingCosts:
           type: boolean
+        isListedBuilding:
+          type: boolean
     HealthAndSafety:
       type: object
       properties:

--- a/packages/appeals-service-api/src/models/appeal.js
+++ b/packages/appeals-service-api/src/models/appeal.js
@@ -9,6 +9,7 @@ exports.appealDocument = {
     enforcementNotice: null,
     householderPlanningPermission: null,
     isClaimingCosts: null,
+    isListedBuilding: null,
   },
   aboutYouSection: {
     yourDetails: {

--- a/packages/appeals-service-api/src/validators/appeals/schemas/insert-appeal.js
+++ b/packages/appeals-service-api/src/validators/appeals/schemas/insert-appeal.js
@@ -139,5 +139,6 @@ exports.insertAppeal = yup
       enforcementNotice: yup.bool().nullable().default(null),
       householderPlanningPermission: yup.bool().nullable().default(null),
       isClaimingCosts: yup.bool().nullable().default(null),
+      isListedBuilding: yup.bool().nullable().default(null),
     }),
   });

--- a/packages/appeals-service-api/src/validators/appeals/schemas/update-appeal.js
+++ b/packages/appeals-service-api/src/validators/appeals/schemas/update-appeal.js
@@ -84,6 +84,12 @@ exports.updateAppeal = yup
               }
               return yup.mixed().notRequired();
             }),
+            isListedBuilding: yup.lazy((isListedBuilding) => {
+              if (isListedBuilding !== undefined) {
+                return yup.bool().required();
+              }
+              return yup.mixed().notRequired();
+            }),
           })
           .noUnknown(true);
       }

--- a/packages/appeals-service-api/tests/unit/validators/appeals-update.validator.test.js
+++ b/packages/appeals-service-api/tests/unit/validators/appeals-update.validator.test.js
@@ -229,6 +229,7 @@ describe('appeals.validators.schemas', () => {
             enforcementNotice: value,
             householderPlanningPermission: value,
             isClaimingCosts: value,
+            isListedBuilding: value,
           },
         }),
         expected: (result) => {
@@ -246,10 +247,11 @@ describe('appeals.validators.schemas', () => {
             enforcementNotice: value,
             householderPlanningPermission: value,
             isClaimingCosts: value,
+            isListedBuilding: value,
           },
         }),
         expected: (result) => {
-          expect(result.errors.length).toEqual(3);
+          expect(result.errors.length).toEqual(4);
         },
       });
     });

--- a/packages/appeals-service-api/tests/unit/value-appeal.js
+++ b/packages/appeals-service-api/tests/unit/value-appeal.js
@@ -8,6 +8,7 @@ module.exports = (appeal) => {
     enforcementNotice: true,
     householderPlanningPermission: true,
     isClaimingCosts: false,
+    isListedBuilding: false,
   };
   appeal.aboutYouSection.yourDetails = {
     isOriginalApplicant: false,


### PR DESCRIPTION
add isListedBuilding to appeals api

## Ticket Number
<!-- Add the number from the Jira board -->
https://pins-ds.atlassian.net/browse/AS-

## Description of change
<!-- Please describe the change -->

## Checklist
<!-- Put an `x` in all the boxes that apply: -->
- [ ] Requires infrastructure changes
- [ ] If adding or remove environment variables (e.g. in `docker-compose.yaml`) then I have updated the appropriate Helm chart
- [ ] I have updated the documentation accordingly
- [ ] My commit history in this PR is linear
- [ ] New features have tests
- [ ] Breaking change (team conversation required)

## Important

Please do not merge from `master` (please only [rebase](https://github.com/foundry4/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
