### PR TITLE
test: validate against document service when uploading and deleting

### DIFF
--- a/lpa-submissions-e2e-tests/README.md
+++ b/lpa-submissions-e2e-tests/README.md
@@ -1,0 +1,43 @@
+# Cypress E2E tests
+
+### Overview
+
+The [Cypress](https://docs.cypress.io/guides/overview/why-cypress.html#In-a-nutshell) framework provides support
+for automated testing and BDD.
+
+Note - the first time you interact with cypress, or if cypress bumps a version, you may need to run
+```
+npx cypress install --force
+```
+
+#### Interacting with the tests while running the system locally
+
+To run the client locally and pick individual tests to run live in a browser
+```shell
+npx cypress open
+```
+
+To run the all the tests in a browser in front of you
+```shell
+npx cypress run --headed -b chrome
+```
+
+To just run the all the tests in memory (the quickest way to get a red/green result...)
+```shell
+npx cypress run
+```
+
+#### Pointing at other environments
+
+all our defaults for cypress point at localhost:xxxx and assume it can find all our services running under docker-compose..
+
+we can over-ride this and point at other urls, but we have to be aware that we don't have the same level of access to deployed environments, so any tests that need to interact with APIs or queues etc. will not be able to perform their validation.
+
+to handle this, we wrap any such tests + can control them by passing an appropriate variable into our cypress cmd
+
+eg; assuming you wanted to test https://someEnvironment.com and this test environment was protected by a simple https login user/pwd:
+```shell
+CYPRESS_BASE_URL=https://user:pwd@someEnvironment.com npx cypress open --env ASSUME_LIMITED_ACCESS=true
+CYPRESS_BASE_URL=https://user:pwd@someEnvironment.com npx cypress run --headed -b chrome --env ASSUME_LIMITED_ACCESS=true
+CYPRESS_BASE_URL=https://user:pwd@someEnvironment.com npx cypress run --env ASSUME_LIMITED_ACCESS=true
+```

--- a/lpa-submissions-e2e-tests/cypress.json
+++ b/lpa-submissions-e2e-tests/cypress.json
@@ -5,7 +5,9 @@
   "viewportWidth": 1024,
   "viewportHeight": 1600,
   "env": {
-    "demoDelay": 0
+    "demoDelay": 0,
+    "DOCUMENT_SERVICE_BASE_URL": "http://localhost:3001/api/v1",
+    "ASSUME_LIMITED_ACCESS": false
   },
   "retries": {
     "runMode": 1,

--- a/packages/lpa-questionnaire-web-app/src/controllers/upload-plans.js
+++ b/packages/lpa-questionnaire-web-app/src/controllers/upload-plans.js
@@ -17,6 +17,7 @@ exports.getUploadPlans = (req, res) => {
 
   res.render(VIEW.UPLOAD_PLANS, {
     appeal: getAppealSideBarDetails(req.session.appeal),
+    appealReplyId: req.session.appealReply.id,
     backLink: req.session.backLink || `/${req.params.id}/${VIEW.TASK_LIST}`,
     ...fileUploadNunjucksVariables(null, null, uploadedFiles),
   });

--- a/packages/lpa-questionnaire-web-app/src/lib/documents-api-wrapper.js
+++ b/packages/lpa-questionnaire-web-app/src/lib/documents-api-wrapper.js
@@ -85,13 +85,11 @@ exports.deleteDocument = async (parentId, id) => {
     throw new Error(apiResponse.statusText);
   }
 
-  const ok = (await apiResponse.status) === 202;
+  const ok = (await apiResponse.status) === 204;
 
   if (!ok) {
     throw new Error(apiResponse.statusText);
   }
 
-  const response = await apiResponse.json();
-
-  return response;
+  return { deletedId: id };
 };

--- a/packages/lpa-questionnaire-web-app/src/lib/file-upload-helpers.js
+++ b/packages/lpa-questionnaire-web-app/src/lib/file-upload-helpers.js
@@ -1,4 +1,4 @@
-const { createDocument } = require('./documents-api-wrapper');
+const { createDocument, deleteDocument } = require('./documents-api-wrapper');
 
 // https://stackoverflow.com/questions/10420352/converting-file-size-in-bytes-to-human-readable-string/10420404
 const suffixes = ['Bytes', 'KB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB', 'YB'];
@@ -23,13 +23,12 @@ exports.MIME_TYPE_PNG = 'image/png';
 exports.deleteFile = (fileRef, req) => {
   if (!fileRef || !req) throw new Error('Missing required fields');
 
-  // TODO: add handling for deletion from DB and doc store as part of AS-1538
   const file = req.session.uploadedFiles?.find(
     (upload) => upload.id === fileRef || upload.name === fileRef
   );
 
   if (file) {
-    // TODO: when available needs a check here if the file has an ID (meaning it has been uploaded before). If it does needs to be marked for delete
+    deleteDocument(req.session.appealReply.id, file.id);
 
     req.session.uploadedFiles = req.session.uploadedFiles.filter(
       (upload) => upload.id !== file.id || upload.name !== file.name

--- a/packages/lpa-questionnaire-web-app/src/views/includes/head.njk
+++ b/packages/lpa-questionnaire-web-app/src/views/includes/head.njk
@@ -1,4 +1,7 @@
 {% block head %}
+  {% if appealReplyId %}
+    <meta name="appealReplyId" content="{{ appealReplyId }}">
+  {% endif %}
 
   <!--[if lte IE 8]><link href="/public/stylesheets/main-ie8.css" rel="stylesheet" type="text/css" /><![endif]-->
   <!--[if gt IE 8]><!--><link href="/public/stylesheets/main.css" media="all" rel="stylesheet" type="text/css" /><!--<![endif]-->

--- a/packages/lpa-questionnaire-web-app/tests/unit/controllers/upload-plans.test.js
+++ b/packages/lpa-questionnaire-web-app/tests/unit/controllers/upload-plans.test.js
@@ -40,6 +40,7 @@ describe('controllers/upload-plans', () => {
 
       expect(res.render).toHaveBeenCalledWith(VIEW.UPLOAD_PLANS, {
         appeal: null,
+        appealReplyId: null,
         backLink: backLinkUrl,
       });
     });
@@ -49,6 +50,7 @@ describe('controllers/upload-plans', () => {
 
       expect(res.render).toHaveBeenCalledWith(VIEW.UPLOAD_PLANS, {
         appeal: null,
+        appealReplyId: null,
         backLink: `/mock-id/${VIEW.TASK_LIST}`,
       });
     });
@@ -65,6 +67,7 @@ describe('controllers/upload-plans', () => {
 
       expect(res.render).toHaveBeenCalledWith(VIEW.UPLOAD_PLANS, {
         appeal: null,
+        appealReplyId: null,
         backLink: `/mock-id/${VIEW.TASK_LIST}`,
         uploadedFiles,
       });

--- a/packages/lpa-questionnaire-web-app/tests/unit/lib/documents-api-wrapper.test.js
+++ b/packages/lpa-questionnaire-web-app/tests/unit/lib/documents-api-wrapper.test.js
@@ -86,7 +86,7 @@ describe('lib/documents-api-wrapper', () => {
     });
   });
 
-  describe('createDocument', () => {
+  describe('deleteDocument', () => {
     let mockDocument;
 
     beforeEach(() => {
@@ -103,19 +103,19 @@ describe('lib/documents-api-wrapper', () => {
       expect(deleteDocument(mockDocument)).rejects.toThrow('Bad Request');
     });
 
-    it('should throw if the response code is anything other than a 202', async () => {
-      fetch.mockResponse('a response body', { status: 204 });
-      expect(deleteDocument(mockDocument)).rejects.toThrow('No Content');
+    it('should throw if the response code is anything other than a 204', async () => {
+      fetch.mockResponse('a response body', { status: 205 });
+      expect(deleteDocument(mockDocument)).rejects.toThrow('Reset Content');
     });
 
-    it('should return the expected response if the fetch status is 202', async () => {
+    it('should return the expected response if the fetch status is 204', async () => {
       fetch.mockResponse(
         JSON.stringify({
           deletedId: 123,
         }),
-        { status: 202 }
+        { status: 204 }
       );
-      expect(await deleteDocument(mockDocument)).toEqual({
+      expect(await deleteDocument(mockDocument, 123)).toEqual({
         deletedId: 123,
       });
     });

--- a/packages/lpa-questionnaire-web-app/tests/unit/lib/file-upload-helpers.test.js
+++ b/packages/lpa-questionnaire-web-app/tests/unit/lib/file-upload-helpers.test.js
@@ -126,28 +126,30 @@ describe('lib/file-upload-helpers', () => {
       req = {
         session: {
           uploadedFiles: [{ name: 'mock-file' }],
+          appealReply: { id: 'mock-appeal-reply-id' },
         },
       };
     });
 
     it('should throw error if no name', () => {
-      expect(() => deleteFile(undefined, req)).toThrowError();
+      expect(() => deleteFile(undefined, req)).toThrow();
     });
 
     it('should throw error if no request', () => {
-      expect(() => deleteFile('mock-file', undefined)).toThrowError();
+      expect(() => deleteFile('mock-file', undefined)).toThrow();
     });
 
     it('should throw an error if file not found', () => {
-      expect(() => deleteFile('another-file', req)).toThrowError();
+      expect(() => deleteFile('another-file', req)).toThrow();
     });
 
-    it('should delete a file if found', () => {
-      deleteFile('mock-file', req);
+    it('should delete a file if found', async () => {
+      await deleteFile('mock-file', req);
 
       expect(req).toEqual({
         session: {
           uploadedFiles: [],
+          appealReply: { id: 'mock-appeal-reply-id' },
         },
       });
     });


### PR DESCRIPTION
## Ticket Number
https://pins-ds.atlassian.net/browse/AS-1900

## Description of change
prove we have deleted the document from document service when we say we have

## Checklist
<!-- Put an `x` in all the boxes that apply: -->
- [ ] Requires infrastructure changes
- [ ] If adding or remove environment variables (e.g. in `docker-compose.yaml`) then I have updated the appropriate Helm chart
- [ ] I have updated the documentation accordingly
- [ ] My commit history in this PR is linear
- [ ] New features have tests
- [ ] Breaking change (team conversation required)

## Important

Please do not merge from `master` (please only [rebase](https://github.com/foundry4/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
