### PR TITLE
feat(appeal-reply-service-api): add endpoint to lookup by appeal id

### DIFF
--- a/packages/appeal-reply-service-api/api/openapi.yaml
+++ b/packages/appeal-reply-service-api/api/openapi.yaml
@@ -2,7 +2,7 @@ openapi: 0.0.1
 info:
   title: Appeal Reply Service API Documentation
   description:
-    API to <ul><li>create, retrieve and modify appeal replies</li><li>
+    API to <ul><li>create, retrieve and modify appeal replies</li></ul>
   version: 1.0.3
   license:
     name: MIT
@@ -87,6 +87,29 @@ paths:
                     items:
                       type: string
                       example: 'requiredDocumentsSection.originalApplication.uploadedFile.id must be a valid UUID'
+        '404':
+          description: The reply could not be found
+  '/api/v1/reply/appeal/{id}':
+    get:
+      summary: Returns an existing reply by the appeal ID
+      description: The reply includes the state of all subsections.
+      tags:
+        - Reply
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: string
+            format: uuid
+          description: Unique identifier for Appeal
+      responses:
+        '200':
+          description: Returns an reply
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Reply'
         '404':
           description: The reply could not be found
 components:

--- a/packages/appeal-reply-service-api/src/__tests__/reply.spec.js
+++ b/packages/appeal-reply-service-api/src/__tests__/reply.spec.js
@@ -9,8 +9,8 @@ jest.mock('../db/db');
 const endpoint = '/api/v1/reply';
 const dbId = 'reply';
 
-async function createReply() {
-  const reply = new ReplyModel({ id: uuid.v4() });
+async function createReply(appealId) {
+  const reply = new ReplyModel({ id: uuid.v4(), appealId });
   reply.id = uuid.v4();
   await mongodb.get().collection(dbId).insertOne({ _id: reply.id, uuid: reply.id, reply });
   return reply;
@@ -73,5 +73,18 @@ describe('Replies API', () => {
     const response = await request(app).put(`/api/v1/reply/${reply.id}`).send(reply);
     expect(response.body).toEqual(reply);
     expect(response.statusCode).toBe(200);
+  });
+
+  test('GET /api/v1/reply/{id} - It responds with an existing reply', async () => {
+    const reply = await createReply('1234');
+    const response = await request(app).get(`${endpoint}/appeal/1234`);
+    expect(JSON.stringify(response.body)).toBe(JSON.stringify(reply));
+    expect(response.statusCode).toBe(200);
+  });
+
+  test('GET /api/v1/reply/appeal/{id} - It responds with an error - Not Found', async () => {
+    const response = await request(app).get(`${endpoint}/appeal/non-existent-id`);
+    expect(response.body).toEqual({});
+    expect(response.statusCode).toBe(404);
   });
 });

--- a/packages/appeal-reply-service-api/src/controllers/reply.js
+++ b/packages/appeal-reply-service-api/src/controllers/reply.js
@@ -61,6 +61,28 @@ module.exports = {
     }
   },
 
+  async getByAppeal(req, res) {
+    const appealId = req.params.id;
+    logger.debug(`Retrieving reply by appeal ID ${appealId} ...`);
+    try {
+      await mongodb
+        .get()
+        .collection(dbId)
+        .findOne({ 'reply.appealId': { $eq: appealId } })
+        .then((doc) => {
+          logger.debug(`Reply for appeal ${appealId} retrieved`);
+          res.status(200).send(doc.reply);
+        })
+        .catch((err) => {
+          logger.warn(`Could not find reply for appeal ${appealId}\n${err}`);
+          res.status(404).send(null);
+        });
+    } catch (err) {
+      logger.error(`Problem retrieving reply for appeal ${appealId}\n${err}`);
+      res.status(500).send(`Problem finding reply for appeal ${appealId}`);
+    }
+  },
+
   async update(req, res) {
     const idParam = req.params.id;
     logger.debug(`Updating reply ${idParam} ...`);

--- a/packages/appeal-reply-service-api/src/routes/reply.js
+++ b/packages/appeal-reply-service-api/src/routes/reply.js
@@ -7,4 +7,6 @@ routes.post('/', replyController.create);
 routes.get('/:id', replyController.get);
 routes.put('/:id', replyController.update);
 
+routes.get('/appeal/:id', replyController.getByAppeal);
+
 module.exports = routes;


### PR DESCRIPTION
## Ticket Number
<!-- Add the number from the Jira board -->
https://pins-ds.atlassian.net/browse/AS-2316

## Description of change
Added new endpoint to API to get reply by appeal ID

## Checklist
<!-- Put an `x` in all the boxes that apply: -->
- [ ] Requires infrastructure changes
- [ ] If adding or remove environment variables (e.g. in `docker-compose.yaml`) then I have updated the appropriate Helm chart
- [ ] I have updated the documentation accordingly
- [X] My commit history in this PR is linear
- [X] New features have tests
- [ ] Breaking change (team conversation required)

## Important

Please do not merge from `master` (please only [rebase](https://github.com/foundry4/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
