### PR TITLE
fix: as-2663 adjust for different output

### DIFF
--- a/.github/actions/semantic-release/action.yml
+++ b/.github/actions/semantic-release/action.yml
@@ -31,7 +31,8 @@ runs:
         NEW_VERSION_PUBLISHED=false
         NEW_VERSION=""
         NEW_VERSION_NUMBER=""
-        if [ "${{ inputs.GET_VERSION }}" == "true" ]; then
+        if [ "${{ inputs.GET_VERSION }}" == "true" ] && [[ ${GITHUB_REF#refs/heads/} == "master" ]] ; then
+
           ROOT_DIR=$(pwd)
           npm ci
           cd ${{ inputs.DIR }}
@@ -39,7 +40,7 @@ runs:
 
           # Only run semantic-release once to minimise race conditions with flux.
           ${ROOT_DIR}/node_modules/.bin/semantic-release --ci 2>&1 | tee outputfile
-          NEW_VERSION=$(cat outputfile | awk '/Release note for version/ { getline; print $2 }')
+          NEW_VERSION=$(cat outputfile | grep "Created tag" | awk '{ print $NF }')
 
           if [ -n "$NEW_VERSION" ]; then
             NEW_VERSION_PUBLISHED=true

--- a/packages/forms-web-app/Dockerfile
+++ b/packages/forms-web-app/Dockerfile
@@ -9,7 +9,7 @@ ENV VERSION="${VERSION}"
 # Do not rely on NODE_ENV - exists for performance reasons only
 ENV NODE_ENV=production
 ENV PORT=3000
-# This must be built locally from the common package
+# This must be built locally from the common package.
 COPY --from=common:latest /opt/app ../common
 ADD dist dist
 ADD node_modules node_modules


### PR DESCRIPTION
## Ticket Number

https://pins-ds.atlassian.net/browse/AS-2663

## Description of change
Adjust to grab the new version from the semantic-release output, as it is no longer grabbing it from a dry-run.

## Checklist
<!-- Put an `x` in all the boxes that apply: -->
- [ ] Requires infrastructure changes
- [ ] If adding or remove environment variables (e.g. in `docker-compose.yaml`) then I have updated the appropriate Helm chart
- [ ] I have updated the documentation accordingly
- [x] My commit history in this PR is linear
- [ ] New features have tests
- [ ] Breaking change (team conversation required)

## Important

Please do not merge from `master` (please only [rebase](https://github.com/foundry4/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
