### PR TITLE
feat(as-2819): add env vars for the google tag manager feature flag in dev

### DIFF
--- a/releases/dev/app.yml
+++ b/releases/dev/app.yml
@@ -51,6 +51,8 @@ spec:
         tag: 1.52.4
       config:
         googleAnalyticsId: G-TZBWMVPTHV
+        googleTagManagerId: GTM-KZN7XP4
+        featureFlagGoogleTagManager: 'true'
 
     lpaQuestionnaireWebApp:
       replicaCount: 2


### PR DESCRIPTION
## Ticket Number
https://pins-ds.atlassian.net/browse/AS-2819

## Description of change
Adds env vars for Google Tag Manager in dev to activate the feature flag and set the id for the tracking codes.

## Checklist
<!-- Put an `x` in all the boxes that apply: -->
- [ ] Requires infrastructure changes
- [ ] If adding or remove environment variables (e.g. in `docker-compose.yaml`) then I have updated the appropriate Helm chart
- [ ] I have updated the documentation accordingly
- [x] My commit history in this PR is linear
- [ ] New features have tests
- [ ] Breaking change (team conversation required)

## Important

Please do not merge from `master` (please only [rebase](https://github.com/foundry4/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
