### PR TITLE
chore: force build to 1.26, and 1.8.0 for reply api

### DIFF
--- a/releases/dev/app.yml
+++ b/releases/dev/app.yml
@@ -19,7 +19,7 @@ spec:
       replicaCount: 2
       image:
         repository: pinscommonukscontainers3887default.azurecr.io/appeal-reply-service-api
-        tag: 1.7.1
+        tag: 1.8.0
       config:
         notify:
           secretName: akv-notify-preprod
@@ -51,7 +51,7 @@ spec:
       replicaCount: 2
       image:
         repository: pinscommonukscontainers3887default.azurecr.io/lpa-questionnaire-web-app
-        tag: 1.25.0
+        tag: 1.26.0
 
     pdfServiceApi:
       replicaCount: 2


### PR DESCRIPTION
## Description of change
Build PR for site access question

## Checklist
<!-- Put an `x` in all the boxes that apply: -->
- [ ] Requires infrastructure changes
- [ ] If adding or remove environment variables (e.g. in `docker-compose.yaml`) then I have updated the appropriate Helm chart
- [ ] I have updated the documentation accordingly
- [ ] My commit history in this PR is linear
- [ ] New features have tests
- [ ] Breaking change (team conversation required)

## Important

Please do not merge from `master` (please only [rebase](https://github.com/foundry4/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
