### PR TITLE
chore: as-2541 disable flux automation

### DIFF
--- a/releases/dev/app.yml
+++ b/releases/dev/app.yml
@@ -5,16 +5,7 @@ metadata:
   name: app
   namespace: app-dev
   annotations:
-    fluxcd.io/automated: "true"
-    # Add hyphen to include pre-releases
-    filter.fluxcd.io/appealReplyServiceApi: semver:^1.0.0-0
-    filter.fluxcd.io/appealsServiceApi: semver:^1.0.0-0
-    filter.fluxcd.io/documentServiceApi: semver:^1.0.0-0
-    filter.fluxcd.io/formsWebApp: semver:^1.0.0-0
-    filter.fluxcd.io/horizon-householder-appeal-publish: semver:^1.0.0-0
-    filter.fluxcd.io/lpaQuestionnaireWebApp: semver:^1.0.0-0
-    filter.fluxcd.io/pdfServiceApi: semver:^1.0.0-0
-    filter.fluxcd.io/queueRetryService: semver:^1.0.0-0
+    fluxcd.io/automated: "false"
 spec:
   releaseName: app
   chart:

--- a/releases/dev/functions.yml
+++ b/releases/dev/functions.yml
@@ -5,21 +5,7 @@ metadata:
   name: functions
   namespace: openfaas-fn
   annotations:
-    fluxcd.io/automated: "true"
-    # Add hyphen to include pre-releases
-    filter.fluxcd.io/pingHorizon: semver:^1.0.0-0
-
-    repository.fluxcd.io/horizon-add-document: functions.horizon-add-document.image
-    filter.fluxcd.io/horizon-add-document: semver:^1.0.0-0
-    tag.fluxcd.io/horizon-add-document: functions.horizon-add-document.tag
-
-    repository.fluxcd.io/horizon-create-contact: functions.horizon-create-contact.image
-    filter.fluxcd.io/horizon-create-contact: semver:^1.0.0-0
-    tag.fluxcd.io/horizon-create-contact: functions.horizon-create-contact.tag
-
-    repository.fluxcd.io/horizon-householder-appeal-publish: functions.horizon-householder-appeal-publish.image
-    filter.fluxcd.io/horizon-householder-appeal-publish: semver:^1.0.0-0
-    tag.fluxcd.io/horizon-householder-appeal-publish: functions.horizon-householder-appeal-publish.tag
+    fluxcd.io/automated: "false"
 spec:
   releaseName: functions
   chart:

--- a/releases/preprod/app.yml
+++ b/releases/preprod/app.yml
@@ -5,15 +5,7 @@ metadata:
   name: app
   namespace: app-preprod
   annotations:
-    fluxcd.io/automated: 'true'
-    filter.fluxcd.io/appealReplyServiceApi: semver:~1.1.0
-    filter.fluxcd.io/appealsServiceApi: semver:~1.15.0
-    filter.fluxcd.io/documentServiceApi: semver:~1.4.0
-    filter.fluxcd.io/formsWebApp: semver:~1.46.0
-    filter.fluxcd.io/horizon-householder-appeal-publish: semver:~1.0.0
-    filter.fluxcd.io/lpaQuestionnaireWebApp: semver:~1.15.0
-    filter.fluxcd.io/pdfServiceApi: semver:~1.0.0
-    filter.fluxcd.io/queueRetryService: semver:~1.0.0
+    fluxcd.io/automated: "false"
 spec:
   releaseName: app
   chart:

--- a/releases/preprod/functions.yml
+++ b/releases/preprod/functions.yml
@@ -5,21 +5,7 @@ metadata:
   name: functions
   namespace: openfaas-fn
   annotations:
-    fluxcd.io/automated: "true"
-
-    filter.fluxcd.io/pingHorizon: semver:~1.0.0
-
-    repository.fluxcd.io/horizon-add-document: functions.horizon-add-document.image
-    filter.fluxcd.io/horizon-add-document: semver:~1.2.0
-    tag.fluxcd.io/horizon-add-document: functions.horizon-add-document.tag
-
-    repository.fluxcd.io/horizon-create-contact: functions.horizon-create-contact.image
-    filter.fluxcd.io/horizon-create-contact: semver:~1.1.0
-    tag.fluxcd.io/horizon-create-contact: functions.horizon-create-contact.tag
-
-    repository.fluxcd.io/horizon-householder-appeal-publish: functions.horizon-householder-appeal-publish.image
-    filter.fluxcd.io/horizon-householder-appeal-publish: semver:~1.3.0
-    tag.fluxcd.io/horizon-householder-appeal-publish: functions.horizon-householder-appeal-publish.tag
+    fluxcd.io/automated: "false"
 spec:
   releaseName: functions
   chart:

--- a/releases/prod/app.yml
+++ b/releases/prod/app.yml
@@ -5,15 +5,7 @@ metadata:
   name: app
   namespace: app-prod
   annotations:
-    fluxcd.io/automated: "true"
-    filter.fluxcd.io/appealReplyServiceApi: semver:1.1.1
-    filter.fluxcd.io/appealsServiceApi: semver:1.15.3
-    filter.fluxcd.io/documentServiceApi: semver:1.4.0
-    filter.fluxcd.io/formsWebApp: semver:1.46.3
-    filter.fluxcd.io/horizon-householder-appeal-publish: semver:1.0.0
-    filter.fluxcd.io/lpaQuestionnaireWebApp: semver:1.6.2
-    filter.fluxcd.io/pdfServiceApi: semver:1.0.1
-    filter.fluxcd.io/queueRetryService: semver:1.0.0
+    fluxcd.io/automated: "false"
 spec:
   releaseName: app
   chart:

--- a/releases/prod/functions.yml
+++ b/releases/prod/functions.yml
@@ -5,20 +5,7 @@ metadata:
   name: functions
   namespace: openfaas-fn
   annotations:
-    fluxcd.io/automated: "true"
-    filter.fluxcd.io/pingHorizon: semver:1.0.0
-
-    repository.fluxcd.io/horizon-add-document: functions.horizon-add-document.image
-    filter.fluxcd.io/horizon-add-document: semver:1.2.1
-    tag.fluxcd.io/horizon-add-document: functions.horizon-add-document.tag
-
-    repository.fluxcd.io/horizon-create-contact: functions.horizon-create-contact.image
-    filter.fluxcd.io/horizon-create-contact: semver:1.1.0
-    tag.fluxcd.io/horizon-create-contact: functions.horizon-create-contact.tag
-
-    repository.fluxcd.io/horizon-householder-appeal-publish: functions.horizon-householder-appeal-publish.image
-    filter.fluxcd.io/horizon-householder-appeal-publish: semver:1.3.0
-    tag.fluxcd.io/horizon-householder-appeal-publish: functions.horizon-householder-appeal-publish.tag
+    fluxcd.io/automated: "false"
 spec:
   releaseName: functions
   chart:


### PR DESCRIPTION
## Ticket Number
https://pins-ds.atlassian.net/browse/AS-2541

## Description of change
Flux automated commits to master give rise to race conditions, when used in the current setup of a monorepo, github actions and semantic-release. These conditions result in an unstable system. This change removes flux automation.


## Checklist
<!-- Put an `x` in all the boxes that apply: -->
- [x] Requires infrastructure changes
- [ ] If adding or remove environment variables (e.g. in `docker-compose.yaml`) then I have updated the appropriate Helm chart
- [ ] I have updated the documentation accordingly
- [x] My commit history in this PR is linear
- [ ] New features have tests
- [x] Breaking change (team conversation required)

## Important

Please do not merge from `master` (please only [rebase](https://github.com/foundry4/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
