### PR TITLE
Subtask/as 2868 magic link e2e tests

### DIFF
--- a/lpa-submissions-e2e-tests/cypress/integration/magicLink.feature
+++ b/lpa-submissions-e2e-tests/cypress/integration/magicLink.feature
@@ -1,3 +1,4 @@
+@wip
 Feature: LPA Questionnaire Access - Authentication: Magic Link
   As a LPA Planning Officer
   I want to access the LPA questionnaire

--- a/lpa-submissions-e2e-tests/cypress/integration/magicLink.feature
+++ b/lpa-submissions-e2e-tests/cypress/integration/magicLink.feature
@@ -1,0 +1,72 @@
+Feature: LPA Questionnaire Access - Authentication: Magic Link
+  As a LPA Planning Officer
+  I want to access the LPA questionnaire
+  So that I can complete with the information needed by the Planning Inspector
+
+  Background:
+    Given an appeal has been created
+    And a questionnaire has been created
+
+  Scenario: LPA selects the link in the start email and LPA is asked to provide email address
+    Given LPA Planning Officer wants to complete a questionnaire
+    When they click on the link in the start email
+    Then enter email address page will be displayed
+
+  Scenario: LPA enters email address not matched with the LPA domain -
+    Given access to the questionnaire is requested
+    When the email address does not match the domain of the LPA from the appeal
+    Then progress is made to the confirm your email address page
+    And a magic link is not sent to the user
+
+  Scenario: LPA does not enter an email address
+    Given access to the questionnaire is requested
+    When an email address is not provided
+    Then progress is halted with an error message to enter an email address
+
+  Scenario: LPA enters email address in invalid format
+    Given access to the questionnaire is requested
+    When the email address provided in not in the correct format
+    Then progress is halted with an error message to enter an email address
+
+  Scenario: LPA enters email address matching LPA domain
+    Given access to the questionnaire is requested
+    When a valid email address is provided matching the domain of the LPA
+    Then progress is made to the confirm your email address page
+    And a magic link is sent to that email address via Notify
+
+  Scenario: LPA selects to Email the customer support team
+    Given the LPA is on the confirm your email page
+    When they select to email the customer support team
+    Then a mailto link will be provided
+
+  Scenario:  LPA does not receive magic link and clicks resend
+    Given the LPA is on the confirm your email page
+    When they select ‘resend the email’
+    Then enter email address page will be displayed
+
+  Scenario: LPA selects valid magic link and accesses the questionnaire
+    Given LPA user receives a magic link for accessing the questionnaire
+    When they select a valid link
+    Then the questionnaire page is presented
+
+  Scenario: LPA selects an expired magic link
+    Given LPA user receives a magic link for accessing the questionnaire
+    When they select an expired magic link
+    Then enter email address page will be displayed
+    And a link expired notification banner is displayed on the page
+
+  Scenario: Authentication expired - 4 hours expiry
+    Given the session has timed out
+    When the LPA tries to access the questionnaire
+    Then enter email address page will be displayed
+    And a session expired notification banner is displayed on the page
+
+  Scenario: LPA wants to complete a questionnaire and have not authenticated
+    Given the LPA Planning Officer has not been authenticated
+    When the LPA tries to access the questionnaire
+    Then enter email address page will be displayed
+
+  Scenario: LPA wants to view the questionnaire and have been authenticated
+    Given the LPA Planning Officer is authenticated
+    When the LPA tries to access the questionnaire
+    Then the questionnaire page is presented

--- a/lpa-submissions-e2e-tests/cypress/integration/magicLink.feature
+++ b/lpa-submissions-e2e-tests/cypress/integration/magicLink.feature
@@ -11,7 +11,7 @@ Feature: LPA Questionnaire Access - Authentication: Magic Link
   Scenario: LPA selects the link in the start email and LPA is asked to provide email address
     Given LPA Planning Officer wants to complete a questionnaire
     When they click on the link in the start email
-    Then enter email address page will be displayed
+    Then enter email address page will be opened in the browser
 
   Scenario: LPA enters email address not matched with the LPA domain -
     Given access to the questionnaire is requested
@@ -23,11 +23,13 @@ Feature: LPA Questionnaire Access - Authentication: Magic Link
     Given access to the questionnaire is requested
     When an email address is not provided
     Then progress is halted with an error message to enter an email address
+    And a magic link is not sent to the user
 
   Scenario: LPA enters email address in invalid format
     Given access to the questionnaire is requested
     When the email address provided in not in the correct format
     Then progress is halted with an error message to enter an email address
+    And a magic link is not sent to the user
 
   Scenario: LPA enters email address matching LPA domain
     Given access to the questionnaire is requested

--- a/lpa-submissions-e2e-tests/cypress/integration/magicLink/magicLink.js
+++ b/lpa-submissions-e2e-tests/cypress/integration/magicLink/magicLink.js
@@ -1,0 +1,172 @@
+import { And, Given, Then, When } from 'cypress-cucumber-preprocessor/steps';
+import verifyPage from '../../support/common/verifyPage';
+import verifyNotificationBanner from '../../support/common/verifyNotificationBanner';
+import validateErrorMessage from '../../support/common/validateErrorMessage';
+import goToPage from '../../support/common/goToPage';
+import clickLink from '../../support/common/clickLink';
+import clickSubmit from '../../support/common/clickSubmitButton';
+import hasLink from '../../support/common/hasLink';
+import inputEmailAddress from '../../support/magic-link/inputEmailAddress';
+import authenticateLPA from '../../support/magic-link/authenticateLPA';
+import getMagicLink from '../../support/magic-link/getMagicLink';
+import getMagicLinkEmail from '../../support/magic-link/getMagicLinkEmail';
+
+const enterEmailAddressLink = 'authentication/your-email';
+const confirmEmailAddressLink = 'authentication/confirm-email';
+const questionnairePage = 'task-list';
+const lpaName = 'System Test Borough Council';
+
+Given('LPA wants to access a questionnaire', () => {
+  // nothing to do here
+});
+
+Given('the LPA is on the confirm your email page', () => {
+  goToPage(confirmEmailAddressLink);
+});
+
+Given('LPA user receives a magic link for accessing the questionnaire', () => {
+  goToPage(enterEmailAddressLink);
+  inputEmailAddress();
+  clickSubmit();
+});
+
+And('is trying to access the LPA questionnaire', () => {
+  // nothing to do here
+});
+
+Given('access to the questionnaire is requested', () => {
+  goToPage(enterEmailAddressLink);
+});
+
+Given('LPA user wants to have the magic link resent to them', () => {
+  goToPage(confirmEmailAddressLink);
+});
+
+Given('the session has timed out', () => {
+  // TODO check if the session id cookie name is correct and if this works as expected
+  const expiryDate = new Date();
+  expiryDate.setMinutes(expiryDate.getMinutes() - 20);
+
+  cy.getCookie('connect.sid').then((cookie) => {
+    cy.clearCookies();
+    cy.setCookie(cookie.name, cookie.value, {
+      expiry: expiryDate.valueOf(),
+      domain: cookie.domain,
+    });
+  });
+});
+
+Given('LPA Planning Officer wants to complete a questionnaire', () => {
+  // nothing to do here
+});
+
+Given('the LPA Planning Officer has not been authenticated', () => {
+  cy.clearCookies();
+});
+
+Given('the LPA Planning Officer is authenticated', () => {
+  authenticateLPA();
+});
+
+When('they click on the link in the start email', () => {
+  goToPage(questionnairePage);
+});
+
+When('the email address does not match the domain of the LPA from the appeal', () => {
+  inputEmailAddress('test@test.gov.uk');
+  clickSubmit();
+});
+
+When('an email address is not provided', () => {
+  inputEmailAddress('');
+  clickSubmit();
+});
+
+When('the email address provided in not in the correct format', () => {
+  inputEmailAddress('invalidEmailAddress');
+  clickSubmit();
+});
+
+When('a valid email address is provided matching the domain of the LPA', () => {
+  inputEmailAddress();
+  clickSubmit();
+});
+
+When('they select to email the customer support team', () => {
+  // nothing to do here
+});
+
+When('they select a valid link', () => {
+  getMagicLink().then((magicLink) => goToPage(magicLink));
+});
+
+When('they select an expired magic link', () => {
+  const expiredToken = 'expiredToken';
+  const expiredMagicLink = `${questionnairePage}?token=${expiredToken}`;
+  goToPage(expiredMagicLink);
+});
+
+When('they select ‘resend the email’', () => {
+  clickLink('resend-email-link');
+});
+
+When('the LPA tries to access the questionnaire', () => {
+  goToPage(questionnairePage);
+});
+
+Then('enter email address page will be displayed', () => {
+  verifyPage(enterEmailAddressLink);
+});
+
+Then('a magic link is sent to that email address via Notify', () => {
+  getMagicLinkEmail().then((response) => {
+    // TODO assert email body
+    // expect(response.body).toEqual([]);
+  });
+});
+
+Then('a mailto link will be provided', () => {
+  hasLink(
+    '[data-cy="customer-support-mailto-link"]',
+    'mailto:enquiries@planninginspectorate.gov.uk',
+  );
+});
+
+Then('the questionnaire page is presented', () => {
+  verifyPage(questionnairePage);
+});
+
+And('a session expired notification banner is displayed on the page', () => {
+  verifyPage(`${enterEmailAddressLink}/session-expired`);
+
+  const notificationBody =
+    '<p class="govuk-notification-banner__heading">Your session has timed out</p>' +
+    `<p class="govuk-body">To return to the questionnaire, you need to enter your ${lpaName} email address.</p>`;
+  verifyNotificationBanner('session-expired-notification', 'Session expired', notificationBody);
+});
+
+And('a link expired notification banner is displayed on the page', () => {
+  verifyPage(`${enterEmailAddressLink}/link-expired`);
+
+  const notificationBody =
+    '<p class="govuk-notification-banner__heading">Your link has expired</p>' +
+    `<p class="govuk-body">To get a new link, you need to enter your ${lpaName} email address.< /p>`;
+  verifyNotificationBanner('link-expired-notification', 'Link expired', notificationBody);
+});
+
+Then('progress is made to the confirm your email address page', () => {
+  verifyPage(confirmEmailAddressLink);
+});
+
+And('a magic link is not sent to the user', () => {
+  getMagicLink().then((magicLink) => expect(magicLink).to.be.undefined);
+});
+
+Then('progress is halted with an error message to enter an email address', () => {
+  verifyPage(enterEmailAddressLink);
+  validateErrorMessage(
+    'Enter an email address in the correct format, like name@example.com',
+    '#email',
+    'email',
+  );
+});

--- a/lpa-submissions-e2e-tests/cypress/integration/magicLink/magicLink.js
+++ b/lpa-submissions-e2e-tests/cypress/integration/magicLink/magicLink.js
@@ -114,6 +114,10 @@ When('the LPA tries to access the questionnaire', () => {
   goToPage(questionnairePage);
 });
 
+Then('enter email address page will be opened in the browser', () => {
+  verifyPage(enterEmailAddressLink);
+});
+
 Then('enter email address page will be displayed', () => {
   verifyPage(enterEmailAddressLink);
 });

--- a/lpa-submissions-e2e-tests/cypress/integration/sendEmailConfirmationToNotify/sendEmailConfirmationToNotify.steps.js
+++ b/lpa-submissions-e2e-tests/cypress/integration/sendEmailConfirmationToNotify/sendEmailConfirmationToNotify.steps.js
@@ -1,13 +1,16 @@
 import { Then } from 'cypress-cucumber-preprocessor/steps';
+import getNotificationEmail from '../../support/common/getNotificationEmail';
 
 Then('a confirmation email is sent to the LPA', () => {
   cy.verifyPage('information-submitted');
   cy.get('@appeal').then((appeal) => {
-    cy.request('GET', `${Cypress.env('EMAIL_NOTIFICATION_URL')}`).then((response) => {
+    getNotificationEmail().then((response) => {
       const lastEmailNotificationOnTheStack = response.body.length - 1;
       const emailNotification = response.body[lastEmailNotificationOnTheStack];
       expect(emailNotification.template_id).to.eq('937b4147-8420-42da-859d-d4a65bdf99bc');
-      expect(emailNotification.email_address).to.eq('AppealPlanningDecisionTest@planninginspectorate.gov.uk');
+      expect(emailNotification.email_address).to.eq(
+        'AppealPlanningDecisionTest@planninginspectorate.gov.uk',
+      );
 
       expect(Object.keys(emailNotification.personalisation).length).to.eq(4);
       expect(emailNotification.personalisation['Planning appeal number']).to.eq(appeal.horizonId);
@@ -28,9 +31,7 @@ Then('a confirmation email is sent to the LPA', () => {
         false,
       );
 
-      expect(emailNotification.reference).to.eq(
-        `${appeal.id}.SubmissionConfirmation`,
-      );
+      expect(emailNotification.reference).to.eq(`${appeal.id}.SubmissionConfirmation`);
       expect(emailNotification.email_reply_to_id).to.eq('f1e6c8c5-786e-41ca-9086-10b67f31bc86');
       expect(response.status).to.eq(200);
     });

--- a/lpa-submissions-e2e-tests/cypress/support/common/clickLink.js
+++ b/lpa-submissions-e2e-tests/cypress/support/common/clickLink.js
@@ -1,0 +1,3 @@
+module.exports = (id) => {
+  cy.get(`[data-cy="${id}"]`).click();
+};

--- a/lpa-submissions-e2e-tests/cypress/support/common/getNotificationEmail.js
+++ b/lpa-submissions-e2e-tests/cypress/support/common/getNotificationEmail.js
@@ -1,0 +1,11 @@
+module.exports = (emailAddress) => {
+  let qs = {};
+  if (emailAddress) qs.email_address = emailAddress;
+
+  let options = {
+    url: `${Cypress.env('EMAIL_NOTIFICATION_URL')}`,
+    method: 'GET',
+    qs: qs,
+  };
+  return cy.request(options);
+};

--- a/lpa-submissions-e2e-tests/cypress/support/common/verifyNotificationBanner.js
+++ b/lpa-submissions-e2e-tests/cypress/support/common/verifyNotificationBanner.js
@@ -1,0 +1,9 @@
+module.exports = (id, title, body) => {
+  return cy
+    .get(`[data-cy="${id}"]`)
+    .should('have.class', 'govuk-notification-banner')
+    .then((banner) => {
+      banner.get('.govuk-notification-banner__title').should('have.text', title);
+      banner.get('.govuk-notification-banner__content').should('have.text', body);
+    });
+};

--- a/lpa-submissions-e2e-tests/cypress/support/magic-link/authenticateLPA.js
+++ b/lpa-submissions-e2e-tests/cypress/support/magic-link/authenticateLPA.js
@@ -1,0 +1,11 @@
+import goToPage from '../common/goToPage';
+import inputEmailAddress from './inputEmailAddress';
+import clickSubmit from '../common/clickSubmitButton';
+import getMagicLink from './getMagicLink';
+
+module.exports = () => {
+  goToPage('authentication/your-email');
+  inputEmailAddress();
+  clickSubmit();
+  getMagicLink().then((magicLink) => goToPage(magicLink));
+};

--- a/lpa-submissions-e2e-tests/cypress/support/magic-link/getMagicLink.js
+++ b/lpa-submissions-e2e-tests/cypress/support/magic-link/getMagicLink.js
@@ -1,0 +1,8 @@
+import getMagicLinkEmail from './getMagicLinkEmail';
+
+module.exports = async () => {
+  return getMagicLinkEmail().then((response) => {
+    // TODO get magic link url from email body
+    return undefined;
+  });
+};

--- a/lpa-submissions-e2e-tests/cypress/support/magic-link/getMagicLinkEmail.js
+++ b/lpa-submissions-e2e-tests/cypress/support/magic-link/getMagicLinkEmail.js
@@ -1,0 +1,7 @@
+import getNotificationEmail from '../common/getNotificationEmail';
+
+module.exports = async () => {
+  return cy.get('@lpaEmail').then((lpaEmail) => {
+    return getNotificationEmail(lpaEmail);
+  });
+};

--- a/lpa-submissions-e2e-tests/cypress/support/magic-link/inputEmailAddress.js
+++ b/lpa-submissions-e2e-tests/cypress/support/magic-link/inputEmailAddress.js
@@ -1,7 +1,9 @@
 import uuid from 'uuid';
+import { input } from '../PageObjects/common-page-objects';
 
 module.exports = (emailAddress) => {
   const email =
     emailAddress !== undefined ? emailAddress : `${uuid.v4()}.user@planninginspectorate.gov.uk`;
   cy.wrap(email).as('lpaEmail');
+  input('lpa-authentication-email').type(email);
 };

--- a/lpa-submissions-e2e-tests/cypress/support/magic-link/inputEmailAddress.js
+++ b/lpa-submissions-e2e-tests/cypress/support/magic-link/inputEmailAddress.js
@@ -1,0 +1,7 @@
+import uuid from 'uuid';
+
+module.exports = (emailAddress) => {
+  const email =
+    emailAddress !== undefined ? emailAddress : `${uuid.v4()}.user@planninginspectorate.gov.uk`;
+  cy.wrap(email).as('lpaEmail');
+};

--- a/lpa-submissions-e2e-tests/package-lock.json
+++ b/lpa-submissions-e2e-tests/package-lock.json
@@ -1074,6 +1074,14 @@
         "tough-cookie": "~2.5.0",
         "tunnel-agent": "^0.6.0",
         "uuid": "^3.3.2"
+      },
+      "dependencies": {
+        "uuid": {
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+          "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
+          "dev": true
+        }
       }
     },
     "@cypress/xvfb": {
@@ -4797,6 +4805,12 @@
           "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
           "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
           "dev": true
+        },
+        "uuid": {
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+          "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
+          "dev": true
         }
       }
     },
@@ -5681,6 +5695,13 @@
         "tough-cookie": "~2.5.0",
         "tunnel-agent": "^0.6.0",
         "uuid": "^3.3.2"
+      },
+      "dependencies": {
+        "uuid": {
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+          "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
+        }
       }
     },
     "request-progress": {
@@ -6821,9 +6842,9 @@
       "integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM="
     },
     "uuid": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
-      "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
     },
     "vary": {
       "version": "1.1.2",

--- a/lpa-submissions-e2e-tests/package.json
+++ b/lpa-submissions-e2e-tests/package.json
@@ -23,7 +23,8 @@
   "dependencies": {
     "cypress-ntlm-auth": "^3.1.5",
     "datatables.net": "1.10.23",
-    "pdf-parse": "^1.1.1"
+    "pdf-parse": "^1.1.1",
+    "uuid": "^8.3.1"
   },
   "cypress-cucumber-preprocessor": {
     "nonGlobalStepDefinitions": true,

--- a/packages/lpa-questionnaire-web-app/src/views/authentication/confirm-email.njk
+++ b/packages/lpa-questionnaire-web-app/src/views/authentication/confirm-email.njk
@@ -23,9 +23,9 @@ Confirm your email address - Appeal questionnaire - Appeal a householder plannin
 
       <p class="govuk-body govuk-!-font-weight-bold">If you're having problems</p>
       <p>Check the email hasn't gone into your spam/bulk folder.</p>
-      <p>We can <a href="{{ enterEmailLink }}" class="govuk-link">resend the email</a>.</p>
+      <p>We can <a href="{{ enterEmailLink }}" class="govuk-link" data-cy="resend-email-link" >resend the email</a>.</p>
       <p>If you're still having problems, you can contact our customer support team:</p>
-      <p>Email: <a href="mailto:enquiries@planninginspectorate.gov.uk" class="govuk-link">enquiries@planninginspectorate.gov.uk</a>
+      <p>Email: <a href="mailto:enquiries@planninginspectorate.gov.uk" class="govuk-link" data-cy="customer-support-mailto-link">enquiries@planninginspectorate.gov.uk</a>
       <br>Telephone: 0303 444 5000
       </p>
     </div>

--- a/packages/lpa-questionnaire-web-app/src/views/authentication/your-email.njk
+++ b/packages/lpa-questionnaire-web-app/src/views/authentication/your-email.njk
@@ -34,7 +34,10 @@
         {{ govukNotificationBanner({
           html: html,
           titleText: 'Linked expired',
-          role: 'alert'
+          role: 'alert',
+          attributes: {
+            'data-cy': 'link-expired-notification'
+          }
         }) }}
       {% elif isSessionExpired %}
         {% set html %}
@@ -47,7 +50,10 @@
         {{ govukNotificationBanner({
           html: html,
           titleText: 'Session expired',
-          role: 'alert'
+          role: 'alert',
+          attributes: {
+            'data-cy': 'session-expired-notification'
+          }
         }) }}
       {% else %}
         <p>Before you can access this questionnaire, we need to check you work at {{ lpaName }}.</p>
@@ -64,11 +70,17 @@
               text: ["Enter your ", lpaName, " email address"] | join
             },
             id: "email",
-            name: "email"
+            name: "email",
+            attributes: {
+               'data-cy': 'lpa-authentication-email'
+            }
           })
         }}
         {{ govukButton({
-              text: "Continue"
+              text: "Continue",
+              attributes: {
+                'data-cy': 'submit'
+              }
            })
         }}
       </form>


### PR DESCRIPTION
## Ticket Number
<!-- Add the number from the Jira board -->
https://pins-ds.atlassian.net/browse/AS-2868

## Description of change
<!-- Please describe the change -->
Add e2e tests for the magic link functionality. 

Note: We will have to update the questionnaire tests by adding an 'authenticateLPA' as a background step. We can do this once the authorisation feature is completed.

## Checklist
<!-- Put an `x` in all the boxes that apply: -->
- [ ] Requires infrastructure changes
- [ ] If adding or remove environment variables (e.g. in `docker-compose.yaml`) then I have updated the appropriate Helm chart
- [ ] I have updated the documentation accordingly
- [ ] My commit history in this PR is linear
- [ ] New features have tests
- [ ] Breaking change (team conversation required)

## Important

Please do not merge from `master` (please only [rebase](https://github.com/foundry4/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
