### PR TITLE
feat(as-2819): add google tag manager code behind a feature flag

### DIFF
--- a/charts/app/templates/formsWebApp.yaml
+++ b/charts/app/templates/formsWebApp.yaml
@@ -89,6 +89,10 @@ spec:
               value: {{ .Values.formsWebApp.config.subdomainOffset | quote }}
             - name: USE_SECURE_SESSION_COOKIES
               value: "true"
+            - name: GOOGLE_TAG_MANAGER_ID
+              value: {{ .Values.formsWebApp.config.googleTagManagerId | quote }}
+            - name: FEATURE_FLAG_GOOGLE_TAG_MANAGER
+              value: {{ .Values.formsWebApp.config.featureFlagGoogleTagManager | quote }}
           volumeMounts:
             - mountPath: {{ .Values.formsWebApp.config.upload.uploadDir | quote }}
               name: upload-cache

--- a/charts/app/values.yaml
+++ b/charts/app/values.yaml
@@ -93,6 +93,8 @@ formsWebApp:
       debug: true
       uploadDir: /upload-dir
       useTmpFiles: true
+    googleTagManagerId: ""
+    featureFlagGoogleTagManager: ""
 
 lpaQuestionnaireWebApp:
   replicaCount: 1

--- a/packages/forms-web-app/src/app.js
+++ b/packages/forms-web-app/src/app.js
@@ -66,6 +66,8 @@ env.addFilter('addKeyValuePair', addKeyValuePair);
 env.addFilter('render', renderTemplateFilter(nunjucks));
 env.addGlobal('fileSizeLimits', config.fileUpload.pins);
 env.addGlobal('googleAnalyticsId', config.server.googleAnalyticsId);
+env.addGlobal('googleTagManagerId', config.server.googleTagManagerId);
+env.addGlobal('featureFlag', config.featureFlag);
 
 if (config.server.useSecureSessionCookie) {
   app.set('trust proxy', 1); // trust first proxy

--- a/packages/forms-web-app/src/config.js
+++ b/packages/forms-web-app/src/config.js
@@ -61,5 +61,9 @@ module.exports = {
     subdomainOffset: parseInt(process.env.SUBDOMAIN_OFFSET, 10) || 3,
     useSecureSessionCookie: process.env.USE_SECURE_SESSION_COOKIES === 'true',
     googleAnalyticsId: process.env.GOOGLE_ANALYTICS_ID,
+    googleTagManagerId: process.env.GOOGLE_TAG_MANAGER_ID,
+  },
+  featureFlag: {
+    googleTagManager: process.env.FEATURE_FLAG_GOOGLE_TAG_MANAGER === 'true',
   },
 };

--- a/packages/forms-web-app/src/lib/client-side/google-analytics.js
+++ b/packages/forms-web-app/src/lib/client-side/google-analytics.js
@@ -1,25 +1,27 @@
 /* eslint-env browser */
 
 const initialiseGoogleAnalytics = (document) => {
-  const gaId = document.getElementById('gaId').textContent;
-
-  const gaScript = document.createElement('script');
-  gaScript.type = 'text/javascript';
-  gaScript.async = true;
-  gaScript.src = `https://www.googletagmanager.com/gtag/js?id=${gaId}`;
-
-  const firstScriptElement = document.getElementsByTagName('script')[0];
-  firstScriptElement.parentNode.insertBefore(gaScript, firstScriptElement);
-
-  window.dataLayer = window.dataLayer || [];
+  const gaId = document.getElementById('gaId') ? document.getElementById('gaId').textContent : null;
 
   function gtag() {
     // eslint-disable-next-line no-undef, prefer-rest-params
     dataLayer.push(arguments);
   }
 
-  gtag('js', new Date());
-  gtag('config', gaId);
+  if (gaId) {
+    const gaScript = document.createElement('script');
+    gaScript.type = 'text/javascript';
+    gaScript.async = true;
+    gaScript.src = `https://www.googletagmanager.com/gtag/js?id=${gaId}`;
+
+    const firstScriptElement = document.getElementsByTagName('script')[0];
+    firstScriptElement.parentNode.insertBefore(gaScript, firstScriptElement);
+
+    window.dataLayer = window.dataLayer || [];
+
+    gtag('js', new Date());
+    gtag('config', gaId);
+  }
 };
 
 module.exports = {

--- a/packages/forms-web-app/src/views/includes/body-start.njk
+++ b/packages/forms-web-app/src/views/includes/body-start.njk
@@ -1,0 +1,12 @@
+{% block bodyStart %}
+
+  {% if featureFlag.googleTagManager %}
+    {% if googleTagManagerId %}
+      <!-- Google Tag Manager (noscript) -->
+      <noscript><iframe src="https://www.googletagmanager.com/ns.html?id={{ googleTagManagerId | safe }}"
+      height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+      <!-- End Google Tag Manager (noscript) -->
+    {% endif %}
+  {% endif %}
+
+{% endblock %}

--- a/packages/forms-web-app/src/views/includes/head.njk
+++ b/packages/forms-web-app/src/views/includes/head.njk
@@ -3,18 +3,30 @@
   <!--[if lte IE 8]><link href="/public/stylesheets/main-ie8.css" rel="stylesheet" type="text/css" /><![endif]-->
   <!--[if gt IE 8]><!--><link href="/public/stylesheets/main.css" media="all" rel="stylesheet" type="text/css" /><!--<![endif]-->
 
-  <script id="gaId" type='text/plain'>{{ googleAnalyticsId }}</script>
+  {% if featureFlag.googleTagManager %}
+    {% if googleTagManagerId %}
+      <!-- Google Tag Manager -->
+      <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+      new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+      j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+      'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+      })(window,document,'script','dataLayer','{{ googleTagManagerId | safe }}');</script>
+      <!-- End Google Tag Manager -->
+    {% endif %}
+  {% else %}
+    <script id="gaId" type='text/plain'>{{ googleAnalyticsId }}</script>
 
-  {% if googleAnalyticsId and cookies.cookie_policy.usage %}
-<!-- Global site tag (gtag.js) - Google Analytics -->
-{#  <script data-cy="Google Analytics" async src="https://www.googletagmanager.com/gtag/js?id={{ googleAnalyticsId | safe }}"></script>#}
-  <script>
-    window.dataLayer = window.dataLayer || [];
-    function gtag(){dataLayer.push(arguments);}
-    gtag('js', new Date());
+    {% if googleAnalyticsId and cookies.cookie_policy.usage %}
+      <!-- Global site tag (gtag.js) - Google Analytics -->
+      {# <script data-cy="Google Analytics" async src="https://www.googletagmanager.com/gtag/js?id={{ googleAnalyticsId | safe }}"></script> #}
+      <script>
+        window.dataLayer = window.dataLayer || [];
+        function gtag(){dataLayer.push(arguments);}
+        gtag('js', new Date());
 
-    gtag('config', '{{ googleAnalyticsId | safe }}');
-  </script>
+        gtag('config', '{{ googleAnalyticsId | safe }}');
+      </script>
+    {% endif %}
   {% endif %}
 
   <script src="/public/javascripts/index.bundle.js" defer></script>

--- a/packages/forms-web-app/src/views/layouts/main.njk
+++ b/packages/forms-web-app/src/views/layouts/main.njk
@@ -20,6 +20,7 @@
 {% endblock %}
 
 {% block bodyStart %}
+  {% include "includes/body-start.njk" %}
 {% endblock %}
 
 {% set mainClasses = mainClasses | default("govuk-main-wrapper--auto-spacing") %}

--- a/packages/forms-web-app/tests/unit/lib/client-side/__snapshots__/google-analytics.test.js.snap
+++ b/packages/forms-web-app/tests/unit/lib/client-side/__snapshots__/google-analytics.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`lib/client-side/google-analytics initialiseGoogleAnalytics 1`] = `
+exports[`lib/client-side/google-analytics initialiseGoogleAnalytics when the Google Tag Manager feature flag is false 1`] = `
 <body>
   <p
     id="gaId"
@@ -14,3 +14,5 @@ exports[`lib/client-side/google-analytics initialiseGoogleAnalytics 1`] = `
   <script />
 </body>
 `;
+
+exports[`lib/client-side/google-analytics initialiseGoogleAnalytics when the Google Tag Manager feature flag is true 1`] = `null`;

--- a/packages/forms-web-app/tests/unit/lib/client-side/google-analytics.test.js
+++ b/packages/forms-web-app/tests/unit/lib/client-side/google-analytics.test.js
@@ -7,13 +7,12 @@ const { initialiseGoogleAnalytics } = require('../../../../src/lib/client-side/g
 
 describe('lib/client-side/google-analytics', () => {
   const FIXED_SYSTEM_TIME = '2020-11-18T00:00:00Z';
-
   const fakeGaId = 'some-test-value';
+  const gaIdElement = document.createElement('p');
+  gaIdElement.id = 'gaId';
+  gaIdElement.textContent = fakeGaId;
 
   const setupFakeDom = () => {
-    const gaIdElement = document.createElement('p');
-    gaIdElement.id = 'gaId';
-    gaIdElement.textContent = fakeGaId;
     document.body.append(gaIdElement);
     const script = document.createElement('script');
     document.body.appendChild(script);
@@ -27,13 +26,15 @@ describe('lib/client-side/google-analytics', () => {
     // https://github.com/facebook/jest/issues/2234#issuecomment-730037781
     jest.useFakeTimers('modern');
     jest.setSystemTime(Date.parse(FIXED_SYSTEM_TIME));
+
+    window.dataLayer = undefined;
   });
 
   afterEach(() => {
     jest.useRealTimers();
   });
 
-  test('initialiseGoogleAnalytics', () => {
+  test('initialiseGoogleAnalytics when the Google Tag Manager feature flag is false', () => {
     expect(window.dataLayer).toBe(undefined);
 
     initialiseGoogleAnalytics(document);
@@ -44,5 +45,17 @@ describe('lib/client-side/google-analytics', () => {
     // https://github.com/facebook/jest/issues/8475#issuecomment-495729482
     expect([...window.dataLayer[0]]).toMatchObject(['js', new Date()]);
     expect([...window.dataLayer[1]]).toMatchObject(['config', fakeGaId]);
+  });
+
+  test('initialiseGoogleAnalytics when the Google Tag Manager feature flag is true', () => {
+    document.body.remove(gaIdElement);
+
+    expect(window.dataLayer).toBe(undefined);
+
+    initialiseGoogleAnalytics(document);
+
+    expect(document.body).toMatchSnapshot();
+
+    expect(window.dataLayer).toBe(undefined);
   });
 });

--- a/packages/forms-web-app/tests/unit/views/includes/__snapshots__/body-start.njk.test.js.snap
+++ b/packages/forms-web-app/tests/unit/views/includes/__snapshots__/body-start.njk.test.js.snap
@@ -1,0 +1,42 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`views/includes/body-start Google Tag Manager section should not render if featureFlag.googleTagManager and googleTagManagerId are not set 1`] = `
+"
+
+  
+
+"
+`;
+
+exports[`views/includes/body-start Google Tag Manager section should not render if featureFlag.googleTagManager is not set but googleTagManagerId is set 1`] = `
+"
+
+  
+
+"
+`;
+
+exports[`views/includes/body-start Google Tag Manager section should not render if featureFlag.googleTagManager is set but googleTagManagerId is not set 1`] = `
+"
+
+  
+    
+  
+
+"
+`;
+
+exports[`views/includes/body-start Google Tag Manager section should render if featureFlag.googleTagManager and googleTagManagerId are set 1`] = `
+"
+
+  
+    
+      <!-- Google Tag Manager (noscript) -->
+      <noscript><iframe src=\\"https://www.googletagmanager.com/ns.html?id=456\\"
+      height=\\"0\\" width=\\"0\\" style=\\"display:none;visibility:hidden\\"></iframe></noscript>
+      <!-- End Google Tag Manager (noscript) -->
+    
+  
+
+"
+`;

--- a/packages/forms-web-app/tests/unit/views/includes/__snapshots__/head.njk.test.js.snap
+++ b/packages/forms-web-app/tests/unit/views/includes/__snapshots__/head.njk.test.js.snap
@@ -2,82 +2,178 @@
 
 exports[`views/includes/head Google Analytics section should not render if googleAnalyticsId and cookies.cookie_policy.usage are not set 1`] = `
 "
-    
 
   <!--[if lte IE 8]><link href=\\"/public/stylesheets/main-ie8.css\\" rel=\\"stylesheet\\" type=\\"text/css\\" /><![endif]-->
   <!--[if gt IE 8]><!--><link href=\\"/public/stylesheets/main.css\\" media=\\"all\\" rel=\\"stylesheet\\" type=\\"text/css\\" /><!--<![endif]-->
 
-  <script id=\\"gaId\\" type='text/plain'></script>
+  
+    <script id=\\"gaId\\" type='text/plain'></script>
 
+    
   
 
   <script src=\\"/public/javascripts/index.bundle.js\\" defer></script>
 
 
-
-    "
+"
 `;
 
 exports[`views/includes/head Google Analytics section should not render if googleAnalyticsId is not set but cookies.cookie_policy.usage is set 1`] = `
 "
-    
 
   <!--[if lte IE 8]><link href=\\"/public/stylesheets/main-ie8.css\\" rel=\\"stylesheet\\" type=\\"text/css\\" /><![endif]-->
   <!--[if gt IE 8]><!--><link href=\\"/public/stylesheets/main.css\\" media=\\"all\\" rel=\\"stylesheet\\" type=\\"text/css\\" /><!--<![endif]-->
 
-  <script id=\\"gaId\\" type='text/plain'></script>
+  
+    <script id=\\"gaId\\" type='text/plain'></script>
 
+    
   
 
   <script src=\\"/public/javascripts/index.bundle.js\\" defer></script>
 
 
-
-    "
+"
 `;
 
 exports[`views/includes/head Google Analytics section should not render if googleAnalyticsId is set but cookies.cookie_policy.usage is not set 1`] = `
 "
-    
 
   <!--[if lte IE 8]><link href=\\"/public/stylesheets/main-ie8.css\\" rel=\\"stylesheet\\" type=\\"text/css\\" /><![endif]-->
   <!--[if gt IE 8]><!--><link href=\\"/public/stylesheets/main.css\\" media=\\"all\\" rel=\\"stylesheet\\" type=\\"text/css\\" /><!--<![endif]-->
 
-  <script id=\\"gaId\\" type='text/plain'>123</script>
+  
+    <script id=\\"gaId\\" type='text/plain'>123</script>
 
+    
   
 
   <script src=\\"/public/javascripts/index.bundle.js\\" defer></script>
 
 
-
-    "
+"
 `;
 
 exports[`views/includes/head Google Analytics section should render if googleAnalyticsId and cookies.cookie_policy.usage are set 1`] = `
 "
-    
 
   <!--[if lte IE 8]><link href=\\"/public/stylesheets/main-ie8.css\\" rel=\\"stylesheet\\" type=\\"text/css\\" /><![endif]-->
   <!--[if gt IE 8]><!--><link href=\\"/public/stylesheets/main.css\\" media=\\"all\\" rel=\\"stylesheet\\" type=\\"text/css\\" /><!--<![endif]-->
 
-  <script id=\\"gaId\\" type='text/plain'>123</script>
-
   
-<!-- Global site tag (gtag.js) - Google Analytics -->
+    <script id=\\"gaId\\" type='text/plain'>123</script>
 
-  <script>
-    window.dataLayer = window.dataLayer || [];
-    function gtag(){dataLayer.push(arguments);}
-    gtag('js', new Date());
+    
+      <!-- Global site tag (gtag.js) - Google Analytics -->
+      
+      <script>
+        window.dataLayer = window.dataLayer || [];
+        function gtag(){dataLayer.push(arguments);}
+        gtag('js', new Date());
 
-    gtag('config', '123');
-  </script>
+        gtag('config', '123');
+      </script>
+    
   
 
   <script src=\\"/public/javascripts/index.bundle.js\\" defer></script>
 
 
+"
+`;
 
-    "
+exports[`views/includes/head Google Tag Manager section should not render if featureFlag.googleTagManager and googleTagManagerId are not set 1`] = `
+"
+
+  <!--[if lte IE 8]><link href=\\"/public/stylesheets/main-ie8.css\\" rel=\\"stylesheet\\" type=\\"text/css\\" /><![endif]-->
+  <!--[if gt IE 8]><!--><link href=\\"/public/stylesheets/main.css\\" media=\\"all\\" rel=\\"stylesheet\\" type=\\"text/css\\" /><!--<![endif]-->
+
+  
+    <script id=\\"gaId\\" type='text/plain'>123</script>
+
+    
+      <!-- Global site tag (gtag.js) - Google Analytics -->
+      
+      <script>
+        window.dataLayer = window.dataLayer || [];
+        function gtag(){dataLayer.push(arguments);}
+        gtag('js', new Date());
+
+        gtag('config', '123');
+      </script>
+    
+  
+
+  <script src=\\"/public/javascripts/index.bundle.js\\" defer></script>
+
+
+"
+`;
+
+exports[`views/includes/head Google Tag Manager section should not render if featureFlag.googleTagManager is not set but googleTagManagerId is set 1`] = `
+"
+
+  <!--[if lte IE 8]><link href=\\"/public/stylesheets/main-ie8.css\\" rel=\\"stylesheet\\" type=\\"text/css\\" /><![endif]-->
+  <!--[if gt IE 8]><!--><link href=\\"/public/stylesheets/main.css\\" media=\\"all\\" rel=\\"stylesheet\\" type=\\"text/css\\" /><!--<![endif]-->
+
+  
+    <script id=\\"gaId\\" type='text/plain'>123</script>
+
+    
+      <!-- Global site tag (gtag.js) - Google Analytics -->
+      
+      <script>
+        window.dataLayer = window.dataLayer || [];
+        function gtag(){dataLayer.push(arguments);}
+        gtag('js', new Date());
+
+        gtag('config', '123');
+      </script>
+    
+  
+
+  <script src=\\"/public/javascripts/index.bundle.js\\" defer></script>
+
+
+"
+`;
+
+exports[`views/includes/head Google Tag Manager section should not render if featureFlag.googleTagManager is set but googleTagManagerId is not set 1`] = `
+"
+
+  <!--[if lte IE 8]><link href=\\"/public/stylesheets/main-ie8.css\\" rel=\\"stylesheet\\" type=\\"text/css\\" /><![endif]-->
+  <!--[if gt IE 8]><!--><link href=\\"/public/stylesheets/main.css\\" media=\\"all\\" rel=\\"stylesheet\\" type=\\"text/css\\" /><!--<![endif]-->
+
+  
+    
+  
+
+  <script src=\\"/public/javascripts/index.bundle.js\\" defer></script>
+
+
+"
+`;
+
+exports[`views/includes/head Google Tag Manager section should render if featureFlag.googleTagManager and googleTagManagerId are set 1`] = `
+"
+
+  <!--[if lte IE 8]><link href=\\"/public/stylesheets/main-ie8.css\\" rel=\\"stylesheet\\" type=\\"text/css\\" /><![endif]-->
+  <!--[if gt IE 8]><!--><link href=\\"/public/stylesheets/main.css\\" media=\\"all\\" rel=\\"stylesheet\\" type=\\"text/css\\" /><!--<![endif]-->
+
+  
+    
+      <!-- Google Tag Manager -->
+      <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+      new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+      j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+      'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+      })(window,document,'script','dataLayer','456');</script>
+      <!-- End Google Tag Manager -->
+    
+  
+
+  <script src=\\"/public/javascripts/index.bundle.js\\" defer></script>
+
+
+"
 `;

--- a/packages/forms-web-app/tests/unit/views/includes/body-start.njk.test.js
+++ b/packages/forms-web-app/tests/unit/views/includes/body-start.njk.test.js
@@ -1,36 +1,10 @@
 const nunjucksTestRenderer = require('../nunjucks-render-helper');
 const { deleteGlobalVars, matchesSnapshot } = require('../nunjucks-helper-functions');
 
-describe('views/includes/head', () => {
-  const includePath = '{% include "includes/head.njk" %}';
-
-  describe('Google Analytics section', () => {
-    beforeEach(() => {
-      deleteGlobalVars(['cookies', 'googleAnalyticsId']);
-    });
-
-    it(`should not render if googleAnalyticsId and cookies.cookie_policy.usage are not set`, () => {
-      matchesSnapshot(includePath);
-    });
-
-    it(`should not render if googleAnalyticsId is set but cookies.cookie_policy.usage is not set`, () => {
-      nunjucksTestRenderer.addGlobal('googleAnalyticsId', 123);
-      matchesSnapshot(includePath);
-    });
-
-    it(`should not render if googleAnalyticsId is not set but cookies.cookie_policy.usage is set`, () => {
-      nunjucksTestRenderer.addGlobal('cookies', { cookie_policy: { usage: true } });
-      matchesSnapshot(includePath);
-    });
-
-    it(`should render if googleAnalyticsId and cookies.cookie_policy.usage are set`, () => {
-      nunjucksTestRenderer.addGlobal('googleAnalyticsId', 123);
-      nunjucksTestRenderer.addGlobal('cookies', { cookie_policy: { usage: true } });
-      matchesSnapshot(includePath);
-    });
-  });
-
+describe('views/includes/body-start', () => {
   describe('Google Tag Manager section', () => {
+    const includePath = '{% include "includes/body-start.njk" %}';
+
     beforeEach(() => {
       deleteGlobalVars(['featureFlag', 'googleTagManagerId']);
     });

--- a/packages/forms-web-app/tests/unit/views/nunjucks-helper-functions.js
+++ b/packages/forms-web-app/tests/unit/views/nunjucks-helper-functions.js
@@ -1,0 +1,15 @@
+const nunjucksTestRenderer = require('./nunjucks-render-helper');
+
+const deleteGlobalVars = (vars) =>
+  vars.forEach((key) => {
+    delete nunjucksTestRenderer.globals[key];
+    expect(() => nunjucksTestRenderer.getGlobal(key)).toThrow(`global not found: ${key}`);
+  });
+
+const matchesSnapshot = (includePath) =>
+  expect(nunjucksTestRenderer.renderString(includePath)).toMatchSnapshot();
+
+module.exports = {
+  deleteGlobalVars,
+  matchesSnapshot,
+};


### PR DESCRIPTION
## Ticket Number
https://pins-ds.atlassian.net/browse/AS-2819

## Description of change
Add Google Tag Manager code behind a feature flag. 

Initially this is for testing the Google Tag Manager functionality so will be toggled on in Dev and off in PreProd and Prod.

The feature flag is set with an env var so it can be toggled on/off in each env. When the flag is toggled on the new Tag Manager code is used and the original Google Analytics code is not used and when the flag is toggled off the new Tag Manager code is not used and the original Google Analytics code is used.

Unit tests have been updated to check that the correct code is used when the flag is toggled on and off.

E2E tests are unchanged as we can't toggle the env var on/off whilst the tests are running and they currently reflect the state of the code in Prod so they can be updated when we finally toggle the flag on in Prod. 

## Checklist
<!-- Put an `x` in all the boxes that apply: -->
- [ ] Requires infrastructure changes
- [x] If adding or remove environment variables (e.g. in `docker-compose.yaml`) then I have updated the appropriate Helm chart
- [ ] I have updated the documentation accordingly
- [x] My commit history in this PR is linear
- [x] New features have tests
- [ ] Breaking change (team conversation required)

## Important

Please do not merge from `master` (please only [rebase](https://github.com/foundry4/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
