### PR TITLE
test: updated failing cypress tests for lpa-questionnaire

### DIFF
--- a/.github/workflows/branch.yml
+++ b/.github/workflows/branch.yml
@@ -23,6 +23,7 @@ on:
       - 'dependabot/**' # Automatic dependabot updates
       - 'feature/**'
       - 'subtask/**'
+      - 'bugfix/**'
       - 'fix/**'
 
 jobs:

--- a/.github/workflows/branch.yml
+++ b/.github/workflows/branch.yml
@@ -13,6 +13,7 @@ on:
       - 'dependabot/**' # Automatic dependabot updates
       - 'feature/**'
       - 'subtask/**'
+      - 'bugfix/**'
       - 'fix/**'
   pull_request:
     branches-ignore:

--- a/lpa-submissions-e2e-tests/cypress/integration/common/uploadFiles.js
+++ b/lpa-submissions-e2e-tests/cypress/integration/common/uploadFiles.js
@@ -70,7 +70,7 @@ const documentsFor = (appealReplyId) => {
 };
 
 const scanDocumentsForOurFile = (documents, fileName) => {
-  return documents && documents.length && documents.find((document) => document.name === fileName);
+  return documents && documents.length && documents.find((document) => document.metadata.name === fileName);
 };
 
 const fileIsInDocumentService = (appealReplyId, fileName) => {

--- a/packages/lpa-questionnaire-web-app/Dockerfile
+++ b/packages/lpa-questionnaire-web-app/Dockerfile
@@ -13,12 +13,16 @@ ENV PORT=3000
 COPY --from=pinscommonukscontainers3887default.azurecr.io/common:latest /opt/app ../common
 ADD package.json package.json
 ADD package-lock.json package-lock.json
+ADD src src
 ADD __tests__ __tests__
 ADD jest.config.js jest.config.js
 
 RUN npm prune --production \
   && npm rebuild \
   && npm version ${VERSION} --no-git-tag-version --allow-same-version || true
+
+RUN npm run documentation; echo $? > /npm.exitcode
+
 EXPOSE 3000
 USER node
 CMD [ "npm", "start" ]

--- a/packages/lpa-questionnaire-web-app/__tests__/unit/controllers/supplementary-documents/uploaded-documents.test.js
+++ b/packages/lpa-questionnaire-web-app/__tests__/unit/controllers/supplementary-documents/uploaded-documents.test.js
@@ -52,6 +52,7 @@ describe('controllers/uploaded-documents', () => {
       };
 
       req.session.backLink = '/appeal-questionnaire/mock-id/mock-back-link';
+      renderObject.continueLink = '/appeal-questionnaire/mock-id/mock-back-link';
       uploadedDocumentsController.getUploadedDocuments(mockRequest, res);
 
       expect(res.render).toHaveBeenCalledWith(view, renderObject);
@@ -60,6 +61,7 @@ describe('controllers/uploaded-documents', () => {
     it.only('should call task-list as a default back link if nothing set in session', () => {
       uploadedDocumentsController.getUploadedDocuments(req, res);
       renderObject.backLink = `/appeal-questionnaire/mock-id/${VIEW.TASK_LIST}`;
+      renderObject.continueLink = '/appeal-questionnaire/mock-id/task-list';
 
       expect(res.render).toHaveBeenCalledWith(view, renderObject);
     });
@@ -68,6 +70,7 @@ describe('controllers/uploaded-documents', () => {
       req.session.backLink = '/appeal-questionnaire/mock-id/mock-back-link';
       res.locals.backLink = '/appeal-questionnaire/some/other/backlink';
       renderObject.backLink = '/appeal-questionnaire/some/other/backlink';
+      renderObject.continueLink = '/appeal-questionnaire/some/other/backlink';
 
       uploadedDocumentsController.getUploadedDocuments(req, res);
 
@@ -113,8 +116,7 @@ describe('controllers/uploaded-documents', () => {
           { class: 'govuk-link', html: '<a href="delete-document?row=1">Delete</a>' },
         ],
       ];
-
-      // console.log({ mockRequest });
+      renderObject.continueLink = '/appeal-questionnaire/mock-id/mock-back-link';
 
       uploadedDocumentsController.getUploadedDocuments(mockRequest, res);
       expect(res.render).toHaveBeenCalledWith(view, renderObject);

--- a/packages/lpa-questionnaire-web-app/__tests__/unit/routes/supplementaryPlanningRouter.test.js
+++ b/packages/lpa-questionnaire-web-app/__tests__/unit/routes/supplementaryPlanningRouter.test.js
@@ -1,14 +1,14 @@
 const { get, post } = require('./router-mock');
-
 const supplementaryDocumentsController = require('../../../src/controllers/supplementary-documents/add-supplementary-document');
 const uploadedDocumentsController = require('../../../src/controllers/supplementary-documents/uploaded-documents');
-
 const fetchExistingAppealReplyMiddleware = require('../../../src/middleware/fetch-existing-appeal-reply');
 const fetchAppealMiddleware = require('../../../src/middleware/fetch-appeal');
 const combineDateInputsMiddleware = require('../../../src/middleware/combine-date-inputs');
 const reqFilesToReqBodyFilesMiddleware = require('../../../src/middleware/req-files-to-req-body-files');
 const { validationErrorHandler } = require('../../../src/validators/validation-error-handler');
 const supplementaryDocumentsValidationRules = require('../../../src/validators/supplementary-documents');
+const checkIfSupplementaryDocuments = require('../../../src/middleware/check-if-supplementary-documents');
+const deleteSupplementaryDocumentController = require('../../../src/controllers/supplementary-documents/delete-supplementary-document');
 
 jest.mock('../../../src/middleware/req-files-to-req-body-files');
 jest.mock('../../../src/validators/supplementary-documents');
@@ -43,7 +43,14 @@ describe('routes/supplementary-documents', () => {
       expect(get).toHaveBeenCalledWith(
         '/appeal-questionnaire/:id/supplementary-documents/uploaded-documents',
         [fetchAppealMiddleware, fetchExistingAppealReplyMiddleware],
+        checkIfSupplementaryDocuments,
         uploadedDocumentsController.getUploadedDocuments
+      );
+
+      expect(get).toHaveBeenCalledWith(
+        '/appeal-questionnaire/:id/supplementary-documents/delete-document',
+        [fetchAppealMiddleware, fetchExistingAppealReplyMiddleware],
+        deleteSupplementaryDocumentController.getDeleteDocument
       );
     });
   });

--- a/packages/lpa-questionnaire-web-app/azure-lpa-questionnaire-web-app-build.yml
+++ b/packages/lpa-questionnaire-web-app/azure-lpa-questionnaire-web-app-build.yml
@@ -5,8 +5,10 @@
 trigger:
   branches:
     include:
-      - feature/as-3074-override
-  #    - master
+      - feature/*
+      - fix/*
+      - subtask/*
+      - master
   paths:
     include:
       - packages/lpa-questionnaire-web-app
@@ -72,68 +74,68 @@ stages:
                 $(versionNumber)
                 lpa-questionnaire-web-app
                 latest
-#          - task: PowerShell@2
-#            displayName: Copy Test Results
-#            inputs:
-#              targetType: 'inline'
-#              script: |
-#                Write-Host "Looking for images with tag $(versionNumber)"
-#                $imageId = (docker images ***/$(imageRepository):$(versionNumber) --quiet)
-#
-#                Write-Host "Setting the imageId to '${imageId}'."
-#
-#                Write-Host "Running Docker..."
-#                $containerId = docker run -d ${imageId}
-#                Write-Host "Setting the containerId to '${containerId}'."
-#
-#                # I found that is was sometimes necessary to have a delay before attempting the copy
-#                # A more elegant retry solution would be better
-#                Start-Sleep -Seconds 2
-#
-#                $testLocation = "${containerId}:/opt/app/junit.xml"
-#                $coverageLocation = "${containerId}:/opt/app/coverage"
-#                $exitCodeLocation = "${containerId}:/npm.exitcode"
-#
-#                Write-Host "Copying test results from '$testLocation'"
-#                docker cp "${testLocation}" "$(Pipeline.Workspace)/junit.xml"
-#
-#                Write-Host "Copying coverage results from '$coverageLocation'"
-#                docker cp "${coverageLocation}" "$(Pipeline.Workspace)/coverage"
-#
-#                Write-Host "Copying exit code from '$exitCodeLocation'."
-#                docker cp "${exitCodeLocation}" "$(Pipeline.Workspace)/npm.exitcode"
-#          - task: PublishTestResults@2
-#            displayName: Publish Test Results
-#            condition: succeededOrFailed()
-#            inputs:
-#              testResultsFormat: 'JUnit'
-#              testResultsFiles: 'junit.xml'
-#              searchFolder: $(Pipeline.Workspace)
-#              mergeTestResults: true
-#              failTaskOnFailedTests: true
-#              testRunTitle: 'LPA Questionnaire Web App Jest Tests'
-#          - task: PublishCodeCoverageResults@1
-#            displayName: Publish Code Coverage Results
-#            inputs:
-#              codeCoverageTool: Cobertura
-#              summaryFileLocation: $(Pipeline.Workspace)/coverage/cobertura-coverage.xml
-#          - task: PowerShell@2
-#            displayName: Verify Tests Passed
-#            inputs:
-#              targetType: 'inline'
-#              script: |
-#                # Check exitcode file exists
-#                  If("$(Test-Path $(Pipeline.Workspace)/npm.exitcode))" -eq "False") {
-#                      Write-Host "Exit code for test run not found"
-#                      exit 9
-#                  }
-#
-#                  $exitCode = cat $(Pipeline.Workspace)/npm.exitcode
-#
-#                  If($exitCode -ne "0") {
-#                      Write-Host "Tests failed"
-#                      exit $exitCode
-#                  }
+          - task: PowerShell@2
+            displayName: Copy Test Results
+            inputs:
+              targetType: 'inline'
+              script: |
+                Write-Host "Looking for images with tag $(versionNumber)"
+                $imageId = (docker images ***/$(imageRepository):$(versionNumber) --quiet)
+
+                Write-Host "Setting the imageId to '${imageId}'."
+
+                Write-Host "Running Docker..."
+                $containerId = docker run -d ${imageId}
+                Write-Host "Setting the containerId to '${containerId}'."
+
+                # I found that is was sometimes necessary to have a delay before attempting the copy
+                # A more elegant retry solution would be better
+                Start-Sleep -Seconds 2
+
+                $testLocation = "${containerId}:/opt/app/junit.xml"
+                $coverageLocation = "${containerId}:/opt/app/coverage"
+                $exitCodeLocation = "${containerId}:/npm.exitcode"
+
+                Write-Host "Copying test results from '$testLocation'"
+                docker cp "${testLocation}" "$(Pipeline.Workspace)/junit.xml"
+
+                Write-Host "Copying coverage results from '$coverageLocation'"
+                docker cp "${coverageLocation}" "$(Pipeline.Workspace)/coverage"
+
+                Write-Host "Copying exit code from '$exitCodeLocation'."
+                docker cp "${exitCodeLocation}" "$(Pipeline.Workspace)/npm.exitcode"
+          - task: PublishTestResults@2
+            displayName: Publish Test Results
+            condition: succeededOrFailed()
+            inputs:
+              testResultsFormat: 'JUnit'
+              testResultsFiles: 'junit.xml'
+              searchFolder: $(Pipeline.Workspace)
+              mergeTestResults: true
+              failTaskOnFailedTests: true
+              testRunTitle: 'LPA Questionnaire Web App Jest Tests'
+          - task: PublishCodeCoverageResults@1
+            displayName: Publish Code Coverage Results
+            inputs:
+              codeCoverageTool: Cobertura
+              summaryFileLocation: $(Pipeline.Workspace)/coverage/cobertura-coverage.xml
+          - task: PowerShell@2
+            displayName: Verify Tests Passed
+            inputs:
+              targetType: 'inline'
+              script: |
+                # Check exitcode file exists
+                  If("$(Test-Path $(Pipeline.Workspace)/npm.exitcode))" -eq "False") {
+                      Write-Host "Exit code for test run not found"
+                      exit 9
+                  }
+
+                  $exitCode = cat $(Pipeline.Workspace)/npm.exitcode
+
+                  If($exitCode -ne "0") {
+                      Write-Host "Tests failed"
+                      exit $exitCode
+                  }
           - task: Docker@2
             displayName: Push Image
             inputs:

--- a/packages/lpa-questionnaire-web-app/src/controllers/confirm-answers.js
+++ b/packages/lpa-questionnaire-web-app/src/controllers/confirm-answers.js
@@ -13,7 +13,7 @@ module.exports = (req, res) => {
   renderView(res, VIEW.CONFIRM_ANSWERS, {
     prefix: 'appeal-questionnaire',
     submissionLink: `/appeal-questionnaire/${req.params.id}/${VIEW.INFORMATION_SUBMITTED}`,
-    taskListLink: '/appeal-questionnaire/mock-id/task-list',
+    taskListLink: `/appeal-questionnaire/${req.params.id}/task-list`,
     sections,
   });
 };

--- a/packages/lpa-questionnaire-web-app/src/controllers/supplementary-documents/delete-supplementary-document.js
+++ b/packages/lpa-questionnaire-web-app/src/controllers/supplementary-documents/delete-supplementary-document.js
@@ -40,7 +40,7 @@ exports.getDeleteDocument = (req, res) => {
     cancelLink,
     fileToDelete,
     appeal: getAppealSideBarDetails(req.session.appeal),
-    backLink: backLink || `/appeal-questionnaire/${req.params.id}/${VIEW.TASK_LIST}`,
+    backLink: backLink || `/${req.params.id}/${VIEW.TASK_LIST}`,
     question,
   });
 };

--- a/packages/lpa-questionnaire-web-app/src/controllers/supplementary-documents/uploaded-documents.js
+++ b/packages/lpa-questionnaire-web-app/src/controllers/supplementary-documents/uploaded-documents.js
@@ -31,8 +31,8 @@ exports.getUploadedDocuments = (req, res) => {
   const backLink = res.locals.backLink || req.session.backLink;
   const continueLink =
     req.session.isCheckingAnswers === true
-      ? `/${req.session.appealReply.appealId}/confirm-answers`
-      : backLink;
+      ? `/appeal-questionnaire/${req.session.appealReply.appealId}/confirm-answers`
+      : `${backLink || `/appeal-questionnaire/${req.params.id}/${VIEW.TASK_LIST}`}`;
   const uploadedDocumentsUrl = `${req.protocol}://${req.headers.host}${req.url}`.replace(
     '/uploaded-documents',
     ''

--- a/packages/lpa-questionnaire-web-app/src/middleware/check-if-supplementary-documents.js
+++ b/packages/lpa-questionnaire-web-app/src/middleware/check-if-supplementary-documents.js
@@ -10,7 +10,9 @@ module.exports = async (req, res, next) => {
   } = req.session.appealReply.optionalDocumentsSection.supplementaryPlanningDocuments;
 
   if (uploadedFiles.length < 1) {
-    res.redirect(`/${req.session.appealReply.appealId}/supplementary-documents`);
+    res.redirect(
+      `/appeal-questionnaire/${req.session.appealReply.appealId}/supplementary-documents`
+    );
     return false;
   }
 


### PR DESCRIPTION
fix(as-3319): fix for failing test when returning from supplementary docs page to tasklist in lpaq

fix(as-3380): remove mock id from url

fix(as-3360): fix supplementary uploaded document

fix(as-3360): fix supplementary document delete

## Ticket Number
AS-3380
https://pins-ds.atlassian.net/browse/AS-3380

## Description of change
Fixed minor issues with routing

## Checklist
<!-- Put an `x` in all the boxes that apply: -->
- [ ] Requires infrastructure changes
- [ ] If adding or remove environment variables (e.g. in `docker-compose.yaml`) then I have updated the appropriate Helm chart
- [ ] I have updated the documentation accordingly
- [ ] My commit history in this PR is linear
- [ ] New features have tests
- [ ] Breaking change (team conversation required)

## Important

Please do not merge from `master` (please only [rebase](https://github.com/foundry4/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
