### PR TITLE
fix(questionnaire-web-app): ensure error exported in upload files method

### DIFF
--- a/packages/lpa-questionnaire-web-app/src/lib/file-upload-helpers.js
+++ b/packages/lpa-questionnaire-web-app/src/lib/file-upload-helpers.js
@@ -128,6 +128,7 @@ exports.uploadFiles = async (files, appealReplyId) => {
             text: file.name,
           },
           fileName: file.name,
+          error: file.error,
           originalFileName: file.name,
           // needed for Cypress testing
           location: document.location,


### PR DESCRIPTION
## Ticket Number
<!-- Add the number from the Jira board -->
https://pins-ds.atlassian.net/browse/AS-2107

## Description of change
Fix to upload files method to ensure errors get exported

## Checklist
<!-- Put an `x` in all the boxes that apply: -->
- [ ] Requires infrastructure changes
- [ ] If adding or remove environment variables (e.g. in `docker-compose.yaml`) then I have updated the appropriate Helm chart
- [ ] I have updated the documentation accordingly
- [X] My commit history in this PR is linear
- [ ] New features have tests
- [ ] Breaking change (team conversation required)

## Important

Please do not merge from `master` (please only [rebase](https://github.com/foundry4/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
