### PR TITLE
Fix/as 2504 pdf issues

### DIFF
--- a/lpa-submissions-e2e-tests/cypress/integration/planningOfficersReport.feature
+++ b/lpa-submissions-e2e-tests/cypress/integration/planningOfficersReport.feature
@@ -1,18 +1,18 @@
-Feature: Upload the Planning Officer’s report
+Feature: Upload the Planning Officer's report
   As a LPA Planning Officer
-  I want to provide the Planning Inspectorate with a copy of the Planning Officer’s Report
+  I want to provide the Planning Inspectorate with a copy of the Planning Officer's Report
   So that this can form part of the Inspectors decision.
 
-  Scenario: AC1 LPA Planning Officer navigations to Upload the Planning Officer’s report question
+  Scenario: AC1 LPA Planning Officer navigations to Upload the Planning Officer's report question
     Given a LPA Planning Officer is reviewing their LPA Questionnaire task list
     When LPA Planning Officer chooses to upload Planning Officer report
-    Then LPA Planning Officer is presented with the ability to upload the Planning Officer’s report
+    Then LPA Planning Officer is presented with the ability to upload the Planning Officer's report
 
   Scenario Outline: AC2 LPA Planning Officer successfully uploads file via upload button
-    Given Upload the Planning Officer’s report question is requested
+    Given Upload the Planning Officer's report question is requested
     When valid file '<valid_file>' is successfully uploaded
     Then progress is made to the task list
-    And Upload the Planning Officer’s report subsection is shown as completed
+    And Upload the Planning Officer's report subsection is shown as completed
     Examples:
       | valid_file             |
       | upload-file-valid.tiff |
@@ -25,10 +25,10 @@ Feature: Upload the Planning Officer’s report
       | upload-file-valid.docx |
 
   Scenario Outline: AC3 LPA Planning Officer successfully uploads file via Drag and Drop
-    Given Upload the Planning Officer’s report question is requested
+    Given Upload the Planning Officer's report question is requested
     When valid file '<valid_file>' is uploaded via drag and drop
     Then progress is made to the task list
-    And Upload the Planning Officer’s report subsection is shown as completed
+    And Upload the Planning Officer's report subsection is shown as completed
     Examples:
       | valid_file             |
       | upload-file-valid.tiff |
@@ -41,10 +41,10 @@ Feature: Upload the Planning Officer’s report
       | upload-file-valid.docx |
 
   Scenario Outline: AC4 LPA Planning Officer successfully uploads multiple files
-    Given Upload the Planning Officer’s report question is requested
+    Given Upload the Planning Officer's report question is requested
     When valid multiple files '<multiple_files>' are uploaded
     Then progress is made to the task list
-    And Upload the Planning Officer’s report subsection is shown as completed
+    And Upload the Planning Officer's report subsection is shown as completed
     Examples:
       | multiple_files                                                       |
       | upload-file-valid.tiff, upload-file-valid.tif, upload-file-valid.png |
@@ -52,12 +52,12 @@ Feature: Upload the Planning Officer’s report
       | upload-file-valid.doc, upload-file-valid.docx                        |
 
   Scenario: AC5 LPA Planning Officer does not upload a file and is provided with an error.
-    Given Upload the Planning Officer’s report question is requested
+    Given Upload the Planning Officer's report question is requested
     When no file has been uploaded
-    Then progress is halted with a message to 'Upload the planning officer’s report or other documents and minutes'
+    Then progress is halted with a message to "Upload the planning officer's report or other documents and minutes"
 
   Scenario Outline: AC6 LPA Planning Officer selects invalid file size
-    Given Upload the Planning Officer’s report question is requested
+    Given Upload the Planning Officer's report question is requested
     When invalid files '<invalid_file_size>' have been selected
     Then progress is halted with a message the file '<invalid_file_size>' 'is too big'
     Examples:
@@ -65,7 +65,7 @@ Feature: Upload the Planning Officer’s report
       | upload_file_large.tiff |
 
   Scenario Outline: AC7 LPA Planning Officer selects Invalid file format
-    Given Upload the Planning Officer’s report question is requested
+    Given Upload the Planning Officer's report question is requested
     When invalid files '<invalid_format>' have been selected
     Then progress is halted with a message the file '<invalid_format>' 'format is incorrect'
     Examples:
@@ -73,7 +73,7 @@ Feature: Upload the Planning Officer’s report
       | upload-file-invalid-wrong-type.csv |
 
   Scenario: AC8 LPA Planning Officer selects to return to previous page
-    Given Upload the Planning Officer’s report question is requested
+    Given Upload the Planning Officer's report question is requested
     And a file has been uploaded
     When Back is then requested
     Then the LPA Planning Officer is taken to the Task List
@@ -86,25 +86,25 @@ Feature: Upload the Planning Officer’s report
 
   Scenario: AC10  LPA Planning Officer deletes a file after save and continue
     Given a file has been uploaded and confirmed
-    And Upload the Planning Officer’s report question is requested
+    And Upload the Planning Officer's report question is requested
     When LPA Planning Officer deletes the file
     Then the file is removed
 
   Scenario: AC11 LPA Planning Officer returns to the completed Upload the plans used to reach the decision question
-    Given The question 'Upload the Planning Officer’s report' has been completed
-    When the Upload the Planning Officer’s report question is requested
+    Given The question "Upload the Planning Officer's report" has been completed
+    When the Upload the Planning Officer's report question is requested
     Then the information they previously entered is still populated
 
   Scenario: AC12 Appeal details side panel
-    Given Upload the Planning Officer’s report question is requested
+    Given Upload the Planning Officer's report question is requested
     Then the appeal details panel is displayed on the right hand side of the page
 
   @nojs
   Scenario Outline: AC13 JavaScript Disabled
-    Given Upload the Planning Officer’s report question is requested
+    Given Upload the Planning Officer's report question is requested
     When valid file '<valid_file>' is successfully uploaded
     Then progress is made to the task list
-    And Upload the Planning Officer’s report subsection is shown as completed
+    And Upload the Planning Officer's report subsection is shown as completed
     Examples:
       | valid_file             |
       | upload-file-valid.tiff |
@@ -112,7 +112,7 @@ Feature: Upload the Planning Officer’s report
   Scenario: AC14 Check your answers
     Given all the mandatory questions for the questionnaire have been completed
     When Check your Answers is displayed
-    Then Upload the Planning Officer’s report heading and the uploaded file name should be displayed
+    Then Upload the Planning Officer's report heading and the uploaded file name should be displayed
 
   Scenario: AC15 Change answers
     Given a change to answer 'Upload Planning Officers report' is requested from Change your answers page

--- a/lpa-submissions-e2e-tests/cypress/integration/planningOfficersReport/planningOfficersReport.step.js
+++ b/lpa-submissions-e2e-tests/cypress/integration/planningOfficersReport/planningOfficersReport.step.js
@@ -24,7 +24,7 @@ Before({ tags: '@nojs' }, () => {
   disableJs = true;
 });
 
-Given('Upload the Planning Officer’s report question is requested', () => {
+Given("Upload the Planning Officer's report question is requested", () => {
   goToOfficersReportPage();
 });
 
@@ -33,11 +33,11 @@ When('LPA Planning Officer chooses to upload Planning Officer report', () => {
   cy.verifyPage(page.url);
 });
 
-When('the Upload the Planning Officer’s report question is requested', () => {
+When("the Upload the Planning Officer's report question is requested", () => {
   goToOfficersReportPage();
 });
 
-Then('LPA Planning Officer is presented with the ability to upload the Planning Officer’s report', () => {
+Then("LPA Planning Officer is presented with the ability to upload the Planning Officer's report", () => {
   cy.verifyPage(page.url);
   cy.verifyPageTitle(page.title);
   cy.verifyPageHeading(page.heading);
@@ -45,10 +45,10 @@ Then('LPA Planning Officer is presented with the ability to upload the Planning 
   cy.checkPageA11y(`/${defaultPathId}/${page.url}`);
 });
 
-Then('Upload the Planning Officer’s report subsection is shown as completed', () => {
+Then("Upload the Planning Officer's report subsection is shown as completed", () => {
   cy.verifyCompletedStatus(page.id);
 });
 
-Then('Upload the Planning Officer’s report heading and the uploaded file name should be displayed', () => {
+Then("Upload the Planning Officer's report heading and the uploaded file name should be displayed", () => {
   cy.confirmCheckYourAnswersDisplayed('plansDecision', 'upload-file-valid.pdf');
 });

--- a/packages/lpa-questionnaire-web-app/src/routes/officers-report.js
+++ b/packages/lpa-questionnaire-web-app/src/routes/officers-report.js
@@ -15,7 +15,7 @@ const getConfig = (_, res, next) => {
     sectionName: 'requiredDocumentsSection',
     taskName: 'officersReport',
     view: VIEW.OFFICERS_REPORT,
-    name: 'Planning Officer’s report',
+    name: "Planning Officer's report",
   };
 
   next();
@@ -32,7 +32,7 @@ router.post(
   '/:id/officers-report',
   [
     reqFilesToReqBodyFilesMiddleware('documents'),
-    uploadValidationRules('Upload the planning officer’s report or other documents and minutes'),
+    uploadValidationRules("Upload the planning officer's report or other documents and minutes"),
   ],
   validationErrorHandler,
   getConfig,

--- a/packages/lpa-questionnaire-web-app/src/services/pdf.service.js
+++ b/packages/lpa-questionnaire-web-app/src/services/pdf.service.js
@@ -22,8 +22,8 @@ const getAppealDetails = (appeal) => {
   const sidebarDetails = appealSidebarDetails(appeal);
   return {
     'Planning Application Number': sidebarDetails.number,
-    'Site Address': sidebarDetails.address,
     'Appellant Name': sidebarDetails.appellant,
+    'Site Address': sidebarDetails.address,
   };
 };
 
@@ -68,10 +68,10 @@ const createPdf = async (appealReply, appeal) => {
     log.info('Creating PDF appeal document');
 
     const renderedHtml = convertToHtml(appealReply, appeal);
-    const pdfBuffer = await generatePDF(`${id}.pdf`, renderedHtml);
+    const pdfBuffer = await generatePDF('lpa-questionnaire.pdf', renderedHtml);
 
     log.debug('Creating document from PDF buffer');
-    const document = await createDocument(id, pdfBuffer, `${id}.pdf`);
+    const document = await createDocument(id, pdfBuffer, 'lpa-questionnaire.pdf');
 
     log.debug('PDF document successfully created');
 

--- a/packages/lpa-questionnaire-web-app/src/services/task.service.js
+++ b/packages/lpa-questionnaire-web-app/src/services/task.service.js
@@ -103,7 +103,7 @@ const HEADERS = {
   otherAppeals: 'Tell us about any appeals in the immediate area',
   requiredDocumentsSection: 'Required documents',
   plansDecision: 'Plans used to reach the decision',
-  officersReport: 'Planning Officer’s report',
+  officersReport: "Planning Officer's report",
   optionalDocumentsSection: 'Optional supporting documents',
   representationsInterestedParties: 'Representations from interested parties',
   interestedPartiesAppeal: 'Notifying interested parties of the appeal',

--- a/packages/lpa-questionnaire-web-app/src/views/officers-report.njk
+++ b/packages/lpa-questionnaire-web-app/src/views/officers-report.njk
@@ -5,7 +5,7 @@
 {% endblock %}
 
 {% block pageDescription %}
-  Upload the Planning Officer’s report to committee or delegated report on the application, and any other relevant documents/minutes.
+  Upload the Planning Officer's report to committee or delegated report on the application, and any other relevant documents/minutes.
 {% endblock %}
 
 {% block sectionName %}

--- a/packages/lpa-questionnaire-web-app/src/views/pdf-generation.njk
+++ b/packages/lpa-questionnaire-web-app/src/views/pdf-generation.njk
@@ -3,7 +3,7 @@
 <!DOCTYPE html>
 <html lang="{{ htmlLang | default('en') }}" class="govuk-template {{ htmlClasses }}">
   <head>
-      <title>Response to householder planning appeal</title>
+      <title>Questionnaire for householder appeal</title>
       <style>{{ css | safe }}</style>
       <style>.govuk-template { background-color: #FFFFFF; }</style>
   </head>

--- a/packages/lpa-questionnaire-web-app/tests/unit/routes/officers-report.test.js
+++ b/packages/lpa-questionnaire-web-app/tests/unit/routes/officers-report.test.js
@@ -63,7 +63,7 @@ describe('routes/officers-report', () => {
         sectionName: 'requiredDocumentsSection',
         taskName: 'officersReport',
         view: VIEW.OFFICERS_REPORT,
-        name: 'Planning Officer’s report',
+        name: "Planning Officer's report",
       });
     });
   });

--- a/packages/lpa-questionnaire-web-app/tests/unit/services/pdf.service.test.js
+++ b/packages/lpa-questionnaire-web-app/tests/unit/services/pdf.service.test.js
@@ -43,8 +43,8 @@ describe('services/pdf.service', () => {
 
       const document = await createPdf(mockAppealReply, mockAppeal);
 
-      expect(generatePDF).toHaveBeenCalledWith('mock-id.pdf', html);
-      expect(createDocument).toHaveBeenCalledWith('mock-id', 'mock-pdf', 'mock-id.pdf');
+      expect(generatePDF).toHaveBeenCalledWith('lpa-questionnaire.pdf', html);
+      expect(createDocument).toHaveBeenCalledWith('mock-id', 'mock-pdf', 'lpa-questionnaire.pdf');
       expect(document).toEqual('mock-document');
     });
   });


### PR DESCRIPTION
## Ticket Number
<!-- Add the number from the Jira board -->
https://pins-ds.atlassian.net/browse/AS-2504

## Description of change
- Fixed issue with `&rsquo;` character in Planning officer's report encoding poorly in PDF. Changed to single quote across system
- Rearranged order of appeal info in PDF
- Renamed PDF output (kept ID naming in e2e tests)
- Updated PDF title

## Checklist
<!-- Put an `x` in all the boxes that apply: -->
- [ ] Requires infrastructure changes
- [ ] If adding or remove environment variables (e.g. in `docker-compose.yaml`) then I have updated the appropriate Helm chart
- [ ] I have updated the documentation accordingly
- [X] My commit history in this PR is linear
- [X] New features have tests
- [ ] Breaking change (team conversation required)

## Important

Please do not merge from `master` (please only [rebase](https://github.com/foundry4/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
