### PR TITLE
chore: Run a semantic-release dry-run as part of the CI pipeline, …

### DIFF
--- a/.github/actions/semantic-release/action.yml
+++ b/.github/actions/semantic-release/action.yml
@@ -41,6 +41,9 @@ runs:
           cd ${{ inputs.DIR }}
           export GITHUB_TOKEN="${{ inputs.GITHUB_TOKEN }}"
 
+          echo "Run a semantic-release dry-run so the output can be debugged."
+          ${ROOT_DIR}/node_modules/.bin/semantic-release -d
+
           NEW_VERSION=$(${ROOT_DIR}/node_modules/.bin/semantic-release -d | awk '/Release note for version/ { getline; print $2 }')
 
           if [ -n "$NEW_VERSION" ]; then


### PR DESCRIPTION
…so that its log output can be used for debugging.

## Ticket Number
https://pins-ds.atlassian.net/browse/AS-2275

## Description of change
Currently we are unable to view the output log generated by semantic-release. In order to debug recent deployment issues, we need to inspect exactly what semantic-release is doing. This change runs it in dry-run mode so that the output will appear in the CI pipeline logs.

## Checklist
- [ ] Requires infrastructure changes
- [ ] If adding or remove environment variables (e.g. in `docker-compose.yaml`) then I have updated the appropriate Helm chart
- [ ] I have updated the documentation accordingly
- [x] My commit history in this PR is linear
- [ ] New features have tests
- [ ] Breaking change (team conversation required)

## Important

Please do not merge from `master` (please only [rebase](https://github.com/foundry4/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
