### PR TITLE
fix(lpa-questionnaire-web-app): fix non appearance of appeal-reply-id…

### DIFF
--- a/packages/lpa-questionnaire-web-app/src/controllers/upload-question.js
+++ b/packages/lpa-questionnaire-web-app/src/controllers/upload-question.js
@@ -19,23 +19,27 @@ exports.getUpload = (req, res) => {
   const { sectionName, taskName, view } = res.locals.routeInfo;
 
   let uploadedFiles;
+  let appealReplyId;
 
   if (!req.session.appealReply[sectionName][taskName]) {
     req.session.appealReply[sectionName][taskName] = { uploadFiles: [] };
   } else {
     uploadedFiles = req.session.appealReply[sectionName][taskName].uploadedFiles;
+    appealReplyId = req.session.appealReply.id;
   }
 
   res.render(view, {
     appeal: getAppealSideBarDetails(req.session.appeal),
     backLink: req.session.backLink || `/${req.params.id}/${VIEW.TASK_LIST}`,
     ...fileUploadNunjucksVariables(null, null, uploadedFiles),
+    appealReplyId,
   });
 };
 
 exports.postUpload = async (req, res) => {
   const { sectionName, taskName, view, name } = res.locals.routeInfo;
   const { appealReply } = req.session;
+  const { appealReplyId } = appealReply;
   const documents = req.body?.files?.documents || [];
   const { delete: deleteId = '', errors = {}, submit = '' } = req.body;
   const backLink = req.session.backLink || `/${req.params.id}/${VIEW.TASK_LIST}`;
@@ -117,6 +121,7 @@ exports.postUpload = async (req, res) => {
         ...fileUploadNunjucksVariables(errorMessage, constructedErrorSummary, validFiles),
         appeal: getAppealSideBarDetails(req.session.appeal),
         backLink,
+        appealReplyId,
       });
     } else {
       res.redirect(req.session.backLink || `/${req.params.id}/${VIEW.TASK_LIST}`);
@@ -129,6 +134,7 @@ exports.postUpload = async (req, res) => {
       ...fileUploadNunjucksVariables(err, fileErrorSummary(err, req), validFiles),
       appeal: getAppealSideBarDetails(req.session.appeal),
       backLink,
+      appealReplyId,
     });
   }
 };

--- a/packages/lpa-questionnaire-web-app/src/views/includes/head.njk
+++ b/packages/lpa-questionnaire-web-app/src/views/includes/head.njk
@@ -1,4 +1,7 @@
 {% block head %}
+  {% if appealReplyId %}
+      <meta name="appeal-reply-id" content="{{ appealReplyId }}">
+    {% endif %}
   <!--[if lte IE 8]><link href="/public/stylesheets/main-ie8.css" rel="stylesheet" type="text/css" /><![endif]-->
   <!--[if gt IE 8]><!--><link href="/public/stylesheets/main.css" media="all" rel="stylesheet" type="text/css"/><!--<![endif]-->
 

--- a/packages/lpa-questionnaire-web-app/tests/unit/controllers/upload-question.test.js
+++ b/packages/lpa-questionnaire-web-app/tests/unit/controllers/upload-question.test.js
@@ -63,6 +63,7 @@ describe('controllers/upload-question', () => {
       expect(res.render).toHaveBeenCalledWith('mock-view', {
         appeal: null,
         backLink: backLinkUrl,
+        appealReplyId: 'mock-id',
       });
     });
 
@@ -85,6 +86,7 @@ describe('controllers/upload-question', () => {
       expect(res.render).toHaveBeenCalledWith('mock-view', {
         appeal: null,
         backLink: `/mock-id/${VIEW.TASK_LIST}`,
+        appealReplyId: 'mock-id',
       });
     });
 
@@ -102,6 +104,7 @@ describe('controllers/upload-question', () => {
         appeal: null,
         backLink: `/mock-id/${VIEW.TASK_LIST}`,
         uploadedFiles,
+        appealReplyId: 'mock-id',
       });
     });
   });


### PR DESCRIPTION
… meta tags in file-upload pages

## Ticket Number
<!-- Add the number from the Jira board -->
https://pins-ds.atlassian.net/browse/AS-3013

## Description of change
<!-- Please describe the change -->
fix non appearance of appeal-reply-id meta tags in file-upload pages

## Checklist
<!-- Put an `x` in all the boxes that apply: -->
- [ ] Requires infrastructure changes
- [ ] If adding or remove environment variables (e.g. in `docker-compose.yaml`) then I have updated the appropriate Helm chart
- [ ] I have updated the documentation accordingly
- [x] My commit history in this PR is linear
- [ ] New features have tests
- [ ] Breaking change (team conversation required)

## Important

Please do not merge from `master` (please only [rebase](https://github.com/foundry4/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
