### PR TITLE
fix(as-3452): specify that metadata should be included in the blob properties response

### DIFF
--- a/packages/document-service-api/src/lib/blobStorage.js
+++ b/packages/document-service-api/src/lib/blobStorage.js
@@ -79,7 +79,10 @@ const getMetadataForAllFiles = async (containerClient, applicationId) => {
     const blobs = [];
 
     // eslint-disable-next-line no-restricted-syntax
-    for await (const blob of containerClient.listBlobsFlat({ prefix: applicationId })) {
+    for await (const blob of containerClient.listBlobsFlat({
+      prefix: applicationId,
+      includeMetadata: true,
+    })) {
       blobs.push(blob);
     }
 


### PR DESCRIPTION
## Ticket Number
https://pins-ds.atlassian.net/browse/AS-3452

## Description of change
It appears that when tested locally the metadata is automatically returned in the blob properties response but in Dev its not so we need to set the `includeMetadata` option in the request so we get it in the response.

This should fix the issue with deleting documents and also the issue with fetching the document in the Horizon function, which are both failing for this same reason.

More info at https://github.com/Azure/azure-sdk-for-js/issues/12708

## Checklist
<!-- Put an `x` in all the boxes that apply: -->
- [ ] Requires infrastructure changes
- [ ] If adding or remove environment variables (e.g. in `docker-compose.yaml`) then I have updated the appropriate Helm chart
- [ ] I have updated the documentation accordingly
- [ ] My commit history in this PR is linear
- [ ] New features have tests
- [ ] Breaking change (team conversation required)

## Important

Please do not merge from `master` (please only [rebase](https://github.com/foundry4/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
