### PR TITLE
fix(as-2556): enable parallelisation for lpa cypress tests

### DIFF
--- a/.github/workflows/e2e-tests-on-PR.yml
+++ b/.github/workflows/e2e-tests-on-PR.yml
@@ -24,10 +24,32 @@ jobs:
         id: uuid
         run: echo "::set-output name=value::$GITHUB_SHA-$(date +"%s")"
 
+  context-LPA:
+    name: "Build ID LPA"
+    if: "! contains(toJSON(github.event.commits.*.message), '[ci skip]')"
+    runs-on: ubuntu-latest
+    outputs:
+      uuid: ${{ steps.uuid.outputs.value }}
+    steps:
+      - name: 'uuid'
+        id: uuid
+        run: echo "::set-output name=value::$GITHUB_SHA-$(date +"%s")"
+
   cypress-LPA:
+    needs: ['context-LPA']
     name: "Cypress- LPA questionnaire"
     if: "! contains(toJSON(github.event.commits.*.message), '[ci skip]')"
     runs-on: ubuntu-latest
+    strategy:
+      # when one test fails, DO NOT cancel the other
+      # containers, because this will kill Cypress processes
+      # leaving the Dashboard hanging ...
+      # https://github.com/cypress-io/github-action/issues/48
+      fail-fast: false
+      matrix:
+        # run 3 copies of the job in parallel
+        machines: [ 1 ]
+
     steps:
       - uses: actions/checkout@v2
 
@@ -43,7 +65,6 @@ jobs:
             lpa-${{ runner.os }}-node-${{ github.ref }}-
             lpa-${{ runner.os }}-node-
             lpa-${{ runner.os }}-
-
       - name: Cache Cypress binary
         uses: actions/cache@v2
         env:
@@ -56,7 +77,6 @@ jobs:
             lpa-${{ runner.os }}-cypress-${{ github.ref }}-
             lpa-${{ runner.os }}-cypress-
             lpa-${{ runner.os }}-
-
       - name: Cache local node_modules
         uses: actions/cache@v2
         env:
@@ -69,14 +89,25 @@ jobs:
             lpa-${{ runner.os }}-node-modules-${{ github.ref }}-
             lpa-${{ runner.os }}-node-modules-
             lpa-${{ runner.os }}-
-
       - name: Install the world
         run: make install
 
       - name: Start the world
         run: docker-compose up -d
-      - name: Run the tests against LPA questionaire
-        run: npm run test:e2e:lpa
+
+      - name: Run the tests against LPA questionaire in parallel
+        uses: cypress-io/github-action@v2
+        env:
+          # pass the Dashboard record key as an environment variable
+          CYPRESS_RECORD_KEY: ${{ secrets.CYPRESS_RECORD_KEY }}
+          # Pass the Github token lets this action correctly
+          # determine the unique run id necessary to re-run the checks
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          working-directory: ./lpa-submissions-e2e-tests
+          record: true
+          parallel: true
+          ci-build-id: ${{ needs.context.outputs.uuid }}
 
       - name: Post-process results
         if: ${{ always() }}
@@ -126,7 +157,6 @@ jobs:
             cypress-${{ runner.os }}-node-${{ github.ref }}-
             cypress-${{ runner.os }}-node-
             cypress-${{ runner.os }}-
-
       - name: Cache Cypress binary
         uses: actions/cache@v2
         env:
@@ -139,7 +169,6 @@ jobs:
             cypress-${{ runner.os }}-cypress-${{ github.ref }}-
             cypress-${{ runner.os }}-cypress-
             cypress-${{ runner.os }}-
-
       - name: Cache local node_modules
         uses: actions/cache@v2
         env:
@@ -152,7 +181,6 @@ jobs:
             cypress-${{ runner.os }}-node-modules-${{ github.ref }}-
             cypress-${{ runner.os }}-node-modules-
             cypress-${{ runner.os }}-
-
       - name: Install the world
         run: make install
 
@@ -190,3 +218,4 @@ jobs:
         with:
           name: screenshots-pins
           path: ${{ env.CYPRESS_SCREENSHOTS }}
+

--- a/.github/workflows/e2e-tests-on-PR.yml
+++ b/.github/workflows/e2e-tests-on-PR.yml
@@ -48,7 +48,7 @@ jobs:
       fail-fast: false
       matrix:
         # run 3 copies of the job in parallel
-        machines: [ 1 ]
+        machines: [ 1, 2, 3 ]
 
     steps:
       - uses: actions/checkout@v2

--- a/lpa-submissions-e2e-tests/cypress.json
+++ b/lpa-submissions-e2e-tests/cypress.json
@@ -9,10 +9,12 @@
     "demoDelay": 0,
     "DOCUMENT_SERVICE_BASE_URL": "http://localhost:3001/api/v1",
     "ASSUME_LIMITED_ACCESS": false,
-    "APPEAL_REPLY_SERVICE_BASE_URL": "http://localhost:3002/api/v1"
+    "APPEAL_REPLY_SERVICE_BASE_URL": "http://localhost:3002/api/v1",
+    "TAGS": "not @wip"
   },
   "retries": {
     "runMode": 1,
     "openMode": 0
-  }
+  },
+  "projectId": "ud8v53"
 }


### PR DESCRIPTION
## Ticket Number
https://pins-ds.atlassian.net/browse/AS-2556

## Description of change
Enable parallelisation for lpa cypress tests

## Checklist
<!-- Put an `x` in all the boxes that apply: -->
- [ ] Requires infrastructure changes
- [ ] If adding or remove environment variables (e.g. in `docker-compose.yaml`) then I have updated the appropriate Helm chart
- [ ] I have updated the documentation accordingly
- [ ] My commit history in this PR is linear
- [ ] New features have tests
- [ ] Breaking change (team conversation required)

## Important

Please do not merge from `master` (please only [rebase](https://github.com/foundry4/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
