### PR TITLE
fix(forms-web-app): address county is no longer mandatory

### DIFF
--- a/e2e-tests/cypress/integration/appeal-submission-appeal-site-address.feature
+++ b/e2e-tests/cypress/integration/appeal-submission-appeal-site-address.feature
@@ -12,6 +12,7 @@ Feature: Appellant provides the Appeal Site Address
     When invalid appeal site address is submitted
     Then Address of the appeal site section is "NOT STARTED"
 
+  @as-2483
   Scenario Outline: Prospective Appellant submits a valid appeal site address
     Given the user is prompted for the site address
     When the user provides their appeal site address as <Address Line 1> and <Address Line 2> and <Town or City> and <County> and <Postcode>
@@ -20,10 +21,12 @@ Feature: Appellant provides the Appeal Site Address
     Examples:
       | Address Line 1  | Address Line 2 | Town or City | County       | Postcode   |
       | "1 Taylor Road" | "Clifton"      | "Bristol"    | "South Glos" | "BS8 1TG"  |
-      | "2 Taylor Road" | ""             | ""           | "South Glos" | "M1 1AA"   |
+      | "2 Taylor Road" | ""             | ""           | ""           | "M1 1AA"   |
       | "4 Taylor Road" | ""             | "Bristol"    | "South Glos" | "M60 1NW"  |
       | "5 Taylor Road" | "Clifton"      | ""           | "South Glos" | "DN55 1PT" |
+      | "5 Taylor Road" | "Clifton"      | "Bristol"    | ""           | "DN55 1PT" |
 
+  @as-2483
   Scenario Outline: Prospective Appellant submits an appeal site address without mandatory information
     Given the user is prompted for the site address
     When the user provides their appeal site address as <Address Line 1> and <Address Line 2> and <Town or City> and <County> and <Postcode>
@@ -32,33 +35,19 @@ Feature: Appellant provides the Appeal Site Address
     Examples:
       | Address Line 1 | Address Line 2 | Town or City | County       | Postcode   | reason                       |
       | ""             | ""             | ""           | "South Glos" | "W1A 1HQ"  | "Address Line 1 is required" |
-      | "aaa"          | ""             | ""           | ""           | "EC1A 1BB" | "County is required"         |
-      | "aaa"          | ""             | ""           | "South Glos" | ""         | "Postcode is required"       |
+      | "aaa"          | ""             | ""           | ""           | ""         | "Postcode is required"       |
 
-  @as-1680
+  @as-1680 @as-2483
   Scenario: Prospective appellant fails to provide any address information
     Given the user is prompted for the site address
     When the user provides their appeal site address as "" and "" and "" and "" and ""
     Then the user is informed that "Address Line 1 is required"
-    And the user is informed that "County is required"
     And the user is informed that "Postcode is required"
-
-  Scenario: Prospective appellant fails to provide first address line and county
-    Given the user is prompted for the site address
-    When the user provides their appeal site address as "" and "" and "" and "" and "BS8 1TG"
-    Then the user is informed that "Address Line 1 is required"
-    And the user is informed that "County is required"
 
   Scenario: Prospective appellant fails to provide first address line and Postcode
     Given the user is prompted for the site address
     When the user provides their appeal site address as "" and "" and "" and "South Glos" and ""
     Then the user is informed that "Address Line 1 is required"
-    And the user is informed that "Postcode is required"
-
-  Scenario: Prospective appellant fails to provide County and Postcode
-    Given the user is prompted for the site address
-    When the user provides their appeal site address as "1 Taylor Road" and "" and "" and "" and ""
-    Then the user is informed that "County is required"
     And the user is informed that "Postcode is required"
 
   Scenario Outline: Prospective appellant provides address data that exceeds the maximum length constraint for each field
@@ -84,13 +73,13 @@ Feature: Appellant provides the Appeal Site Address
     And the user is informed that "Postcode has a limit of 8 characters"
     And the user can see that their appeal has not been updated with the provided address
 
+  @as-2483
   Scenario: Prospective appellant provides invalid address data with some missing fields and others that exceed the maximum length constraint
     Given the user is prompted for the site address
     When the user provides values that are too long for Address Line 2 and Town or City and provides no other data
     Then the user is informed that "Address Line 1 is required"
     And the user is informed that "Address Line 2 has a limit of 60 characters"
     And the user is informed that "Town or City has a limit of 60 characters"
-    And the user is informed that "County is required"
     And the user is informed that "Postcode is required"
     And the user can see that their appeal has not been updated with the provided address
 

--- a/e2e-tests/cypress/integration/appeal-submission-appeal-site-address.feature
+++ b/e2e-tests/cypress/integration/appeal-submission-appeal-site-address.feature
@@ -50,6 +50,7 @@ Feature: Appellant provides the Appeal Site Address
     Then the user is informed that "Address Line 1 is required"
     And the user is informed that "Postcode is required"
 
+  @as-2483
   Scenario Outline: Prospective appellant provides address data that exceeds the maximum length constraint for each field
     Given the user is prompted for the site address
     When the user provides a value which is too long - <component> : <count>
@@ -63,6 +64,7 @@ Feature: Appellant provides the Appeal Site Address
       | "County"         | 61    | "County has a limit of 60 characters"         |
       | "Postcode"       | 9     | "Postcode has a limit of 8 characters"        |
 
+  @as-2483
   Scenario: Prospective appellant provides address data that exceeds the maximum length constraint for multiple fields
     Given the user is prompted for the site address
     When the user provides values that are too long for Address Line 1, Address Line 2, Town or City, County and Postcode

--- a/e2e-tests/cypress/integration/appeal-submission-appeal-site-address/appeal-submission-appeal-site-address.js
+++ b/e2e-tests/cypress/integration/appeal-submission-appeal-site-address/appeal-submission-appeal-site-address.js
@@ -78,7 +78,7 @@ Then(
   (reason) => {
     switch (reason) {
       case 'Address Line 1 is required':
-        cy.confirmSiteAddressWasRejectedBecause('Enter a building and/or street');
+        cy.confirmSiteAddressWasRejectedBecause('Enter the first line of the address');
         break;
       case 'County is required':
         cy.confirmSiteAddressWasRejectedBecause('Enter a county');
@@ -88,12 +88,12 @@ Then(
         break;
       case 'Address Line 1 has a limit of 60 characters':
         cy.confirmSiteAddressWasRejectedBecause(
-          'Building and/or street must be 60 characters or fewer',
+          'The first line of the address must be 60 characters or fewer',
         );
         break;
       case 'Address Line 2 has a limit of 60 characters':
         cy.confirmSiteAddressWasRejectedBecause(
-          'Building and/or street must be 60 characters or fewer',
+          'The first line of the address must be 60 characters or fewer',
         );
         break;
       case 'Town or City has a limit of 60 characters':
@@ -120,16 +120,16 @@ Then(
 Then('the user is informed that {string}', (reason) => {
   switch (reason) {
     case 'Address Line 1 is required':
-      cy.confirmSiteAddressWasRejectedBecause('Enter a building and/or street');
+      cy.confirmSiteAddressWasRejectedBecause('Enter the first line of the address');
       break;
     case 'Address Line 1 has a limit of 60 characters':
       cy.confirmSiteAddressWasRejectedBecause(
-        'Building and/or street must be 60 characters or fewer',
+        'The first line of the address must be 60 characters or fewer',
       );
       break;
     case 'Address Line 2 has a limit of 60 characters':
       cy.confirmSiteAddressWasRejectedBecause(
-        'Building and/or street must be 60 characters or fewer',
+        'The first line of the address must be 60 characters or fewer',
       );
       break;
     case 'Town or City has a limit of 60 characters':

--- a/e2e-tests/cypress/integration/appeal-submission-appeal-site-address/appeal-submission-appeal-site-address.js
+++ b/e2e-tests/cypress/integration/appeal-submission-appeal-site-address/appeal-submission-appeal-site-address.js
@@ -80,9 +80,6 @@ Then(
       case 'Address Line 1 is required':
         cy.confirmSiteAddressWasRejectedBecause('Enter the first line of the address');
         break;
-      case 'County is required':
-        cy.confirmSiteAddressWasRejectedBecause('Enter a county');
-        break;
       case 'Postcode is required':
         cy.confirmSiteAddressWasRejectedBecause('Enter a postcode');
         break;
@@ -93,7 +90,7 @@ Then(
         break;
       case 'Address Line 2 has a limit of 60 characters':
         cy.confirmSiteAddressWasRejectedBecause(
-          'The first line of the address must be 60 characters or fewer',
+          'The second line of the address must be 60 characters or fewer',
         );
         break;
       case 'Town or City has a limit of 60 characters':
@@ -129,7 +126,7 @@ Then('the user is informed that {string}', (reason) => {
       break;
     case 'Address Line 2 has a limit of 60 characters':
       cy.confirmSiteAddressWasRejectedBecause(
-        'The first line of the address must be 60 characters or fewer',
+        'The second line of the address must be 60 characters or fewer',
       );
       break;
     case 'Town or City has a limit of 60 characters':
@@ -137,9 +134,6 @@ Then('the user is informed that {string}', (reason) => {
       break;
     case 'County has a limit of 60 characters':
       cy.confirmSiteAddressWasRejectedBecause('County must be 60 characters or fewer');
-      break;
-    case 'County is required':
-      cy.confirmSiteAddressWasRejectedBecause('Enter a county');
       break;
     case 'Postcode is required':
       cy.confirmSiteAddressWasRejectedBecause('Enter a postcode');

--- a/packages/appeals-service-api/src/services/appeal.service.js
+++ b/packages/appeals-service-api/src/services/appeal.service.js
@@ -29,17 +29,14 @@ const validateAppeal = (appeal) => {
   // All mandatory fields are valued or none of them are the only accepted states.
   if (
     (appeal.appealSiteSection.siteAddress.addressLine1 ||
-      appeal.appealSiteSection.siteAddress.county ||
       appeal.appealSiteSection.siteAddress.postcode) &&
     !(
       appeal.appealSiteSection.siteAddress.postcode &&
-      appeal.appealSiteSection.siteAddress.county &&
       appeal.appealSiteSection.siteAddress.addressLine1
     )
   ) {
-    const siteAddressErrorMessage = `The appeal appellant site address must have addressLine1, county and postcode valued.
+    const siteAddressErrorMessage = `The appeal appellant site address must have addressLine1 and postcode valued.
     addressLine1=${appeal.appealSiteSection.siteAddress.addressLine1}
-    county=${appeal.appealSiteSection.siteAddress.county}
     postcode=${appeal.appealSiteSection.siteAddress.postcode}`;
 
     errors.push(siteAddressErrorMessage);

--- a/packages/appeals-service-api/tests/unit/lib/notify.test.js
+++ b/packages/appeals-service-api/tests/unit/lib/notify.test.js
@@ -55,10 +55,9 @@ describe('lib/notify', () => {
     test('Format address with minimum fields', () => {
       const input = {
         addressLine1: 'Line 1',
-        county: 'County',
         postcode: 'SA18 3RT',
       };
-      const output = 'Line 1\nCounty\nSA18 3RT';
+      const output = 'Line 1\nSA18 3RT';
       expect(getAddress(input)).toEqual(output);
     });
   });

--- a/packages/appeals-service-api/tests/unit/services/appeal.service.test.js
+++ b/packages/appeals-service-api/tests/unit/services/appeal.service.test.js
@@ -220,26 +220,18 @@ describe('services/validation.service', () => {
     [
       {
         addressLine1: '',
-        county: 'county',
         postcode: 'postcode',
       },
       {
         addressLine1: 'addressLine1',
-        county: '',
-        postcode: 'postcode',
-      },
-      {
-        addressLine1: 'addressLine1',
-        county: 'county',
         postcode: '',
       },
     ].forEach((siteAddress) => {
       test('the site address should see all its mandatory fields valued or none of them, other it should fail', async () => {
         appeal.appealSiteSection.siteAddress = siteAddress;
 
-        const siteAddressErrorMessage = `The appeal appellant site address must have addressLine1, county and postcode valued.
+        const siteAddressErrorMessage = `The appeal appellant site address must have addressLine1 and postcode valued.
     addressLine1=${appeal.appealSiteSection.siteAddress.addressLine1}
-    county=${appeal.appealSiteSection.siteAddress.county}
     postcode=${appeal.appealSiteSection.siteAddress.postcode}`;
 
         const errors = validateAppeal(appeal);

--- a/packages/forms-web-app/src/services/task-status/status-appeal-site-address.js
+++ b/packages/forms-web-app/src/services/task-status/status-appeal-site-address.js
@@ -1,0 +1,6 @@
+const TASK_STATUS = require('./task-statuses');
+
+exports.statusAppealSiteAddress = (appeal) => {
+  const { addressLine1, postcode } = appeal.appealSiteSection.siteAddress;
+  return addressLine1 && postcode ? TASK_STATUS.COMPLETED : TASK_STATUS.NOT_STARTED;
+};

--- a/packages/forms-web-app/src/services/task.service.js
+++ b/packages/forms-web-app/src/services/task.service.js
@@ -1,6 +1,7 @@
 const { VIEW } = require('../lib/views');
 
 const TASK_STATUS = require('./task-status/task-statuses');
+const { statusAppealSiteAddress } = require('./task-status/status-appeal-site-address');
 const { statusSiteOwnership } = require('./task-status/status-site-ownership');
 const { statusYourDetails } = require('./task-status/status-your-details');
 
@@ -27,11 +28,6 @@ function statusDecisionLetter(appeal) {
 function statusApplicationNumber(appeal) {
   const task = appeal.requiredDocumentsSection;
   return task.applicationNumber ? TASK_STATUS.COMPLETED : TASK_STATUS.NOT_STARTED;
-}
-
-function statusAppealSiteAddress(appeal) {
-  const { addressLine1, county, postcode } = appeal.appealSiteSection.siteAddress;
-  return addressLine1 && county && postcode ? TASK_STATUS.COMPLETED : TASK_STATUS.NOT_STARTED;
 }
 
 function statusHealthAndSafety(appeal) {

--- a/packages/forms-web-app/src/validators/appellant-submission/site-location.js
+++ b/packages/forms-web-app/src/validators/appellant-submission/site-location.js
@@ -13,18 +13,18 @@ const ruleAddressLine1 = () =>
   body('site-address-line-one')
     .escape()
     .notEmpty()
-    .withMessage('Enter a building and/or street')
+    .withMessage('Enter the first line of the address')
     .bail()
     .isLength({ min: 1, max: 60 })
     .bail()
-    .withMessage('Building and/or street must be 60 characters or fewer');
+    .withMessage('The first line of the address must be 60 characters or fewer');
 
 const ruleAddressLine2 = () =>
   body('site-address-line-two')
     .escape()
     .isLength({ min: 0, max: 60 })
     .bail()
-    .withMessage('Building and/or street must be 60 characters or fewer');
+    .withMessage('The first line of the address must be 60 characters or fewer');
 
 const ruleAddressTownCity = () =>
   body('site-town-city')
@@ -36,10 +36,7 @@ const ruleAddressTownCity = () =>
 const ruleAddressCounty = () =>
   body('site-county')
     .escape()
-    .notEmpty()
-    .withMessage('Enter a county')
-    .bail()
-    .isLength({ min: 1, max: 60 })
+    .isLength({ min: 0, max: 60 })
     .bail()
     .withMessage('County must be 60 characters or fewer');
 

--- a/packages/forms-web-app/src/validators/appellant-submission/site-location.js
+++ b/packages/forms-web-app/src/validators/appellant-submission/site-location.js
@@ -24,7 +24,7 @@ const ruleAddressLine2 = () =>
     .escape()
     .isLength({ min: 0, max: 60 })
     .bail()
-    .withMessage('The first line of the address must be 60 characters or fewer');
+    .withMessage('The second line of the address must be 60 characters or fewer');
 
 const ruleAddressTownCity = () =>
   body('site-town-city')

--- a/packages/forms-web-app/src/views/appellant-submission/site-location.njk
+++ b/packages/forms-web-app/src/views/appellant-submission/site-location.njk
@@ -36,95 +36,120 @@
 
           <p>The appeal site is the area of property or land that your original planning application relates to.</p>
 
+          {% set addressLine1Id = "site-address-line-one" %}
+          {% set addressLine1LabelId = addressLine1Id + "-label" %}
           {% set addressLine1Text = "Address line 1" %}
           {{ govukInput({
             label: {
+              attributes: {
+                id: addressLine1LabelId
+              },
               text: addressLine1Text
             },
-            id: "site-address-line-one",
+            id: addressLine1Id,
             value: appeal.appealSiteSection.siteAddress.addressLine1,
-            name: "site-address-line-one",
+            name: addressLine1Id,
             autocomplete: "address-line1",
-            describedBy: addressLine1Text,
+            describedBy: addressLine1LabelId,
             attributes: {
               title: addressLine1Text
             },
-            errorMessage: errors['site-address-line-one'] and {
-              text: errors['site-address-line-one'].msg
+            errorMessage: errors[addressLine1Id] and {
+              text: errors[addressLine1Id].msg
             }
           }) }}
 
+          {% set addressLine2Id = "site-address-line-two" %}
+          {% set addressLine2LabelId = addressLine2Id + "-label" %}
           {% set addressLine2Text = "Address line 2 (optional)" %}
           {{ govukInput({
             label: {
+              attributes: {
+                id: addressLine2LabelId
+              },
               text: addressLine2Text
             },
-            id: "site-address-line-two",
+            id: addressLine2Id,
             value: appeal.appealSiteSection.siteAddress.addressLine2,
-            name: "site-address-line-two",
+            name: addressLine2Id,
             autocomplete: "address-line2",
-            describedBy: addressLine2Text,
+            describedBy: addressLine2LabelId,
             attributes: {
               title: addressLine2Text
             },
-            errorMessage: errors['site-address-line-two'] and {
-              text: errors['site-address-line-two'].msg
+            errorMessage: errors[addressLine2Id] and {
+              text: errors[addressLine2Id].msg
             }
           }) }}
 
+          {% set townOrCityId = "site-town-city" %}
+          {% set townOrCityLabelId = townOrCityId + "-label" %}
           {% set townOrCityText = "Town or city (optional)" %}
           {{ govukInput({
             label: {
+              attributes: {
+                id: townOrCityLabelId
+              },
               text: townOrCityText
             },
             classes: "govuk-!-width-two-thirds",
-            id: "site-town-city",
+            id: townOrCityId,
             value: appeal.appealSiteSection.siteAddress.town,
-            name: "site-town-city",
+            name: townOrCityId,
             autocomplete: "address-level2",
-            describedBy: townOrCityText,
+            describedBy: townOrCityLabelId,
             attributes: {
               title: townOrCityText
             },
-            errorMessage: errors['site-town-city'] and {
-              text: errors['site-town-city'].msg
+            errorMessage: errors[townOrCityId] and {
+              text: errors[townOrCityId].msg
             }
           }) }}
 
+          {% set countyId = "site-county" %}
+          {% set countyLabelId = countyId + "-label" %}
           {% set countyText = "County (optional)" %}
           {{ govukInput({
             label: {
+              attributes: {
+                id: countyLabelId
+              },
               text: countyText
             },
             classes: "govuk-!-width-two-thirds",
-            id: "site-county",
+            id: countyId,
             value: appeal.appealSiteSection.siteAddress.county,
-            name: "site-county",
-            describedBy: countyText,
+            name: countyId,
+            describedBy: countyLabelId,
             attributes: {
               title: countyText
             },
-            errorMessage: errors['site-county'] and {
-              text: errors['site-county'].msg
+            errorMessage: errors[countyId] and {
+              text: errors[countyId].msg
             }
           }) }}
 
+          {% set postcodeId = "site-postcode" %}
+          {% set postcodeLabelId = postcodeId + "-label" %}
           {% set postcodeText = "Postcode" %}
           {{ govukInput({
             label: {
+              attributes: {
+                id: postcodeLabelId
+              },
               text: "Postcode"
             },
             classes: "govuk-input--width-10",
-            id: "site-postcode",
+            id: postcodeId,
             value: appeal.appealSiteSection.siteAddress.postcode,
-            name: "site-postcode",
+            name: postcodeId,
             autocomplete: "postal-code",
-            describedBy: postcodeText,
+            describedBy: postcodeLabelId,
             attributes: {
               title: postcodeText
             },
-            errorMessage: errors['site-postcode'] and {
-              text: errors['site-postcode'].msg
+            errorMessage: errors[postcodeId] and {
+              text: errors[postcodeId].msg
             }
           }) }}
 

--- a/packages/forms-web-app/src/views/appellant-submission/site-location.njk
+++ b/packages/forms-web-app/src/views/appellant-submission/site-location.njk
@@ -36,59 +36,80 @@
 
           <p>The appeal site is the area of property or land that your original planning application relates to.</p>
 
+          {% set addressLine1Text = "Address line 1" %}
           {{ govukInput({
             label: {
-              html: 'Building and street <span class="govuk-visually-hidden">line 1 of 2</span>'
+              text: addressLine1Text
             },
             id: "site-address-line-one",
             value: appeal.appealSiteSection.siteAddress.addressLine1,
             name: "site-address-line-one",
             autocomplete: "address-line1",
+            describedBy: addressLine1Text,
+            attributes: {
+              title: addressLine1Text
+            },
             errorMessage: errors['site-address-line-one'] and {
               text: errors['site-address-line-one'].msg
             }
           }) }}
 
+          {% set addressLine2Text = "Address line 2 (optional)" %}
           {{ govukInput({
             label: {
-              html: '<span class="govuk-visually-hidden">Building and street line 2 of 2</span>'
+              text: addressLine2Text
             },
             id: "site-address-line-two",
             value: appeal.appealSiteSection.siteAddress.addressLine2,
             name: "site-address-line-two",
             autocomplete: "address-line2",
+            describedBy: addressLine2Text,
+            attributes: {
+              title: addressLine2Text
+            },
             errorMessage: errors['site-address-line-two'] and {
               text: errors['site-address-line-two'].msg
             }
           }) }}
 
+          {% set townOrCityText = "Town or city (optional)" %}
           {{ govukInput({
             label: {
-              text: "Town or city"
+              text: townOrCityText
             },
             classes: "govuk-!-width-two-thirds",
             id: "site-town-city",
             value: appeal.appealSiteSection.siteAddress.town,
             name: "site-town-city",
             autocomplete: "address-level2",
+            describedBy: townOrCityText,
+            attributes: {
+              title: townOrCityText
+            },
             errorMessage: errors['site-town-city'] and {
               text: errors['site-town-city'].msg
             }
           }) }}
 
+          {% set countyText = "County (optional)" %}
           {{ govukInput({
             label: {
-              text: "County"
+              text: countyText
             },
             classes: "govuk-!-width-two-thirds",
             id: "site-county",
             value: appeal.appealSiteSection.siteAddress.county,
             name: "site-county",
+            describedBy: countyText,
+            attributes: {
+              title: countyText
+            },
             errorMessage: errors['site-county'] and {
               text: errors['site-county'].msg
             }
           }) }}
 
+          {% set postcodeText = "Postcode" %}
           {{ govukInput({
             label: {
               text: "Postcode"
@@ -98,6 +119,10 @@
             value: appeal.appealSiteSection.siteAddress.postcode,
             name: "site-postcode",
             autocomplete: "postal-code",
+            describedBy: postcodeText,
+            attributes: {
+              title: postcodeText
+            },
             errorMessage: errors['site-postcode'] and {
               text: errors['site-postcode'].msg
             }

--- a/packages/forms-web-app/tests/unit/services/task-status/status-appeal-site-address.test.js
+++ b/packages/forms-web-app/tests/unit/services/task-status/status-appeal-site-address.test.js
@@ -1,0 +1,78 @@
+const {
+  statusAppealSiteAddress,
+} = require('../../../../src/services/task-status/status-appeal-site-address');
+
+const { APPEAL_DOCUMENT } = require('../../../../src/lib/empty-appeal');
+const TASK_STATUS = require('../../../../src/services/task-status/task-statuses');
+
+describe('services/task-status/status-appeal-site-address', () => {
+  [
+    {
+      description: 'Not started by default',
+      given: APPEAL_DOCUMENT.empty,
+      expected: TASK_STATUS.NOT_STARTED,
+    },
+    {
+      description: 'Requires postcode',
+      given: {
+        ...APPEAL_DOCUMENT.empty,
+        appealSiteSection: {
+          ...APPEAL_DOCUMENT.empty.appealSiteSection,
+          siteAddress: {
+            ...APPEAL_DOCUMENT.empty.appealSiteSection.siteAddress,
+            addressLine1: 'fake line 1',
+          },
+        },
+      },
+      expected: TASK_STATUS.NOT_STARTED,
+    },
+    {
+      description: 'Requires addressLine1',
+      given: {
+        ...APPEAL_DOCUMENT.empty,
+        appealSiteSection: {
+          ...APPEAL_DOCUMENT.empty.appealSiteSection,
+          siteAddress: {
+            ...APPEAL_DOCUMENT.empty.appealSiteSection.siteAddress,
+            postcode: 'fake postcode',
+          },
+        },
+      },
+      expected: TASK_STATUS.NOT_STARTED,
+    },
+    {
+      description: 'Empty strings are not valid',
+      given: {
+        ...APPEAL_DOCUMENT.empty,
+        appealSiteSection: {
+          ...APPEAL_DOCUMENT.empty.appealSiteSection,
+          siteAddress: {
+            ...APPEAL_DOCUMENT.empty.appealSiteSection.siteAddress,
+            addressLine1: '',
+            postcode: '',
+          },
+        },
+      },
+      expected: TASK_STATUS.NOT_STARTED,
+    },
+    {
+      description: 'Happy path',
+      given: {
+        ...APPEAL_DOCUMENT.empty,
+        appealSiteSection: {
+          ...APPEAL_DOCUMENT.empty.appealSiteSection,
+          siteAddress: {
+            ...APPEAL_DOCUMENT.empty.appealSiteSection.siteAddress,
+            addressLine1: 'fake line 1',
+            postcode: 'fake postcode',
+          },
+        },
+      },
+      expected: TASK_STATUS.COMPLETED,
+    },
+  ].forEach(({ description, given, expected }) => {
+    it(`should return the expected status - ${expected} - ${description}`, () => {
+      expect(statusAppealSiteAddress(given)).toEqual(expected);
+    });
+  });
+});

--- a/packages/forms-web-app/tests/unit/validators/appellant-submission/site-location.test.js
+++ b/packages/forms-web-app/tests/unit/validators/appellant-submission/site-location.test.js
@@ -30,13 +30,13 @@ describe('validators/appellant-submission/site-location', () => {
 
         expect(rule.stack[1].negated).toBeTruthy();
         expect(rule.stack[1].validator.name).toEqual('isEmpty');
-        expect(rule.stack[1].message).toEqual('Enter a building and/or street');
+        expect(rule.stack[1].message).toEqual('Enter the first line of the address');
 
         expect(rule.stack[3].negated).toBeFalsy();
         expect(rule.stack[3].validator.name).toEqual('isLength');
         expect(rule.stack[3].options).toEqual([{ max: 60, min: 1 }]);
         expect(rule.stack[3].message).toEqual(
-          'Building and/or street must be 60 characters or fewer'
+          'The first line of the address must be 60 characters or fewer'
         );
       });
     });
@@ -56,7 +56,7 @@ describe('validators/appellant-submission/site-location', () => {
         expect(rule.stack[1].validator.name).toEqual('isLength');
         expect(rule.stack[1].options).toEqual([{ max: 60, min: 0 }]);
         expect(rule.stack[1].message).toEqual(
-          'Building and/or street must be 60 characters or fewer'
+          'The first line of the address must be 60 characters or fewer'
         );
       });
     });
@@ -86,18 +86,14 @@ describe('validators/appellant-submission/site-location', () => {
         expect(rule.fields).toEqual(['site-county']);
         expect(rule.locations).toEqual(['body']);
         expect(rule.optional).toBeFalsy();
-        expect(rule.stack).toHaveLength(5);
+        expect(rule.stack).toHaveLength(3);
 
         expect(rule.stack[0].sanitizer.name).toEqual('escape');
 
-        expect(rule.stack[1].negated).toBeTruthy();
-        expect(rule.stack[1].validator.name).toEqual('isEmpty');
-        expect(rule.stack[1].message).toEqual('Enter a county');
-
-        expect(rule.stack[3].negated).toBeFalsy();
-        expect(rule.stack[3].validator.name).toEqual('isLength');
-        expect(rule.stack[3].options).toEqual([{ max: 60, min: 1 }]);
-        expect(rule.stack[3].message).toEqual('County must be 60 characters or fewer');
+        expect(rule.stack[1].negated).toBeFalsy();
+        expect(rule.stack[1].validator.name).toEqual('isLength');
+        expect(rule.stack[1].options).toEqual([{ max: 60, min: 0 }]);
+        expect(rule.stack[1].message).toEqual('County must be 60 characters or fewer');
       });
     });
 
@@ -146,7 +142,6 @@ describe('validators/appellant-submission/site-location', () => {
         given: () => ({
           body: {
             'site-address-line-one': '1 Taylor Road',
-            'site-county': 'South Glos',
             'site-postcode': 'BS8 1TG',
           },
         }),
@@ -183,6 +178,20 @@ describe('validators/appellant-submission/site-location', () => {
         },
       },
       {
+        title: 'valid - county is missing',
+        given: () => ({
+          body: {
+            'site-address-line-one': '1 Taylor Road',
+            'site-address-line-two': 'Clifton',
+            'site-town-city': 'Bristol',
+            'site-postcode': 'BS8 1TG',
+          },
+        }),
+        expected: (result) => {
+          expect(result.errors).toHaveLength(0);
+        },
+      },
+      {
         title: 'invalid - site-address-line-one is missing',
         given: () => ({
           body: {
@@ -194,22 +203,7 @@ describe('validators/appellant-submission/site-location', () => {
         }),
         expected: (result) => {
           expect(result.errors).toHaveLength(1);
-          expect(result.errors[0].msg).toEqual('Enter a building and/or street');
-        },
-      },
-      {
-        title: 'invalid - site-county is missing',
-        given: () => ({
-          body: {
-            'site-address-line-one': '1 Taylor Road',
-            'site-address-line-two': 'Clifton',
-            'site-town-city': 'Bristol',
-            'site-postcode': 'BS8 1TG',
-          },
-        }),
-        expected: (result) => {
-          expect(result.errors).toHaveLength(1);
-          expect(result.errors[0].msg).toEqual('Enter a county');
+          expect(result.errors[0].msg).toEqual('Enter the first line of the address');
         },
       },
       {
@@ -228,7 +222,7 @@ describe('validators/appellant-submission/site-location', () => {
         },
       },
       {
-        title: 'invalid - site-address-line-one and site-county are missing',
+        title: 'invalid - site-address-line-one (required) and site-county (optional) are missing',
         given: () => ({
           body: {
             'site-address-line-two': 'Clifton',
@@ -237,9 +231,8 @@ describe('validators/appellant-submission/site-location', () => {
           },
         }),
         expected: (result) => {
-          expect(result.errors).toHaveLength(2);
-          expect(result.errors[0].msg).toEqual('Enter a building and/or street');
-          expect(result.errors[1].msg).toEqual('Enter a county');
+          expect(result.errors).toHaveLength(1);
+          expect(result.errors[0].msg).toEqual('Enter the first line of the address');
         },
       },
       {
@@ -253,12 +246,12 @@ describe('validators/appellant-submission/site-location', () => {
         }),
         expected: (result) => {
           expect(result.errors).toHaveLength(2);
-          expect(result.errors[0].msg).toEqual('Enter a building and/or street');
+          expect(result.errors[0].msg).toEqual('Enter the first line of the address');
           expect(result.errors[1].msg).toEqual('Enter a postcode');
         },
       },
       {
-        title: 'invalid - site-county and site-postcode are missing',
+        title: 'invalid - site-county (optional) and site-postcode (required) are missing',
         given: () => ({
           body: {
             'site-address-line-one': '1 Taylor Road',
@@ -267,9 +260,8 @@ describe('validators/appellant-submission/site-location', () => {
           },
         }),
         expected: (result) => {
-          expect(result.errors).toHaveLength(2);
-          expect(result.errors[0].msg).toEqual('Enter a county');
-          expect(result.errors[1].msg).toEqual('Enter a postcode');
+          expect(result.errors).toHaveLength(1);
+          expect(result.errors[0].msg).toEqual('Enter a postcode');
         },
       },
       {
@@ -278,10 +270,9 @@ describe('validators/appellant-submission/site-location', () => {
           body: {},
         }),
         expected: (result) => {
-          expect(result.errors).toHaveLength(3);
-          expect(result.errors[0].msg).toEqual('Enter a building and/or street');
-          expect(result.errors[1].msg).toEqual('Enter a county');
-          expect(result.errors[2].msg).toEqual('Enter a postcode');
+          expect(result.errors).toHaveLength(2);
+          expect(result.errors[0].msg).toEqual('Enter the first line of the address');
+          expect(result.errors[1].msg).toEqual('Enter a postcode');
         },
       },
       {
@@ -298,7 +289,7 @@ describe('validators/appellant-submission/site-location', () => {
         expected: (result) => {
           expect(result.errors).toHaveLength(1);
           expect(result.errors[0].msg).toEqual(
-            'Building and/or street must be 60 characters or fewer'
+            'The first line of the address must be 60 characters or fewer'
           );
         },
       },
@@ -316,7 +307,7 @@ describe('validators/appellant-submission/site-location', () => {
         expected: (result) => {
           expect(result.errors).toHaveLength(1);
           expect(result.errors[0].msg).toEqual(
-            'Building and/or street must be 60 characters or fewer'
+            'The first line of the address must be 60 characters or fewer'
           );
         },
       },

--- a/packages/forms-web-app/tests/unit/validators/appellant-submission/site-location.test.js
+++ b/packages/forms-web-app/tests/unit/validators/appellant-submission/site-location.test.js
@@ -56,7 +56,7 @@ describe('validators/appellant-submission/site-location', () => {
         expect(rule.stack[1].validator.name).toEqual('isLength');
         expect(rule.stack[1].options).toEqual([{ max: 60, min: 0 }]);
         expect(rule.stack[1].message).toEqual(
-          'The first line of the address must be 60 characters or fewer'
+          'The second line of the address must be 60 characters or fewer'
         );
       });
     });
@@ -307,7 +307,7 @@ describe('validators/appellant-submission/site-location', () => {
         expected: (result) => {
           expect(result.errors).toHaveLength(1);
           expect(result.errors[0].msg).toEqual(
-            'The first line of the address must be 60 characters or fewer'
+            'The second line of the address must be 60 characters or fewer'
           );
         },
       },


### PR DESCRIPTION
## Ticket Number
<!-- Add the number from the Jira board -->
https://pins-ds.atlassian.net/browse/AS-2483

## Description of change
Address county is no longer mandatory

Updates to FWA, Appeals Service API, and the e2e tests.

## Checklist
<!-- Put an `x` in all the boxes that apply: -->
- [ ] Requires infrastructure changes
- [ ] If adding or remove environment variables (e.g. in `docker-compose.yaml`) then I have updated the appropriate Helm chart
- [ ] I have updated the documentation accordingly
- [x] My commit history in this PR is linear
- [x] New features have tests
- [ ] Breaking change (team conversation required)

## Important

Please do not merge from `master` (please only [rebase](https://github.com/foundry4/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
