### PR TITLE
fix(as-3452): fix document api by modifying object shape

### DIFF
--- a/packages/document-service-api/src/controllers/documents.js
+++ b/packages/document-service-api/src/controllers/documents.js
@@ -150,8 +150,7 @@ const deleteDocument = async (req, res) => {
 
   try {
     const containerClient = await initContainerClient();
-    const metadata =
-      (await getMetadataForSingleFile(containerClient, applicationId, documentId)) || {};
+    const metadata = await getMetadataForSingleFile(containerClient, applicationId, documentId);
 
     if (!metadata) {
       req.log.debug({ applicationId, documentId }, 'Invalid application or document id');
@@ -163,7 +162,7 @@ const deleteDocument = async (req, res) => {
 
     req.log.info('Deleting file');
 
-    const success = await deleteFile(containerClient, metadata.name);
+    const success = await deleteFile(containerClient, metadata.location);
 
     if (success) {
       res.status(204).send();

--- a/packages/document-service-api/src/controllers/documents.js
+++ b/packages/document-service-api/src/controllers/documents.js
@@ -150,7 +150,7 @@ const deleteDocument = async (req, res) => {
 
   try {
     const containerClient = await initContainerClient();
-    const { metadata } =
+    const metadata =
       (await getMetadataForSingleFile(containerClient, applicationId, documentId)) || {};
 
     if (!metadata) {
@@ -163,7 +163,7 @@ const deleteDocument = async (req, res) => {
 
     req.log.info('Deleting file');
 
-    const success = await deleteFile(containerClient, metadata.location);
+    const success = await deleteFile(containerClient, metadata.name);
 
     if (success) {
       res.status(204).send();

--- a/packages/document-service-api/src/lib/blobStorage.js
+++ b/packages/document-service-api/src/lib/blobStorage.js
@@ -93,8 +93,9 @@ const getMetadataForAllFiles = async (containerClient, applicationId) => {
 const getMetadataForSingleFile = async (containerClient, applicationId, documentId) => {
   try {
     const blobs = await getMetadataForAllFiles(containerClient, applicationId);
-    const files = blobs.filter(({ metadata = {} }) => metadata.id === documentId);
-    return files.length ? files[0] : null;
+    const files = blobs.filter((blob) => blob.name.includes(`${applicationId}/${documentId}`));
+    const [file] = files;
+    return file;
   } catch (err) {
     logger.error({ err }, 'Error getting blob');
     throw err;

--- a/packages/document-service-api/src/lib/blobStorage.js
+++ b/packages/document-service-api/src/lib/blobStorage.js
@@ -90,14 +90,13 @@ const getMetadataForAllFiles = async (containerClient, applicationId) => {
   }
 };
 
-const getMetadataForSingleFile = async (containerClient, applicationId, documentId) => {
+const getMetadataForSingleFile = async (containerClient, applicationId, documentId, filename) => {
   try {
-    const blobs = await getMetadataForAllFiles(containerClient, applicationId);
-    const files = blobs.filter((blob) => blob.name.includes(`${applicationId}/${documentId}`));
-    const [file] = files;
-    return file;
+    const blob = await containerClient.getBlobClient(`${applicationId}/${documentId}/${filename}`);
+    const { metadata } = await blob.getProperties();
+    return metadata;
   } catch (err) {
-    logger.error({ err }, 'Error getting blob');
+    logger.error({ err }, 'Error getting metadata');
     throw err;
   }
 };

--- a/packages/document-service-api/src/lib/blobStorage.js
+++ b/packages/document-service-api/src/lib/blobStorage.js
@@ -90,9 +90,17 @@ const getMetadataForAllFiles = async (containerClient, applicationId) => {
   }
 };
 
-const getMetadataForSingleFile = async (containerClient, applicationId, documentId, filename) => {
+const getMetadataForSingleFile = async (containerClient, applicationId, documentId) => {
   try {
-    const blob = await containerClient.getBlobClient(`${applicationId}/${documentId}/${filename}`);
+    const blobs = await getMetadataForAllFiles(containerClient, applicationId);
+    const files = blobs.filter((blob) => blob.name.includes(`${applicationId}/${documentId}`));
+    const [file] = files;
+
+    if (typeof file === 'undefined') {
+      return undefined;
+    }
+
+    const blob = await containerClient.getBlobClient(file.name);
     const { metadata } = await blob.getProperties();
     return metadata;
   } catch (err) {


### PR DESCRIPTION
## Ticket Number
AS-3452
https://pins-ds.atlassian.net/browse/AS-3452

## Description of change
 When uploading on the develop environment, it seems the metadata object within the blob payload is missing. As such this meant that the api was referring to the wrong shape for the document blobs when it came to deleting data. this fix remedies that.

## Checklist
<!-- Put an `x` in all the boxes that apply: -->
- [ ] Requires infrastructure changes
- [ ] If adding or remove environment variables (e.g. in `docker-compose.yaml`) then I have updated the appropriate Helm chart
- [ ] I have updated the documentation accordingly
- [ ] My commit history in this PR is linear
- [ ] New features have tests
- [ ] Breaking change (team conversation required)

## Important

Please do not merge from `master` (please only [rebase](https://github.com/foundry4/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
