### PR TITLE
chore: as-2663 run semantic release once only

### DIFF
--- a/.github/actions/semantic-release/action.yml
+++ b/.github/actions/semantic-release/action.yml
@@ -11,10 +11,6 @@ inputs:
   GITHUB_TOKEN:
     description: GITHUB_TOKEN secret
     required: true
-  SET_VERSION:
-    description: Workflow is to set the next version number
-    required: false
-    default: "false"
 outputs:
   new_release_published:
     description: Tells you if a new release is to be published - either "true" or "false"
@@ -41,10 +37,9 @@ runs:
           cd ${{ inputs.DIR }}
           export GITHUB_TOKEN="${{ inputs.GITHUB_TOKEN }}"
 
-          echo "Run a semantic-release dry-run so the output can be debugged."
-          ${ROOT_DIR}/node_modules/.bin/semantic-release -d
-
-          NEW_VERSION=$(${ROOT_DIR}/node_modules/.bin/semantic-release -d | awk '/Release note for version/ { getline; print $2 }')
+          # Only run semantic-release once to minimise race conditions with flux.
+          ${ROOT_DIR}/node_modules/.bin/semantic-release --ci 2>&1 | tee outputfile
+          NEW_VERSION=$(cat outputfile | awk '/Release note for version/ { getline; print $2 }')
 
           if [ -n "$NEW_VERSION" ]; then
             NEW_VERSION_PUBLISHED=true
@@ -55,14 +50,3 @@ runs:
         echo "::set-output name=new_release_published::$NEW_VERSION_PUBLISHED"
         echo "::set-output name=new_release_version::$NEW_VERSION"
         echo "::set-output name=new_release_version_number::$NEW_VERSION_NUMBER"
-
-    - name: Set version
-      shell: bash
-      run: |
-        if [ "${{ inputs.SET_VERSION }}" == "true" ]; then
-          ROOT_DIR=$(pwd)
-          npm ci
-          cd ${{ inputs.DIR }}
-          export GITHUB_TOKEN="${{ inputs.GITHUB_TOKEN }}"
-          ${ROOT_DIR}/node_modules/.bin/semantic-release --ci
-        fi

--- a/.github/workflows/appeal-reply-service-api.yml
+++ b/.github/workflows/appeal-reply-service-api.yml
@@ -50,17 +50,6 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.CUSTOM_GITHUB_TOKEN }}
           GET_VERSION: 'true'
 
-      - uses: ./.github/actions/flux
-        if: ${{ steps.version_number.outputs.new_release_published == 'true' }}
-
-      - name: Set next version number
-        uses: ./.github/actions/semantic-release
-        if: ${{ steps.version_number.outputs.new_release_published == 'true' }}
-        with:
-          DIR: packages/${{ env.APP_DIR }}
-          GITHUB_TOKEN: ${{ secrets.CUSTOM_GITHUB_TOKEN }}
-          SET_VERSION: 'true'
-
       - name: Exit if no git tag was created
         if: ${{ steps.version_number.outputs.new_release_published == 'true' }}
         run: |

--- a/.github/workflows/appeals-service-api.yml
+++ b/.github/workflows/appeals-service-api.yml
@@ -50,17 +50,6 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.CUSTOM_GITHUB_TOKEN }}
           GET_VERSION: 'true'
 
-      - uses: ./.github/actions/flux
-        if: ${{ steps.version_number.outputs.new_release_published == 'true' }}
-
-      - name: Set next version number
-        uses: ./.github/actions/semantic-release
-        if: ${{ steps.version_number.outputs.new_release_published == 'true' }}
-        with:
-          DIR: packages/${{ env.APP_DIR }}
-          GITHUB_TOKEN: ${{ secrets.CUSTOM_GITHUB_TOKEN }}
-          SET_VERSION: 'true'
-
       - name: Exit if no git tag was created
         if: ${{ steps.version_number.outputs.new_release_published == 'true' }}
         run: |

--- a/.github/workflows/document-service-api.yml
+++ b/.github/workflows/document-service-api.yml
@@ -50,17 +50,6 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.CUSTOM_GITHUB_TOKEN }}
           GET_VERSION: 'true'
 
-      - uses: ./.github/actions/flux
-        if: ${{ steps.version_number.outputs.new_release_published == 'true' }}
-
-      - name: Set next version number
-        uses: ./.github/actions/semantic-release
-        if: ${{ steps.version_number.outputs.new_release_published == 'true' }}
-        with:
-          DIR: packages/${{ env.APP_DIR }}
-          GITHUB_TOKEN: ${{ secrets.CUSTOM_GITHUB_TOKEN }}
-          SET_VERSION: 'true'
-
       - name: Exit if no git tag was created
         if: ${{ steps.version_number.outputs.new_release_published == 'true' }}
         run: |

--- a/.github/workflows/forms-web-app.yml
+++ b/.github/workflows/forms-web-app.yml
@@ -50,17 +50,6 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.CUSTOM_GITHUB_TOKEN }}
           GET_VERSION: 'true'
 
-      - uses: ./.github/actions/flux
-        if: ${{ steps.version_number.outputs.new_release_published == 'true' }}
-
-      - name: Set next version number
-        uses: ./.github/actions/semantic-release
-        if: ${{ steps.version_number.outputs.new_release_published == 'true' }}
-        with:
-          DIR: packages/${{ env.APP_DIR }}
-          GITHUB_TOKEN: ${{ secrets.CUSTOM_GITHUB_TOKEN }}
-          SET_VERSION: 'true'
-
       - name: Exit if no git tag was created
         if: ${{ steps.version_number.outputs.new_release_published == 'true' }}
         run: |

--- a/.github/workflows/horizon-add-document.yml
+++ b/.github/workflows/horizon-add-document.yml
@@ -53,17 +53,6 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.CUSTOM_GITHUB_TOKEN }}
           GET_VERSION: 'true'
 
-      - uses: ./.github/actions/flux
-        if: ${{ steps.version_number.outputs.new_release_published == 'true' }}
-
-      - name: Set next version number
-        uses: ./.github/actions/semantic-release
-        if: ${{ steps.version_number.outputs.new_release_published == 'true' }}
-        with:
-          DIR: packages/${{ env.APP_DIR }}
-          GITHUB_TOKEN: ${{ secrets.CUSTOM_GITHUB_TOKEN }}
-          SET_VERSION: 'true'
-
       - name: Exit if no git tag was created
         if: ${{ steps.version_number.outputs.new_release_published == 'true' }}
         run: |

--- a/.github/workflows/horizon-create-case.yml
+++ b/.github/workflows/horizon-create-case.yml
@@ -53,17 +53,6 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.CUSTOM_GITHUB_TOKEN }}
           GET_VERSION: 'true'
 
-      - uses: ./.github/actions/flux
-        if: ${{ steps.version_number.outputs.new_release_published == 'true' }}
-
-      - name: Set next version number
-        uses: ./.github/actions/semantic-release
-        if: ${{ steps.version_number.outputs.new_release_published == 'true' }}
-        with:
-          DIR: packages/${{ env.APP_DIR }}
-          GITHUB_TOKEN: ${{ secrets.CUSTOM_GITHUB_TOKEN }}
-          SET_VERSION: 'true'
-
       - name: Exit if no git tag was created
         if: ${{ steps.version_number.outputs.new_release_published == 'true' }}
         run: |

--- a/.github/workflows/horizon-householder-appeal-publish.yml
+++ b/.github/workflows/horizon-householder-appeal-publish.yml
@@ -53,17 +53,6 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.CUSTOM_GITHUB_TOKEN }}
           GET_VERSION: 'true'
 
-      - uses: ./.github/actions/flux
-        if: ${{ steps.version_number.outputs.new_release_published == 'true' }}
-
-      - name: Set next version number
-        uses: ./.github/actions/semantic-release
-        if: ${{ steps.version_number.outputs.new_release_published == 'true' }}
-        with:
-          DIR: packages/${{ env.APP_DIR }}
-          GITHUB_TOKEN: ${{ secrets.CUSTOM_GITHUB_TOKEN }}
-          SET_VERSION: 'true'
-
       - name: Exit if no git tag was created
         if: ${{ steps.version_number.outputs.new_release_published == 'true' }}
         run: |

--- a/.github/workflows/lpa-questionnaire.yml
+++ b/.github/workflows/lpa-questionnaire.yml
@@ -50,17 +50,6 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.CUSTOM_GITHUB_TOKEN }}
           GET_VERSION: 'true'
 
-      - uses: ./.github/actions/flux
-        if: ${{ steps.version_number.outputs.new_release_published == 'true' }}
-
-      - name: Set next version number
-        uses: ./.github/actions/semantic-release
-        if: ${{ steps.version_number.outputs.new_release_published == 'true' }}
-        with:
-          DIR: packages/${{ env.APP_DIR }}
-          GITHUB_TOKEN: ${{ secrets.CUSTOM_GITHUB_TOKEN }}
-          SET_VERSION: 'true'
-
       - name: Exit if no git tag was created
         if: ${{ steps.version_number.outputs.new_release_published == 'true' }}
         run: |

--- a/.github/workflows/openfaas-amqp-connector.yml
+++ b/.github/workflows/openfaas-amqp-connector.yml
@@ -50,17 +50,6 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.CUSTOM_GITHUB_TOKEN }}
           GET_VERSION: 'true'
 
-      - uses: ./.github/actions/flux
-        if: ${{ steps.version_number.outputs.new_release_published == 'true' }}
-
-      - name: Set next version number
-        uses: ./.github/actions/semantic-release
-        if: ${{ steps.version_number.outputs.new_release_published == 'true' }}
-        with:
-          DIR: packages/${{ env.APP_DIR }}
-          GITHUB_TOKEN: ${{ secrets.CUSTOM_GITHUB_TOKEN }}
-          SET_VERSION: 'true'
-
       - name: Exit if no git tag was created
         if: ${{ steps.version_number.outputs.new_release_published == 'true' }}
         run: |

--- a/.github/workflows/pdf-service-api.yml
+++ b/.github/workflows/pdf-service-api.yml
@@ -50,17 +50,6 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GET_VERSION: 'true'
 
-      - uses: ./.github/actions/flux
-        if: ${{ steps.version_number.outputs.new_release_published == 'true' }}
-
-      - name: Set next version number
-        uses: ./.github/actions/semantic-release
-        if: ${{ steps.version_number.outputs.new_release_published == 'true' }}
-        with:
-          DIR: packages/${{ env.APP_DIR }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          SET_VERSION: 'true'
-
       - name: Exit if no git tag was created
         if: ${{ steps.version_number.outputs.new_release_published == 'true' }}
         run: |

--- a/.github/workflows/ping.yml
+++ b/.github/workflows/ping.yml
@@ -50,17 +50,6 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.CUSTOM_GITHUB_TOKEN }}
           GET_VERSION: 'true'
 
-      - uses: ./.github/actions/flux
-        if: ${{ steps.version_number.outputs.new_release_published == 'true' }}
-
-      - name: Set next version number
-        uses: ./.github/actions/semantic-release
-        if: ${{ steps.version_number.outputs.new_release_published == 'true' }}
-        with:
-          DIR: packages/${{ env.APP_DIR }}
-          GITHUB_TOKEN: ${{ secrets.CUSTOM_GITHUB_TOKEN }}
-          SET_VERSION: 'true'
-
       - name: Exit if no git tag was created
         if: ${{ steps.version_number.outputs.new_release_published == 'true' }}
         run: |

--- a/.github/workflows/queue-retry.yml
+++ b/.github/workflows/queue-retry.yml
@@ -50,17 +50,6 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.CUSTOM_GITHUB_TOKEN }}
           GET_VERSION: 'true'
 
-      - uses: ./.github/actions/flux
-        if: ${{ steps.version_number.outputs.new_release_published == 'true' }}
-
-      - name: Set next version number
-        uses: ./.github/actions/semantic-release
-        if: ${{ steps.version_number.outputs.new_release_published == 'true' }}
-        with:
-          DIR: packages/${{ env.APP_DIR }}
-          GITHUB_TOKEN: ${{ secrets.CUSTOM_GITHUB_TOKEN }}
-          SET_VERSION: 'true'
-
       - name: Exit if no git tag was created
         if: ${{ steps.version_number.outputs.new_release_published == 'true' }}
         run: |


### PR DESCRIPTION
## Ticket Number
https://pins-ds.atlassian.net/browse/AS-2663

## Description of change
As DevOps, I want to reduce the number of runs of semantic-release from 3 to 1, so that we can reduce race condition errors.


## Checklist
<!-- Put an `x` in all the boxes that apply: -->
- [ ] Requires infrastructure changes
- [ ] If adding or remove environment variables (e.g. in `docker-compose.yaml`) then I have updated the appropriate Helm chart
- [ ] I have updated the documentation accordingly
- [x] My commit history in this PR is linear
- [ ] New features have tests
- [ ] Breaking change (team conversation required)

## Important

Please do not merge from `master` (please only [rebase](https://github.com/foundry4/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
