### PR TITLE
Subtask/as 1878 hook up pdf handling

### DIFF
--- a/lpa-submissions-e2e-tests/cypress.json
+++ b/lpa-submissions-e2e-tests/cypress.json
@@ -8,7 +8,7 @@
     "demoDelay": 0,
     "DOCUMENT_SERVICE_BASE_URL": "http://localhost:3001/api/v1",
     "ASSUME_LIMITED_ACCESS": false,
-    "APPEAL_REPLY_SERVICE_BASE_URL": "http://localhost:3002"
+    "APPEAL_REPLY_SERVICE_BASE_URL": "http://localhost:3002/api/v1"
   },
   "retries": {
     "runMode": 1,

--- a/lpa-submissions-e2e-tests/cypress/fixtures/completedAppealReply.json
+++ b/lpa-submissions-e2e-tests/cypress/fixtures/completedAppealReply.json
@@ -108,5 +108,10 @@
       "supplementaryPlanningDocuments": "COMPLETED",
       "developmentOrNeighbourhood": "COMPLETED"
     }
+  },
+  "submission": {
+    "pdfStatement": {
+        "uploadedFile": null
+    }
   }
 }

--- a/lpa-submissions-e2e-tests/cypress/integration/generateSubmissionPdf.feature
+++ b/lpa-submissions-e2e-tests/cypress/integration/generateSubmissionPdf.feature
@@ -2,6 +2,6 @@ Feature: Creation of a PDF file containing the LPA Questionnaires submission inf
   Once a questionnaire has been submitted a PDF version of the check your answers screen is generated.
 
   Scenario: AC01 - PLA Planing officer submits their answers and pdf should generate
-    Given a questionnaire has been completed
+    Given the questionnaire has been completed
     When the LPA Questionnaire is submitted
     Then a PDF of the Check Your Answers page is created

--- a/lpa-submissions-e2e-tests/cypress/integration/generateSubmissionPdf/generateSubmissionPdf.step.js
+++ b/lpa-submissions-e2e-tests/cypress/integration/generateSubmissionPdf/generateSubmissionPdf.step.js
@@ -1,37 +1,39 @@
 import { Then } from 'cypress-cucumber-preprocessor/steps';
 
-
 Then('a PDF of the Check Your Answers page is created', () => {
   cy.verifyPage('information-submitted');
-
-  let replyId;
-  cy.getAppealReplyId().then((id) => (replyId = id));
 
   let pdfFile;
 
   // only run when in an environment with full access to APIs
   if (!Cypress.env('ASSUME_LIMITED_ACCESS')) {
-    cy.request(
-      'GET',
-      `${Cypress.env('APPEAL_REPLY_SERVICE_BASE_URL')}/api/v1/reply/${replyId}`,
-    ).then((response) => {
-      const pdfId = response.body.submission.pdfStatement.uploadedFile.id;
-
+    cy.getAppealReplyId().then((replyId) => {
       cy.request(
         'GET',
-        `${Cypress.env('DOCUMENTS_SERVICE_BASE_URL')}/api/v1/${replyId}/${pdfId}/file`,
+        `${Cypress.env('APPEAL_REPLY_SERVICE_BASE_URL')}/reply/${replyId}`,
       ).then((response) => {
-        pdfFile = response.body['application/pdf'];
+        const pdfId = response.body.submission.pdfStatement.uploadedFile.id;
+
+        cy.request(
+          'GET',
+          `${Cypress.env('DOCUMENT_SERVICE_BASE_URL')}/${replyId}/${pdfId}/file`,
+        ).then((response) => {
+          pdfFile = response.body['application/pdf'];
+        });
       });
     });
   }
 
-  if(pdfFile) {
-    cy.task('getPdfContent', pdfFile).then(content => {
+  if (pdfFile) {
+    cy.task('getPdfContent', pdfFile).then((content) => {
       expect(content).to.contain('Bob Smith');
       expect(content).to.contain('999 Letsby Avenue');
-      expect(content).to.contain('Does the information from the appellant accurately reflect the original planning application?');
-      expect(content).to.contain('Lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer nec odio. Praesent libero. Sed cursus ante dapibus diam. Sed nisi. Nulla quis sem at nibh elementum imperdiet. Duis sagittis ipsum. Praesent mauris. Fusce nec tellus sed augue semper porta. Mauris massa. Vestibulum lacinia arcu eget nulla. Class aptent taciti sociosqu ad litora torquent per conubia nostra, per inceptos himenaeos. Curabitur sodales ligula in libero.');
+      expect(content).to.contain(
+        'Does the information from the appellant accurately reflect the original planning application?',
+      );
+      expect(content).to.contain(
+        'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer nec odio. Praesent libero. Sed cursus ante dapibus diam. Sed nisi. Nulla quis sem at nibh elementum imperdiet. Duis sagittis ipsum. Praesent mauris. Fusce nec tellus sed augue semper porta. Mauris massa. Vestibulum lacinia arcu eget nulla. Class aptent taciti sociosqu ad litora torquent per conubia nostra, per inceptos himenaeos. Curabitur sodales ligula in libero.',
+      );
     });
   }
 });

--- a/lpa-submissions-e2e-tests/cypress/support/common/completeQuestionnaire.js
+++ b/lpa-submissions-e2e-tests/cypress/support/common/completeQuestionnaire.js
@@ -17,19 +17,23 @@ const uploadFiles = (fileName) => {
 const stepCompletion = () => {
   // Accuracy of submission
   cy.goToPage('accuracy-submission');
-  input('accurate-submission-no').check()
-  textArea('inaccuracy-reason').type('Lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer nec odio. Praesent libero. Sed cursus ante dapibus diam. Sed nisi. Nulla quis sem at nibh elementum imperdiet. Duis sagittis ipsum. Praesent mauris. Fusce nec tellus sed augue semper porta. Mauris massa. Vestibulum lacinia arcu eget nulla. Class aptent taciti sociosqu ad litora torquent per conubia nostra, per inceptos himenaeos. Curabitur sodales ligula in libero.');
+  input('accurate-submission-no').check();
+  textArea('inaccuracy-reason').type(
+    'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer nec odio. Praesent libero. Sed cursus ante dapibus diam. Sed nisi. Nulla quis sem at nibh elementum imperdiet. Duis sagittis ipsum. Praesent mauris. Fusce nec tellus sed augue semper porta. Mauris massa. Vestibulum lacinia arcu eget nulla. Class aptent taciti sociosqu ad litora torquent per conubia nostra, per inceptos himenaeos. Curabitur sodales ligula in libero.',
+  );
   cy.clickSaveAndContinue();
 
   // Extra conditions
   cy.goToPage('extra-conditions');
-  input('has-extra-conditions-yes').check()
-  textArea('extra-conditions-text').type('Sed dignissim lacinia nunc. Curabitur tortor. Pellentesque nibh. Aenean quam. In scelerisque sem at dolor. Maecenas mattis.\n\nSed convallis tristique sem. Proin ut ligula vel nunc egestas porttitor. Morbi lectus risus, iaculis vel, suscipit quis, luctus non, massa. Fusce ac turpis quis ligula lacinia aliquet. Mauris ipsum. Nulla metus metus, ullamcorper vel, tincidunt sed, euismod in, nibh.');
+  input('has-extra-conditions-yes').check();
+  textArea('extra-conditions-text').type(
+    'Sed dignissim lacinia nunc. Curabitur tortor. Pellentesque nibh. Aenean quam. In scelerisque sem at dolor. Maecenas mattis.\n\nSed convallis tristique sem. Proin ut ligula vel nunc egestas porttitor. Morbi lectus risus, iaculis vel, suscipit quis, luctus non, massa. Fusce ac turpis quis ligula lacinia aliquet. Mauris ipsum. Nulla metus metus, ullamcorper vel, tincidunt sed, euismod in, nibh.',
+  );
   cy.clickSaveAndContinue();
 
   // Other appeals
   cy.goToPage('other-appeals');
-  input('adjacent-appeals-yes').check()
+  input('adjacent-appeals-yes').check();
   textBox('appeal-reference-numbers').type('abc-123, def-456');
   cy.clickSaveAndContinue();
 
@@ -60,28 +64,31 @@ const stepCompletion = () => {
 
   // Development Plan
   cy.goToPage('development-plan');
-  input('has-plan-submitted-yes').check()
+  input('has-plan-submitted-yes').check();
   textArea('plan-changes-text').type('mock plan changes');
   cy.clickSaveAndContinue();
-}
+};
 
 const apiCompletion = () => {
   // Visit task list page to invoke session, which generates an appeal reply ID
   cy.goToTaskListPage();
 
-  let id
-  cy.getAppealReplyId().then(replyId => id = replyId);
-
-  cy.fixture('completedAppealReply.json').then((reply) => {
-    cy.request(
-      'PUT',
-      `${Cypress.env('APPEAL_REPLY_SERVICE_BASE_URL')}/api/v1/reply/${id}`,
-      reply
-    ).then(response => {
-      expect(response.body.aboutAppealSection.submissionAccuracy).to.have.property('accurateSubmission', false);
+  cy.getAppealReplyId().then((replyId) => {
+    cy.fixture('completedAppealReply.json').then((reply) => {
+      reply.id = replyId;
+      cy.request(
+        'PUT',
+        `${Cypress.env('APPEAL_REPLY_SERVICE_BASE_URL')}/reply/${replyId}`,
+        reply,
+      ).then((response) => {
+        expect(response.body.aboutAppealSection.submissionAccuracy).to.have.property(
+          'accurateSubmission',
+          false,
+        );
+      });
     });
   });
-}
+};
 
 module.exports = () => {
   if (!Cypress.env('ASSUME_LIMITED_ACCESS')) {

--- a/packages/appeal-reply-service-api/src/models/replySchema.js
+++ b/packages/appeal-reply-service-api/src/models/replySchema.js
@@ -102,6 +102,11 @@ const replySchema = new Mongoose.Schema({
       developmentOrNeighbourhood: { type: String, default: 'NOT STARTED' },
     },
   },
+  submission: {
+    pdfStatement: {
+      uploadedFile: { type: uploadedFilesSchema, default: null },
+    },
+  },
 });
 
 module.exports = Mongoose.model('Reply', replySchema);

--- a/packages/lpa-questionnaire-web-app/src/controllers/information-submitted.js
+++ b/packages/lpa-questionnaire-web-app/src/controllers/information-submitted.js
@@ -1,38 +1,33 @@
 const { VIEW } = require('../lib/views');
 const { createOrUpdateAppealReply } = require('../lib/appeal-reply-api-wrapper');
 const logger = require('../lib/logger');
+const { createPdf } = require('../services/pdf.service');
 
-exports.getInformationSubmitted = (_, res) => {
-  res.render(VIEW.INFORMATION_SUBMITTED, {});
+exports.getInformationSubmitted = (req, res) => {
+  res.render(VIEW.INFORMATION_SUBMITTED, {
+    appealReplyId: req.session?.appealReply?.id,
+  });
 };
 
 exports.postInformationSubmitted = async (req, res) => {
-  const { appealReply } = req.session;
+  const { appealReply, appeal } = req.session;
   const log = logger.child({ appealReplyId: appealReply.id });
 
   log.info('Submitting the appeal reply');
 
   try {
-    /**
-     * TODO: call PDF service here. something like:
-     * const { id, name, location, size } = await createAppealReplyPdf(appealReply);
-     */
+    const { id, name } = await createPdf(appealReply, appeal);
 
     appealReply.state = 'SUBMITTED';
 
-    /**
-     * TODO: add PDF to submission. Expected structure:
-     * appealReply.submission = {
-     *   pdfStatement: {
-     *     uploadedFile: {
-     *       id,
-     *       name,
-     *       location,
-     *       size,
-     *     },
-     *   },
-     * };
-     */
+    appealReply.submission = {
+      pdfStatement: {
+        uploadedFile: {
+          id,
+          name,
+        },
+      },
+    };
 
     req.session.appealReply = await createOrUpdateAppealReply(appealReply);
 

--- a/packages/lpa-questionnaire-web-app/src/lib/documents-api-wrapper.js
+++ b/packages/lpa-questionnaire-web-app/src/lib/documents-api-wrapper.js
@@ -6,7 +6,15 @@ const uuid = require('uuid');
 const config = require('../config');
 const parentLogger = require('./logger');
 
-exports.createDocument = async (parentId, formData) => {
+function isDataBuffer(data) {
+  return data !== null && data !== undefined && typeof data === 'object';
+}
+
+function isTheFormDataBuffer(data) {
+  return isDataBuffer(data) && data.tempFilePath;
+}
+
+exports.createDocument = async (parentId, data, fileName) => {
   const correlationId = uuid.v4();
 
   const url = `${config.documents.url}/api/v1/${parentId}`;
@@ -19,7 +27,14 @@ exports.createDocument = async (parentId, formData) => {
   let apiResponse;
   try {
     const fd = new FormData();
-    fd.append('file', fs.createReadStream(formData.tempFilePath), formData.name);
+    if (isTheFormDataBuffer(data)) {
+      const documentName = fileName || data.name;
+      fd.append('file', fs.createReadStream(data.tempFilePath), documentName);
+    } else if (isDataBuffer(data)) {
+      fd.append('file', data, fileName);
+    } else {
+      throw new Error('The type of provided data to create a document with is wrong');
+    }
 
     apiResponse = await fetch(url, {
       method: 'POST',

--- a/packages/lpa-questionnaire-web-app/src/middleware/fetch-existing-appeal-reply.js
+++ b/packages/lpa-questionnaire-web-app/src/middleware/fetch-existing-appeal-reply.js
@@ -23,11 +23,11 @@ module.exports = async (req, res, next) => {
   }
 
   try {
-    req.log.debug({ id: req.session.appealReply.id }, 'Get existing appeal');
+    req.log.debug({ id: req.session.appealReply.id }, 'Get existing appeal reply');
     req.session.appealReply = await getExistingAppealReply(req.session.appealReply.id);
   } catch (err) {
-    req.log.debug({ err }, 'Error retrieving appeal');
-    req.session.appeal = await createOrUpdateAppealReply({ appealId: req.params.id });
+    req.log.debug({ err }, 'Error retrieving appeal reply');
+    req.session.appealReply = await createOrUpdateAppealReply({ appealId: req.params.id });
   }
   return next();
 };

--- a/packages/lpa-questionnaire-web-app/src/routes/confirm-answers.js
+++ b/packages/lpa-questionnaire-web-app/src/routes/confirm-answers.js
@@ -1,9 +1,14 @@
 const express = require('express');
+const fetchAppealMiddleware = require('../middleware/fetch-appeal');
 const fetchExistingAppealReplyMiddleware = require('../middleware/fetch-existing-appeal-reply');
 const confirmAnswersController = require('../controllers/confirm-answers');
 
 const router = express.Router();
 
-router.get('/:id/confirm-answers', [fetchExistingAppealReplyMiddleware], confirmAnswersController);
+router.get(
+  '/:id/confirm-answers',
+  [fetchAppealMiddleware, fetchExistingAppealReplyMiddleware],
+  confirmAnswersController
+);
 
 module.exports = router;

--- a/packages/lpa-questionnaire-web-app/src/services/pdf.service.js
+++ b/packages/lpa-questionnaire-web-app/src/services/pdf.service.js
@@ -67,7 +67,7 @@ const createPdf = async (appealReply, appeal) => {
     const pdfBuffer = await generatePDF(`${id}.pdf`, renderedHtml);
 
     log.debug('Creating document from PDF buffer');
-    const document = await createDocument(id, pdfBuffer);
+    const document = await createDocument(id, pdfBuffer, `${id}.pdf`);
 
     log.debug('PDF document successfully created');
 

--- a/packages/lpa-questionnaire-web-app/src/views/pdf-generation.njk
+++ b/packages/lpa-questionnaire-web-app/src/views/pdf-generation.njk
@@ -4,7 +4,8 @@
 <html lang="{{ htmlLang | default('en') }}" class="govuk-template {{ htmlClasses }}">
   <head>
       <title>Response to householder planning appeal</title>
-      <link href="/public/stylesheets/main.css" media="all" rel="stylesheet" type="text/css"/>
+      <style>{{ css | safe }}</style>
+      <style>.govuk-template { background-color: #FFFFFF; }</style>
   </head>
   <body>
       <div class="govuk-grid-row">

--- a/packages/lpa-questionnaire-web-app/tests/unit/controllers/information-submitted.test.js
+++ b/packages/lpa-questionnaire-web-app/tests/unit/controllers/information-submitted.test.js
@@ -3,6 +3,7 @@ const {
   postInformationSubmitted,
 } = require('../../../src/controllers/information-submitted');
 const { createOrUpdateAppealReply } = require('../../../src/lib/appeal-reply-api-wrapper');
+const { createPdf } = require('../../../src/services/pdf.service');
 const { VIEW } = require('../../../src/lib/views');
 const { mockReq, mockRes } = require('../mocks');
 
@@ -15,6 +16,7 @@ jest.mock('../../../src/lib/logger', () => ({
     warn: jest.fn(),
   }),
 }));
+jest.mock('../../../src/services/pdf.service');
 
 describe('../../../src/controllers/information-submitted', () => {
   let req;
@@ -29,7 +31,9 @@ describe('../../../src/controllers/information-submitted', () => {
     it('should call the correct template', () => {
       getInformationSubmitted(req, res);
 
-      expect(res.render).toHaveBeenCalledWith(VIEW.INFORMATION_SUBMITTED, {});
+      expect(res.render).toHaveBeenCalledWith(VIEW.INFORMATION_SUBMITTED, {
+        appealReplyId: null,
+      });
     });
   });
 
@@ -45,6 +49,7 @@ describe('../../../src/controllers/information-submitted', () => {
 
     it('should redirect to information submitted page on success', async () => {
       createOrUpdateAppealReply.mockReturnValue('reply ok');
+      createPdf.mockReturnValue({ id: 'mock-pdf', name: 'mock.pdf' });
 
       await postInformationSubmitted(req, res);
 

--- a/packages/lpa-questionnaire-web-app/tests/unit/lib/documents-api-wrapper.test.js
+++ b/packages/lpa-questionnaire-web-app/tests/unit/lib/documents-api-wrapper.test.js
@@ -21,29 +21,39 @@ describe('lib/documents-api-wrapper', () => {
   });
 
   describe('createDocument', () => {
-    let mockAppeal;
-    let formData;
+    let mockId;
+    let data;
 
     beforeEach(() => {
-      mockAppeal = { id: 123 };
-      formData = {
+      mockId = 'mock-id';
+      data = {
         tempFilePath: 'some/fake/file.ext',
       };
     });
 
     it('should throw if fetch fails', async () => {
       fetch.mockReject(new Error('fake error message'));
-      expect(createDocument(mockAppeal, formData)).rejects.toThrow('fake error message');
+      expect(createDocument(mockId, data)).rejects.toThrow('fake error message');
     });
 
-    it('should throw if the remote API response is not ok', () => {
+    it('should throw if the remote API response is not ok', async () => {
       fetch.mockResponse('fake response body', { status: 400 });
-      expect(createDocument(mockAppeal, formData)).rejects.toThrow('Bad Request');
+      try {
+        await createDocument(mockId, data);
+        expect('to be').not.toBe('to be');
+      } catch (e) {
+        expect(e.message).toBe('Bad Request');
+      }
     });
 
     it('should throw if the response code is anything other than a 202', async () => {
       fetch.mockResponse('a response body', { status: 204 });
-      expect(createDocument(mockAppeal, formData)).rejects.toThrow('No Content');
+      try {
+        await createDocument(mockId, data);
+        expect('to be').not.toBe('to be');
+      } catch (e) {
+        expect(e.message).toBe('No Content');
+      }
     });
 
     it('should throw if the document response is missing an `id`', async () => {
@@ -53,7 +63,12 @@ describe('lib/documents-api-wrapper', () => {
         }),
         { status: 202 }
       );
-      expect(createDocument(mockAppeal, formData)).rejects.toThrow('Document had no ID');
+      try {
+        await createDocument(mockId, data);
+        expect('to be').not.toBe('to be');
+      } catch (e) {
+        expect(e.message).toBe('Document had no ID');
+      }
     });
 
     [null, undefined].forEach((given) => {
@@ -65,11 +80,30 @@ describe('lib/documents-api-wrapper', () => {
           }),
           { status: 202 }
         );
-        expect(createDocument(mockAppeal, formData)).rejects.toThrow('Document had no ID');
+
+        try {
+          await createDocument(mockId, data);
+          expect('to be').not.toBe('to be');
+        } catch (e) {
+          expect(e.message).toBe('Document had no ID');
+        }
       });
     });
 
-    it('should return the expected response if the fetch status is 202', async () => {
+    [null, undefined].forEach((given) => {
+      it(`should throw if the document response 'id' is ${given}`, async () => {
+        try {
+          await createDocument(mockId, given);
+          expect('to be').not.toBe('to be');
+        } catch (e) {
+          expect(e.message).toBe(
+            'Error: The type of provided data to create a document with is wrong'
+          );
+        }
+      });
+    });
+
+    it('should return the expected response if the fetch status is 202 with form data input', async () => {
       fetch.mockResponse(
         JSON.stringify({
           applicationId: 123,
@@ -78,7 +112,40 @@ describe('lib/documents-api-wrapper', () => {
         }),
         { status: 202 }
       );
-      expect(await createDocument(mockAppeal, formData)).toEqual({
+      expect(await createDocument(mockId, data)).toEqual({
+        applicationId: 123,
+        id: '123-abc-456-xyz',
+        name: 'tmp-2-1607684291243',
+      });
+    });
+
+    it('should return the expected response if the fetch status is 202 with form data input with name overrided', async () => {
+      fetch.mockResponse(
+        JSON.stringify({
+          applicationId: 123,
+          id: '123-abc-456-xyz',
+          name: 'namePreferred.pdf',
+        }),
+        { status: 202 }
+      );
+
+      expect(await createDocument(mockId, data, 'namePreferred.pdf')).toEqual({
+        applicationId: 123,
+        id: '123-abc-456-xyz',
+        name: 'namePreferred.pdf',
+      });
+    });
+
+    it('should return the expected response if the fetch status is 202 with data buffer input', async () => {
+      fetch.mockResponse(
+        JSON.stringify({
+          applicationId: 123,
+          id: '123-abc-456-xyz',
+          name: 'tmp-2-1607684291243',
+        }),
+        { status: 202 }
+      );
+      expect(await createDocument(mockId, Buffer.from('data'))).toEqual({
         applicationId: 123,
         id: '123-abc-456-xyz',
         name: 'tmp-2-1607684291243',

--- a/packages/lpa-questionnaire-web-app/tests/unit/middleware/fetch-existing-appeal-reply.test.js
+++ b/packages/lpa-questionnaire-web-app/tests/unit/middleware/fetch-existing-appeal-reply.test.js
@@ -58,7 +58,7 @@ describe('middleware/fetch-existing-appeal-reply', () => {
       expected: (req, res, next) => {
         expect(getExistingAppealReply).toHaveBeenCalledWith('123-abc');
         expect(createOrUpdateAppealReply).toHaveBeenCalledWith({ appealId: 'mock-id' });
-        expect(req.session.appeal).toEqual({ fake: 'appeal data' });
+        expect(req.session.appealReply).toEqual({ fake: 'appeal data' });
         expect(next).toHaveBeenCalled();
       },
     },

--- a/packages/lpa-questionnaire-web-app/tests/unit/mockAppeal.js
+++ b/packages/lpa-questionnaire-web-app/tests/unit/mockAppeal.js
@@ -78,6 +78,11 @@ module.exports = {
       },
     },
   },
+  submission: {
+    pdfStatement: {
+      uploadedFile: null,
+    },
+  },
   aboutYouSection: {
     yourDetails: {
       appealingOnBehalfOf: '',

--- a/packages/lpa-questionnaire-web-app/tests/unit/routes/confirm-answers.test.js
+++ b/packages/lpa-questionnaire-web-app/tests/unit/routes/confirm-answers.test.js
@@ -1,6 +1,7 @@
 const { get } = require('./router-mock');
 const { VIEW } = require('../../../src/lib/views');
 const confirmAnswersController = require('../../../src/controllers/confirm-answers');
+const fetchAppealMiddleware = require('../../../src/middleware/fetch-appeal');
 const fetchExistingAppealReplyMiddleware = require('../../../src/middleware/fetch-existing-appeal-reply');
 
 describe('routes/confirm-answers', () => {
@@ -16,7 +17,7 @@ describe('routes/confirm-answers', () => {
   it('should define the expected routes', () => {
     expect(get).toHaveBeenCalledWith(
       `/:id/${VIEW.CONFIRM_ANSWERS}`,
-      [fetchExistingAppealReplyMiddleware],
+      [fetchAppealMiddleware, fetchExistingAppealReplyMiddleware],
       confirmAnswersController
     );
   });

--- a/packages/lpa-questionnaire-web-app/tests/unit/services/pdf.service.test.js
+++ b/packages/lpa-questionnaire-web-app/tests/unit/services/pdf.service.test.js
@@ -44,7 +44,7 @@ describe('services/pdf.service', () => {
       const document = await createPdf(mockAppealReply, mockAppeal);
 
       expect(generatePDF).toHaveBeenCalledWith('mock-id.pdf', html);
-      expect(createDocument).toHaveBeenCalledWith('mock-id', 'mock-pdf');
+      expect(createDocument).toHaveBeenCalledWith('mock-id', 'mock-pdf', 'mock-id.pdf');
       expect(document).toEqual('mock-document');
     });
   });


### PR DESCRIPTION
## Ticket Number
<!-- Add the number from the Jira board -->
https://pins-ds.atlassian.net/browse/AS-1878

## Description of change
- Changes to appeal reply service to add pdf submission to reply
- Added handling to web app to generate PDF at submission
- Fixed some issues with middleware and check your answers routes causing issues with tests

## Checklist
<!-- Put an `x` in all the boxes that apply: -->
- [ ] Requires infrastructure changes
- [ ] If adding or remove environment variables (e.g. in `docker-compose.yaml`) then I have updated the appropriate Helm chart
- [ ] I have updated the documentation accordingly
- [X] My commit history in this PR is linear
- [X] New features have tests
- [ ] Breaking change (team conversation required)

## Important

Please do not merge from `master` (please only [rebase](https://github.com/foundry4/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
