### PR TITLE
fix(lpa-questionnaire-web-app): fix deletion event for invalid files

### DIFF
--- a/packages/lpa-questionnaire-web-app/src/controllers/files.js
+++ b/packages/lpa-questionnaire-web-app/src/controllers/files.js
@@ -54,7 +54,8 @@ exports.deleteFile = async (req, res) => {
   }
 
   try {
-    await deleteDocument(req.session.appealReply.id, deleteId);
+    // deleteId will be 'undefined' if file upload error
+    if (deleteId !== 'undefined') await deleteDocument(req.session.appealReply.id, deleteId);
   } catch (err) {
     res.status(404).send('Files to delete not found');
     return;

--- a/packages/lpa-questionnaire-web-app/src/controllers/upload-question.js
+++ b/packages/lpa-questionnaire-web-app/src/controllers/upload-question.js
@@ -42,7 +42,8 @@ exports.postUpload = async (req, res) => {
   // Chance for delete to be triggered due to non-JS solution. delete will be set to value of filename if button clicked
   if (deleteId) {
     try {
-      await deleteDocument(appealReply.id, deleteId);
+      // deleteId will be 'undefined' if file upload error
+      if (deleteId !== 'undefined') await deleteDocument(appealReply.id, deleteId);
     } catch (err) {
       req.log.error({ err }, `Error deleting ${deleteId} from ${name}`);
     }

--- a/packages/lpa-questionnaire-web-app/tests/unit/controllers/files.test.js
+++ b/packages/lpa-questionnaire-web-app/tests/unit/controllers/files.test.js
@@ -151,6 +151,24 @@ describe('controllers/files', () => {
           });
         },
       },
+      {
+        title: 'should return status 200 if deleted file is invalid (id is "undefined" string)',
+        given: () => ({
+          ...mockReq(),
+          body: {
+            delete: 'undefined',
+          },
+        }),
+        expected: (req, res) => {
+          expect(res.status).toHaveBeenCalledWith(200);
+          expect(res.json).toHaveBeenCalledWith({
+            id: 'undefined',
+            success: {
+              messageText: 'undefined deleted',
+            },
+          });
+        },
+      },
     ].forEach(({ title, given, expected, deleteMock }) => {
       it(title, async () => {
         const req = given();

--- a/packages/lpa-questionnaire-web-app/tests/unit/controllers/upload-question.test.js
+++ b/packages/lpa-questionnaire-web-app/tests/unit/controllers/upload-question.test.js
@@ -120,6 +120,28 @@ describe('controllers/upload-question', () => {
       });
     });
 
+    it('should delete a document from temporary files if invalid (id is undefined)', async () => {
+      fileUploadNunjucksVariables.mockReturnValue({
+        uploadedFiles: [{ name: 'another-file' }],
+      });
+
+      const mockRequest = {
+        ...req,
+        body: {
+          delete: 'undefined',
+          tempDocs: '{ "name": "some-file" }, { "name": "another-file" }',
+        },
+      };
+
+      await uploadQuestionController.postUpload(mockRequest, res);
+
+      expect(res.render).toHaveBeenCalledWith('mock-view', {
+        appeal: null,
+        backLink: '/mock-id/task-list',
+        uploadedFiles: [{ name: 'another-file' }],
+      });
+    });
+
     it('should log an error if delete function returns one', async () => {
       deleteDocument.mockImplementation(() => {
         throw new Error('mock delete error');


### PR DESCRIPTION
## Ticket Number
<!-- Add the number from the Jira board -->
https://pins-ds.atlassian.net/browse/AS-2726

## Description of change
Fixes incident when user could not delete file when it is invalid

## Checklist
<!-- Put an `x` in all the boxes that apply: -->
- [ ] Requires infrastructure changes
- [ ] If adding or remove environment variables (e.g. in `docker-compose.yaml`) then I have updated the appropriate Helm chart
- [ ] I have updated the documentation accordingly
- [X] My commit history in this PR is linear
- [ ] New features have tests
- [ ] Breaking change (team conversation required)

## Important

Please do not merge from `master` (please only [rebase](https://github.com/foundry4/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
