### PR TITLE
Fix/as 3095 fix rabbitmq

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -305,8 +305,7 @@ services:
   rabbitmq:
     image: rabbitmq:3.8.18-management-alpine
     environment:
-      RABBITMQ_DEFAULT_USER: admin
-      RABBITMQ_DEFAULT_PASS: admin
+      RABBITMQ_SERVER_ADDITIONAL_ERL_ARGS: "-rabbit default_pass admin default_user admin"
     ports:
       - 4004:5672
       - 4005:15672

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -303,7 +303,7 @@ services:
 
   # In prod we use Azure Service Bus which uses AMQP1.0
   rabbitmq:
-    image: rabbitmq:3.8.18-management-alpine
+    image: rabbitmq:3-management-alpine
     environment:
       RABBITMQ_SERVER_ADDITIONAL_ERL_ARGS: "-rabbit default_pass admin default_user admin"
     ports:


### PR DESCRIPTION
Replace rabbitmq  env variables with RABBITMQ_SERVER_ADDITIONAL_ERL_ARGS because the env variables were
removed in the 3.9 version.

## Ticket Number
<!-- Add the number from the Jira board -->
https://pins-ds.atlassian.net/browse/AS-3095

## Description of change
<!-- Please describe the change -->

Replace rabbitmq  env variables with `RABBITMQ_SERVER_ADDITIONAL_ERL_ARGS` because starting with 3.9 versions the deprecated env variables `RABBITMQ_DEFAULT_USER` and `RABBITMQ_DEFAULT_PASS` are no longer used. 

This problem was causing the creation of the rabbitmq container to fail.

## Checklist
<!-- Put an `x` in all the boxes that apply: -->
- [ ] Requires infrastructure changes
- [ ] If adding or remove environment variables (e.g. in `docker-compose.yaml`) then I have updated the appropriate Helm chart
- [ ] I have updated the documentation accordingly
- [ ] My commit history in this PR is linear
- [ ] New features have tests
- [ ] Breaking change (team conversation required)

## Important

Please do not merge from `master` (please only [rebase](https://github.com/foundry4/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
