### PR TITLE
fix(terraform-validate): increases terraform-security-scan version

### DIFF
--- a/.github/workflows/terraform-validate.yml
+++ b/.github/workflows/terraform-validate.yml
@@ -43,7 +43,7 @@ jobs:
           terraform validate
 
       - name: Terraform security scan
-        uses: triat/terraform-security-scan@v2.2.3
+        uses: triat/terraform-security-scan@v3.0.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:


### PR DESCRIPTION
## Ticket Number
<!-- Add the number from the Jira board -->
https://pins-ds.atlassian.net/browse/AS-3005

## Description of change
<!-- Please describe the change -->
Increases the terraform-security-scan version because the tfsec GitHub location changed, causing the terraform-validate Workflow to fail.

## Checklist
<!-- Put an `x` in all the boxes that apply: -->
- [ ] Requires infrastructure changes
- [ ] If adding or remove environment variables (e.g. in `docker-compose.yaml`) then I have updated the appropriate Helm chart
- [ ] I have updated the documentation accordingly
- [x] My commit history in this PR is linear
- [ ] New features have tests
- [ ] Breaking change (team conversation required)

## Important

Please do not merge from `master` (please only [rebase](https://github.com/foundry4/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
