### PR TITLE
fix(appeals-service-api): fix helm lint issue with overly long config variable name

### DIFF
--- a/charts/app/templates/appealsServiceApi.yaml
+++ b/charts/app/templates/appealsServiceApi.yaml
@@ -106,7 +106,7 @@ spec:
             - name: SRV_NOTIFY_TEMPLATE_ID
               value: {{ .Values.appealsServiceApi.config.notify.templateId | quote }}
             - name: SRV_NOTIFY_APPEAL_SUBMISSION_RECEIVED_NOTIFICATION_EMAIL_TO_LPA_TEMPLATE_ID
-              value: { { .Values.appealsServiceApi.config.notify.templates.appealSubmissionReceivedNotificationEmailToLpa | quote } }
+              value: {{ .Values.appealsServiceApi.config.notify.templates.appealNotificationEmailToLpa | quote }}
           volumeMounts:
             - name: lpa-data-volume
               mountPath: /data/lpa

--- a/charts/app/values.yaml
+++ b/charts/app/values.yaml
@@ -33,7 +33,7 @@ appealsServiceApi:
       serviceId: ""
       templateId: 15ed37a9-506c-4845-88ea-95502282a863
       templates:
-        appealSubmissionReceivedNotificationEmailToLpa: 79488d5d-7efd-4273-a11f-e73f11d19676
+        appealNotificationEmailToLpa: 79488d5d-7efd-4273-a11f-e73f11d19676
 
 documentServiceApi:
   replicaCount: 1

--- a/packages/appeals-service-api/src/lib/config.js
+++ b/packages/appeals-service-api/src/lib/config.js
@@ -75,7 +75,7 @@ module.exports = {
       // deprecated, see `sendEmail` inside `./notify`
       templateId: process.env.SRV_NOTIFY_TEMPLATE_ID,
       templates: {
-        appealSubmissionReceivedNotificationEmailToLpa:
+        appealNotificationEmailToLpa:
           process.env.SRV_NOTIFY_APPEAL_SUBMISSION_RECEIVED_NOTIFICATION_EMAIL_TO_LPA_TEMPLATE_ID,
       },
     },

--- a/packages/appeals-service-api/src/lib/notify.js
+++ b/packages/appeals-service-api/src/lib/notify.js
@@ -140,9 +140,7 @@ async function sendAppealSubmissionReceivedNotificationEmailToLpa(appeal) {
     }
 
     await NotifyBuilder()
-      .setTemplateId(
-        config.services.notify.templates.appealSubmissionReceivedNotificationEmailToLpa
-      )
+      .setTemplateId(config.services.notify.templates.appealNotificationEmailToLpa)
       .setDestinationEmailAddress(lpa.email)
       .setTemplateVariablesFromObject({
         LPA: lpa.name,

--- a/packages/appeals-service-api/tests/unit/lib/notify.test.js
+++ b/packages/appeals-service-api/tests/unit/lib/notify.test.js
@@ -216,7 +216,7 @@ describe('lib/notify', () => {
         expect(mockError).not.toHaveBeenCalled();
 
         expect(mockSetTemplateId).toHaveBeenCalledWith(
-          config.services.notify.templates.appealSubmissionReceivedNotificationEmailToLpa
+          config.services.notify.templates.appealNotificationEmailToLpa
         );
         expect(mockSetDestinationEmailAddress).toHaveBeenCalledWith('some@example.com');
         expect(mockSetTemplateVariablesFromObject).toHaveBeenCalledWith({

--- a/releases/prod/app.yml
+++ b/releases/prod/app.yml
@@ -39,7 +39,7 @@ spec:
           secretName: akv-notify-prod
           templateId: 83c02ec6-c2ec-4551-86b3-807d4f203e19
           templates:
-            appealSubmissionReceivedNotificationEmailToLpa: b8c7a449-3bc1-4ce1-b07c-4e90f4bd9c17
+            appealNotificationEmailToLpa: b8c7a449-3bc1-4ce1-b07c-4e90f4bd9c17
 
     documentServiceApi:
       replicaCount: 2


### PR DESCRIPTION


## Ticket Number
<!-- Add the number from the Jira board -->
https://pins-ds.atlassian.net/browse/AS-1864

## Description of change
fix helm lint issue with overly long config variable name

## Checklist
<!-- Put an `x` in all the boxes that apply: -->
- [ ] Requires infrastructure changes
- [x] If adding or remove environment variables (e.g. in `docker-compose.yaml`) then I have updated the appropriate Helm chart
- [ ] I have updated the documentation accordingly
- [x] My commit history in this PR is linear
- [ ] New features have tests
- [ ] Breaking change (team conversation required)

## Important

Please do not merge from `master` (please only [rebase](https://github.com/foundry4/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
