### PR TITLE
chore(k8s-envvars): revert destination of ping service [ci skip]

### DIFF
--- a/releases/dev/functions.yml
+++ b/releases/dev/functions.yml
@@ -23,7 +23,7 @@ spec:
         tag: 1.0.0
       config:
         ping:
-          url: http://10.0.7.4:8000/horizon
+          url: http://10.0.7.4:8001/status
 
     functions:
       horizon-add-document:


### PR DESCRIPTION
## Ticket Number
<!-- Add the number from the Jira board -->
https://pins-ds.atlassian.net/browse/AS-2845

## Description of change
Changing the destination endpoint for the ping service on Dev back to /status rather than /horizon, due to PreProd Horizon being offline overnight.

## Checklist
<!-- Put an `x` in all the boxes that apply: -->
- [ ] Requires infrastructure changes
- [ ] If adding or remove environment variables (e.g. in `docker-compose.yaml`) then I have updated the appropriate Helm chart
- [ ] I have updated the documentation accordingly
- [ ] My commit history in this PR is linear
- [ ] New features have tests
- [ ] Breaking change (team conversation required)

## Important

Please do not merge from `master` (please only [rebase](https://github.com/foundry4/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
