### PR TITLE
fix(appeals-service): fix notify to use package not relative route

### DIFF
--- a/packages/appeals-service-api/src/lib/notify.js
+++ b/packages/appeals-service-api/src/lib/notify.js
@@ -1,10 +1,10 @@
 const { NotifyClient } = require('notifications-node-client');
 const fetch = require('node-fetch');
 const { format } = require('date-fns');
+const NotifyBuilder = require('@pins/common/src/lib/notify/notify-builder');
 const config = require('./config');
 const logger = require('./logger');
 const { getLpa } = require('../services/lpa.service');
-const NotifyBuilder = require('../../../common/src/lib/notify/notify-builder');
 const { isValidAppealForSubmissionReceivedNotificationEmail } = require('./notify-validation');
 
 function getAddress(siteAddress) {

--- a/packages/appeals-service-api/tests/unit/lib/notify.test.js
+++ b/packages/appeals-service-api/tests/unit/lib/notify.test.js
@@ -20,7 +20,7 @@ const mockSetTemplateVariablesFromObject = jest.fn().mockReturnThis();
 const mockSetReference = jest.fn().mockReturnThis();
 const mockSend = jest.fn();
 
-jest.doMock('../../../../common/src/lib/notify/notify-builder', () => {
+jest.doMock('@pins/common/src/lib/notify/notify-builder', () => {
   return () => ({
     setTemplateId: mockSetTemplateId,
     setDestinationEmailAddress: mockSetDestinationEmailAddress,


### PR DESCRIPTION
## Description of change
Fixes issues discovered on windows machines using appeals service. Notify common module was being called relatively to a different package. This now uses the common package as it ideally should do. Resolves the error seen.

## Checklist
<!-- Put an `x` in all the boxes that apply: -->
- [ ] Requires infrastructure changes
- [ ] If adding or remove environment variables (e.g. in `docker-compose.yaml`) then I have updated the appropriate Helm chart
- [ ] I have updated the documentation accordingly
- [X] My commit history in this PR is linear
- [X] New features have tests
- [ ] Breaking change (team conversation required)

## Important

Please do not merge from `master` (please only [rebase](https://github.com/foundry4/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
