### PR TITLE
Fix/as 2982 content change inspector capitalized

### DIFF
--- a/lpa-submissions-e2e-tests/cypress/integration/accessNeighboursLand/accessNeighboursLand.step.js
+++ b/lpa-submissions-e2e-tests/cypress/integration/accessNeighboursLand/accessNeighboursLand.step.js
@@ -7,7 +7,7 @@ const page = {
   title:
     "Would the Inspector need access to a neighbour's land? - Appeal questionnaire - Appeal a householder planning decision - GOV.UK",
   url: 'neighbours-land',
-  emptyError: 'Select yes if the inspector needs access to a neighbour’s land',
+  emptyError: 'Select yes if the Inspector needs access to a neighbour’s land',
   textEmptyError: "Enter the reasons the Inspector would need to enter a neighbour's land",
   textChildOf: 'Yes',
   textMock:

--- a/lpa-submissions-e2e-tests/cypress/integration/accessNeighboursLand/accessNeighboursLand.step.js
+++ b/lpa-submissions-e2e-tests/cypress/integration/accessNeighboursLand/accessNeighboursLand.step.js
@@ -2,10 +2,10 @@ import { Before } from 'cypress-cucumber-preprocessor/steps';
 
 const page = {
   id: 'accessNeighboursLand',
-  heading: "Would the inspector need access to a neighbour's land?",
+  heading: "Would the Inspector need access to a neighbour's land?",
   section: 'About the Appeal Site',
   title:
-    "Would the inspector need access to a neighbour's land? - Appeal questionnaire - Appeal a householder planning decision - GOV.UK",
+    "Would the Inspector need access to a neighbour's land? - Appeal questionnaire - Appeal a householder planning decision - GOV.UK",
   url: 'neighbours-land',
   emptyError: 'Select yes if the inspector needs access to a neighbour’s land',
   textEmptyError: "Enter the reasons the Inspector would need to enter a neighbour's land",

--- a/lpa-submissions-e2e-tests/cypress/integration/enterAppealSite/enterAppealSite.step.js
+++ b/lpa-submissions-e2e-tests/cypress/integration/enterAppealSite/enterAppealSite.step.js
@@ -2,7 +2,7 @@ import { Before } from 'cypress-cucumber-preprocessor/steps';
 
 const page = {
   id: 'enterAppealSite',
-  heading: 'Would the inspector need to enter the appeal site?',
+  heading: 'Would the Inspector need to enter the appeal site?',
   section: 'About the Appeal Site',
   title:
     'Would the Inspector need to enter the appeal site? - Appeal Questionnaire - Appeal a householder planning decision - GOV.UK',

--- a/lpa-submissions-e2e-tests/cypress/integration/enterAppealSite/enterAppealSite.step.js
+++ b/lpa-submissions-e2e-tests/cypress/integration/enterAppealSite/enterAppealSite.step.js
@@ -7,7 +7,7 @@ const page = {
   title:
     'Would the Inspector need to enter the appeal site? - Appeal Questionnaire - Appeal a householder planning decision - GOV.UK',
   url: 'site-access',
-  emptyError: 'Select yes if the inspector would need to enter the appeal site',
+  emptyError: 'Select yes if the Inspector would need to enter the appeal site',
   textEmptyError: 'Enter the reasons the Inspector would need to enter the appeal site',
   textChildOf: 'Yes',
   textMock:

--- a/lpa-submissions-e2e-tests/cypress/integration/siteSeenPublicLand/siteSeenPublicLand.step.js
+++ b/lpa-submissions-e2e-tests/cypress/integration/siteSeenPublicLand/siteSeenPublicLand.step.js
@@ -2,10 +2,10 @@ import { Before } from 'cypress-cucumber-preprocessor/steps';
 
 const page = {
   id: 'siteSeenPublicLand',
-  heading: 'Can the inspector see the relevant parts of the appeal site from public land?',
+  heading: 'Can the Inspector see the relevant parts of the appeal site from public land?',
   section: 'About the Appeal Site',
   title:
-    'Can the inspector see the relevant parts of the appeal site from public land? - Appeal Questionnaire - Appeal a householder planning decision - GOV.UK',
+    'Can the Inspector see the relevant parts of the appeal site from public land? - Appeal Questionnaire - Appeal a householder planning decision - GOV.UK',
   url: 'public-land',
   emptyError: 'Select yes if relevant parts of the site can be seen from public land',
 };

--- a/packages/lpa-questionnaire-web-app/src/lib/questionTypes.js
+++ b/packages/lpa-questionnaire-web-app/src/lib/questionTypes.js
@@ -23,16 +23,16 @@
 exports.booleanQuestions = [
   {
     id: 'siteSeenPublicLand',
-    heading: 'Can the inspector see the relevant parts of the appeal site from public land?',
+    heading: 'Can the Inspector see the relevant parts of the appeal site from public land?',
     section: 'About the Appeal Site',
     title:
-      'Can the inspector see the relevant parts of the appeal site from public land? - Appeal Questionnaire - Appeal a householder planning decision - GOV.UK',
+      'Can the Inspector see the relevant parts of the appeal site from public land? - Appeal Questionnaire - Appeal a householder planning decision - GOV.UK',
     emptyError: 'Select yes if relevant parts of the site can be seen from public land',
     url: 'public-land',
   },
   {
     id: 'enterAppealSite',
-    heading: 'Would the inspector need to enter the appeal site?',
+    heading: 'Would the Inspector need to enter the appeal site?',
     section: 'About the Appeal Site',
     title:
       'Would the Inspector need to enter the appeal site? - Appeal Questionnaire - Appeal a householder planning decision - GOV.UK',
@@ -49,10 +49,10 @@ exports.booleanQuestions = [
   },
   {
     id: 'accessNeighboursLand',
-    heading: "Would the inspector need access to a neighbour's land?",
+    heading: "Would the Inspector need access to a neighbour's land?",
     section: 'About the Appeal Site',
     title:
-      "Would the inspector need access to a neighbour's land? - Appeal questionnaire - Appeal a householder planning decision - GOV.UK",
+      "Would the Inspector need access to a neighbour's land? - Appeal questionnaire - Appeal a householder planning decision - GOV.UK",
     emptyError: 'Select yes if the inspector needs access to a neighbour’s land',
     url: 'neighbours-land',
     dataId: 'needsAccess',

--- a/packages/lpa-questionnaire-web-app/src/lib/questionTypes.js
+++ b/packages/lpa-questionnaire-web-app/src/lib/questionTypes.js
@@ -36,7 +36,7 @@ exports.booleanQuestions = [
     section: 'About the Appeal Site',
     title:
       'Would the Inspector need to enter the appeal site? - Appeal Questionnaire - Appeal a householder planning decision - GOV.UK',
-    emptyError: 'Select yes if the inspector would need to enter the appeal site',
+    emptyError: 'Select yes if the Inspector would need to enter the appeal site',
     url: 'site-access',
     dataId: 'mustEnter',
     text: {
@@ -53,7 +53,7 @@ exports.booleanQuestions = [
     section: 'About the Appeal Site',
     title:
       "Would the Inspector need access to a neighbour's land? - Appeal questionnaire - Appeal a householder planning decision - GOV.UK",
-    emptyError: 'Select yes if the inspector needs access to a neighbour’s land',
+    emptyError: 'Select yes if the Inspector needs access to a neighbour’s land',
     url: 'neighbours-land',
     dataId: 'needsAccess',
     text: {

--- a/packages/lpa-questionnaire-web-app/src/services/task.service.js
+++ b/packages/lpa-questionnaire-web-app/src/services/task.service.js
@@ -155,9 +155,9 @@ const HEADERS = {
   otherAppeals: 'Tell us about any appeals in the immediate area',
   aboutSiteSection: 'About the Appeal Site',
   siteSeenPublicLand:
-    'Can the inspector see the relevant parts of the appeal site from public land?',
-  enterAppealSite: 'Would the inspector need to enter the appeal site?',
-  accessNeighboursLand: "Would the inspector need access to a neighbour's land?",
+    'Can the Inspector see the relevant parts of the appeal site from public land?',
+  enterAppealSite: 'Would the Inspector need to enter the appeal site?',
+  accessNeighboursLand: "Would the Inspector need access to a neighbour's land?",
   listedBuilding: 'Would the development affect the setting of a listed building?',
   greenBelt: 'Is the appeal site in a green belt?',
   nearConservationArea: 'Is the appeal site in or near a conservation area?',


### PR DESCRIPTION
## Ticket Number
<!-- Add the number from the Jira board -->
https://pins-ds.atlassian.net/browse/AS-2982

## Description of change
<!-- Please describe the change -->
Update the content for the LPA questionnaire  so that the word inspector starts with capital letter. 
## Checklist
<!-- Put an `x` in all the boxes that apply: -->
- [ ] Requires infrastructure changes
- [ ] If adding or remove environment variables (e.g. in `docker-compose.yaml`) then I have updated the appropriate Helm chart
- [ ] I have updated the documentation accordingly
- [ ] My commit history in this PR is linear
- [ ] New features have tests
- [ ] Breaking change (team conversation required)

## Important

Please do not merge from `master` (please only [rebase](https://github.com/foundry4/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
