### PR TITLE
fix(as-3494): update the local dev env to work with M1 Macs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,6 +42,7 @@ run:
 .PHONY: run
 
 serve:
+	docker buildx build packages/pdf-service-api --platform=linux/amd64 --tag appeal-planning-decision_pdf-service-api:latest && \
 	docker-compose up
 .PHONY: serve
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,7 @@
 version: '3.7'
 services:
   pdf-service-api:
-    build: './packages/pdf-service-api'
+    image: appeal-planning-decision_pdf-service-api:latest
     environment:
       SERVER_SHOW_ERRORS: 'true'
       LOGGER_LEVEL: 'debug'


### PR DESCRIPTION
## Ticket Number
<!-- Add the number from the Jira board -->
https://pins-ds.atlassian.net/browse/AS-3494

## Description of change
The PDF Service in the local dev env wasn't building on M1 Macs because of an issue with Chromium on the M1. This change fixes that by building the PDF Service first and then running it with the docker-compose file.

The key was to pass the `--platform=linux/amd64` flag when building the image and this doesn't seem to affect it building on other platforms, it's been tested on Linux Mac M1 and Windows.

## Checklist
<!-- Put an `x` in all the boxes that apply: -->
- [ ] Requires infrastructure changes
- [ ] If adding or remove environment variables (e.g. in `docker-compose.yaml`) then I have updated the appropriate Helm chart
- [ ] I have updated the documentation accordingly
- [ ] My commit history in this PR is linear
- [ ] New features have tests
- [ ] Breaking change (team conversation required)

## Important

Please do not merge from `master` (please only [rebase](https://github.com/foundry4/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
