### PR TITLE
fix(appeals-service-api): capture originalFileName for files in appeals-service-api submissions

### DIFF
--- a/packages/appeals-service-api/src/validators/appeals/schemas/insert-appeal.js
+++ b/packages/appeals-service-api/src/validators/appeals/schemas/insert-appeal.js
@@ -24,6 +24,7 @@ exports.insertAppeal = yup
       originalApplication: yup.object().shape({
         uploadedFile: yup.object().shape({
           name: yup.string().max(255).ensure(),
+          originalFileName: yup.string().max(255).ensure(),
           id: yup
             .string()
             .uuid()
@@ -35,6 +36,7 @@ exports.insertAppeal = yup
       decisionLetter: yup.object().shape({
         uploadedFile: yup.object().shape({
           name: yup.string().max(255).ensure(),
+          originalFileName: yup.string().max(255).ensure(),
           id: yup
             .string()
             .uuid()
@@ -48,6 +50,7 @@ exports.insertAppeal = yup
       appealStatement: yup.object().shape({
         uploadedFile: yup.object().shape({
           name: yup.string().max(255).ensure(),
+          originalFileName: yup.string().max(255).ensure(),
           id: yup
             .string()
             .uuid()
@@ -63,6 +66,7 @@ exports.insertAppeal = yup
           .of(
             yup.object().shape({
               name: yup.string().max(255).ensure(),
+              originalFileName: yup.string().max(255).ensure(),
               id: yup
                 .string()
                 .uuid()
@@ -79,6 +83,7 @@ exports.insertAppeal = yup
       appealPDFStatement: yup.object().shape({
         uploadedFile: yup.object().shape({
           name: yup.string().max(255).ensure(),
+          originalFileName: yup.string().max(255).ensure(),
           id: yup
             .string()
             .uuid()

--- a/packages/appeals-service-api/src/validators/appeals/schemas/update-appeal.js
+++ b/packages/appeals-service-api/src/validators/appeals/schemas/update-appeal.js
@@ -7,6 +7,7 @@ function document() {
     .shape({
       uploadedFile: yup.object().shape({
         name: yup.string().max(255).ensure().required(),
+        originalFileName: yup.string().max(255).ensure().required(),
         id: yup
           .string()
           .uuid()
@@ -185,6 +186,7 @@ exports.updateAppeal = yup
                     .object()
                     .shape({
                       name: yup.string().max(255).ensure().required(),
+                      originalFileName: yup.string().max(255).ensure(),
                       id: yup
                         .string()
                         .uuid()

--- a/packages/appeals-service-api/tests/unit/controllers/appeals.test.js
+++ b/packages/appeals-service-api/tests/unit/controllers/appeals.test.js
@@ -6,6 +6,7 @@ const { appealDocument } = require('../../../src/models/appeal');
 const mongodb = require('../../../src/db/db');
 
 jest.mock('../../../src/db/db');
+jest.mock('../../../src/lib/logger');
 const valueAppeal = require('../value-appeal');
 const { mockReq, mockRes } = require('../mocks');
 

--- a/packages/appeals-service-api/tests/unit/services/appeal.service.test.js
+++ b/packages/appeals-service-api/tests/unit/services/appeal.service.test.js
@@ -59,6 +59,8 @@ describe('services/validation.service', () => {
     test('Appeal statement upload file cannot have name without id', async () => {
       appeal.yourAppealSection.appealStatement.uploadedFile.name =
         'my_uploaded_file_appeal_statement.pdf';
+      appeal.yourAppealSection.appealStatement.uploadedFile.originalFileName =
+        'my_uploaded_file_appeal_statement.pdf';
       appeal.yourAppealSection.appealStatement.uploadedFile.id = null;
 
       const errors = validateAppeal(appeal);
@@ -70,6 +72,7 @@ describe('services/validation.service', () => {
 
     test('Appeal statement upload file cannot have id without name', async () => {
       appeal.yourAppealSection.appealStatement.uploadedFile.name = '';
+      appeal.yourAppealSection.appealStatement.uploadedFile.originalFileName = 'a file name';
       appeal.yourAppealSection.appealStatement.uploadedFile.id =
         '3fa85f64-5717-4562-b3fc-2c963f66afa6';
 
@@ -82,6 +85,8 @@ describe('services/validation.service', () => {
 
     test('Appeal statement upload file cannot have sensitive information', async () => {
       appeal.yourAppealSection.appealStatement.uploadedFile.name =
+        'my_uploaded_file_appeal_statement.pdf';
+      appeal.yourAppealSection.appealStatement.uploadedFile.originalFileName =
         'my_uploaded_file_appeal_statement.pdf';
       appeal.yourAppealSection.appealStatement.uploadedFile.id =
         '3fa85f64-5717-4562-b3fc-2c963f66afa6';
@@ -97,6 +102,8 @@ describe('services/validation.service', () => {
     test('Appeal statement upload file must include answer to sensitive information question', async () => {
       appeal.yourAppealSection.appealStatement.uploadedFile.name =
         'my_uploaded_file_appeal_statement.pdf';
+      appeal.yourAppealSection.appealStatement.uploadedFile.originalFileName =
+        'my_uploaded_file_appeal_statement.pdf';
       appeal.yourAppealSection.appealStatement.uploadedFile.id =
         '3fa85f64-5717-4562-b3fc-2c963f66afa6';
       appeal.yourAppealSection.appealStatement.hasSensitiveInformation = null;
@@ -110,9 +117,13 @@ describe('services/validation.service', () => {
 
     test('supporting document files should have both id and names', async () => {
       appeal.yourAppealSection.otherDocuments.uploadedFiles = [
-        { id: '3fa85f64-5717-4562-b3fc-2c963f66afa6', name: 'filename-1' },
-        { id: null, name: 'filename-2' },
-        { id: '3fa85f64-5717-4562-b3fc-2c963f66afa8', name: '' },
+        {
+          id: '3fa85f64-5717-4562-b3fc-2c963f66afa6',
+          name: 'filename-1',
+          originalFileName: 'filename-1',
+        },
+        { id: null, name: 'filename-2', originalFileName: 'filename-2' },
+        { id: '3fa85f64-5717-4562-b3fc-2c963f66afa8', name: '', originalFileName: '' },
       ];
 
       const errors = validateAppeal(appeal);
@@ -128,6 +139,8 @@ describe('services/validation.service', () => {
     test('original planning application upload file cannot have name without id', async () => {
       appeal.requiredDocumentsSection.originalApplication.uploadedFile.name =
         'my_uploaded_file_planning_application.pdf';
+      appeal.requiredDocumentsSection.originalApplication.uploadedFile.originalFileName =
+        'my_uploaded_file_planning_application.pdf';
       appeal.requiredDocumentsSection.originalApplication.uploadedFile.id = null;
 
       const errors = validateAppeal(appeal);
@@ -139,6 +152,7 @@ describe('services/validation.service', () => {
 
     test('original planning application upload file cannot have id without name', async () => {
       appeal.requiredDocumentsSection.originalApplication.uploadedFile.name = '';
+      appeal.requiredDocumentsSection.originalApplication.uploadedFile.originalFileName = '';
       appeal.requiredDocumentsSection.originalApplication.uploadedFile.id =
         '3fa85f64-5717-4562-b3fc-2c963f66afa7';
 
@@ -151,6 +165,8 @@ describe('services/validation.service', () => {
     test('decision letter upload file cannot have name without id', async () => {
       appeal.requiredDocumentsSection.decisionLetter.uploadedFile.name =
         'my_uploaded_file_planning_application.pdf';
+      appeal.requiredDocumentsSection.decisionLetter.uploadedFile.originalFileName =
+        'my_uploaded_file_planning_application.pdf';
       appeal.requiredDocumentsSection.decisionLetter.uploadedFile.id = null;
 
       const errors = validateAppeal(appeal);
@@ -162,6 +178,7 @@ describe('services/validation.service', () => {
 
     test('decision letter upload file cannot have id without name', async () => {
       appeal.requiredDocumentsSection.decisionLetter.uploadedFile.name = '';
+      appeal.requiredDocumentsSection.decisionLetter.uploadedFile.originalFileName = '';
       appeal.requiredDocumentsSection.decisionLetter.uploadedFile.id =
         '3fa85f64-5717-4562-b3fc-2c963f66afa7';
 
@@ -175,6 +192,8 @@ describe('services/validation.service', () => {
     test('appeal statement pdf upload file cannot have name without id', async () => {
       appeal.appealSubmission.appealPDFStatement.uploadedFile.name =
         'c9ce252a-9843-45d9-ab3c-a80590a38282.pdf';
+      appeal.appealSubmission.appealPDFStatement.uploadedFile.originalFileName =
+        'c9ce252a-9843-45d9-ab3c-a80590a38282.pdf';
       appeal.appealSubmission.appealPDFStatement.uploadedFile.id = null;
 
       const errors = validateAppeal(appeal);
@@ -185,9 +204,11 @@ describe('services/validation.service', () => {
     });
 
     test('appeal statement pdf upload file cannot have id without name', async () => {
-      appeal.appealSubmission.appealPDFStatement.uploadedFile.name = '';
-      appeal.appealSubmission.appealPDFStatement.uploadedFile.id =
-        'c9ce252a-9843-45d9-ab3c-a80590a38282';
+      appeal.appealSubmission.appealPDFStatement.uploadedFile = {
+        id: 'c9ce252a-9843-45d9-ab3c-a80590a38282',
+        name: '',
+        originalFileName: '',
+      };
 
       const errors = validateAppeal(appeal);
 

--- a/packages/appeals-service-api/tests/unit/validators/appeals-update.validator.test.js
+++ b/packages/appeals-service-api/tests/unit/validators/appeals-update.validator.test.js
@@ -444,7 +444,11 @@ describe('appeals.validators.schemas', () => {
         given: () => ({
           requiredDocumentsSection: {
             originalApplication: {
-              uploadedFile: { name: 'name of the document', id: appealId },
+              uploadedFile: {
+                name: 'name of the document',
+                originalFileName: 'name of the document',
+                id: appealId,
+              },
             },
           },
         }),
@@ -458,10 +462,11 @@ describe('appeals.validators.schemas', () => {
           requiredDocumentsSection: { originalApplication: {} },
         }),
         expected: (result) => {
-          expect(result.errors.length).toEqual(2);
+          expect(result.errors.length).toEqual(3);
           expect(result.errors).toEqual(
             expect.arrayContaining([
               'requiredDocumentsSection.originalApplication.uploadedFile.name is a required field',
+              'requiredDocumentsSection.originalApplication.uploadedFile.originalFileName is a required field',
               'requiredDocumentsSection.originalApplication.uploadedFile.id is a required field',
             ])
           );
@@ -487,6 +492,7 @@ describe('appeals.validators.schemas', () => {
             originalApplication: {
               uploadedFile: {
                 id: 'this not a good uuid',
+                originalFileName: 'name of the document',
               },
             },
           },
@@ -517,7 +523,13 @@ describe('appeals.validators.schemas', () => {
         title: 'accepted - requiredDocumentsSection.decisionLetter - valid document',
         given: () => ({
           requiredDocumentsSection: {
-            decisionLetter: { uploadedFile: { name: 'name of the document', id: appealId } },
+            decisionLetter: {
+              uploadedFile: {
+                name: 'name of the document',
+                originalFileName: 'name of the document',
+                id: appealId,
+              },
+            },
           },
         }),
         expected: (result) => {
@@ -530,10 +542,11 @@ describe('appeals.validators.schemas', () => {
           requiredDocumentsSection: { decisionLetter: {} },
         }),
         expected: (result) => {
-          expect(result.errors.length).toEqual(2);
+          expect(result.errors.length).toEqual(3);
           expect(result.errors).toEqual(
             expect.arrayContaining([
               'requiredDocumentsSection.decisionLetter.uploadedFile.name is a required field',
+              'requiredDocumentsSection.decisionLetter.uploadedFile.originalFileName is a required field',
               'requiredDocumentsSection.decisionLetter.uploadedFile.id is a required field',
             ])
           );
@@ -559,6 +572,7 @@ describe('appeals.validators.schemas', () => {
             decisionLetter: {
               uploadedFile: {
                 id: 'this not a good uuid',
+                originalFileName: 'a file name',
               },
             },
           },
@@ -611,11 +625,12 @@ describe('appeals.validators.schemas', () => {
           yourAppealSection: { appealStatement: {} },
         }),
         expected: (result) => {
-          expect(result.errors.length).toEqual(3);
+          expect(result.errors.length).toEqual(4);
           expect(result.errors).toEqual(
             expect.arrayContaining([
               'yourAppealSection.appealStatement.hasSensitiveInformation is a required field',
               'yourAppealSection.appealStatement.uploadedFile.name is a required field',
+              'yourAppealSection.appealStatement.uploadedFile.originalFileName is a required field',
               'yourAppealSection.appealStatement.uploadedFile.id is a required field',
             ])
           );
@@ -639,7 +654,11 @@ describe('appeals.validators.schemas', () => {
           yourAppealSection: {
             appealStatement: {
               hasSensitiveInformation: 'true',
-              uploadedFile: { name: 'name of the document', id: appealId },
+              uploadedFile: {
+                name: 'name of the document',
+                originalFileName: 'name of the document',
+                id: appealId,
+              },
             },
           },
         }),
@@ -656,6 +675,7 @@ describe('appeals.validators.schemas', () => {
               hasSensitiveInformation: 'bad format',
               uploadedFile: {
                 id: 'this not a good uuid',
+                originalFileName: 'a file name',
               },
             },
           },
@@ -717,7 +737,9 @@ describe('appeals.validators.schemas', () => {
         title: 'accepted - yourAppealSection.otherDocuments - good uploadedFiles list',
         given: () => ({
           yourAppealSection: {
-            otherDocuments: { uploadedFiles: [{ name: 'Good name', id: appealId }] },
+            otherDocuments: {
+              uploadedFiles: [{ name: 'Good name', originalFileName: 'Good name', id: appealId }],
+            },
           },
         }),
         expected: (result) => {
@@ -730,8 +752,8 @@ describe('appeals.validators.schemas', () => {
           yourAppealSection: {
             otherDocuments: {
               uploadedFiles: [
-                { name: 'Good name', id: 'bad id' },
-                { name: '', id: appealId },
+                { name: 'Good name', originalFileName: 'Good name', id: 'bad id' },
+                { name: '', originalFileName: '', id: appealId },
               ],
             },
           },

--- a/packages/appeals-service-api/tests/unit/value-appeal.js
+++ b/packages/appeals-service-api/tests/unit/value-appeal.js
@@ -19,24 +19,29 @@ module.exports = (appeal) => {
   appeal.requiredDocumentsSection.applicationNumber = 'S/35552';
   appeal.requiredDocumentsSection.originalApplication.uploadedFile = {
     name: 'my_uploaded_file_original_application.pdf',
+    originalFileName: 'my_uploaded_file_original_application.pdf',
     id: '3fa85f64-5717-4562-b3fc-2c963f66afa6',
   };
   appeal.requiredDocumentsSection.decisionLetter.uploadedFile = {
     name: 'my_uploaded_file_decision_letter.pdf',
+    originalFileName: 'my_uploaded_file_decision_letter.pdf',
     id: '3fa85f64-5717-4562-b3fc-2c963f66afa6',
   };
   appeal.yourAppealSection.appealStatement.uploadedFile = {
     name: 'my_uploaded_file_appeal_statement.pdf',
+    originalFileName: 'my_uploaded_file_appeal_statement.pdf',
     id: '3fa85f64-5717-4562-b3fc-2c963f66afa6',
   };
   appeal.yourAppealSection.appealStatement.hasSensitiveInformation = false;
   appeal.yourAppealSection.otherDocuments.uploadedFiles = [
     {
       name: 'my_uploaded_file_other_documents_one.pdf',
+      originalFileName: 'my_uploaded_file_other_documents_one.pdf',
       id: '3fa85f64-5717-4562-b3fc-2c963f66afa6',
     },
     {
       name: 'my_uploaded_fileother_documents_two.pdf',
+      originalFileName: 'my_uploaded_fileother_documents_two.pdf',
       id: '3fa85f64-5717-4562-b3fc-2c963f66afa6',
     },
   ];
@@ -61,6 +66,7 @@ module.exports = (appeal) => {
   };
   appeal.appealSubmission.appealPDFStatement.uploadedFile = {
     name: 'c9ce252a-9843-45d9-ab3c-a80590a38282.pdf',
+    originalFileName: 'c9ce252a-9843-45d9-ab3c-a80590a38282.pdf',
     id: 'c9ce252a-9843-45d9-ab3c-a80590a38282',
   };
   appeal.sectionStates.aboutYouSection = {


### PR DESCRIPTION


## Ticket Number
<!-- Add the number from the Jira board -->
https://pins-ds.atlassian.net/browse/AS-2133

## Description of change
capture originalFileName for files in appeals-service-api submissions

## Checklist
<!-- Put an `x` in all the boxes that apply: -->
- [ ] Requires infrastructure changes
- [ ] If adding or remove environment variables (e.g. in `docker-compose.yaml`) then I have updated the appropriate Helm chart
- [ ] I have updated the documentation accordingly
- [ ] My commit history in this PR is linear
- [ ] New features have tests
- [ ] Breaking change (team conversation required)

## Important

Please do not merge from `master` (please only [rebase](https://github.com/foundry4/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
