### PR TITLE
fix(e2e-tests): allow cookies inside cypress non-js iframe hack

### DIFF
--- a/e2e-tests/cypress/support/visit-without-javascript-enabled.js
+++ b/e2e-tests/cypress/support/visit-without-javascript-enabled.js
@@ -13,7 +13,7 @@ Cypress.Commands.overwrite('visit', (orig, url, options = { script: true }) => {
         "When you disable script you also have to set 'chromeWebSecurity' in your config to 'false'",
       );
     }
-    iframe.sandbox = 'allow-forms';
+    iframe.sandbox = 'allow-forms allow-same-origin';
   } else {
     iframe.removeAttribute('sandbox');
   }


### PR DESCRIPTION
## Ticket Number
<!-- Add the number from the Jira board -->
https://pins-ds.atlassian.net/browse/AS-1925

## Description of change
<!-- Please describe the change -->
allow cookies inside cypress non-js iframe hack.

Somehow the non JS tests have broken locally. This is a poorly understood hack, and this 'fix' doesn't directly address the root cause which is using a JS testing tool to fudge testing pages without JS is always going to be flaky.

## Checklist
<!-- Put an `x` in all the boxes that apply: -->
- [ ] Requires infrastructure changes
- [ ] If adding or remove environment variables (e.g. in `docker-compose.yaml`) then I have updated the appropriate Helm chart
- [ ] I have updated the documentation accordingly
- [x] My commit history in this PR is linear
- [ ] New features have tests
- [ ] Breaking change (team conversation required)

## Important

Please do not merge from `master` (please only [rebase](https://github.com/foundry4/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
