### PR TITLE
fix(as-3486): only store build in acr if merge to master

### DIFF
--- a/packages/appeal-reply-service-api/azure-appeal-reply-service-api-build.yml
+++ b/packages/appeal-reply-service-api/azure-appeal-reply-service-api-build.yml
@@ -5,9 +5,9 @@
 trigger:
   branches:
     include:
-      - feature/*
-      - fix/*
-      - subtask/*
+#      - feature/*
+#      - fix/*
+#      - subtask/*
       - master
   paths:
     include:

--- a/packages/document-service-api/azure-document-service-api-build.yml
+++ b/packages/document-service-api/azure-document-service-api-build.yml
@@ -5,9 +5,9 @@
 trigger:
   branches:
     include:
-      - feature/*
-      - fix/*
-      - subtask/*
+#      - feature/*
+#      - fix/*
+#      - subtask/*
       - master
   paths:
     include:

--- a/packages/forms-web-app/azure-forms-web-app-build.yml
+++ b/packages/forms-web-app/azure-forms-web-app-build.yml
@@ -5,9 +5,9 @@
 trigger:
   branches:
     include:
-      - feature/*
-      - fix/*
-      - subtask/*
+#      - feature/*
+#      - fix/*
+#      - subtask/*
       - master
   paths:
     include:

--- a/packages/lpa-questionnaire-web-app/azure-lpa-questionnaire-web-app-build.yml
+++ b/packages/lpa-questionnaire-web-app/azure-lpa-questionnaire-web-app-build.yml
@@ -5,9 +5,9 @@
 trigger:
   branches:
     include:
-      - feature/*
-      - fix/*
-      - subtask/*
+#      - feature/*
+#      - fix/*
+#      - subtask/*
       - master
   paths:
     include:

--- a/packages/pdf-service-api/azure-pdf-service-api-build.yml
+++ b/packages/pdf-service-api/azure-pdf-service-api-build.yml
@@ -5,9 +5,9 @@
 trigger:
   branches:
     include:
-      - feature/*
-      - fix/*
-      - subtask/*
+#      - feature/*
+#      - fix/*
+#      - subtask/*
       - master
   paths:
     include:


### PR DESCRIPTION
## Ticket Number
https://pins-ds.atlassian.net/browse/AS-3486

## Description of change
only store build in acr if merge to master

## Checklist
<!-- Put an `x` in all the boxes that apply: -->
- [ ] Requires infrastructure changes
- [ ] If adding or remove environment variables (e.g. in `docker-compose.yaml`) then I have updated the appropriate Helm chart
- [ ] I have updated the documentation accordingly
- [ ] My commit history in this PR is linear
- [ ] New features have tests
- [ ] Breaking change (team conversation required)

## Important

Please do not merge from `master` (please only [rebase](https://github.com/foundry4/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
