### PR TITLE
fix(horizon-householder-appeal-publish): fixed depth id bug

### DIFF
--- a/packages/appeal-reply-service-api/src/controllers/reply.js
+++ b/packages/appeal-reply-service-api/src/controllers/reply.js
@@ -73,8 +73,7 @@ module.exports = {
       .collection(dbId)
       .findOne({ _id: idParam })
       .then(async (originalDoc) => {
-        // logger.debug(`Original doc \n${originalDoc.reply}`);
-        logger.debug(...originalDoc.reply, 'STEVE-ORIGINAL');
+        logger.debug(`Original doc \n${originalDoc.reply}`);
 
         const isFirstSubmission = originalDoc.state !== 'SUBMITTED' && newDoc.state === 'SUBMITTED';
 

--- a/packages/horizon-householder-appeal-publish/handler-reply.js
+++ b/packages/horizon-householder-appeal-publish/handler-reply.js
@@ -45,10 +45,10 @@ const populateDocuments = (body) => {
   const documents = [];
 
   Object.keys(documentsSections).forEach((key) => {
-    if (body[documentsSections[key]] !== undefined) {
+    if (body.reply[documentsSections[key]] !== undefined) {
       documents.push(
         convertDocumentArray(
-          body[documentsSections[key]][key].uploadedFiles,
+          body.reply[documentsSections[key]][key].uploadedFiles,
           sectionTypes[`${key}Type`]
         )
       );
@@ -78,7 +78,7 @@ const handlerReply = async (event, horizonCaseId, context) => {
   try {
     event.log.info({ event }, 'STEVE: handler-reply');
     const { body } = event;
-    const replyId = body.id;
+    const replyId = body.reply.id;
     await publishDocuments(event.log, populateDocuments(body), replyId, horizonCaseId);
     event.log.info({ horizonCaseId }, 'Successful reply publish to Horizon');
     return {

--- a/packages/horizon-householder-appeal-publish/tests/handler-reply.spec.js
+++ b/packages/horizon-householder-appeal-publish/tests/handler-reply.spec.js
@@ -67,7 +67,7 @@ describe('populateDocuments', () => {
 
   beforeEach(() => {
     mockAppealReply = getMockAppealReply();
-    body = { ...mockAppealReply };
+    body = { reply: mockAppealReply };
     expectation = getFullExpectation(mockAppealReply);
   });
 
@@ -104,7 +104,7 @@ describe('handlerReply', () => {
     };
 
     newMockAppealReply = getMockAppealReply();
-    body = { ...newMockAppealReply };
+    body = { reply: newMockAppealReply };
   });
 
   afterEach(() => {
@@ -114,6 +114,7 @@ describe('handlerReply', () => {
 
   it('should simulate an reply with documents to publish', async () => {
     const horizonFullCaseId = `ABC/1234/${horizonCaseId}`;
+    const replyId = 'mock-id';
 
     const event = {
       log: logMock,
@@ -135,7 +136,7 @@ describe('handlerReply', () => {
           documentId,
           documentType,
           caseReference: horizonCaseId,
-          applicationId: body.id,
+          applicationId: replyId,
         },
         {
           baseURL: process.env.GATEWAY_URL,


### PR DESCRIPTION
This reverts commit 13705075843ce0b747b396df6ff828759c430732.

## Ticket Number
<!-- Add the number from the Jira board -->
https://pins-ds.atlassian.net/browse/AS-

## Description of change
<!-- Please describe the change -->

## Checklist
<!-- Put an `x` in all the boxes that apply: -->
- [ ] Requires infrastructure changes
- [ ] If adding or remove environment variables (e.g. in `docker-compose.yaml`) then I have updated the appropriate Helm chart
- [ ] I have updated the documentation accordingly
- [ ] My commit history in this PR is linear
- [ ] New features have tests
- [ ] Breaking change (team conversation required)

## Important

Please do not merge from `master` (please only [rebase](https://github.com/foundry4/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
