### PR TITLE
feat(lpa-submissions-e2e-tests): set questionnaire submission date an…

### DIFF
--- a/lpa-submissions-e2e-tests/cypress/integration/generateSubmissionPdf/generateSubmissionPdf.step.js
+++ b/lpa-submissions-e2e-tests/cypress/integration/generateSubmissionPdf/generateSubmissionPdf.step.js
@@ -12,5 +12,6 @@ Then('a PDF of the Check Your Answers page is created', () => {
     cy.checkSubmissionPdfContent(
       'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer nec odio. Praesent libero. Sed cursus ante dapibus diam. Sed nisi. Nulla quis sem at nibh elementum imperdiet. Duis sagittis ipsum. Praesent mauris. Fusce nec tellus sed augue semper porta. Mauris massa. Vestibulum lacinia arcu eget nulla. Class aptent taciti sociosqu ad litora torquent per conubia nostra, per inceptos himenaeos. Curabitur sodales ligula in libero.',
     );
+    cy.checkSubmissionPdfContent('Submitted to the Planning Inspectorate on');
   });
 });

--- a/packages/lpa-questionnaire-web-app/src/controllers/information-submitted.js
+++ b/packages/lpa-questionnaire-web-app/src/controllers/information-submitted.js
@@ -32,6 +32,7 @@ exports.postInformationSubmitted = async (req, res) => {
   log.info('Submitting the appeal reply');
 
   try {
+    appealReply.submissionDate = new Date();
     const { id, name } = await createPdf(appealReply, appeal);
 
     appealReply.state = 'SUBMITTED';

--- a/packages/lpa-questionnaire-web-app/src/services/pdf.service.js
+++ b/packages/lpa-questionnaire-web-app/src/services/pdf.service.js
@@ -2,6 +2,8 @@ const fs = require('fs');
 const nunjucks = require('nunjucks');
 const path = require('path');
 const uuid = require('uuid');
+const { format } = require('date-fns');
+const gbLocale = require('date-fns/locale/en-GB');
 
 const checkAnswersSections = require('../lib/check-answers-sections');
 const appealSidebarDetails = require('../lib/appeal-sidebar-details');
@@ -45,6 +47,8 @@ const buildAppealDetailsRows = (appealData) => {
 };
 
 const convertToHtml = (appealReply, appeal) => {
+  const submissionDate = format(appealReply.submissionDate, 'dd MMMM yyyy', gbLocale);
+
   const sections = checkAnswersSections(appealReply, null, false);
 
   const appealDetails = getAppealDetails(appeal);
@@ -55,6 +59,7 @@ const convertToHtml = (appealReply, appeal) => {
 
   return nunjucks.render(path.resolve(__dirname, '../views/pdf-generation.njk'), {
     css,
+    submissionDate,
     sections,
   });
 };

--- a/packages/lpa-questionnaire-web-app/src/views/pdf-generation.njk
+++ b/packages/lpa-questionnaire-web-app/src/views/pdf-generation.njk
@@ -11,6 +11,7 @@
       <div class="govuk-grid-row">
         <div class="govuk-grid-column-full">
           <h1 class="govuk-heading-l">Questionnaire for householder appeal</h1>
+          <p>Submitted to the Planning Inspectorate on {{ submissionDate }}</p>
 
           {{ pdfGeneration({
             sections: sections

--- a/packages/lpa-questionnaire-web-app/src/views/pdf-generation.njk
+++ b/packages/lpa-questionnaire-web-app/src/views/pdf-generation.njk
@@ -11,7 +11,7 @@
       <div class="govuk-grid-row">
         <div class="govuk-grid-column-full">
           <h1 class="govuk-heading-l">Questionnaire for householder appeal</h1>
-          <p>Submitted to the Planning Inspectorate on {{ submissionDate }}</p>
+          <p class="govuk-body">Submitted to the Planning Inspectorate on {{ submissionDate }}</p>
 
           {{ pdfGeneration({
             sections: sections

--- a/packages/lpa-questionnaire-web-app/tests/unit/controllers/information-submitted.test.js
+++ b/packages/lpa-questionnaire-web-app/tests/unit/controllers/information-submitted.test.js
@@ -32,6 +32,15 @@ describe('../../../src/controllers/information-submitted', () => {
   let lpaEmailString;
   let mockLPAObject;
 
+  beforeAll(() => {
+    jest.useFakeTimers('modern');
+    jest.setSystemTime(Date.parse('2021-07-29T07:35:11.426Z'));
+  });
+
+  afterAll(() => {
+    jest.useRealTimers();
+  });
+
   beforeEach(() => {
     req = mockReq();
     res = mockRes();
@@ -95,6 +104,27 @@ describe('../../../src/controllers/information-submitted', () => {
 
       expect(res.redirect).toHaveBeenCalledWith(`/mock-id/${VIEW.INFORMATION_SUBMITTED}`);
       expect(res.status).not.toHaveBeenCalled();
+    });
+
+    it('should update the appealReply session object on success', async () => {
+      createOrUpdateAppealReply.mockReturnValue('reply ok');
+      createPdf.mockReturnValue({ id: 'mock-pdf', name: 'mock.pdf' });
+
+      await postInformationSubmitted(req, res);
+
+      const { appealReply } = req.session;
+      appealReply.state = 'SUBMITTED';
+      appealReply.submissionDate = Date.parse('2021-07-29T07:35:11.426Z');
+      appealReply.submission = {
+        pdfStatement: {
+          uploadedFile: {
+            id: 'mock-pdf',
+            name: 'mock.pdf',
+          },
+        },
+      };
+
+      expect(req.session.appealReply).toEqual(appealReply);
     });
   });
 });

--- a/packages/lpa-questionnaire-web-app/tests/unit/services/pdf.service.test.js
+++ b/packages/lpa-questionnaire-web-app/tests/unit/services/pdf.service.test.js
@@ -20,7 +20,8 @@ describe('services/pdf.service', () => {
   let mockAppeal;
 
   beforeEach(() => {
-    mockAppealReply = originalMockAppealReply;
+    mockAppealReply = { ...originalMockAppealReply };
+    mockAppealReply.submissionDate = Date.parse('2021-07-29T07:35:11.426Z');
     mockAppeal = originalMockAppeal;
   });
 
@@ -33,6 +34,12 @@ describe('services/pdf.service', () => {
       mockAppealReply.aboutAppealSection.submissionAccuracy.inaccuracyReason =
         'mock-inaccuracy-reason';
       expect(convertToHtml(mockAppealReply, mockAppeal)).toContain('mock-inaccuracy-reason');
+    });
+
+    it('should contain submissionDate included in the html document', () => {
+      expect(convertToHtml(mockAppealReply, mockAppeal)).toContain(
+        'Submitted to the Planning Inspectorate on 29 July 2021'
+      );
     });
   });
   describe('createPdf', () => {


### PR DESCRIPTION
…d append it to the pdf

Set and save questionnaire submission date and append it to the generated pdf.

## Ticket Number
<!-- Add the number from the Jira board -->
https://pins-ds.atlassian.net/browse/AS-2049

## Description of change
<!-- Please describe the change -->
* Create questionnaire submission date on the server side and save it using the appeal-reply-service-api.
* Update the questionnaire pdf to contain the date. Please check the image below to see the new pdf format.

<img width="753" alt="Screenshot 2021-07-29 at 13 55 43" src="https://user-images.githubusercontent.com/26301971/127496309-59627ddf-5ee6-410f-8779-6821539f83cf.png">


## Checklist
<!-- Put an `x` in all the boxes that apply: -->
- [ ] Requires infrastructure changes
- [ ] If adding or remove environment variables (e.g. in `docker-compose.yaml`) then I have updated the appropriate Helm chart
- [ ] I have updated the documentation accordingly
- [ ] My commit history in this PR is linear
- [X] New features have tests
- [ ] Breaking change (team conversation required)

## Important

Please do not merge from `master` (please only [rebase](https://github.com/foundry4/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
