### PR TITLE
chore(k8s-envvars): reintroduce readinessProbe to ping service

### DIFF
--- a/charts/functions/templates/horizon-ping.yaml
+++ b/charts/functions/templates/horizon-ping.yaml
@@ -43,6 +43,11 @@ spec:
             httpGet:
               path: /ping
               port: ping-hzn-srv
+          readinessProbe:
+            periodSeconds: 60
+            httpGet:
+              path: /ping
+              port: ping-hzn-srv
           env:
             - name: APP_NAME
               value: {{ .Values.pingHorizon.config.serviceName }}


### PR DESCRIPTION
## Ticket Number
<!-- Add the number from the Jira board -->
https://pins-ds.atlassian.net/browse/AS-2845

## Description of change
Removing the readinessProbe triggered horizon-ping-test alerts, so I have reintroduced it but with a 60 second period.

## Checklist
<!-- Put an `x` in all the boxes that apply: -->
- [ ] Requires infrastructure changes
- [ ] If adding or remove environment variables (e.g. in `docker-compose.yaml`) then I have updated the appropriate Helm chart
- [ ] I have updated the documentation accordingly
- [ ] My commit history in this PR is linear
- [ ] New features have tests
- [ ] Breaking change (team conversation required)

## Important

Please do not merge from `master` (please only [rebase](https://github.com/foundry4/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
