### PR TITLE
Feature/as 1903 questionnaire appeal relationship

### DIFF
--- a/charts/app/templates/lpaQuestionnaireWebApp.yaml
+++ b/charts/app/templates/lpaQuestionnaireWebApp.yaml
@@ -49,6 +49,8 @@ spec:
               path: /health
               port: {{.Values.lpaQuestionnaireWebApp.service.name }}
           env:
+            - name: ALLOW_APPEAL_REPLY_CREATE
+              value: {{ .Values.lpaQuestionnaireWebApp.config.allowCreate }}
             - name: APPEAL_REPLY_SERVICE_API_URL
               value: "http://{{ include "app.fullname" . }}:{{ .Values.appealReplyServiceApi.service.port }}"
             - name: APPEALS_SERVICE_API_URL

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -129,7 +129,7 @@ services:
       FILE_UPLOAD_USE_TEMP_FILES: 'true'
       FILE_UPLOAD_TMP_PATH: '/tmp'
       GOOGLE_ANALYTICS_ID: G-TZBWMVPTHV
-      SESSION_MONGODB_URL: mongodb://mongodb:27017/fwa-sessions
+      SESSION_MONGODB_URL: mongodb://mongodb:27017/lpa-sessions
       SESSION_KEY: some_secure_key_goes_here
       # please override this locally if using not using localhost or ip address to browse the site in dev.
       SUBDOMAIN_OFFSET: 0

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -157,15 +157,16 @@ services:
   lpa-questionnaire-web-app:
     image: node:14-alpine
     environment:
+      ALLOW_APPEAL_REPLY_CREATE: "true"
       APPEALS_SERVICE_API_URL: http://appeals-service-api:3000
       PDF_SERVICE_API_URL: http://pdf-service-api:3000
       APPEAL_REPLY_SERVICE_API_URL: http://appeal-reply-service-api:3000
       DOCUMENTS_SERVICE_API_URL: http://document-service-api:3000
       FILE_UPLOAD_DEBUG: 'false'
       FILE_UPLOAD_MAX_FILE_SIZE_BYTES: 15000000
-      FILE_UPLOAD_USE_TEMP_FILES: 'true'
-      FILE_UPLOAD_TMP_PATH: '/tmp'
-      SESSION_MONGODB_URL: mongodb://mongodb:27017/fwa-sessions
+      FILE_UPLOAD_USE_TEMP_FILES: "true"
+      FILE_UPLOAD_TMP_PATH: "/tmp"
+      SESSION_MONGODB_URL: mongodb://mongodb:27017/lpa-sessions
       SESSION_KEY: some_secure_key_goes_here
       USE_SECURE_SESSION_COOKIES: 'false'
     ports:

--- a/lpa-submissions-e2e-tests/cypress.json
+++ b/lpa-submissions-e2e-tests/cypress.json
@@ -7,8 +7,8 @@
   "video": false,
   "env": {
     "demoDelay": 0,
-    "ASSUME_LIMITED_ACCESS": false,
     "APPEAL_REPLY_SERVICE_BASE_URL": "http://localhost:3002/api/v1",
+    "APPEAL_SERVICE_BASE_URL": "http://localhost:3000/api/v1",
     "DOCUMENT_SERVICE_BASE_URL": "http://localhost:3001/api/v1",
     "EMAIL_NOTIFICATION_URL": "http://localhost:5001/notifications",
     "TAGS": "not @wip"

--- a/lpa-submissions-e2e-tests/cypress/fixtures/completedAppeal.json
+++ b/lpa-submissions-e2e-tests/cypress/fixtures/completedAppeal.json
@@ -1,0 +1,91 @@
+{
+  "horizonId": 3218951,
+  "lpaCode": "E69999999",
+  "decisionDate": "2021-01-20T12:00:00.000Z",
+  "state": "SUBMITTED",
+  "eligibility": {
+    "enforcementNotice": false,
+    "householderPlanningPermission": true,
+    "isClaimingCosts": false,
+    "isListedBuilding": false
+  },
+  "aboutYouSection": {
+    "yourDetails": {
+      "appealingOnBehalfOf": "",
+      "email": "bob@smith.com",
+      "name": "Bob Smith",
+      "isOriginalApplicant": true
+    }
+  },
+  "requiredDocumentsSection": {
+    "applicationNumber": "ValidNumber/12345",
+    "originalApplication": {
+      "uploadedFile": {
+        "name": "appeal-statement-valid.doc",
+        "id": "7e9cf5db-8ec6-4e4d-a10d-cafec3030ec2",
+        "size": 22528
+      }
+    },
+    "decisionLetter": {
+      "uploadedFile": {
+        "name": "appeal-statement-valid.doc",
+        "id": "7e9cf5db-8ec6-4e4d-a10d-cafec3030ec2",
+        "size": 22528
+      }
+    }
+  },
+  "yourAppealSection": {
+    "appealStatement": {
+      "uploadedFile": {
+        "name": "appeal-statement-valid.doc",
+        "id": "7e9cf5db-8ec6-4e4d-a10d-cafec3030ec2",
+        "size": 22528
+      },
+      "hasSensitiveInformation": false
+    },
+    "otherDocuments": {
+      "uploadedFiles": []
+    }
+  },
+  "appealSiteSection": {
+    "siteAddress": {
+      "addressLine1": "1 Taylor Road",
+      "addressLine2": "Clifton",
+      "town": "Bristol",
+      "county": "South Glos",
+      "postcode": "BS8 1TG"
+    },
+    "siteOwnership": {
+      "ownsWholeSite": false,
+      "haveOtherOwnersBeenTold": false
+    },
+    "siteAccess": {
+      "canInspectorSeeWholeSiteFromPublicRoad": true,
+      "howIsSiteAccessRestricted": ""
+    },
+    "healthAndSafety": {
+      "hasIssues": false,
+      "healthAndSafetyIssues": ""
+    }
+  },
+  "sectionStates": {
+    "aboutYouSection": {
+      "yourDetails": "COMPLETED"
+    },
+    "requiredDocumentsSection": {
+      "applicationNumber": "COMPLETED",
+      "originalApplication": "COMPLETED",
+      "decisionLetter": "COMPLETED"
+    },
+    "yourAppealSection": {
+      "appealStatement": "COMPLETED",
+      "otherDocuments": "NOT STARTED"
+    },
+    "appealSiteSection": {
+      "siteAddress": "COMPLETED",
+      "siteAccess": "COMPLETED",
+      "siteOwnership": "COMPLETED",
+      "healthAndSafety": "COMPLETED"
+    }
+  }
+}

--- a/lpa-submissions-e2e-tests/cypress/integration/accessNeighboursLand.feature
+++ b/lpa-submissions-e2e-tests/cypress/integration/accessNeighboursLand.feature
@@ -3,6 +3,10 @@ Feature: Access neighbours land
   I want to provide details about the appeal site
   So that the Planning Inspectorate has the information it needs to decide the appeal.
 
+  Background:
+    Given an appeal has been created
+    And a questionnaire has been created
+
   Scenario: AC01 LPA Officer navigates to Access neighbours land
     Given a LPA Planning Officer is reviewing their LPA Questionnaire task list
     When LPA Planning Officer chooses to provide information about 'Access neighbours land'

--- a/lpa-submissions-e2e-tests/cypress/integration/accuracyAppellantsSubmission.feature
+++ b/lpa-submissions-e2e-tests/cypress/integration/accuracyAppellantsSubmission.feature
@@ -3,6 +3,10 @@ Feature: Accuracy of the Apellants Submission
   As a beta LPA I want to respond whether the information from the appellant accurately reflects the original planning application
   so that the Planning Inspectorate can make a decision.
 
+  Background:
+    Given an appeal has been created
+    And a questionnaire has been created
+
   Scenario: AC01 Access Review accuracy of the appellant's submission page
     Given a LPA Planning Officer is reviewing their LPA Questionnaire task list
     When the user selects the link "Review accuracy of the appellant's submission"

--- a/lpa-submissions-e2e-tests/cypress/integration/appealDetailsSidebar.feature
+++ b/lpa-submissions-e2e-tests/cypress/integration/appealDetailsSidebar.feature
@@ -8,20 +8,10 @@ Feature: appealDetailsSidebar:
   Site address
   Apellant Name
 
-  Scenario Outline: AC1-Appeal details sidebar is displayed with the correct information
-    Given A subsection page is presented with id of <id>
-    Then The appeal details sidebar is displayed with the heading "Planning application number", "Site address", and "Appellant Name"
-    And The <application-number>, <address>, and <apellant-name> is displayed
-    Examples:
-      | id                                     | application-number   | address                                                 | apellant-name   |
-      | "89aa8504-773c-42be-bb68-029716ad9756" | "ABC/123"            | "999 Letsby Avenue, Sheffield, South Yorkshire, S9 1XY" | "Bob Smith"     |
+  Background:
+    Given an appeal has been created
+    And a questionnaire has been created
 
-  Scenario Outline: Appeal details sidebar not shown if invalid ID is provided
-    Given A subsection page is presented with id of <id>
-    Then The appeal sidebar is not displayed
-    Examples:
-      | id                                     |
-      | " "                                    |
-      | "invalidId"                            |
-      | "89aa8504 773c 42be bb68 029716ad9756" |
-      | "89aa8504/773c/42be/bb68/029716ad9756" |
+  Scenario: AC1-Appeal details sidebar is displayed with the correct information
+    Given A subsection page is presented
+    Then The appeal details sidebar is displayed with the correct information

--- a/lpa-submissions-e2e-tests/cypress/integration/appealDetailsSidebar/appealDetailsSidebarSteps.js
+++ b/lpa-submissions-e2e-tests/cypress/integration/appealDetailsSidebar/appealDetailsSidebarSteps.js
@@ -1,31 +1,26 @@
 import { Given, Then } from 'cypress-cucumber-preprocessor/steps';
 
-Given('A subsection page is presented with id of {string}', (id) => {
-  cy.goToPage('other-appeals', id);
+Given('A subsection page is presented', () => {
+  cy.goToPage('other-appeals');
 });
 
 Then(
-  'The appeal details sidebar is displayed with the heading "Planning application number", "Site address", and "Appellant Name"',
+  'The appeal details sidebar is displayed with the correct information',
   () => {
     cy.getAppealDetailsSidebar().then((text) => {
       expect(text).to.contain('Planning application number');
       expect(text).to.contain('Site address');
       expect(text).to.contain('Appellant Name');
     });
-  },
-);
 
-Then(
-  'The {string}, {string}, and {string} is displayed',
-  (applicationNumber, applicationAddress, apellantName) => {
-    cy.verifyAppealDetailsSidebar({
-      applicationNumber,
-      applicationAddress,
-      apellantName,
+    cy.get('@appeal').then((appeal) => {
+      const address = Object.values(appeal.appealSiteSection.siteAddress).filter((value) => !!value);
+
+      cy.verifyAppealDetailsSidebar({
+        applicationNumber: appeal.requiredDocumentsSection.applicationNumber,
+        applicationAddress: address.join(', '),
+        apellantName: appeal.aboutYouSection.yourDetails.name,
+      });
     });
   },
 );
-
-Then('The appeal sidebar is not displayed', () => {
-  cy.getAppealDetailsSidebar().should('not.exist');
-});

--- a/lpa-submissions-e2e-tests/cypress/integration/appealsDevelopmentPlan.feature
+++ b/lpa-submissions-e2e-tests/cypress/integration/appealsDevelopmentPlan.feature
@@ -2,6 +2,10 @@ Feature: Appeals Development Plan
   As a beta LPA I want to inform the Planning Inspector of whether any Development Plan Document or Neighbourhood Plan relevant to the appeal has been submitted for examination,
   so that this can form part of the evidence on which the Inspector makes a decision
 
+  Background:
+    Given an appeal has been created
+    And a questionnaire has been created
+
   Scenario: AC01 - The LPA Planning Officer navigates to the Development Plan Document and Neighbourhood Plan question
     Given a LPA Planning Officer is reviewing their LPA Questionnaire task list
     When the LPA Planning Officer chooses to provide information regarding the Development Plan and Neighbourhood Plan
@@ -43,7 +47,7 @@ Feature: Appeals Development Plan
 
   Scenario: AC07 - Appeal details side panel
     Given the Development Plan Document and Neighbourhood Plan question is requested
-    Then the appeal details panel on the right hand side of the page can be viewed
+    Then the appeal details panel is displayed on the right hand side of the page
 
   Scenario: AC08 - The LPA Planning Officer has selected no and completed the Development Plan Document and Neighbourhood Plan question and returns to that page from the Task List
     Given the LPA Planning Officer has selected no and completed the Development Plan Document and Neighbourhood Plan question

--- a/lpa-submissions-e2e-tests/cypress/integration/appealsDevelopmentPlan/appealsDevelopmentPlanSteps.js
+++ b/lpa-submissions-e2e-tests/cypress/integration/appealsDevelopmentPlan/appealsDevelopmentPlanSteps.js
@@ -77,7 +77,6 @@ When('the LPA Planning Officer chooses to go to the previous page', () => {
 When(
   `the LPA Planning Officer returns to the Development Plan Document and Neighbourhood Plan question from the Task List`,
   () => {
-    cy.goToTaskListPage();
     cy.clickOnSubTaskLink(taskListId);
     cy.verifyPageTitle(pageTitle);
   },
@@ -117,14 +116,6 @@ Then('any information they have entered will not be saved', () => {
   input(yesButtonId).should('not.be.checked');
   input(noButtonId).should('not.be.checked');
   textArea(textAreaId).should('have.value', '');
-});
-
-Then('the appeal details panel on the right hand side of the page can be viewed', () => {
-  cy.verifyAppealDetailsSidebar({
-    applicationNumber: 'ABC/123',
-    applicationAddress: '999 Letsby Avenue, Sheffield, South Yorkshire, S9 1XY',
-    apellantName: 'Bob Smith',
-  });
 });
 
 Then('no is still selected', () => {

--- a/lpa-submissions-e2e-tests/cypress/integration/appealsExtraConditions.feature
+++ b/lpa-submissions-e2e-tests/cypress/integration/appealsExtraConditions.feature
@@ -1,64 +1,68 @@
 Feature: Appeals Extra Conditions
   As a beta LPA I want to inform the Planning Inspectorate of any extra conditions I wish to be attached to the appeal decision (over and above the standard ones)
-So that the Inspector can decide whether or not to attach them to their decision.
+  So that the Inspector can decide whether or not to attach them to their decision.
 
-Scenario: AC01 - User navigates to 'Do you have extra conditions' page
-  Given a LPA Planning Officer is reviewing their LPA Questionnaire task list
-  When the user selects the link 'Do you have any extra conditions?'
-  Then the user is presented with the 'Do you have any extra conditions?' page
-  And the Page title is 'Do you have any extra conditions? - Appeal Questionnaire - Appeal a householder planning decision - GOV.UK'
+  Background:
+    Given an appeal has been created
+    And a questionnaire has been created
 
-Scenario: AC02 - User makes no selection and is provided an error
-  Given user is in the extra conditions page
-  When user does not select an option
-  And user selects Save and Continue
-  Then user is shown an error message "Select yes if you have extra conditions"
+  Scenario: AC01 - User navigates to 'Do you have extra conditions' page
+    Given a LPA Planning Officer is reviewing their LPA Questionnaire task list
+    When the user selects the link 'Do you have any extra conditions?'
+    Then the user is presented with the 'Do you have any extra conditions?' page
+    And the Page title is 'Do you have any extra conditions? - Appeal Questionnaire - Appeal a householder planning decision - GOV.UK'
 
-Scenario: AC03 - User selects no and proceeds to task list
-  Given user is in the extra conditions page
-  When user selects the option 'No'
-  And user selects Save and Continue
-  Then progress is made to the task list
-  And a Completed status is populated for the task
+  Scenario: AC02 - User makes no selection and is provided an error
+    Given user is in the extra conditions page
+    When user does not select an option
+    And user selects Save and Continue
+    Then user is shown an error message "Select yes if you have extra conditions"
 
-Scenario Outline: AC04 - user selects yes and provides further information in text field and proceeds to task list
-  Given user is in the extra conditions page
-  And user selects the option 'Yes'
-  And user enters '<extra_information>'
-  When user selects Save and Continue
-  Then progress is made to the task list
-  And a Completed status is populated for the task
-  Examples:
-    | extra_information           |
-    | some extra information      |
-    | some more extra information |
-    |  some extra information with a space at the beginning |
-    | extra information with special characters ,. !" }]* & -+%$£@! |
-    | a very long piece of extra information a very long piece of extra information\na very long piece of extra information a very long piece of extra information\na very long piece of extra information a very long piece of extra information\na very long piece of extra information |
+  Scenario: AC03 - User selects no and proceeds to task list
+    Given user is in the extra conditions page
+    When user selects the option 'No'
+    And user selects Save and Continue
+    Then progress is made to the task list
+    And a Completed status is populated for the task
 
-Scenario: AC05 - user does not provides further information in text field and is provided an error
-  Given user is in the extra conditions page
-  And user selects the option 'Yes'
-  And user does not provide extra information
-  When user selects Save and Continue
-  Then user is shown an error message "What are the extra conditions?"
+  Scenario Outline: AC04 - user selects yes and provides further information in text field and proceeds to task list
+    Given user is in the extra conditions page
+    And user selects the option 'Yes'
+    And user enters '<extra_information>'
+    When user selects Save and Continue
+    Then progress is made to the task list
+    And a Completed status is populated for the task
+    Examples:
+      | extra_information                                                                                                                                                                                                                                                                   |
+      | some extra information                                                                                                                                                                                                                                                              |
+      | some more extra information                                                                                                                                                                                                                                                         |
+      | some extra information with a space at the beginning                                                                                                                                                                                                                                |
+      | extra information with special characters ,. !" }]* & -+%$£@!                                                                                                                                                                                                                       |
+      | a very long piece of extra information a very long piece of extra information\na very long piece of extra information a very long piece of extra information\na very long piece of extra information a very long piece of extra information\na very long piece of extra information |
 
-Scenario: AC06 - user can see the Appeal details side panel
-  Given user is in the extra conditions page
-  Then the appeal details panel is displayed on the right hand side of the page
+  Scenario: AC05 - user does not provides further information in text field and is provided an error
+    Given user is in the extra conditions page
+    And user selects the option 'Yes'
+    And user does not provide extra information
+    When user selects Save and Continue
+    Then user is shown an error message "What are the extra conditions?"
 
-Scenario: AC07 - Back link
-  Given user is in the extra conditions page
-  When user selects the back link
-  Then progress is made to the task list
-  And any information they have entered will not be saved
+  Scenario: AC06 - user can see the Appeal details side panel
+    Given user is in the extra conditions page
+    Then the appeal details panel is displayed on the right hand side of the page
 
-Scenario: AC08 - User has completed the extra conditions page and returns to that page from the Task List
-  Given a user has completed the information needed on the extra conditions page
-  When the user returns to the extra conditions page from the Task List
-  Then the information they previously entered is still populated
+  Scenario: AC07 - Back link
+    Given user is in the extra conditions page
+    When user selects the back link
+    Then progress is made to the task list
+    And any information they have entered will not be saved
 
-Scenario: AC09 - Change answers
+  Scenario: AC08 - User has completed the extra conditions page and returns to that page from the Task List
+    Given a user has completed the information needed on the extra conditions page
+    When the user returns to the extra conditions page from the Task List
+    Then the information they previously entered is still populated
+
+  Scenario: AC09 - Change answers
     Given a change to answer 'Extra Conditions' is requested from Change your answers page
     When an answer is saved
     Then progress is made to the Check Your Answers page

--- a/lpa-submissions-e2e-tests/cypress/integration/appealsInImmediateArea.feature
+++ b/lpa-submissions-e2e-tests/cypress/integration/appealsInImmediateArea.feature
@@ -2,6 +2,10 @@ Feature: Appeals in immediate area
   As a beta LPA I want to inform the Planning Inspectorate of any appeals in the immediate area
   So that the Planning Inspectorate can consider the appeal in light of others nearby.
 
+  Background:
+    Given an appeal has been created
+    And a questionnaire has been created
+
   Scenario: Verify The Tell us about any appeals in the immediate area page
     Given a LPA Planning Officer is reviewing their LPA Questionnaire task list
     When the user selects the link Tell us about any appeals in the immediate area

--- a/lpa-submissions-e2e-tests/cypress/integration/appealsInformationSubmitted.feature
+++ b/lpa-submissions-e2e-tests/cypress/integration/appealsInformationSubmitted.feature
@@ -1,8 +1,12 @@
 Feature: Appeals Questionnaire Submitted Confirmation
-As a beta LPA, I want confirmation that the LPA Questionnaire has been submitted
-so that I know that the Planning Inspectors have received it
+  As a beta LPA, I want confirmation that the LPA Questionnaire has been submitted
+  so that I know that the Planning Inspectors have received it
 
-Scenario: AC01 - LPA Planning Officer submits finished LPA Questionnaire
-Given the Information Submitted page is requested
-Then the Information Submitted page will be shown
-And the LPA email address is displayed on the Information Submitted page
+  Background:
+    Given an appeal has been created
+    And a questionnaire has been created
+
+  Scenario: AC01 - LPA Planning Officer submits finished LPA Questionnaire
+    Given the Information Submitted page is requested
+    Then the Information Submitted page will be shown
+    And the LPA email address is displayed on the Information Submitted page

--- a/lpa-submissions-e2e-tests/cypress/integration/appealsQuestionnaireTaskList.feature
+++ b/lpa-submissions-e2e-tests/cypress/integration/appealsQuestionnaireTaskList.feature
@@ -6,6 +6,10 @@ Feature: Task lists
 
   The "Check your answer" task state should be "CANNOT START YET"
 
+  Background:
+    Given an appeal has been created
+    And a questionnaire has been created
+
   Scenario: LPA Questionnaire task list page is displayed with static text
     Given a LPA Planning Officer is reviewing their LPA Questionnaire task list
     Then the LPA Planning Officer is taken to the Task List

--- a/lpa-submissions-e2e-tests/cypress/integration/betaServiceFeedbackLink.feature
+++ b/lpa-submissions-e2e-tests/cypress/integration/betaServiceFeedbackLink.feature
@@ -1,9 +1,13 @@
 Feature: Beta Service feedback Link
-As a LPA Planning Officer
-I want to provide feedback about the service to the Planning Inspectorate
-So that improvements can be made
+  As a LPA Planning Officer
+  I want to provide feedback about the service to the Planning Inspectorate
+  So that improvements can be made
 
-Scenario: AC01 - Access to the feedback survey from the Beta banner
-Given the LPA Questionnaire is accessed
-When the feedback link is selected
-Then the feedback survey is presented
+  Background:
+    Given an appeal has been created
+    And a questionnaire has been created
+
+  Scenario: AC01 - Access to the feedback survey from the Beta banner
+    Given the LPA Questionnaire is accessed
+    When the feedback link is selected
+    Then the feedback survey is presented

--- a/lpa-submissions-e2e-tests/cypress/integration/checkYourAnswers.feature
+++ b/lpa-submissions-e2e-tests/cypress/integration/checkYourAnswers.feature
@@ -8,6 +8,10 @@ Feature: Check Your Answers
 
   The user will only be able to access the Check Your Answers page when all mandatory sections are completed.
 
+  Background:
+    Given an appeal has been created
+    And a questionnaire has been created
+
   Scenario: AC01 - Accessing 'Check Your Answers' from the task list
     Given all the mandatory questions for the questionnaire have been completed
     And a LPA Planning Officer is reviewing their LPA Questionnaire task list
@@ -19,12 +23,12 @@ Feature: Check Your Answers
     Then a summary of questions and answers is provided
 
   Scenario: AC03 - Submit answers
-    Given Check Your Answers in presented
+    Given Check Your Answers is presented
     When the answers are completed
     Then progress is made to the submission confirmation page
 
   Scenario: AC04 - Back Link
-    Given Check Your Answers in presented
+    Given Check Your Answers is presented
     When the LPA Planning Officer selects a question
     And the LPA Planning Officer chooses to go to the previous page
     Then user is returned to the Check your answers page

--- a/lpa-submissions-e2e-tests/cypress/integration/checkYourAnswers/checkYourAnswers.step.js
+++ b/lpa-submissions-e2e-tests/cypress/integration/checkYourAnswers/checkYourAnswers.step.js
@@ -6,7 +6,7 @@ const title =
   'Check your answers - Appeal questionnaire - Appeal a householder planning decision - GOV.UK';
 const heading = 'Check your answers';
 
-Given('Check Your Answers in presented', () => {
+Given('Check Your Answers is presented', () => {
   cy.completeQuestionnaire();
   cy.goToCheckYourAnswersPage();
 });

--- a/lpa-submissions-e2e-tests/cypress/integration/common/appealsDetailsPanel.js
+++ b/lpa-submissions-e2e-tests/cypress/integration/common/appealsDetailsPanel.js
@@ -1,7 +1,11 @@
 Then('the appeal details panel is displayed on the right hand side of the page', () => {
-  cy.verifyAppealDetailsSidebar({
-    applicationNumber: 'ABC/123',
-    applicationAddress: '999 Letsby Avenue, Sheffield, South Yorkshire, S9 1XY',
-    apellantName: 'Bob Smith',
+  cy.get('@appeal').then((appeal) => {
+    const address = Object.values(appeal.appealSiteSection.siteAddress).filter((value) => !!value);
+
+    cy.verifyAppealDetailsSidebar({
+      applicationNumber: appeal.requiredDocumentsSection.applicationNumber,
+      applicationAddress: address.join(', '),
+      apellantName: appeal.aboutYouSection.yourDetails.name,
+    });
   });
 });

--- a/lpa-submissions-e2e-tests/cypress/integration/common/common.js
+++ b/lpa-submissions-e2e-tests/cypress/integration/common/common.js
@@ -1,5 +1,13 @@
 import { Given, When } from 'cypress-cucumber-preprocessor/steps';
 
+Given('an appeal has been created', () => {
+  cy.completeAppeal();
+})
+
+Given('a questionnaire has been created', () => {
+  cy.generateQuestionnaire();
+})
+
 Given('all the mandatory questions for the questionnaire have been completed', () => {
   cy.completeQuestionnaire();
 });
@@ -14,17 +22,8 @@ Given('{string} question has been requested', () => {
   });
 });
 
-Given('the questionnaire for appeal {string} has been completed', (appealId) => {
-  cy.completeQuestionnaire(appealId);
-});
-
 When('the LPA Questionnaire is submitted', () => {
   cy.goToCheckYourAnswersPage();
-  cy.clickSubmitButton();
-});
-
-When('the LPA Questionnaire for appeal {string} is submitted', (appealId) => {
-  cy.goToCheckYourAnswersPage(appealId);
   cy.clickSubmitButton();
 });
 

--- a/lpa-submissions-e2e-tests/cypress/integration/conservationAreaMap.feature
+++ b/lpa-submissions-e2e-tests/cypress/integration/conservationAreaMap.feature
@@ -3,6 +3,10 @@ Feature: Conservation Area Map
   I want to upload the property conservation area map considered in the application,
   So that it can form part of the evidence on which the Inspector makes a decision.
 
+  Background:
+    Given an appeal has been created
+    And a questionnaire has been created
+
   Scenario: AC1 LPA Planning Officer navigates to conservation area map question
     Given a LPA Planning Officer is reviewing their LPA Questionnaire task list
     When LPA Planning Officer chooses to upload the conservation area map

--- a/lpa-submissions-e2e-tests/cypress/integration/enterAppealSite.feature
+++ b/lpa-submissions-e2e-tests/cypress/integration/enterAppealSite.feature
@@ -3,6 +3,10 @@ Feature: Enter Appeal Site
   I want to provide details about the appeal site
   So that the Planning Inspectorate has the information it needs to decide the appeal.
 
+  Background:
+    Given an appeal has been created
+    And a questionnaire has been created
+
   Scenario: AC01 LPA Officer navigates to Enter the appeal site
     Given a LPA Planning Officer is reviewing their LPA Questionnaire task list
     When LPA Planning Officer chooses to provide information about 'Enter the appeal site'

--- a/lpa-submissions-e2e-tests/cypress/integration/generateSubmissionPdf.feature
+++ b/lpa-submissions-e2e-tests/cypress/integration/generateSubmissionPdf.feature
@@ -1,6 +1,10 @@
 Feature: Creation of a PDF file containing the LPA Questionnaires submission information
   Once a questionnaire has been submitted a PDF version of the check your answers screen is generated.
 
+  Background:
+    Given an appeal has been created
+    And a questionnaire has been created
+
   Scenario: AC01 - PLA Planing officer submits their answers and pdf should generate
     Given the questionnaire has been completed
     When the LPA Questionnaire is submitted

--- a/lpa-submissions-e2e-tests/cypress/integration/generateSubmissionPdf/generateSubmissionPdf.step.js
+++ b/lpa-submissions-e2e-tests/cypress/integration/generateSubmissionPdf/generateSubmissionPdf.step.js
@@ -1,22 +1,16 @@
 import { Then } from 'cypress-cucumber-preprocessor/steps';
-import ignoreAddedFormatting from '../../support/common/ignoreAddedFormatting';
 
 Then('a PDF of the Check Your Answers page is created', () => {
   cy.verifyPage('information-submitted');
 
-  let pdfFile;
-
-  // only run when in an environment with full access to APIs
-  if (!Cypress.env('ASSUME_LIMITED_ACCESS')) {
-    cy.downloadSubmissionPdf().then(() => {
-      cy.checkSubmissionPdfContent('Bob Smith');
-      cy.checkSubmissionPdfContent('999 Letsby Avenue');
-      cy.checkSubmissionPdfContent(
-        'Does the information from the appellant accurately reflect the original planning application?',
-      );
-      cy.checkSubmissionPdfContent(
-        'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer nec odio. Praesent libero. Sed cursus ante dapibus diam. Sed nisi. Nulla quis sem at nibh elementum imperdiet. Duis sagittis ipsum. Praesent mauris. Fusce nec tellus sed augue semper porta. Mauris massa. Vestibulum lacinia arcu eget nulla. Class aptent taciti sociosqu ad litora torquent per conubia nostra, per inceptos himenaeos. Curabitur sodales ligula in libero.',
-      );
-    });
-  }
+  cy.downloadSubmissionPdf().then(() => {
+    cy.checkSubmissionPdfContent('Bob Smith');
+    cy.checkSubmissionPdfContent('1 Taylor Road');
+    cy.checkSubmissionPdfContent(
+      'Does the information from the appellant accurately reflect the original planning application?',
+    );
+    cy.checkSubmissionPdfContent(
+      'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer nec odio. Praesent libero. Sed cursus ante dapibus diam. Sed nisi. Nulla quis sem at nibh elementum imperdiet. Duis sagittis ipsum. Praesent mauris. Fusce nec tellus sed augue semper porta. Mauris massa. Vestibulum lacinia arcu eget nulla. Class aptent taciti sociosqu ad litora torquent per conubia nostra, per inceptos himenaeos. Curabitur sodales ligula in libero.',
+    );
+  });
 });

--- a/lpa-submissions-e2e-tests/cypress/integration/greenBelt.feature
+++ b/lpa-submissions-e2e-tests/cypress/integration/greenBelt.feature
@@ -3,6 +3,10 @@ Feature: Green belt
   I want to provide details about the appeal site
   So that the Planning Inspectorate has the information it needs to decide the appeal.
 
+  Background:
+    Given an appeal has been created
+    And a questionnaire has been created
+
   Scenario: AC01 LPA Officer navigates to Green belt
     Given a LPA Planning Officer is reviewing their LPA Questionnaire task list
     When LPA Planning Officer chooses to provide information about 'Green belt'

--- a/lpa-submissions-e2e-tests/cypress/integration/interestedPartiesApplication.feature
+++ b/lpa-submissions-e2e-tests/cypress/integration/interestedPartiesApplication.feature
@@ -1,127 +1,131 @@
-  Feature: Interested Parties Application
-    As a LPA Planning Officer
-    I want to provide the Planning Inspectorate with documents that was used to notify interested parties on the application.
-    So that it can form part of the evidence on which the Inspector makes a decision.
+Feature: Interested Parties Application
+  As a LPA Planning Officer
+  I want to provide the Planning Inspectorate with documents that was used to notify interested parties on the application.
+  So that it can form part of the evidence on which the Inspector makes a decision.
 
-    Scenario: AC1 LPA Planning Officer navigates to interested parties application question
-      Given a LPA Planning Officer is reviewing their LPA Questionnaire task list
-      When LPA Planning Officer chooses upload the interested parties application
-      Then LPA Planning Officer is presented with the ability to upload the interested parties application
+  Background:
+    Given an appeal has been created
+    And a questionnaire has been created
 
-    Scenario: AC2 Task list shows the correct initial status
-      Given LPA Planning Officer has not added any data to the interested parties application question
-      When LPA Planning Officer is reviewing the Task List
-      Then the status is not started
+  Scenario: AC1 LPA Planning Officer navigates to interested parties application question
+    Given a LPA Planning Officer is reviewing their LPA Questionnaire task list
+    When LPA Planning Officer chooses upload the interested parties application
+    Then LPA Planning Officer is presented with the ability to upload the interested parties application
 
-    Scenario Outline: AC3 LPA Planning Officer successfully uploads file via upload button
-      Given interested parties application question is requested
-      When valid file '<valid_file>' is successfully uploaded
-      Then progress is made to the task list
-      And interested parties application subsection is shown as completed
-      Examples:
-        | valid_file             |
-        | upload-file-valid.tiff |
-        | upload-file-valid.tif  |
-        | upload-file-valid.png  |
-        | upload-file-valid.pdf  |
-        | upload-file-valid.jpg  |
-        | upload-file-valid.jpeg |
-        | upload-file-valid.doc  |
-        | upload-file-valid.docx |
+  Scenario: AC2 Task list shows the correct initial status
+    Given LPA Planning Officer has not added any data to the interested parties application question
+    When LPA Planning Officer is reviewing the Task List
+    Then the status is not started
 
-    Scenario Outline: AC4 LPA Planning Officer successfully uploads file via Drag and Drop
-      Given interested parties application question is requested
-      When valid file '<valid_file>' is uploaded via drag and drop
-      Then progress is made to the task list
-      And interested parties application subsection is shown as completed
-      Examples:
-        | valid_file             |
-        | upload-file-valid.tiff |
-        | upload-file-valid.tif  |
-        | upload-file-valid.png  |
-        | upload-file-valid.pdf  |
-        | upload-file-valid.jpg  |
-        | upload-file-valid.jpeg |
-        | upload-file-valid.doc  |
-        | upload-file-valid.docx |
+  Scenario Outline: AC3 LPA Planning Officer successfully uploads file via upload button
+    Given interested parties application question is requested
+    When valid file '<valid_file>' is successfully uploaded
+    Then progress is made to the task list
+    And interested parties application subsection is shown as completed
+    Examples:
+      | valid_file             |
+      | upload-file-valid.tiff |
+      | upload-file-valid.tif  |
+      | upload-file-valid.png  |
+      | upload-file-valid.pdf  |
+      | upload-file-valid.jpg  |
+      | upload-file-valid.jpeg |
+      | upload-file-valid.doc  |
+      | upload-file-valid.docx |
 
-    Scenario Outline: AC5 LPA Planning Officer successfully uploads multiple files
-      Given interested parties application question is requested
-      When valid multiple files '<multiple_files>' are uploaded
-      Then progress is made to the task list
-      And interested parties application subsection is shown as completed
-      Examples:
-        | multiple_files                                                       |
-        | upload-file-valid.tiff, upload-file-valid.tif, upload-file-valid.png |
-        | upload-file-valid.pdf, upload-file-valid.jpg, upload-file-valid.jpeg |
-        | upload-file-valid.doc, upload-file-valid.docx                        |
+  Scenario Outline: AC4 LPA Planning Officer successfully uploads file via Drag and Drop
+    Given interested parties application question is requested
+    When valid file '<valid_file>' is uploaded via drag and drop
+    Then progress is made to the task list
+    And interested parties application subsection is shown as completed
+    Examples:
+      | valid_file             |
+      | upload-file-valid.tiff |
+      | upload-file-valid.tif  |
+      | upload-file-valid.png  |
+      | upload-file-valid.pdf  |
+      | upload-file-valid.jpg  |
+      | upload-file-valid.jpeg |
+      | upload-file-valid.doc  |
+      | upload-file-valid.docx |
 
-    Scenario Outline: AC6 LPA Planning Officer selects invalid file size
-      Given interested parties application question is requested
-      When invalid files '<invalid_file_size>' have been selected
-      Then progress is halted with a message the file '<invalid_file_size>' 'is too big'
-      Examples:
-        | invalid_file_size      |
-        | upload_file_large.tiff |
+  Scenario Outline: AC5 LPA Planning Officer successfully uploads multiple files
+    Given interested parties application question is requested
+    When valid multiple files '<multiple_files>' are uploaded
+    Then progress is made to the task list
+    And interested parties application subsection is shown as completed
+    Examples:
+      | multiple_files                                                       |
+      | upload-file-valid.tiff, upload-file-valid.tif, upload-file-valid.png |
+      | upload-file-valid.pdf, upload-file-valid.jpg, upload-file-valid.jpeg |
+      | upload-file-valid.doc, upload-file-valid.docx                        |
 
-    Scenario Outline: AC7 LPA Planning Officer selects Invalid file format
-      Given interested parties application question is requested
-      When invalid files '<invalid_format>' have been selected
-      Then progress is halted with a message the file '<invalid_format>' 'format is incorrect'
-      Examples:
-        | invalid_format                     |
-        | upload-file-invalid-wrong-type.csv |
+  Scenario Outline: AC6 LPA Planning Officer selects invalid file size
+    Given interested parties application question is requested
+    When invalid files '<invalid_file_size>' have been selected
+    Then progress is halted with a message the file '<invalid_file_size>' 'is too big'
+    Examples:
+      | invalid_file_size      |
+      | upload_file_large.tiff |
 
-    Scenario: AC8 LPA Planning Officer selects to return to previous page
-      Given interested parties application question is requested
-      And a file has been uploaded
-      When Back is then requested
-      Then the LPA Planning Officer is taken to the Task List
-      And any document uploaded will not be saved
+  Scenario Outline: AC7 LPA Planning Officer selects Invalid file format
+    Given interested parties application question is requested
+    When invalid files '<invalid_format>' have been selected
+    Then progress is halted with a message the file '<invalid_format>' 'format is incorrect'
+    Examples:
+      | invalid_format                     |
+      | upload-file-invalid-wrong-type.csv |
 
-    Scenario: AC9 LPA Planning Officer deletes a file prior to save and continue
-      Given a file has been uploaded
-      When LPA Planning Officer deletes the file
-      Then the file is removed
+  Scenario: AC8 LPA Planning Officer selects to return to previous page
+    Given interested parties application question is requested
+    And a file has been uploaded
+    When Back is then requested
+    Then the LPA Planning Officer is taken to the Task List
+    And any document uploaded will not be saved
 
-    Scenario: AC10 LPA Planning Officer deletes a file after save and continue
-      Given a file has been uploaded and confirmed
-      And interested parties application question is requested
-      When LPA Planning Officer deletes the file
-      Then the file is removed
+  Scenario: AC9 LPA Planning Officer deletes a file prior to save and continue
+    Given a file has been uploaded
+    When LPA Planning Officer deletes the file
+    Then the file is removed
 
-    Scenario: AC11 LPA Planning Officer returns to the completed Interested Parties Application question
-      Given The question 'Telling interested parties about the application' has been completed
-      When interested parties application question is requested
-      Then the information they previously entered is still populated
+  Scenario: AC10 LPA Planning Officer deletes a file after save and continue
+    Given a file has been uploaded and confirmed
+    And interested parties application question is requested
+    When LPA Planning Officer deletes the file
+    Then the file is removed
 
-    Scenario: AC12 Appeal details side panel
-      Given interested parties application question is requested
-      Then the appeal details panel is displayed on the right hand side of the page
+  Scenario: AC11 LPA Planning Officer returns to the completed Interested Parties Application question
+    Given The question 'Telling interested parties about the application' has been completed
+    When interested parties application question is requested
+    Then the information they previously entered is still populated
 
-    @nojs
-    Scenario Outline: AC13 JavaScript Disabled
-      Given interested parties application question is requested
-      When valid file '<valid_file>' is successfully uploaded
-      Then progress is made to the task list
-      And interested parties application subsection is shown as completed
-      Examples:
-        | valid_file             |
-        | upload-file-valid.tiff |
+  Scenario: AC12 Appeal details side panel
+    Given interested parties application question is requested
+    Then the appeal details panel is displayed on the right hand side of the page
 
-    Scenario: AC14 Check your answers
-      Given all the mandatory questions for the questionnaire have been completed
-      When Check your Answers is displayed
-      Then interested parties application question heading is shown and the uploaded file name should be displayed
+  @nojs
+  Scenario Outline: AC13 JavaScript Disabled
+    Given interested parties application question is requested
+    When valid file '<valid_file>' is successfully uploaded
+    Then progress is made to the task list
+    And interested parties application subsection is shown as completed
+    Examples:
+      | valid_file             |
+      | upload-file-valid.tiff |
 
-    Scenario: AC15 Change answers
-      Given a change to answer 'Telling interested parties about the application' is requested from Change your answers page
-      When an answer is saved
-      Then progress is made to the Check Your Answers page
-      And the updated answer is displayed
+  Scenario: AC14 Check your answers
+    Given all the mandatory questions for the questionnaire have been completed
+    When Check your Answers is displayed
+    Then interested parties application question heading is shown and the uploaded file name should be displayed
 
-  # Scenario: AC16 PDF & Horizon
-  #   Given the questionnaire has been completed
-  #   When the LPA Planning Officer submits the questionnaire
-  #   Then interested parties application is displayed on the questionnaire PDF
-  #   And interested parties application and uploaded files are present in Horizon
+  Scenario: AC15 Change answers
+    Given a change to answer 'Telling interested parties about the application' is requested from Change your answers page
+    When an answer is saved
+    Then progress is made to the Check Your Answers page
+    And the updated answer is displayed
+
+# Scenario: AC16 PDF & Horizon
+#   Given the questionnaire has been completed
+#   When the LPA Planning Officer submits the questionnaire
+#   Then interested parties application is displayed on the questionnaire PDF
+#   And interested parties application and uploaded files are present in Horizon

--- a/lpa-submissions-e2e-tests/cypress/integration/matchAppealId.feature
+++ b/lpa-submissions-e2e-tests/cypress/integration/matchAppealId.feature
@@ -1,0 +1,19 @@
+Feature: Associate Appeal ID with a single Reply
+  As an LPA Planning Officer
+  I want the questionnaire to be linked with a submitted appeal
+  So that I can ensure I am giving the information about the correct appeal and when I return to the same questionnaire it presents the previously entered data.
+
+  Background:
+    Given an appeal has been created
+    And a questionnaire has been created
+
+  Scenario: Viewing saved information
+    Given answers have been saved to the questionnaire
+    When the questionnaire is revisited in a new session
+    Then previously entered data will be visible
+
+  Scenario: Changes made to questionnaire
+    Given answers have been saved to the questionnaire
+    When the questionnaire is revisited in a new session
+    And changes are made to the questions
+    Then the changes over write the previously saved answers

--- a/lpa-submissions-e2e-tests/cypress/integration/matchAppealId/matchAppealId.step.js
+++ b/lpa-submissions-e2e-tests/cypress/integration/matchAppealId/matchAppealId.step.js
@@ -1,0 +1,33 @@
+import { Given, When, Then } from 'cypress-cucumber-preprocessor/steps';
+import { input } from '../../support/PageObjects/common-page-objects';
+
+Given('answers have been saved to the questionnaire', () => {
+  cy.completeQuestionnaire();
+});
+
+When('the questionnaire is revisited in a new session', () => {
+  // First go to a page to create an initial session
+  cy.goToTaskListPage();
+  cy.verifyCompletedStatus('submissionAccuracy');
+
+  // Clear cookies to remove tie to session
+  cy.clearCookies();
+
+  // Reloading the page will generate a new session
+  cy.reload();
+});
+
+When('changes are made to the questions', () => {
+  cy.goToPage('accuracy-submission');
+  input('accurate-submission-yes').check();
+  cy.clickSaveAndContinue();
+});
+
+Then('previously entered data will be visible', () => {
+  cy.verifyCompletedStatus('submissionAccuracy');
+});
+
+Then('the changes over write the previously saved answers', () => {
+  cy.goToPage('accuracy-submission');
+  input('accurate-submission-yes').should('be.checked');
+});

--- a/lpa-submissions-e2e-tests/cypress/integration/nearConservationArea.feature
+++ b/lpa-submissions-e2e-tests/cypress/integration/nearConservationArea.feature
@@ -3,6 +3,10 @@ Feature: Near conservation area
   I want to provide details about the appeal site
   So that the Planning Inspectorate has the information it needs to decide the appeal.
 
+  Background:
+    Given an appeal has been created
+    And a questionnaire has been created
+
   Scenario: AC01 LPA Officer navigates to Near conservation area
     Given a LPA Planning Officer is reviewing their LPA Questionnaire task list
     When LPA Planning Officer chooses to provide information about 'Near conservation area'

--- a/lpa-submissions-e2e-tests/cypress/integration/notifyingInterestedParties.feature
+++ b/lpa-submissions-e2e-tests/cypress/integration/notifyingInterestedParties.feature
@@ -3,6 +3,10 @@ Feature: Notifying interested parties of the appeal
   I want to provide the Planning Inspectorate with documents that was used to notify interested parties on the application.
   So that this can form part of the Inspectors decision.
 
+  Background:
+    Given an appeal has been created
+    And a questionnaire has been created
+
   Scenario: AC1 Access Notifying interested parties of the appeal about the application question
     Given a LPA Planning Officer is reviewing their LPA Questionnaire task list
     When LPA Planning Officer chooses to upload the document Notifying interested parties of the appeal

--- a/lpa-submissions-e2e-tests/cypress/integration/originalPlanningApplicationPublicised.feature
+++ b/lpa-submissions-e2e-tests/cypress/integration/originalPlanningApplicationPublicised.feature
@@ -3,6 +3,10 @@ Feature: Original planning application publicised
   I want to provide details about the appeal site
   So that the Planning Inspectorate has the information it needs to decide the appeal.
 
+  Background:
+    Given an appeal has been created
+    And a questionnaire has been created
+
   Scenario: AC01 LPA Officer navigates to Original planning application publicised
     Given a LPA Planning Officer is reviewing their LPA Questionnaire task list
     When LPA Planning Officer chooses to provide information about 'Original planning application publicised'

--- a/lpa-submissions-e2e-tests/cypress/integration/otherRelevantPolicies.feature
+++ b/lpa-submissions-e2e-tests/cypress/integration/otherRelevantPolicies.feature
@@ -1,127 +1,131 @@
-  Feature: Other Relevant Policies
-    As a LPA Planning Officer
-    I want to upload any other relevant policies,
-    So that it can form part of the evidence on which the Inspector makes a decision.
+Feature: Other Relevant Policies
+  As a LPA Planning Officer
+  I want to upload any other relevant policies,
+  So that it can form part of the evidence on which the Inspector makes a decision.
 
-    Scenario: AC1 LPA Planning Officer navigations to other relevant policies question
-      Given a LPA Planning Officer is reviewing their LPA Questionnaire task list
-      When LPA Planning Officer chooses upload the other relevant policies
-      Then LPA Planning Officer is presented with the ability to upload the policies
+  Background:
+    Given an appeal has been created
+    And a questionnaire has been created
 
-    Scenario: AC2 Task list shows the correct initial status
-      Given LPA Planning Officer has not added any data to the other relevant policies question
-      When LPA Planning Officer is reviewing the Task List
-      Then the status is not started
+  Scenario: AC1 LPA Planning Officer navigations to other relevant policies question
+    Given a LPA Planning Officer is reviewing their LPA Questionnaire task list
+    When LPA Planning Officer chooses upload the other relevant policies
+    Then LPA Planning Officer is presented with the ability to upload the policies
 
-    Scenario Outline: AC3 LPA Planning Officer successfully uploads file via upload button
-      Given other relevant policies question is requested
-      When valid file '<valid_file>' is successfully uploaded
-      Then progress is made to the task list
-      And other relevant policies subsection is shown as completed
-      Examples:
-        | valid_file             |
-        | upload-file-valid.tiff |
-        | upload-file-valid.tif  |
-        | upload-file-valid.png  |
-        | upload-file-valid.pdf  |
-        | upload-file-valid.jpg  |
-        | upload-file-valid.jpeg |
-        | upload-file-valid.doc  |
-        | upload-file-valid.docx |
+  Scenario: AC2 Task list shows the correct initial status
+    Given LPA Planning Officer has not added any data to the other relevant policies question
+    When LPA Planning Officer is reviewing the Task List
+    Then the status is not started
 
-    Scenario Outline: AC4 LPA Planning Officer successfully uploads file via Drag and Drop
-      Given other relevant policies question is requested
-      When valid file '<valid_file>' is uploaded via drag and drop
-      Then progress is made to the task list
-      And other relevant policies subsection is shown as completed
-      Examples:
-        | valid_file             |
-        | upload-file-valid.tiff |
-        | upload-file-valid.tif  |
-        | upload-file-valid.png  |
-        | upload-file-valid.pdf  |
-        | upload-file-valid.jpg  |
-        | upload-file-valid.jpeg |
-        | upload-file-valid.doc  |
-        | upload-file-valid.docx |
+  Scenario Outline: AC3 LPA Planning Officer successfully uploads file via upload button
+    Given other relevant policies question is requested
+    When valid file '<valid_file>' is successfully uploaded
+    Then progress is made to the task list
+    And other relevant policies subsection is shown as completed
+    Examples:
+      | valid_file             |
+      | upload-file-valid.tiff |
+      | upload-file-valid.tif  |
+      | upload-file-valid.png  |
+      | upload-file-valid.pdf  |
+      | upload-file-valid.jpg  |
+      | upload-file-valid.jpeg |
+      | upload-file-valid.doc  |
+      | upload-file-valid.docx |
 
-    Scenario Outline: AC5 LPA Planning Officer successfully uploads multiple files
-      Given other relevant policies question is requested
-      When valid multiple files '<multiple_files>' are uploaded
-      Then progress is made to the task list
-      And other relevant policies subsection is shown as completed
-      Examples:
-        | multiple_files                                                       |
-        | upload-file-valid.tiff, upload-file-valid.tif, upload-file-valid.png |
-        | upload-file-valid.pdf, upload-file-valid.jpg, upload-file-valid.jpeg |
-        | upload-file-valid.doc, upload-file-valid.docx                        |
+  Scenario Outline: AC4 LPA Planning Officer successfully uploads file via Drag and Drop
+    Given other relevant policies question is requested
+    When valid file '<valid_file>' is uploaded via drag and drop
+    Then progress is made to the task list
+    And other relevant policies subsection is shown as completed
+    Examples:
+      | valid_file             |
+      | upload-file-valid.tiff |
+      | upload-file-valid.tif  |
+      | upload-file-valid.png  |
+      | upload-file-valid.pdf  |
+      | upload-file-valid.jpg  |
+      | upload-file-valid.jpeg |
+      | upload-file-valid.doc  |
+      | upload-file-valid.docx |
 
-    Scenario Outline: AC6 LPA Planning Officer selects invalid file size
-      Given other relevant policies question is requested
-      When invalid files '<invalid_file_size>' have been selected
-      Then progress is halted with a message the file '<invalid_file_size>' 'is too big'
-      Examples:
-        | invalid_file_size      |
-        | upload_file_large.tiff |
+  Scenario Outline: AC5 LPA Planning Officer successfully uploads multiple files
+    Given other relevant policies question is requested
+    When valid multiple files '<multiple_files>' are uploaded
+    Then progress is made to the task list
+    And other relevant policies subsection is shown as completed
+    Examples:
+      | multiple_files                                                       |
+      | upload-file-valid.tiff, upload-file-valid.tif, upload-file-valid.png |
+      | upload-file-valid.pdf, upload-file-valid.jpg, upload-file-valid.jpeg |
+      | upload-file-valid.doc, upload-file-valid.docx                        |
 
-    Scenario Outline: AC7 LPA Planning Officer selects Invalid file format
-      Given other relevant policies question is requested
-      When invalid files '<invalid_format>' have been selected
-      Then progress is halted with a message the file '<invalid_format>' 'format is incorrect'
-      Examples:
-        | invalid_format                     |
-        | upload-file-invalid-wrong-type.csv |
+  Scenario Outline: AC6 LPA Planning Officer selects invalid file size
+    Given other relevant policies question is requested
+    When invalid files '<invalid_file_size>' have been selected
+    Then progress is halted with a message the file '<invalid_file_size>' 'is too big'
+    Examples:
+      | invalid_file_size      |
+      | upload_file_large.tiff |
 
-    Scenario: AC8 LPA Planning Officer selects to return to previous page
-      Given other relevant policies question is requested
-      And a file has been uploaded
-      When Back is then requested
-      Then the LPA Planning Officer is taken to the Task List
-      And any document uploaded will not be saved
+  Scenario Outline: AC7 LPA Planning Officer selects Invalid file format
+    Given other relevant policies question is requested
+    When invalid files '<invalid_format>' have been selected
+    Then progress is halted with a message the file '<invalid_format>' 'format is incorrect'
+    Examples:
+      | invalid_format                     |
+      | upload-file-invalid-wrong-type.csv |
 
-    Scenario: AC9 LPA Planning Officer deletes a file prior to save and continue
-      Given a file has been uploaded
-      When LPA Planning Officer deletes the file
-      Then the file is removed
+  Scenario: AC8 LPA Planning Officer selects to return to previous page
+    Given other relevant policies question is requested
+    And a file has been uploaded
+    When Back is then requested
+    Then the LPA Planning Officer is taken to the Task List
+    And any document uploaded will not be saved
 
-    Scenario: AC10 LPA Planning Officer deletes a file after save and continue
-      Given a file has been uploaded and confirmed
-      And other relevant policies question is requested
-      When LPA Planning Officer deletes the file
-      Then the file is removed
+  Scenario: AC9 LPA Planning Officer deletes a file prior to save and continue
+    Given a file has been uploaded
+    When LPA Planning Officer deletes the file
+    Then the file is removed
 
-    Scenario: AC11 LPA Planning Officer returns to the completed Other Policies question
-      Given The question 'Other Relevant Policies' has been completed
-      When other relevant policies question is requested
-      Then the information they previously entered is still populated
+  Scenario: AC10 LPA Planning Officer deletes a file after save and continue
+    Given a file has been uploaded and confirmed
+    And other relevant policies question is requested
+    When LPA Planning Officer deletes the file
+    Then the file is removed
 
-    Scenario: AC12 Appeal details side panel
-      Given other relevant policies question is requested
-      Then the appeal details panel is displayed on the right hand side of the page
+  Scenario: AC11 LPA Planning Officer returns to the completed Other Policies question
+    Given The question 'Other Relevant Policies' has been completed
+    When other relevant policies question is requested
+    Then the information they previously entered is still populated
 
-    @nojs
-    Scenario Outline: AC13 JavaScript Disabled
-      Given other relevant policies question is requested
-      When valid file '<valid_file>' is successfully uploaded
-      Then progress is made to the task list
-      And other relevant policies subsection is shown as completed
-      Examples:
-        | valid_file             |
-        | upload-file-valid.tiff |
+  Scenario: AC12 Appeal details side panel
+    Given other relevant policies question is requested
+    Then the appeal details panel is displayed on the right hand side of the page
 
-    Scenario: AC14 Check your answers
-      Given all the mandatory questions for the questionnaire have been completed
-      When Check your Answers is displayed
-      Then other relevant policies question heading is shown and the uploaded file name should be displayed
+  @nojs
+  Scenario Outline: AC13 JavaScript Disabled
+    Given other relevant policies question is requested
+    When valid file '<valid_file>' is successfully uploaded
+    Then progress is made to the task list
+    And other relevant policies subsection is shown as completed
+    Examples:
+      | valid_file             |
+      | upload-file-valid.tiff |
 
-    Scenario: AC15 Change answers
-      Given a change to answer 'Other relevant policies' is requested from Change your answers page
-      When an answer is saved
-      Then progress is made to the Check Your Answers page
-      And the updated answer is displayed
+  Scenario: AC14 Check your answers
+    Given all the mandatory questions for the questionnaire have been completed
+    When Check your Answers is displayed
+    Then other relevant policies question heading is shown and the uploaded file name should be displayed
 
-  # Scenario: AC16 PDF & Horizon
-  #   Given the questionnaire has been completed
-  #   When the LPA Planning Officer submits the questionnaire
-  #   Then other relevant policies is displayed on the questionnaire PDF
-  #   And other relevant policies and uploaded files are present in Horizon
+  Scenario: AC15 Change answers
+    Given a change to answer 'Other relevant policies' is requested from Change your answers page
+    When an answer is saved
+    Then progress is made to the Check Your Answers page
+    And the updated answer is displayed
+
+# Scenario: AC16 PDF & Horizon
+#   Given the questionnaire has been completed
+#   When the LPA Planning Officer submits the questionnaire
+#   Then other relevant policies is displayed on the questionnaire PDF
+#   And other relevant policies and uploaded files are present in Horizon

--- a/lpa-submissions-e2e-tests/cypress/integration/pageFooter.feature
+++ b/lpa-submissions-e2e-tests/cypress/integration/pageFooter.feature
@@ -1,16 +1,20 @@
 Feature: As a LPA Planning officer
-I want to access the Planning Inspectorates policies
-So that I can see what they do with personal information when I’m using of the the Planning Inspectorate’s services
+  I want to access the Planning Inspectorates policies
+  So that I can see what they do with personal information when I’m using of the the Planning Inspectorate’s services
 
-Scenario Outline: AC-01 LPA taken to correct page when accessed links in the footer
-  Given LPA planning officer accesses the LPA Questionnaire
-  When they click on the '<links>' in the footer
-  Then the '<page>' correct page should be displayed
-  And the page title should be '<title>'
-  Examples:
-  |links               |page                                        |title                                                             |
-  |Privacy             |appeals-casework-portal-privacy-cookies     |Appeals casework portal - Cookies - GOV.UK                        |
-  |Cookies             |appeals-casework-portal-privacy-cookies     |Appeals casework portal - Cookies - GOV.UK                        |
-  |Accessibility       |appeals-casework-portal-accessibility       |Accessibility statement for the appeals casework portal - GOV.UK  |
-  |Terms and Conditions|appeals-casework-portal-terms-and-conditions|Appeals casework portal - Terms and Conditions - GOV.UK           |
+  Background:
+    Given an appeal has been created
+    And a questionnaire has been created
+
+  Scenario Outline: AC-01 LPA taken to correct page when accessed links in the footer
+    Given LPA planning officer accesses the LPA Questionnaire
+    When they click on the '<links>' in the footer
+    Then the '<page>' correct page should be displayed
+    And the page title should be '<title>'
+    Examples:
+      | links                | page                                         | title                                                            |
+      | Privacy              | appeals-casework-portal-privacy-cookies      | Appeals casework portal - Cookies - GOV.UK                       |
+      | Cookies              | appeals-casework-portal-privacy-cookies      | Appeals casework portal - Cookies - GOV.UK                       |
+      | Accessibility        | appeals-casework-portal-accessibility        | Accessibility statement for the appeals casework portal - GOV.UK |
+      | Terms and Conditions | appeals-casework-portal-terms-and-conditions | Appeals casework portal - Terms and Conditions - GOV.UK          |
 

--- a/lpa-submissions-e2e-tests/cypress/integration/planningHistory.feature
+++ b/lpa-submissions-e2e-tests/cypress/integration/planningHistory.feature
@@ -3,6 +3,10 @@ Feature: Planning History
   I want to upload the property planning history considered in the application,
   So that it can form part of the evidence on which the Inspector makes a decision.
 
+  Background:
+    Given an appeal has been created
+    And a questionnaire has been created
+
   Scenario: AC1 LPA Planning Officer navigations to planning history question
     Given a LPA Planning Officer is reviewing their LPA Questionnaire task list
     When LPA Planning Officer chooses to upload the planning history

--- a/lpa-submissions-e2e-tests/cypress/integration/planningOfficersReport.feature
+++ b/lpa-submissions-e2e-tests/cypress/integration/planningOfficersReport.feature
@@ -3,6 +3,10 @@ Feature: Upload the Planning Officer's report
   I want to provide the Planning Inspectorate with a copy of the Planning Officer's Report
   So that this can form part of the Inspectors decision.
 
+  Background:
+    Given an appeal has been created
+    And a questionnaire has been created
+
   Scenario: AC1 LPA Planning Officer navigations to Upload the Planning Officer's report question
     Given a LPA Planning Officer is reviewing their LPA Questionnaire task list
     When LPA Planning Officer chooses to upload Planning Officer report

--- a/lpa-submissions-e2e-tests/cypress/integration/representationsInterestedParties.feature
+++ b/lpa-submissions-e2e-tests/cypress/integration/representationsInterestedParties.feature
@@ -3,6 +3,10 @@ Feature: Representations from interested parties
   I want to provide the Planning Inspectorate with any Representations from interested parties.
   So that this can form part of the Inspectors decision.
 
+  Background:
+    Given an appeal has been created
+    And a questionnaire has been created
+
   Scenario: AC1 LPA  Planning officer navigates to ‘Representations from interested parties.’ question
     Given a LPA Planning Officer is reviewing their LPA Questionnaire task list
     When LPA Planning Officer chooses to upload the document Representations from interested parties

--- a/lpa-submissions-e2e-tests/cypress/integration/sendEmailConfirmationToNotify.feature
+++ b/lpa-submissions-e2e-tests/cypress/integration/sendEmailConfirmationToNotify.feature
@@ -2,7 +2,11 @@ Feature: As a planning officer
   I want to receive confirmation by email that the LPA questionnaire has been submitted
   So that we have a copy for our records
 
+  Background:
+    Given an appeal has been created
+    And a questionnaire has been created
+
   Scenario: AC01 Send email confirmation to LPA
-    Given the questionnaire for appeal "15549118-106f-4394-95c6-c63887b7d4c9" has been completed
-    When the LPA Questionnaire for appeal "15549118-106f-4394-95c6-c63887b7d4c9" is submitted
+    Given the questionnaire has been completed
+    When the LPA Questionnaire is submitted
     Then a confirmation email is sent to the LPA

--- a/lpa-submissions-e2e-tests/cypress/integration/sendEmailConfirmationToNotify/sendEmailConfirmationToNotify.steps.js
+++ b/lpa-submissions-e2e-tests/cypress/integration/sendEmailConfirmationToNotify/sendEmailConfirmationToNotify.steps.js
@@ -2,7 +2,7 @@ import { Then } from 'cypress-cucumber-preprocessor/steps';
 
 Then('a confirmation email is sent to the LPA', () => {
   cy.verifyPage('information-submitted');
-  if (!Cypress.env('ASSUME_LIMITED_ACCESS')) {
+  cy.get('@appeal').then((appeal) => {
     cy.request('GET', `${Cypress.env('EMAIL_NOTIFICATION_URL')}`).then((response) => {
       const lastEmailNotificationOnTheStack = response.body.length - 1;
       const emailNotification = response.body[lastEmailNotificationOnTheStack];
@@ -10,12 +10,12 @@ Then('a confirmation email is sent to the LPA', () => {
       expect(emailNotification.email_address).to.eq('AppealPlanningDecisionTest@planninginspectorate.gov.uk');
 
       expect(Object.keys(emailNotification.personalisation).length).to.eq(4);
-      expect(emailNotification.personalisation['Planning appeal number']).to.eq('fake-horizon-id');
+      expect(emailNotification.personalisation['Planning appeal number']).to.eq(appeal.horizonId);
       expect(emailNotification.personalisation['Name of local planning department']).to.eq(
         'System Test Borough Council',
       );
       expect(emailNotification.personalisation['Planning application number']).to.eq(
-        'ValidNumber/12345',
+        appeal.requiredDocumentsSection.applicationNumber,
       );
 
       expect(
@@ -29,10 +29,10 @@ Then('a confirmation email is sent to the LPA', () => {
       );
 
       expect(emailNotification.reference).to.eq(
-        '15549118-106f-4394-95c6-c63887b7d4c9.SubmissionConfirmation',
+        `${appeal.id}.SubmissionConfirmation`,
       );
       expect(emailNotification.email_reply_to_id).to.eq('f1e6c8c5-786e-41ca-9086-10b67f31bc86');
       expect(response.status).to.eq(200);
     });
-  }
+  });
 });

--- a/lpa-submissions-e2e-tests/cypress/integration/settingListedBuilding.feature
+++ b/lpa-submissions-e2e-tests/cypress/integration/settingListedBuilding.feature
@@ -3,6 +3,10 @@ Feature: Setting listed building
   I want to provide details about the appeal site
   So that the Planning Inspectorate has the information it needs to decide the appeal.
 
+  Background:
+    Given an appeal has been created
+    And a questionnaire has been created
+
   Scenario: AC01 LPA Officer navigates to Setting listed building
     Given a LPA Planning Officer is reviewing their LPA Questionnaire task list
     When LPA Planning Officer chooses to provide information about 'Setting listed building'

--- a/lpa-submissions-e2e-tests/cypress/integration/siteNotices.feature
+++ b/lpa-submissions-e2e-tests/cypress/integration/siteNotices.feature
@@ -3,6 +3,10 @@ Feature: Site Notices
   I want to upload the property site notices considered in the application,
   So that it can form part of the evidence on which the Inspector makes a decision.
 
+  Background:
+    Given an appeal has been created
+    And a questionnaire has been created
+
   Scenario: AC1 LPA Planning Officer navigates to site notices question
     Given a LPA Planning Officer is reviewing their LPA Questionnaire task list
     When LPA Planning Officer chooses to upload the site notices

--- a/lpa-submissions-e2e-tests/cypress/integration/siteSeenPublicLand.feature
+++ b/lpa-submissions-e2e-tests/cypress/integration/siteSeenPublicLand.feature
@@ -3,6 +3,10 @@ Feature: Site seen from public land
   I want to provide details about the appeal site
   So that the Planning Inspectorate has the information it needs to decide the appeal.
 
+  Background:
+    Given an appeal has been created
+    And a questionnaire has been created
+
   Scenario: AC01 LPA Officer navigates to Site seen from public land
     Given a LPA Planning Officer is reviewing their LPA Questionnaire task list
     When LPA Planning Officer chooses to provide information about 'Site seen from public land'

--- a/lpa-submissions-e2e-tests/cypress/integration/statutoryDevelopmentPlanPolicy.feature
+++ b/lpa-submissions-e2e-tests/cypress/integration/statutoryDevelopmentPlanPolicy.feature
@@ -3,6 +3,10 @@ Feature: Statutory Development Plan Policy
   I want to upload the Statutory development plan policy,
   so that it can form part of the evidence on which the Inspector makes a decision.
 
+  Background:
+    Given an appeal has been created
+    And a questionnaire has been created
+
   Scenario: AC1 LPA Planning Officer navigations to Statutory development plan policy question
     Given a LPA Planning Officer is reviewing their LPA Questionnaire task list
     When LPA Planning Officer chooses to upload Statutory development plan policy
@@ -120,8 +124,8 @@ Feature: Statutory Development Plan Policy
     Then progress is made to the Check Your Answers page
     And the updated answer is displayed
 
-  # Scenario: AC16 PDF & Horizon
-  #   Given the questionnaire has been completed
-  #   When the LPA Planning Officer submits the questionnaire
-  #   Then Statutory development plan policy is displayed on the  questionnaire PDF
-  #   And Statutory development plan policy & PDF is present in Horizon
+# Scenario: AC16 PDF & Horizon
+#   Given the questionnaire has been completed
+#   When the LPA Planning Officer submits the questionnaire
+#   Then Statutory development plan policy is displayed on the  questionnaire PDF
+#   And Statutory development plan policy & PDF is present in Horizon

--- a/lpa-submissions-e2e-tests/cypress/integration/supplementaryAddDocument.feature
+++ b/lpa-submissions-e2e-tests/cypress/integration/supplementaryAddDocument.feature
@@ -3,6 +3,10 @@ Feature: Supplementary Planning Documents - Add Document
   I want to upload supplementary planning documents,
   so that it can form part of the evidence on which the Inspector makes a decision
 
+  Background:
+    Given an appeal has been created
+    And a questionnaire has been created
+
   Scenario: AC1 LPA Planning Officer navigates to Add Supplementary planning document questions
     Given Add supplementary document is requested
     Then the LPA Planning Officer is presented with add supplementary document questions

--- a/lpa-submissions-e2e-tests/cypress/integration/uploadThePlansToReachDecision.feature
+++ b/lpa-submissions-e2e-tests/cypress/integration/uploadThePlansToReachDecision.feature
@@ -3,6 +3,10 @@ Feature: Upload the plans used to reach the LPA decision
   I want to upload the plans which were used to reach the LPA decision
   So that they can form part of the evidence on which the Inspector makes a decision
 
+  Background:
+    Given an appeal has been created
+    And a questionnaire has been created
+
   Scenario: AC1 LPA Planning Officer navigates to 'Upload the plans used to reach the decision' question
     Given a LPA Planning Officer is reviewing their LPA Questionnaire task list
     When LPA Planning Officer chooses to upload plans used to reach the decision

--- a/lpa-submissions-e2e-tests/cypress/support/appeals-questionnaire-tasklist/goToTaskListPage.js
+++ b/lpa-submissions-e2e-tests/cypress/support/appeals-questionnaire-tasklist/goToTaskListPage.js
@@ -1,5 +1,3 @@
-import defaultAppealId from '../../utils/defaultPathId';
-
-module.exports = (appealId = defaultAppealId) => {
-  cy.goToPage('task-list', appealId);
+module.exports = () => {
+  cy.goToPage('task-list');
 };

--- a/lpa-submissions-e2e-tests/cypress/support/check-your-answers/goToCheckYourAnswersPage.js
+++ b/lpa-submissions-e2e-tests/cypress/support/check-your-answers/goToCheckYourAnswersPage.js
@@ -1,5 +1,3 @@
-import defaultAppealId from '../../utils/defaultPathId';
-
-module.exports = (appealId = defaultAppealId) => {
-  cy.goToPage('confirm-answers', appealId);
+module.exports = () => {
+  cy.goToPage('confirm-answers');
 };

--- a/lpa-submissions-e2e-tests/cypress/support/commands.js
+++ b/lpa-submissions-e2e-tests/cypress/support/commands.js
@@ -57,6 +57,8 @@ Cypress.Commands.add('clickBackButton', require('./common/clickBackButton'));
 
 Cypress.Commands.add('validateErrorMessage', require('./common/validateErrorMessage'));
 
+Cypress.Commands.add('generateQuestionnaire', require('./common/generateQuestionnaire'));
+
 Cypress.Commands.add('completeQuestionnaire', require('./common/completeQuestionnaire'));
 
 Cypress.Commands.add('hasLink', require('./common/hasLink'));
@@ -70,3 +72,5 @@ Cypress.Commands.add(
   'checkSubmissionPdfContent',
   require('./common/pdfFunctions').checkSubmissionPdfContent,
 );
+
+Cypress.Commands.add('completeAppeal', require('./common/completeAppeal'));

--- a/lpa-submissions-e2e-tests/cypress/support/common/completeAppeal.js
+++ b/lpa-submissions-e2e-tests/cypress/support/common/completeAppeal.js
@@ -1,0 +1,19 @@
+const completeAppeal = () => {
+  cy.request('POST', `${Cypress.env('APPEAL_SERVICE_BASE_URL')}/appeals`).then((response) => {
+    expect(response.status).to.equal(201, 'expect a happy response from the appeal-api.create');
+    const appeal = response.body;
+    cy.fixture('completedAppeal.json').then((appealData) => {
+      appealData.id = appeal.id;
+      cy.request('PUT', `${Cypress.env('APPEAL_SERVICE_BASE_URL')}/appeals/${appeal.id}`, appealData)
+        .then((response) => {
+          expect(response.status).to.equal(
+            200,
+            'expect a happy response from the appeal-api.update',
+          );
+          cy.wrap(response.body).as('appeal');
+        })
+    });
+  })
+};
+
+export default completeAppeal;

--- a/lpa-submissions-e2e-tests/cypress/support/common/completeQuestionnaire.js
+++ b/lpa-submissions-e2e-tests/cypress/support/common/completeQuestionnaire.js
@@ -1,122 +1,20 @@
-import { input, textBox, textArea } from '../PageObjects/common-page-objects';
-import defaultAppealId from '../../utils/defaultPathId';
-
-const uploadFiles = (fileName) => {
-  // start watching the POST requests
-  cy.server({ method: 'POST' });
-  cy.route({
-    method: 'POST',
-    url: 'upload',
-  }).as('upload');
-
-  cy.get('input#documents').attachFile([fileName]);
-
-  cy.wait('@upload', { requestTimeout: 3000 });
-  cy.server({ enable: false });
-};
-
-const stepCompletion = (appealId) => {
-  // Accuracy of submission
-  cy.goToPage('accuracy-submission', appealId);
-  input('accurate-submission-no').check();
-  textArea('inaccuracy-reason').type(
-    'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer nec odio. Praesent libero. Sed cursus ante dapibus diam. Sed nisi. Nulla quis sem at nibh elementum imperdiet. Duis sagittis ipsum. Praesent mauris. Fusce nec tellus sed augue semper porta. Mauris massa. Vestibulum lacinia arcu eget nulla. Class aptent taciti sociosqu ad litora torquent per conubia nostra, per inceptos himenaeos. Curabitur sodales ligula in libero.',
-  );
-  cy.clickSaveAndContinue();
-
-  // Extra conditions
-  cy.goToPage('extra-conditions', appealId);
-  input('has-extra-conditions-yes').check();
-  textArea('extra-conditions-text').type(
-    'Sed dignissim lacinia nunc. Curabitur tortor. Pellentesque nibh. Aenean quam. In scelerisque sem at dolor. Maecenas mattis.\n\nSed convallis tristique sem. Proin ut ligula vel nunc egestas porttitor. Morbi lectus risus, iaculis vel, suscipit quis, luctus non, massa. Fusce ac turpis quis ligula lacinia aliquet. Mauris ipsum. Nulla metus metus, ullamcorper vel, tincidunt sed, euismod in, nibh.',
-  );
-  cy.clickSaveAndContinue();
-
-  // Other appeals
-  cy.goToPage('other-appeals', appealId);
-  input('adjacent-appeals-yes').check();
-  textBox('appeal-reference-numbers').type('abc-123, def-456');
-  cy.clickSaveAndContinue();
-
-  // Plans
-  cy.goToPage('plans', appealId);
-  uploadFiles('upload-file-valid.pdf');
-  cy.clickSaveAndContinue();
-
-  // Officers Report
-  cy.goToPage('officers-report');
-  uploadFiles('upload-file-valid.pdf');
-  cy.clickSaveAndContinue();
-
-  // Representations of interested parties
-  cy.goToPage('representations', appealId);
-  uploadFiles('upload-file-valid.pdf');
-  cy.clickSaveAndContinue();
-
-  // Notifying interested parties
-  cy.goToPage('notifications', appealId);
-  uploadFiles('upload-file-valid.pdf');
-  cy.clickSaveAndContinue();
-
-  // Site Notices
-  cy.goToPage('site-notice', appealId);
-  uploadFiles('upload-file-valid.pdf');
-  cy.clickSaveAndContinue();
-
-  // Notifying interested parties
-  cy.goToPage('conservation-area-map', appealId);
-  uploadFiles('upload-file-valid.pdf');
-  cy.clickSaveAndContinue();
-
-  // Planning History
-  cy.goToPage('planning-history', appealId);
-  uploadFiles('upload-file-valid.pdf');
-  cy.clickSaveAndContinue();
-
-  // Other relevant policies
-  cy.goToPage('other-policies', appealId);
-  uploadFiles('upload-file-valid.pdf');
-  cy.clickSaveAndContinue();
-
-  // Development Plan
-  cy.goToPage('development-plan', appealId);
-  input('has-plan-submitted-yes').check();
-  textArea('plan-changes-text').type('mock plan changes');
-  cy.clickSaveAndContinue();
-
-  // Statutory Development Plan Policy
-  cy.goToPage('statutory-development', appealId);
-  uploadFiles('upload-file-valid.pdf');
-  cy.clickSaveAndContinue();
-};
-
-const apiCompletion = (appealId) => {
-  // Visit task list page to invoke session, which generates an appeal reply ID
-  cy.goToTaskListPage(appealId);
-
-  cy.getAppealReplyId().then((replyId) => {
+const completeQuestionnaire = () => {
+  cy.get('@appealReply').then((appealReply) => {
     cy.fixture('completedAppealReply.json').then((reply) => {
-      reply.id = replyId;
-      // force the completed appeal reply fixture data to take the set appeal id.
-      reply.appealId = appealId;
+      reply.id = appealReply.id;
+      reply.appealId = appealReply.appealId;
       cy.request(
         'PUT',
-        `${Cypress.env('APPEAL_REPLY_SERVICE_BASE_URL')}/reply/${replyId}`,
+        `${Cypress.env('APPEAL_REPLY_SERVICE_BASE_URL')}/reply/${appealReply.id}`,
         reply,
       ).then((response) => {
-        expect(response.body.aboutAppealSection.submissionAccuracy).to.have.property(
-          'accurateSubmission',
-          false,
+        expect(response.status).to.equal(
+          200,
+          'expect a happy response from the appeal-reply-api.update',
         );
       });
     });
   });
 };
 
-module.exports = (appealId = defaultAppealId) => {
-  if (!Cypress.env('ASSUME_LIMITED_ACCESS')) {
-    apiCompletion(appealId);
-  } else {
-    stepCompletion(appealId);
-  }
-};
+export default completeQuestionnaire;

--- a/lpa-submissions-e2e-tests/cypress/support/common/generateQuestionnaire.js
+++ b/lpa-submissions-e2e-tests/cypress/support/common/generateQuestionnaire.js
@@ -1,0 +1,17 @@
+const generateQuestionnaire = () => {
+  cy.get('@appeal').then((appeal) => {
+    cy.request(
+      'POST',
+      `${Cypress.env('APPEAL_REPLY_SERVICE_BASE_URL')}/reply/`,
+      { appealId: appeal.id },
+    ).then((response) => {
+      expect(response.status).to.equal(
+        201,
+        'expect a happy response from the appeal-reply-api.post',
+      );
+      cy.wrap(response.body).as('appealReply');
+    });
+  });
+};
+
+export default generateQuestionnaire;

--- a/lpa-submissions-e2e-tests/cypress/support/common/getAppealReplyId.js
+++ b/lpa-submissions-e2e-tests/cypress/support/common/getAppealReplyId.js
@@ -1,3 +1,3 @@
 module.exports = () => {
-  return cy.get('meta[name="appeal-reply-id"]').invoke('attr', 'content');
+  return cy.get('@appealReply').then((appealReply) => appealReply.id);
 };

--- a/lpa-submissions-e2e-tests/cypress/support/common/goToPage.js
+++ b/lpa-submissions-e2e-tests/cypress/support/common/goToPage.js
@@ -1,6 +1,15 @@
-import defaultPathId from '../../utils/defaultPathId';
-
-module.exports = (url, id = defaultPathId, disableJs) => {
-  const path = `/${id}/${url}`;
-  cy.visit(path, { failOnStatusCode: false, script: !disableJs });
+module.exports = (url, id, disableJs) => {
+  if (id) {
+    cy.visit(`/${id}/${url}`, {
+      failOnStatusCode: false,
+      script: !disableJs,
+    });
+  } else {
+    cy.get('@appeal').then((appeal) => {
+      cy.visit(`/${appeal.id}/${url}`, {
+        failOnStatusCode: false,
+        script: !disableJs,
+      });
+    });
+  }
 };

--- a/packages/appeal-reply-service-api/api/openapi.yaml
+++ b/packages/appeal-reply-service-api/api/openapi.yaml
@@ -2,7 +2,7 @@ openapi: 0.0.1
 info:
   title: Appeal Reply Service API Documentation
   description:
-    API to <ul><li>create, retrieve and modify appeal replies</li><li>
+    API to <ul><li>create, retrieve and modify appeal replies</li></ul>
   version: 1.0.3
   license:
     name: MIT
@@ -87,6 +87,29 @@ paths:
                     items:
                       type: string
                       example: 'requiredDocumentsSection.originalApplication.uploadedFile.id must be a valid UUID'
+        '404':
+          description: The reply could not be found
+  '/api/v1/reply/appeal/{id}':
+    get:
+      summary: Returns an existing reply by the appeal ID
+      description: The reply includes the state of all subsections.
+      tags:
+        - Reply
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: string
+            format: uuid
+          description: Unique identifier for Appeal
+      responses:
+        '200':
+          description: Returns an reply
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Reply'
         '404':
           description: The reply could not be found
 components:

--- a/packages/appeal-reply-service-api/package-lock.json
+++ b/packages/appeal-reply-service-api/package-lock.json
@@ -6355,9 +6355,9 @@
           "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw=="
         },
         "y18n": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
-          "integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w=="
+          "version": "4.0.3",
+          "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
+          "integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ=="
         },
         "yargs": {
           "version": "15.4.1",
@@ -9536,9 +9536,9 @@
       "dev": true
     },
     "hosted-git-info": {
-      "version": "2.8.8",
-      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.8.tgz",
-      "integrity": "sha512-f/wzC2QaWBs7t9IYqB4T3sR1xviIViXJRJTWBlx2Gf3g0Xi5vI7Yy4koXQ1c9OYDGHN9sBy1DQ2AB8fqZBWhUg==",
+      "version": "2.8.9",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.9.tgz",
+      "integrity": "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==",
       "dev": true
     },
     "html-encoding-sniffer": {
@@ -11229,9 +11229,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.20",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
-      "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
       "dev": true
     },
     "lodash.includes": {

--- a/packages/appeal-reply-service-api/src/__tests__/reply.spec.js
+++ b/packages/appeal-reply-service-api/src/__tests__/reply.spec.js
@@ -13,8 +13,8 @@ jest.mock('../db/db');
 const endpoint = '/api/v1/reply';
 const dbId = 'reply';
 
-async function createReply() {
-  const reply = new ReplyModel({ id: uuid.v4() });
+async function createReply(appealId) {
+  const reply = new ReplyModel({ id: uuid.v4(), appealId });
   reply.id = uuid.v4();
   await mongodb.get().collection(dbId).insertOne({ _id: reply.id, uuid: reply.id, reply });
   return reply;
@@ -67,6 +67,21 @@ describe('Replies API', () => {
     const response = await request(app).get(`${endpoint}/non-existent-id`);
     expect(response.body).toEqual({});
     expect(response.statusCode).toBe(404);
+  });
+
+  test('GET /api/v1/reply/appeal/{id} - It responds with an error - Not Found', async () => {
+    const response = await request(app).get(`${endpoint}/appeal/non-existent-id`);
+    expect(response.body).toEqual({});
+    expect(response.statusCode).toBe(404);
+  });
+
+  test('GET /api/v1/reply/appeal/{id} - It responds with an error - Database error', async () => {
+    mongodb.get.mockImplementationOnce(() => {
+      throw new Error('mock error');
+    });
+
+    const response = await request(app).get(`${endpoint}/appeal/1234`);
+    expect(response.statusCode).toBe(500);
   });
 
   test('PUT /api/v1/reply/{id} - It responds with status 200 and matching reply', async () => {

--- a/packages/appeal-reply-service-api/src/controllers/reply.js
+++ b/packages/appeal-reply-service-api/src/controllers/reply.js
@@ -63,6 +63,28 @@ module.exports = {
     }
   },
 
+  async getByAppeal(req, res) {
+    const appealId = req.params.id;
+    logger.debug(`Retrieving reply by appeal ID ${appealId} ...`);
+    try {
+      await mongodb
+        .get()
+        .collection(dbId)
+        .findOne({ 'reply.appealId': { $eq: appealId } })
+        .then((doc) => {
+          logger.debug(`Reply for appeal ${appealId} retrieved`);
+          res.status(200).send(doc.reply);
+        })
+        .catch((err) => {
+          logger.warn(`Could not find reply for appeal ${appealId}\n${err}`);
+          res.status(404).send(null);
+        });
+    } catch (err) {
+      logger.error({ appealId, err }, 'Problem retrieving reply for appeal');
+      res.status(500).send(`Problem finding reply for appeal ${appealId}`);
+    }
+  },
+
   async update(req, res) {
     const idParam = req.params.id;
     logger.debug({ idParam }, `Updating reply ...`);

--- a/packages/appeal-reply-service-api/src/routes/reply.js
+++ b/packages/appeal-reply-service-api/src/routes/reply.js
@@ -7,4 +7,6 @@ routes.post('/', replyController.create);
 routes.get('/:id', replyController.get);
 routes.put('/:id', replyController.update);
 
+routes.get('/appeal/:id', replyController.getByAppeal);
+
 module.exports = routes;

--- a/packages/lpa-questionnaire-web-app/src/config.js
+++ b/packages/lpa-questionnaire-web-app/src/config.js
@@ -37,6 +37,7 @@ module.exports = {
     redact: ['opts.body', 'config.db.session.uri', 'config.server.sessionSecret'],
   },
   appealReply: {
+    allowCreate: process.env.ALLOW_APPEAL_REPLY_CREATE === 'true',
     timeout: Number(process.env.APPEAL_REPLY_SERVICE_API_TIMEOUT || 10000),
     url: process.env.APPEAL_REPLY_SERVICE_API_URL,
   },

--- a/packages/lpa-questionnaire-web-app/src/controllers/information-submitted.js
+++ b/packages/lpa-questionnaire-web-app/src/controllers/information-submitted.js
@@ -21,7 +21,6 @@ exports.getInformationSubmitted = async (req, res) => {
   }
 
   res.render(VIEW.INFORMATION_SUBMITTED, {
-    appealReplyId: req.session?.appealReply?.id,
     lpaEmailString,
   });
 };

--- a/packages/lpa-questionnaire-web-app/src/controllers/task-list.js
+++ b/packages/lpa-questionnaire-web-app/src/controllers/task-list.js
@@ -43,7 +43,6 @@ exports.getTaskList = (req, res) => {
   req.session.backLink = `/${req.params.id}/${VIEW.TASK_LIST}`;
 
   res.render(VIEW.TASK_LIST, {
-    appealReplyId: req.session.appealReply?.id,
     applicationStatus,
     sections,
   });

--- a/packages/lpa-questionnaire-web-app/src/controllers/upload-question.js
+++ b/packages/lpa-questionnaire-web-app/src/controllers/upload-question.js
@@ -22,7 +22,6 @@ exports.getUpload = (req, res) => {
 
   res.render(view, {
     appeal: getAppealSideBarDetails(req.session.appeal),
-    appealReplyId: req.session.appealReply.id,
     backLink: req.session.backLink || `/${req.params.id}/${VIEW.TASK_LIST}`,
     ...fileUploadNunjucksVariables(null, null, uploadedFiles),
   });

--- a/packages/lpa-questionnaire-web-app/src/lib/appeal-reply-api-wrapper.js
+++ b/packages/lpa-questionnaire-web-app/src/lib/appeal-reply-api-wrapper.js
@@ -82,6 +82,20 @@ exports.createOrUpdateAppealReply = (appealReply) => {
   });
 };
 
-exports.getExistingAppealReply = async (id) => {
-  return handler(`/api/v1/reply/${id}`);
+/**
+ * Gets an existing appeal reply by it's ID
+ * @param {*} replyId appeal reply ID
+ * @returns get request to to reply API
+ */
+exports.getExistingAppealReply = async (replyId) => {
+  return handler(`/api/v1/reply/${replyId}`);
+};
+
+/**
+ * Gets an existing appeal reply by the appeal id associated with it
+ * @param {*} appealId appeal ID
+ * @returns get request to reply API
+ */
+exports.getAppealReplyByAppeal = async (appealId) => {
+  return handler(`/api/v1/reply/appeal/${appealId}`);
 };

--- a/packages/lpa-questionnaire-web-app/src/views/includes/head.njk
+++ b/packages/lpa-questionnaire-web-app/src/views/includes/head.njk
@@ -1,8 +1,4 @@
 {% block head %}
-  {% if appealReplyId %}
-    <meta name="appeal-reply-id" content="{{ appealReplyId }}">
-  {% endif %}
-
   <!--[if lte IE 8]><link href="/public/stylesheets/main-ie8.css" rel="stylesheet" type="text/css" /><![endif]-->
   <!--[if gt IE 8]><!--><link href="/public/stylesheets/main.css" media="all" rel="stylesheet" type="text/css"/><!--<![endif]-->
 

--- a/packages/lpa-questionnaire-web-app/tests/unit/controllers/information-submitted.test.js
+++ b/packages/lpa-questionnaire-web-app/tests/unit/controllers/information-submitted.test.js
@@ -61,7 +61,6 @@ describe('../../../src/controllers/information-submitted', () => {
       fetch.mockResponseOnce(JSON.stringify(mockLPAObject));
       await getInformationSubmitted(req, res);
       expect(res.render).toHaveBeenCalledWith(VIEW.INFORMATION_SUBMITTED, {
-        appealReplyId: null,
         lpaEmailString,
       });
     });
@@ -73,7 +72,6 @@ describe('../../../src/controllers/information-submitted', () => {
       });
       await getInformationSubmitted(req, res);
       expect(res.render).toHaveBeenCalledWith(VIEW.INFORMATION_SUBMITTED, {
-        appealReplyId: null,
         lpaEmailString,
       });
     });

--- a/packages/lpa-questionnaire-web-app/tests/unit/controllers/task-list.test.js
+++ b/packages/lpa-questionnaire-web-app/tests/unit/controllers/task-list.test.js
@@ -40,7 +40,6 @@ describe('controllers/task-list', () => {
       taskListController.getTaskList(req, res);
 
       expect(res.render).toHaveBeenCalledWith(VIEW.TASK_LIST, {
-        appealReplyId: null,
         applicationStatus: 'Application incomplete',
         sections: [
           {

--- a/packages/lpa-questionnaire-web-app/tests/unit/controllers/upload-question.test.js
+++ b/packages/lpa-questionnaire-web-app/tests/unit/controllers/upload-question.test.js
@@ -62,7 +62,6 @@ describe('controllers/upload-question', () => {
 
       expect(res.render).toHaveBeenCalledWith('mock-view', {
         appeal: null,
-        appealReplyId: 'mock-id',
         backLink: backLinkUrl,
       });
     });
@@ -72,7 +71,6 @@ describe('controllers/upload-question', () => {
 
       expect(res.render).toHaveBeenCalledWith('mock-view', {
         appeal: null,
-        appealReplyId: 'mock-id',
         backLink: `/mock-id/${VIEW.TASK_LIST}`,
       });
     });
@@ -89,7 +87,6 @@ describe('controllers/upload-question', () => {
 
       expect(res.render).toHaveBeenCalledWith('mock-view', {
         appeal: null,
-        appealReplyId: 'mock-id',
         backLink: `/mock-id/${VIEW.TASK_LIST}`,
         uploadedFiles,
       });

--- a/packages/lpa-questionnaire-web-app/tests/unit/lib/appeal-reply-api-wrapper.test.js
+++ b/packages/lpa-questionnaire-web-app/tests/unit/lib/appeal-reply-api-wrapper.test.js
@@ -5,6 +5,7 @@ const uuid = require('uuid');
 const {
   createOrUpdateAppealReply,
   getExistingAppealReply,
+  getAppealReplyByAppeal,
 } = require('../../../src/lib/appeal-reply-api-wrapper');
 
 const config = require('../../../src/config');
@@ -105,6 +106,14 @@ describe('lib/appeal-reply-api-wrapper', () => {
       fetch.mockResponseOnce(JSON.stringify({ shouldBe: 'valid' }));
       await getExistingAppealReply('123');
       expect(fetch.mock.calls[0][0]).toEqual('http://fake.url/api/v1/reply/123');
+    });
+  });
+
+  describe('getAppealReplyByAppeal', () => {
+    it(`should call the expected URL`, async () => {
+      fetch.mockResponseOnce(JSON.stringify({ shouldBe: 'valid' }));
+      await getAppealReplyByAppeal('123');
+      expect(fetch.mock.calls[0][0]).toEqual('http://fake.url/api/v1/reply/appeal/123');
     });
   });
 });

--- a/releases/prod/app.yml
+++ b/releases/prod/app.yml
@@ -21,6 +21,7 @@ spec:
         lpaQuestionnaireWebApp: lpa-questions.planninginspectorate.gov.uk
 
     appealReplyServiceApi:
+      allowCreate: 'false'
       replicaCount: 2
       image:
         repository: pinscommonukscontainers3887default.azurecr.io/appeal-reply-service-api


### PR DESCRIPTION
## Ticket Number
<!-- Add the number from the Jira board -->
https://pins-ds.atlassian.net/browse/AS-1903

## Description of change
Change functionality of questionnaire to only have a single reply for each appeal
- added endpoint for reply service to get 
- changes to how e2e tests work across whole questionnaire. Tasks now to create an appeal and reply before each run.
- port forwarding now required for automated tests in deployed environments
- changes to middleware for getting appeal and reply
- new error handling if appeal does not exist
- allows future work to remove session in future

## Checklist
<!-- Put an `x` in all the boxes that apply: -->
- [ ] Requires infrastructure changes
- [X] If adding or remove environment variables (e.g. in `docker-compose.yaml`) then I have updated the appropriate Helm chart
- [ ] I have updated the documentation accordingly
- [X] My commit history in this PR is linear
- [X] New features have tests
- [ ] Breaking change (team conversation required)

## Important

Please do not merge from `master` (please only [rebase](https://github.com/foundry4/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
