### PR TITLE
Subtask/as 2464 session tests

### DIFF
--- a/lpa-submissions-e2e-tests/cypress/integration/matchAppealId.feature
+++ b/lpa-submissions-e2e-tests/cypress/integration/matchAppealId.feature
@@ -1,0 +1,19 @@
+Feature: Associate Appeal ID with a single Reply
+  As an LPA Planning Officer
+  I want the questionnaire to be linked with a submitted appeal
+  So that I can ensure I am giving the information about the correct appeal and when I return to the same questionnaire it presents the previously entered data.
+
+  Background:
+    Given an appeal has been created
+    And a questionnaire has been created
+
+  Scenario: Viewing saved information
+    Given answers have been saved to the questionnaire
+    When the questionnaire is revisited in a new session
+    Then previously entered data will be visible
+
+  Scenario: Changes made to questionnaire
+    Given answers have been saved to the questionnaire
+    When the questionnaire is revisited in a new session
+    And changes are made to the questions
+    Then the changes over write the previously saved answers

--- a/lpa-submissions-e2e-tests/cypress/integration/matchAppealId/matchAppealId.step.js
+++ b/lpa-submissions-e2e-tests/cypress/integration/matchAppealId/matchAppealId.step.js
@@ -1,0 +1,36 @@
+import { Given, When, Then } from 'cypress-cucumber-preprocessor/steps';
+import { input } from '../../support/PageObjects/common-page-objects';
+
+Given('an appeal has been created', () => {});
+Given('a questionnaire has been created', () => {});
+
+Given('answers have been saved to the questionnaire', () => {
+  cy.completeQuestionnaire();
+});
+
+When('the questionnaire is revisited in a new session', () => {
+  // First go to a page to create an initial session
+  cy.goToTaskListPage();
+  cy.verifyCompletedStatus('submissionAccuracy');
+
+  // Clear cookies to remove tie to session
+  cy.clearCookies();
+
+  // Reloading the page will generate a new session
+  cy.reload();
+});
+
+When('changes are made to the questions', () => {
+  cy.goToPage('accuracy-submission');
+  input('accurate-submission-yes').check();
+  cy.clickSaveAndContinue();
+});
+
+Then('previously entered data will be visible', () => {
+  cy.verifyCompletedStatus('submissionAccuracy');
+});
+
+Then('the changes over write the previously saved answers', () => {
+  cy.goToPage('accuracy-submission');
+  input('accurate-submission-yes').should('be.checked');
+});


### PR DESCRIPTION
## Ticket Number
<!-- Add the number from the Jira board -->
https://pins-ds.atlassian.net/browse/AS-2464

## Description of change
Adds feature file and tests for making questionnaire persistent to a single appeal

## Checklist
<!-- Put an `x` in all the boxes that apply: -->
- [ ] Requires infrastructure changes
- [ ] If adding or remove environment variables (e.g. in `docker-compose.yaml`) then I have updated the appropriate Helm chart
- [ ] I have updated the documentation accordingly
- [X] My commit history in this PR is linear
- [X] New features have tests
- [ ] Breaking change (team conversation required)

## Important

Please do not merge from `master` (please only [rebase](https://github.com/foundry4/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
