### PR TITLE
test(lpa-questionnaire-web-app): added e2e tests for add email to con…

### DIFF
--- a/lpa-submissions-e2e-tests/cypress/integration/appealsInformationSubmitted.feature
+++ b/lpa-submissions-e2e-tests/cypress/integration/appealsInformationSubmitted.feature
@@ -5,3 +5,9 @@ so that I know that the Planning Inspectors have received it
 Scenario: AC01 - LPA Planning Officer submits finished LPA Questionnaire
 Given the Information Submitted page is requested
 Then the Information Submitted page will be shown
+Then the LPA email address is displayed on the Information Submitted page
+
+Scenario: AC02 - LPA Planning Officer submits finished LPA Questionnaire but email recall fails
+Given the Information Submitted page is requested
+Then the Information Submitted page will be shown
+Then the LPA email address is not displayed on the Information Submitted page

--- a/lpa-submissions-e2e-tests/cypress/integration/appealsInformationSubmitted/appealsInformationSubmittedSteps.js
+++ b/lpa-submissions-e2e-tests/cypress/integration/appealsInformationSubmitted/appealsInformationSubmittedSteps.js
@@ -1,8 +1,15 @@
 import { Given, _, Then } from 'cypress-cucumber-preprocessor/steps';
 
+const getAppeal = require('../../../../packages/lpa-questionnaire-web-app/src/lib/appeals-api-wrapper');
+const getLPAList = require('../../../../packages/forms-web-app/src/lib/appeals-api-wrapper');
+
 const informationSubmittedPageId = 'information-submitted';
 const informationSubmittedPageTitle =
   'Information submitted - Appeal questionnaire - Appeal a householder planning decision - GOV.UK';
+
+const getLPAEmail = (lpaId) => {
+  return getLPAList().data.filter((obj) => obj.id === lpaId).email;
+};
 
 Given(`the Information Submitted page is requested`, () => {
   cy.goToPage(informationSubmittedPageId);
@@ -11,4 +18,12 @@ Given(`the Information Submitted page is requested`, () => {
 Then(`the Information Submitted page will be shown`, () => {
   cy.verifyPageTitle(informationSubmittedPageTitle);
   cy.checkPageA11y(informationSubmittedPageId);
+});
+
+Then(`the LPA email address is displayed on the Information Submitted page`, () => {
+  cy.visibleWithText(`${getLPAEmail(getAppeal().lpaCode)}`, 'lpaEmailString');
+});
+
+Then(`the LPA email address is not displayed on the Information Submitted page`, () => {
+  cy.visibleWithText('', 'lpaEmailString');
 });


### PR DESCRIPTION
…firmation screen

## Ticket Number
<!-- Add the number from the Jira board -->
https://pins-ds.atlassian.net/browse/AS-2226

## Description of change
<!-- Please describe the change -->
added e2e tests for add email to confirmation screen

## Checklist
<!-- Put an `x` in all the boxes that apply: -->
- [ ] Requires infrastructure changes
- [ ] If adding or remove environment variables (e.g. in `docker-compose.yaml`) then I have updated the appropriate Helm chart
- [ ] I have updated the documentation accordingly
- [x] My commit history in this PR is linear
- [x] New features have tests
- [ ] Breaking change (team conversation required)

## Important

Please do not merge from `master` (please only [rebase](https://github.com/foundry4/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
