### PR TITLE
fix(lpa-questionnaire-web-app): add enter appeal site to required validator

### DIFF
--- a/lpa-submissions-e2e-tests/cypress/fixtures/completedAppealReply.json
+++ b/lpa-submissions-e2e-tests/cypress/fixtures/completedAppealReply.json
@@ -18,8 +18,8 @@
   },
   "siteSeenPublicLand": true,
   "enterAppealSite": {
-    "value": true,
-    "text": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer nec odio. siteSeenPublicLand."
+    "mustEnter": true,
+    "enterReasons": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer nec odio. siteSeenPublicLand."
   },
   "requiredDocumentsSection": {
     "plansDecision": {

--- a/packages/lpa-questionnaire-web-app/src/services/task-status/check-your-answers.js
+++ b/packages/lpa-questionnaire-web-app/src/services/task-status/check-your-answers.js
@@ -19,6 +19,10 @@ const requiredCompletion = [
     id: 'siteSeenPublicLand',
     func: booleanCompletion,
   },
+  {
+    id: 'enterAppealSite',
+    func: booleanCompletion,
+  },
 ];
 module.exports = (appealReply) => {
   if (!appealReply) return null;


### PR DESCRIPTION
## Ticket Number
<!-- Add the number from the Jira board -->
https://pins-ds.atlassian.net/browse/AS-1688

## Description of change
Adds enter appeal site question to required questions

## Checklist
<!-- Put an `x` in all the boxes that apply: -->
- [ ] Requires infrastructure changes
- [ ] If adding or remove environment variables (e.g. in `docker-compose.yaml`) then I have updated the appropriate Helm chart
- [ ] I have updated the documentation accordingly
- [X] My commit history in this PR is linear
- [ ] New features have tests
- [ ] Breaking change (team conversation required)

## Important

Please do not merge from `master` (please only [rebase](https://github.com/foundry4/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
