### PR TITLE
fix(ping-horizon): Changes horizon ping endpoint and frequency

### DIFF
--- a/charts/functions/templates/horizon-ping.yaml
+++ b/charts/functions/templates/horizon-ping.yaml
@@ -43,10 +43,6 @@ spec:
             httpGet:
               path: /ping
               port: ping-hzn-srv
-          readinessProbe:
-            httpGet:
-              path: /ping
-              port: ping-hzn-srv
           env:
             - name: APP_NAME
               value: {{ .Values.pingHorizon.config.serviceName }}

--- a/releases/dev/functions.yml
+++ b/releases/dev/functions.yml
@@ -23,7 +23,7 @@ spec:
         tag: 1.0.0
       config:
         ping:
-          url: http://10.0.7.4:8001/status
+          url: http://10.0.7.4:8000/horizon
 
     functions:
       horizon-add-document:


### PR DESCRIPTION
## Ticket Number
<!-- Add the number from the Jira board -->
https://pins-ds.atlassian.net/browse/AS-2845

## Description of change
The ping was setup to check the availability of the Horizon REST API Wrapper and trigger an alert if it was down. It had been intended that it would ping the wrapper once a minute, but it also pings it once every 10 seconds. The frequent pings are made by the readinessProbe which I have consequently removed from the horizon-ping.yaml file.

Also, sometimes the /horizon endpoint can be unavailable but the /status endpoint still is, meaning messages won't be received from the Appeal Service and we're not alerted to it until a message fails. Therefore, I have changed the endpoint to /horizon on Dev initially.

## Checklist
<!-- Put an `x` in all the boxes that apply: -->
- [ ] Requires infrastructure changes
- [ ] If adding or remove environment variables (e.g. in `docker-compose.yaml`) then I have updated the appropriate Helm chart
- [ ] I have updated the documentation accordingly
- [ ] My commit history in this PR is linear
- [ ] New features have tests
- [ ] Breaking change (team conversation required)

## Important

Please do not merge from `master` (please only [rebase](https://github.com/foundry4/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
