### PR TITLE
fix(forms-web-app): view-my-appeal - ensure correct name displayed

### DIFF
--- a/packages/forms-web-app/.eslintrc
+++ b/packages/forms-web-app/.eslintrc
@@ -6,18 +6,14 @@
   "extends": ["airbnb-base", "prettier"],
   "plugins": ["jest", "prettier"],
   "root": true,
-  "ignorePatterns": [
-    "node_modules/**",
-    "src/public/javascript/**",
-    "dist/**",
-    "webpack.**"
-  ],
+  "ignorePatterns": ["node_modules/**", "src/public/javascript/**", "dist/**", "webpack.**"],
   "rules": {
     "prettier/prettier": "error"
   },
   "env": {
     "es2021": true,
     "node": true,
-    "jest": true
+    "jest": true,
+    "browser": true
   }
 }

--- a/packages/forms-web-app/src/views/your-planning-appeal/index.njk
+++ b/packages/forms-web-app/src/views/your-planning-appeal/index.njk
@@ -27,6 +27,8 @@
           },
           value: {
             text: summaryField(appeal.aboutYouSection.yourDetails.name, { 'data-cy': "appellant-name" })
+            if appeal.aboutYouSection.yourDetails.isOriginalApplicant
+            else summaryField(appeal.aboutYouSection.yourDetails.appealingOnBehalfOf, { 'data-cy': "appellant-name" })
           }
         },
         {
@@ -49,7 +51,7 @@
 
       <li class="timeline__entry">
         <h2 class="timeline__header">The local planning department submit their case file</h2>
-        <p class="govuk-body">{{lpd.name}} will send you a copy of their questionnaire and supporting documents for your information only, you do not need to do anything.</p>
+        <p class="govuk-body" data-cy="lpd-docs-statement">{{lpd.name}} will send you a copy of their questionnaire and supporting documents for your information only, you do not need to do anything.</p>
       </li>
 
       <li class="timeline__entry">

--- a/packages/forms-web-app/tests/fixtures/appeal.js
+++ b/packages/forms-web-app/tests/fixtures/appeal.js
@@ -1,0 +1,37 @@
+const appealFromAppellant = {
+  id: '11111-22222222-333333333333-44444',
+  submissionDate: '2021-05-05T15:26:23.970Z',
+  aboutYouSection: {
+    yourDetails: {
+      isOriginalApplicant: true,
+      name: 'Valid Name',
+      email: 'valid@email.com',
+      appealingOnBehalfOf: '',
+    },
+  },
+  appealSiteSection: {
+    siteAddress: {
+      addressLine1: '1 Taylor Road',
+      addressLine2: 'Clifton',
+      town: 'Bristol',
+      county: 'South Glos',
+      postcode: 'BS8 1TG',
+    },
+  },
+};
+
+const appealFromAgent = {
+  ...appealFromAppellant,
+  ...{
+    aboutYouSection: {
+      yourDetails: {
+        isOriginalApplicant: false,
+        name: 'Valid Name',
+        email: 'valid@email.com',
+        appealingOnBehalfOf: 'Appellant Name',
+      },
+    },
+  },
+};
+
+module.exports = { appealFromAppellant, appealFromAgent };

--- a/packages/forms-web-app/tests/fixtures/lpd.js
+++ b/packages/forms-web-app/tests/fixtures/lpd.js
@@ -1,0 +1,12 @@
+const lpd = {
+  id: 'E123456789',
+  name: 'Fixture Borough Council',
+  inTrial: true,
+  email: 'lpd@planninginspectorate.gov.uk',
+  domain: 'planninginspectorate.gov.uk',
+  england: true,
+  wales: false,
+  horizonId: null,
+};
+
+module.exports = { lpd };

--- a/packages/forms-web-app/tests/unit/views/nunjucks-render-helper.js
+++ b/packages/forms-web-app/tests/unit/views/nunjucks-render-helper.js
@@ -1,8 +1,9 @@
 const nunjucks = require('nunjucks');
 const path = require('path');
-
+const dateFilter = require('nunjucks-date-filter');
 const filterByKey = require('../../../src/lib/filter-by-key');
 const addKeyValuePair = require('../../../src/lib/add-key-value-pair');
+const appealSiteAddressToArray = require('../../../src/lib/appeal-site-address-to-array');
 const render = require('../../../src/lib/render-template-filter');
 
 const viewPaths = [
@@ -19,6 +20,8 @@ const env = nunjucks.configure(viewPaths, nunjucksConfig);
 
 env.addFilter('filterByKey', filterByKey);
 env.addFilter('addKeyValuePair', addKeyValuePair);
+env.addFilter('appealSiteAddressToArray', appealSiteAddressToArray);
+env.addFilter('date', dateFilter);
 env.addFilter('render', render);
 
 module.exports = env;

--- a/packages/forms-web-app/tests/unit/views/your-planning-appeal/index.njk.test.js
+++ b/packages/forms-web-app/tests/unit/views/your-planning-appeal/index.njk.test.js
@@ -1,0 +1,70 @@
+/**
+ * @jest-environment jsdom
+ */
+const { format } = require('date-fns');
+const { VIEW } = require('../../../../src/lib/views');
+const { appealFromAppellant, appealFromAgent } = require('../../../fixtures/appeal');
+const { lpd } = require('../../../fixtures/lpd');
+const nunjucksTestRenderer = require('../nunjucks-render-helper');
+
+describe('views/your-planning-appeal/index', () => {
+  describe('when an appeal is entered by appellant', () => {
+    it('should render the page as expected with appellant details', () => {
+      document.body.innerHTML = nunjucksTestRenderer.render(
+        `${VIEW.YOUR_PLANNING_APPEAL.INDEX}.njk`,
+        {
+          appeal: appealFromAppellant,
+          lpd,
+        }
+      );
+
+      expect(document.querySelector('[data-cy="appellant-name"]').textContent).toEqual(
+        appealFromAppellant.aboutYouSection.yourDetails.name
+      );
+
+      expect(document.querySelector('[data-cy="appellant-address"]').textContent).toEqual(
+        appealFromAppellant.appealSiteSection.siteAddress.addressLine1 +
+          appealFromAppellant.appealSiteSection.siteAddress.addressLine2 +
+          appealFromAppellant.appealSiteSection.siteAddress.town +
+          appealFromAppellant.appealSiteSection.siteAddress.county +
+          appealFromAppellant.appealSiteSection.siteAddress.postcode
+      );
+      expect(document.querySelector('[data-cy="appeal-submission-date"]').textContent).toEqual(
+        format(new Date(appealFromAppellant.submissionDate), 'd MMMM Y')
+      );
+      expect(document.querySelector('[data-cy="lpd-docs-statement"]').textContent).toContain(
+        lpd.name
+      );
+    });
+  });
+
+  describe('when an appeal is entered by agent', () => {
+    it('should render the page as expected with appellant details', () => {
+      document.body.innerHTML = nunjucksTestRenderer.render(
+        `${VIEW.YOUR_PLANNING_APPEAL.INDEX}.njk`,
+        {
+          appeal: appealFromAgent,
+          lpd,
+        }
+      );
+
+      expect(document.querySelector('[data-cy="appellant-name"]').textContent).toEqual(
+        appealFromAgent.aboutYouSection.yourDetails.appealingOnBehalfOf
+      );
+
+      expect(document.querySelector('[data-cy="appellant-address"]').textContent).toEqual(
+        appealFromAppellant.appealSiteSection.siteAddress.addressLine1 +
+          appealFromAppellant.appealSiteSection.siteAddress.addressLine2 +
+          appealFromAppellant.appealSiteSection.siteAddress.town +
+          appealFromAppellant.appealSiteSection.siteAddress.county +
+          appealFromAppellant.appealSiteSection.siteAddress.postcode
+      );
+      expect(document.querySelector('[data-cy="appeal-submission-date"]').textContent).toEqual(
+        format(new Date(appealFromAppellant.submissionDate), 'd MMMM Y')
+      );
+      expect(document.querySelector('[data-cy="lpd-docs-statement"]').textContent).toContain(
+        lpd.name
+      );
+    });
+  });
+});


### PR DESCRIPTION
## Ticket Number
https://pins-ds.atlassian.net/browse/AS-1606

## Description of change
Ensure that the appellant name is always shown irrespective of who submitted the appeal
Add tests to ensure view shows all correct dynamic data in all scenarios

## Checklist
- [ ] Requires infrastructure changes
- [ ] If adding or remove environment variables (e.g. in `docker-compose.yaml`) then I have updated the appropriate Helm chart
- [ ] I have updated the documentation accordingly
- [x] My commit history in this PR is linear
- [x] New features have tests
- [ ] Breaking change (team conversation required)

## Important

Please do not merge from `master` (please only [rebase](https://github.com/foundry4/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
