### PR TITLE
fix(as-3426): re-enable pdf servce api healthchecks

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,8 +16,8 @@ services:
       LOGGER_LEVEL: 'debug'
     ports:
       - 3003:3000
-    # volumes:
-    #   - ./packages/common:/opt/app/node_modules/@pins/common:ro
+    volumes:
+      - ./packages/common:/opt/app/node_modules/@pins/common:ro
 
   appeal-reply-service-api:
     image: node:14-alpine

--- a/packages/pdf-service-api/Dockerfile
+++ b/packages/pdf-service-api/Dockerfile
@@ -11,8 +11,8 @@ WORKDIR /opt/app
 ENV APP_NAME="pdf-service-api"
 ENV BUILD_ID="1"
 ENV VERSION="1.0.0"
-# # This must be built locally from the common package
-# COPY --from=pinscommonukscontainers3887default.azurecr.io/common:latest /opt/app ../common
+# This must be built locally from the common package
+COPY --from=pinscommonukscontainers3887default.azurecr.io/common:latest /opt/app ../common
 ADD src src
 ADD test test
 ADD package.json package.json

--- a/packages/pdf-service-api/src/server.js
+++ b/packages/pdf-service-api/src/server.js
@@ -1,7 +1,7 @@
 const http = require('http');
 
 const config = require('./config');
-// const healthChecks = require('./lib/healthchecks');
+const healthChecks = require('./lib/healthchecks');
 const logger = require('./lib/logger');
 const app = require('./app');
 
@@ -11,7 +11,7 @@ const {
 
 module.exports = () => {
   const server = http.createServer(app);
-  // healthChecks(server);
+  healthChecks(server);
 
   server.listen(port, () => {
     logger.info({ config }, 'Listening');


### PR DESCRIPTION
## Ticket Number
https://pins-ds.atlassian.net/browse/AS-3426

## Description of change
Re-enable pdf service api healthchecks

## Checklist
<!-- Put an `x` in all the boxes that apply: -->
- [ ] Requires infrastructure changes
- [ ] If adding or remove environment variables (e.g. in `docker-compose.yaml`) then I have updated the appropriate Helm chart
- [ ] I have updated the documentation accordingly
- [ ] My commit history in this PR is linear
- [ ] New features have tests
- [ ] Breaking change (team conversation required)

## Important

Please do not merge from `master` (please only [rebase](https://github.com/foundry4/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
