### PR TITLE
chore: AS-2326 Run semantic-release at the start of the CI pipeline.

### DIFF
--- a/.github/workflows/appeal-reply-service-api.yml
+++ b/.github/workflows/appeal-reply-service-api.yml
@@ -47,6 +47,32 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.CUSTOM_GITHUB_TOKEN }}
           GET_VERSION: 'true'
 
+      - name: Set next version number
+        uses: ./.github/actions/semantic-release
+        if: ${{ steps.version_number.outputs.new_release_published == 'true' }}
+        with:
+          DIR: packages/${{ env.APP_DIR }}
+          GITHUB_TOKEN: ${{ secrets.CUSTOM_GITHUB_TOKEN }}
+          SET_VERSION: 'true'
+
+      - name: Exit if no git tag was created
+        if: ${{ steps.version_number.outputs.new_release_published == 'true' }}
+        run: |
+          echo "Info: Check if a git tag has been created for the new version."
+          if [[ "$NEW_VERSION" == "" ]]
+          then
+            echo "Error: NEW_VERSION should not be blank."
+            exit 1
+          fi
+
+          if (git tag --points-at HEAD | grep "$NEW_VERSION" &>/dev/null)
+          then
+            echo "Info: git tag exists for version: $NEW_VERSION"
+          else
+            echo "Error: git tag does not exist for version: $NEW_VERSION"
+            exit 1
+          fi
+
       - name: Extract variables
         id: vars
         run: |
@@ -101,11 +127,3 @@ jobs:
 
       - uses: ./.github/actions/flux
         if: ${{ steps.version_number.outputs.new_release_published == 'true' }}
-
-      - name: Set next version number
-        uses: ./.github/actions/semantic-release
-        if: ${{ steps.version_number.outputs.new_release_published == 'true' }}
-        with:
-          DIR: packages/${{ env.APP_DIR }}
-          GITHUB_TOKEN: ${{ secrets.CUSTOM_GITHUB_TOKEN }}
-          SET_VERSION: 'true'

--- a/.github/workflows/appeals-service-api.yml
+++ b/.github/workflows/appeals-service-api.yml
@@ -47,6 +47,32 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.CUSTOM_GITHUB_TOKEN }}
           GET_VERSION: 'true'
 
+      - name: Set next version number
+        uses: ./.github/actions/semantic-release
+        if: ${{ steps.version_number.outputs.new_release_published == 'true' }}
+        with:
+          DIR: packages/${{ env.APP_DIR }}
+          GITHUB_TOKEN: ${{ secrets.CUSTOM_GITHUB_TOKEN }}
+          SET_VERSION: 'true'
+
+      - name: Exit if no git tag was created
+        if: ${{ steps.version_number.outputs.new_release_published == 'true' }}
+        run: |
+          echo "Info: Check if a git tag has been created for the new version."
+          if [[ "$NEW_VERSION" == "" ]]
+          then
+            echo "Error: NEW_VERSION should not be blank."
+            exit 1
+          fi
+
+          if (git tag --points-at HEAD | grep "$NEW_VERSION" &>/dev/null)
+          then
+            echo "Info: git tag exists for version: $NEW_VERSION"
+          else
+            echo "Error: git tag does not exist for version: $NEW_VERSION"
+            exit 1
+          fi
+
       - name: Extract variables
         id: vars
         run: |
@@ -101,11 +127,3 @@ jobs:
 
       - uses: ./.github/actions/flux
         if: ${{ steps.version_number.outputs.new_release_published == 'true' }}
-
-      - name: Set next version number
-        uses: ./.github/actions/semantic-release
-        if: ${{ steps.version_number.outputs.new_release_published == 'true' }}
-        with:
-          DIR: packages/${{ env.APP_DIR }}
-          GITHUB_TOKEN: ${{ secrets.CUSTOM_GITHUB_TOKEN }}
-          SET_VERSION: 'true'

--- a/.github/workflows/document-service-api.yml
+++ b/.github/workflows/document-service-api.yml
@@ -47,6 +47,32 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.CUSTOM_GITHUB_TOKEN }}
           GET_VERSION: 'true'
 
+      - name: Set next version number
+        uses: ./.github/actions/semantic-release
+        if: ${{ steps.version_number.outputs.new_release_published == 'true' }}
+        with:
+          DIR: packages/${{ env.APP_DIR }}
+          GITHUB_TOKEN: ${{ secrets.CUSTOM_GITHUB_TOKEN }}
+          SET_VERSION: 'true'
+
+      - name: Exit if no git tag was created
+        if: ${{ steps.version_number.outputs.new_release_published == 'true' }}
+        run: |
+          echo "Info: Check if a git tag has been created for the new version."
+          if [[ "$NEW_VERSION" == "" ]]
+          then
+            echo "Error: NEW_VERSION should not be blank."
+            exit 1
+          fi
+
+          if (git tag --points-at HEAD | grep "$NEW_VERSION" &>/dev/null)
+          then
+            echo "Info: git tag exists for version: $NEW_VERSION"
+          else
+            echo "Error: git tag does not exist for version: $NEW_VERSION"
+            exit 1
+          fi
+
       - name: Extract variables
         id: vars
         run: |
@@ -102,10 +128,3 @@ jobs:
       - uses: ./.github/actions/flux
         if: ${{ steps.version_number.outputs.new_release_published == 'true' }}
 
-      - name: Set next version number
-        uses: ./.github/actions/semantic-release
-        if: ${{ steps.version_number.outputs.new_release_published == 'true' }}
-        with:
-          DIR: packages/${{ env.APP_DIR }}
-          GITHUB_TOKEN: ${{ secrets.CUSTOM_GITHUB_TOKEN }}
-          SET_VERSION: 'true'

--- a/.github/workflows/forms-web-app.yml
+++ b/.github/workflows/forms-web-app.yml
@@ -47,6 +47,32 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.CUSTOM_GITHUB_TOKEN }}
           GET_VERSION: 'true'
 
+      - name: Set next version number
+        uses: ./.github/actions/semantic-release
+        if: ${{ steps.version_number.outputs.new_release_published == 'true' }}
+        with:
+          DIR: packages/${{ env.APP_DIR }}
+          GITHUB_TOKEN: ${{ secrets.CUSTOM_GITHUB_TOKEN }}
+          SET_VERSION: 'true'
+
+      - name: Exit if no git tag was created
+        if: ${{ steps.version_number.outputs.new_release_published == 'true' }}
+        run: |
+          echo "Info: Check if a git tag has been created for the new version."
+          if [[ "$NEW_VERSION" == "" ]]
+          then
+            echo "Error: NEW_VERSION should not be blank."
+            exit 1
+          fi
+
+          if (git tag --points-at HEAD | grep "$NEW_VERSION" &>/dev/null)
+          then
+            echo "Info: git tag exists for version: $NEW_VERSION"
+          else
+            echo "Error: git tag does not exist for version: $NEW_VERSION"
+            exit 1
+          fi
+
       - name: Extract variables
         id: vars
         run: |
@@ -101,11 +127,3 @@ jobs:
 
       - uses: ./.github/actions/flux
         if: ${{ steps.version_number.outputs.new_release_published == 'true' }}
-
-      - name: Set next version number
-        uses: ./.github/actions/semantic-release
-        if: ${{ steps.version_number.outputs.new_release_published == 'true' }}
-        with:
-          DIR: packages/${{ env.APP_DIR }}
-          GITHUB_TOKEN: ${{ secrets.CUSTOM_GITHUB_TOKEN }}
-          SET_VERSION: 'true'

--- a/.github/workflows/horizon-add-document.yml
+++ b/.github/workflows/horizon-add-document.yml
@@ -50,6 +50,32 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.CUSTOM_GITHUB_TOKEN }}
           GET_VERSION: 'true'
 
+      - name: Set next version number
+        uses: ./.github/actions/semantic-release
+        if: ${{ steps.version_number.outputs.new_release_published == 'true' }}
+        with:
+          DIR: packages/${{ env.APP_DIR }}
+          GITHUB_TOKEN: ${{ secrets.CUSTOM_GITHUB_TOKEN }}
+          SET_VERSION: 'true'
+
+      - name: Exit if no git tag was created
+        if: ${{ steps.version_number.outputs.new_release_published == 'true' }}
+        run: |
+          echo "Info: Check if a git tag has been created for the new version."
+          if [[ "$NEW_VERSION" == "" ]]
+          then
+            echo "Error: NEW_VERSION should not be blank."
+            exit 1
+          fi
+
+          if (git tag --points-at HEAD | grep "$NEW_VERSION" &>/dev/null)
+          then
+            echo "Info: git tag exists for version: $NEW_VERSION"
+          else
+            echo "Error: git tag does not exist for version: $NEW_VERSION"
+            exit 1
+          fi
+
       - name: Extract variables
         id: vars
         run: |
@@ -108,11 +134,3 @@ jobs:
 
       - uses: ./.github/actions/flux
         if: ${{ steps.version_number.outputs.new_release_published == 'true' }}
-
-      - name: Set next version number
-        uses: ./.github/actions/semantic-release
-        if: ${{ steps.version_number.outputs.new_release_published == 'true' }}
-        with:
-          DIR: packages/${{ env.APP_DIR }}
-          GITHUB_TOKEN: ${{ secrets.CUSTOM_GITHUB_TOKEN }}
-          SET_VERSION: 'true'

--- a/.github/workflows/horizon-create-case.yml
+++ b/.github/workflows/horizon-create-case.yml
@@ -50,6 +50,32 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.CUSTOM_GITHUB_TOKEN }}
           GET_VERSION: 'true'
 
+      - name: Set next version number
+        uses: ./.github/actions/semantic-release
+        if: ${{ steps.version_number.outputs.new_release_published == 'true' }}
+        with:
+          DIR: packages/${{ env.APP_DIR }}
+          GITHUB_TOKEN: ${{ secrets.CUSTOM_GITHUB_TOKEN }}
+          SET_VERSION: 'true'
+
+      - name: Exit if no git tag was created
+        if: ${{ steps.version_number.outputs.new_release_published == 'true' }}
+        run: |
+          echo "Info: Check if a git tag has been created for the new version."
+          if [[ "$NEW_VERSION" == "" ]]
+          then
+            echo "Error: NEW_VERSION should not be blank."
+            exit 1
+          fi
+
+          if (git tag --points-at HEAD | grep "$NEW_VERSION" &>/dev/null)
+          then
+            echo "Info: git tag exists for version: $NEW_VERSION"
+          else
+            echo "Error: git tag does not exist for version: $NEW_VERSION"
+            exit 1
+          fi
+
       - name: Extract variables
         id: vars
         run: |
@@ -108,11 +134,3 @@ jobs:
 
       - uses: ./.github/actions/flux
         if: ${{ steps.version_number.outputs.new_release_published == 'true' }}
-
-      - name: Set next version number
-        uses: ./.github/actions/semantic-release
-        if: ${{ steps.version_number.outputs.new_release_published == 'true' }}
-        with:
-          DIR: packages/${{ env.APP_DIR }}
-          GITHUB_TOKEN: ${{ secrets.CUSTOM_GITHUB_TOKEN }}
-          SET_VERSION: 'true'

--- a/.github/workflows/horizon-householder-appeal-publish.yml
+++ b/.github/workflows/horizon-householder-appeal-publish.yml
@@ -50,6 +50,32 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.CUSTOM_GITHUB_TOKEN }}
           GET_VERSION: 'true'
 
+      - name: Set next version number
+        uses: ./.github/actions/semantic-release
+        if: ${{ steps.version_number.outputs.new_release_published == 'true' }}
+        with:
+          DIR: packages/${{ env.APP_DIR }}
+          GITHUB_TOKEN: ${{ secrets.CUSTOM_GITHUB_TOKEN }}
+          SET_VERSION: 'true'
+
+      - name: Exit if no git tag was created
+        if: ${{ steps.version_number.outputs.new_release_published == 'true' }}
+        run: |
+          echo "Info: Check if a git tag has been created for the new version."
+          if [[ "$NEW_VERSION" == "" ]]
+          then
+            echo "Error: NEW_VERSION should not be blank."
+            exit 1
+          fi
+
+          if (git tag --points-at HEAD | grep "$NEW_VERSION" &>/dev/null)
+          then
+            echo "Info: git tag exists for version: $NEW_VERSION"
+          else
+            echo "Error: git tag does not exist for version: $NEW_VERSION"
+            exit 1
+          fi
+
       - name: Extract variables
         id: vars
         run: |
@@ -108,11 +134,3 @@ jobs:
 
       - uses: ./.github/actions/flux
         if: ${{ steps.version_number.outputs.new_release_published == 'true' }}
-
-      - name: Set next version number
-        uses: ./.github/actions/semantic-release
-        if: ${{ steps.version_number.outputs.new_release_published == 'true' }}
-        with:
-          DIR: packages/${{ env.APP_DIR }}
-          GITHUB_TOKEN: ${{ secrets.CUSTOM_GITHUB_TOKEN }}
-          SET_VERSION: 'true'

--- a/.github/workflows/lpa-questionnaire.yml
+++ b/.github/workflows/lpa-questionnaire.yml
@@ -47,6 +47,32 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.CUSTOM_GITHUB_TOKEN }}
           GET_VERSION: 'true'
 
+      - name: Set next version number
+        uses: ./.github/actions/semantic-release
+        if: ${{ steps.version_number.outputs.new_release_published == 'true' }}
+        with:
+          DIR: packages/${{ env.APP_DIR }}
+          GITHUB_TOKEN: ${{ secrets.CUSTOM_GITHUB_TOKEN }}
+          SET_VERSION: 'true'
+
+      - name: Exit if no git tag was created
+        if: ${{ steps.version_number.outputs.new_release_published == 'true' }}
+        run: |
+          echo "Info: Check if a git tag has been created for the new version."
+          if [[ "$NEW_VERSION" == "" ]]
+          then
+            echo "Error: NEW_VERSION should not be blank."
+            exit 1
+          fi
+
+          if (git tag --points-at HEAD | grep "$NEW_VERSION" &>/dev/null)
+          then
+            echo "Info: git tag exists for version: $NEW_VERSION"
+          else
+            echo "Error: git tag does not exist for version: $NEW_VERSION"
+            exit 1
+          fi
+
       - name: Extract variables
         id: vars
         run: |
@@ -101,11 +127,3 @@ jobs:
 
       - uses: ./.github/actions/flux
         if: ${{ steps.version_number.outputs.new_release_published == 'true' }}
-
-      - name: Set next version number
-        uses: ./.github/actions/semantic-release
-        if: ${{ steps.version_number.outputs.new_release_published == 'true' }}
-        with:
-          DIR: packages/${{ env.APP_DIR }}
-          GITHUB_TOKEN: ${{ secrets.CUSTOM_GITHUB_TOKEN }}
-          SET_VERSION: 'true'

--- a/.github/workflows/openfaas-amqp-connector.yml
+++ b/.github/workflows/openfaas-amqp-connector.yml
@@ -47,6 +47,32 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.CUSTOM_GITHUB_TOKEN }}
           GET_VERSION: 'true'
 
+      - name: Set next version number
+        uses: ./.github/actions/semantic-release
+        if: ${{ steps.version_number.outputs.new_release_published == 'true' }}
+        with:
+          DIR: packages/${{ env.APP_DIR }}
+          GITHUB_TOKEN: ${{ secrets.CUSTOM_GITHUB_TOKEN }}
+          SET_VERSION: 'true'
+
+      - name: Exit if no git tag was created
+        if: ${{ steps.version_number.outputs.new_release_published == 'true' }}
+        run: |
+          echo "Info: Check if a git tag has been created for the new version."
+          if [[ "$NEW_VERSION" == "" ]]
+          then
+            echo "Error: NEW_VERSION should not be blank."
+            exit 1
+          fi
+
+          if (git tag --points-at HEAD | grep "$NEW_VERSION" &>/dev/null)
+          then
+            echo "Info: git tag exists for version: $NEW_VERSION"
+          else
+            echo "Error: git tag does not exist for version: $NEW_VERSION"
+            exit 1
+          fi
+
       - name: Extract variables
         id: vars
         run: |
@@ -96,11 +122,3 @@ jobs:
 
       - uses: ./.github/actions/flux
         if: ${{ steps.version_number.outputs.new_release_published == 'true' }}
-
-      - name: Set next version number
-        uses: ./.github/actions/semantic-release
-        if: ${{ steps.version_number.outputs.new_release_published == 'true' }}
-        with:
-          DIR: packages/${{ env.APP_DIR }}
-          GITHUB_TOKEN: ${{ secrets.CUSTOM_GITHUB_TOKEN }}
-          SET_VERSION: 'true'

--- a/.github/workflows/pdf-service-api.yml
+++ b/.github/workflows/pdf-service-api.yml
@@ -47,6 +47,32 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GET_VERSION: 'true'
 
+      - name: Set next version number
+        uses: ./.github/actions/semantic-release
+        if: ${{ steps.version_number.outputs.new_release_published == 'true' }}
+        with:
+          DIR: packages/${{ env.APP_DIR }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SET_VERSION: 'true'
+
+      - name: Exit if no git tag was created
+        if: ${{ steps.version_number.outputs.new_release_published == 'true' }}
+        run: |
+          echo "Info: Check if a git tag has been created for the new version."
+          if [[ "$NEW_VERSION" == "" ]]
+          then
+            echo "Error: NEW_VERSION should not be blank."
+            exit 1
+          fi
+
+          if (git tag --points-at HEAD | grep "$NEW_VERSION" &>/dev/null)
+          then
+            echo "Info: git tag exists for version: $NEW_VERSION"
+          else
+            echo "Error: git tag does not exist for version: $NEW_VERSION"
+            exit 1
+          fi
+
       - name: Extract variables
         id: vars
         run: |
@@ -101,11 +127,3 @@ jobs:
 
       - uses: ./.github/actions/flux
         if: ${{ steps.version_number.outputs.new_release_published == 'true' }}
-
-      - name: Set next version number
-        uses: ./.github/actions/semantic-release
-        if: ${{ steps.version_number.outputs.new_release_published == 'true' }}
-        with:
-          DIR: packages/${{ env.APP_DIR }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          SET_VERSION: 'true'

--- a/.github/workflows/ping.yml
+++ b/.github/workflows/ping.yml
@@ -47,6 +47,32 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.CUSTOM_GITHUB_TOKEN }}
           GET_VERSION: 'true'
 
+      - name: Set next version number
+        uses: ./.github/actions/semantic-release
+        if: ${{ steps.version_number.outputs.new_release_published == 'true' }}
+        with:
+          DIR: packages/${{ env.APP_DIR }}
+          GITHUB_TOKEN: ${{ secrets.CUSTOM_GITHUB_TOKEN }}
+          SET_VERSION: 'true'
+
+      - name: Exit if no git tag was created
+        if: ${{ steps.version_number.outputs.new_release_published == 'true' }}
+        run: |
+          echo "Info: Check if a git tag has been created for the new version."
+          if [[ "$NEW_VERSION" == "" ]]
+          then
+            echo "Error: NEW_VERSION should not be blank."
+            exit 1
+          fi
+
+          if (git tag --points-at HEAD | grep "$NEW_VERSION" &>/dev/null)
+          then
+            echo "Info: git tag exists for version: $NEW_VERSION"
+          else
+            echo "Error: git tag does not exist for version: $NEW_VERSION"
+            exit 1
+          fi
+
       - name: Extract variables
         id: vars
         run: |
@@ -94,11 +120,3 @@ jobs:
 
       - uses: ./.github/actions/flux
         if: ${{ steps.version_number.outputs.new_release_published == 'true' }}
-
-      - name: Set next version number
-        uses: ./.github/actions/semantic-release
-        if: ${{ steps.version_number.outputs.new_release_published == 'true' }}
-        with:
-          DIR: packages/${{ env.APP_DIR }}
-          GITHUB_TOKEN: ${{ secrets.CUSTOM_GITHUB_TOKEN }}
-          SET_VERSION: 'true'

--- a/.github/workflows/queue-retry.yml
+++ b/.github/workflows/queue-retry.yml
@@ -47,6 +47,32 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.CUSTOM_GITHUB_TOKEN }}
           GET_VERSION: 'true'
 
+      - name: Set next version number
+        uses: ./.github/actions/semantic-release
+        if: ${{ steps.version_number.outputs.new_release_published == 'true' }}
+        with:
+          DIR: packages/${{ env.APP_DIR }}
+          GITHUB_TOKEN: ${{ secrets.CUSTOM_GITHUB_TOKEN }}
+          SET_VERSION: 'true'
+
+      - name: Exit if no git tag was created
+        if: ${{ steps.version_number.outputs.new_release_published == 'true' }}
+        run: |
+          echo "Info: Check if a git tag has been created for the new version."
+          if [[ "$NEW_VERSION" == "" ]]
+          then
+            echo "Error: NEW_VERSION should not be blank."
+            exit 1
+          fi
+
+          if (git tag --points-at HEAD | grep "$NEW_VERSION" &>/dev/null)
+          then
+            echo "Info: git tag exists for version: $NEW_VERSION"
+          else
+            echo "Error: git tag does not exist for version: $NEW_VERSION"
+            exit 1
+          fi
+
       - name: Extract variables
         id: vars
         run: |
@@ -94,11 +120,3 @@ jobs:
 
       - uses: ./.github/actions/flux
         if: ${{ steps.version_number.outputs.new_release_published == 'true' }}
-
-      - name: Set next version number
-        uses: ./.github/actions/semantic-release
-        if: ${{ steps.version_number.outputs.new_release_published == 'true' }}
-        with:
-          DIR: packages/${{ env.APP_DIR }}
-          GITHUB_TOKEN: ${{ secrets.CUSTOM_GITHUB_TOKEN }}
-          SET_VERSION: 'true'


### PR DESCRIPTION
## Ticket Number
<!-- Add the number from the Jira board -->
https://pins-ds.atlassian.net/browse/AS-2326

## Description of change
Run semantic-release at the start of the CI pipeline, so that git tagging happens before docker tagging.

## Checklist
<!-- Put an `x` in all the boxes that apply: -->
- [ ] Requires infrastructure changes
- [ ] If adding or remove environment variables (e.g. in `docker-compose.yaml`) then I have updated the appropriate Helm chart
- [ ] I have updated the documentation accordingly
- [x] My commit history in this PR is linear
- [ ] New features have tests
- [ ] Breaking change (team conversation required)

## Important

Please do not merge from `master` (please only [rebase](https://github.com/foundry4/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
