### PR TITLE
feat: adding cypress tests for full planning

### DIFF
--- a/packages/e2e-tests/cypress/cucumber-json/appeal-form-task-list.cucumber.json
+++ b/packages/e2e-tests/cypress/cucumber-json/appeal-form-task-list.cucumber.json
@@ -13,7 +13,12 @@
         "keyword": "Scenario",
         "line": 6,
         "name": "Appellant has been successful through the Eligibility and they are now able to continue to start their appeal",
-        "tags": [],
+        "tags": [
+          {
+            "name": "@smoke",
+            "line": 5
+          }
+        ],
         "type": "scenario",
         "steps": [
           {
@@ -23,7 +28,7 @@
             "name": "Appellant has been successful on their eligibility",
             "result": {
               "status": "passed",
-              "duration": 3539000000
+              "duration": 1155000000
             }
           },
           {
@@ -33,7 +38,7 @@
             "name": "they are on the 'Appeal a Planning Decision' page",
             "result": {
               "status": "passed",
-              "duration": 7000000
+              "duration": 20000000
             }
           },
           {
@@ -43,7 +48,7 @@
             "name": "they are presented with the list of tasks that they are required to complete in order to submit their appeal",
             "result": {
               "status": "passed",
-              "duration": 7000000
+              "duration": 266000000
             }
           },
           {
@@ -53,7 +58,7 @@
             "name": "when a section has been completed they are able to see what has been completed or incompleted",
             "result": {
               "status": "passed",
-              "duration": 6000000
+              "duration": 51000000
             }
           }
         ]

--- a/packages/e2e-tests/cypress/integration/full-planning/appeals-service/appeal-form-task-list.feature
+++ b/packages/e2e-tests/cypress/integration/full-planning/appeals-service/appeal-form-task-list.feature
@@ -2,7 +2,7 @@ Feature: As an Appellant I want, at a glance, to see what information
          I need to submit and once started to see my progress
          So that the Planning Inspectorate has what it needs to consider my appeal
 
-
+  @smoke
   Scenario: Appellant has been successful through the Eligibility and they are now able to continue to start their appeal
     Given Appellant has been successful on their eligibility
     When they are on the 'Appeal a Planning Decision' page

--- a/packages/e2e-tests/cypress/integration/full-planning/appeals-service/appeal-form-task-list/appeal-form-task-list.js
+++ b/packages/e2e-tests/cypress/integration/full-planning/appeals-service/appeal-form-task-list/appeal-form-task-list.js
@@ -1,18 +1,45 @@
 import { Given, Then } from 'cypress-cucumber-preprocessor/steps';
+import { verifyPageTitle } from '../../../../../../../e2e-tests/cypress/support/common/verify-page-title';
+import {
+  applicationStatusDetailedText,
+  applicationStatusText,
+  linkProvideYourContactDetails,
+  linkTellAboutTheAppealSite,
+  linkUploadDocsFromPlanningApplication,
+  linkUploadDocsForYourAppeal,
+  linkCheckYourAnswers,
+  var1,
+  statusProvideYourContactDetails,
+  statusTellAboutTheAppealSite,
+  statusUploadDocsFromPlanningApplication,
+  statusUploadDocsForYourAppeal, statusCheckYourAnswers,
+} from '../../../../support/full-planning/appeals-service/page-objects/appeal-form-task-list-po';
 
 const pageHeading = 'Appeal a planning decision';
-const url = '/appellant-submission/task-list';
-const pageTitle = 'Task list - Appeal a planning decision - Appeal a planning decision - GOV.UK';
+const url = '/full-appeal/task-list';
+const pageTitle = 'Appeal a planning decision - Appeal a planning decision - GOV.UK';
 
 Given('Appellant has been successful on their eligibility',()=> {
- cy.visit('http://localhost:9003/before-you-appeal');
+ cy.visit('http://localhost:9003/full-appeal/task-list');
 })
 When("they are on the 'Appeal a Planning Decision' page",()=> {
+  verifyPageTitle(pageTitle);
 
 })
 Then('they are presented with the list of tasks that they are required to complete in order to submit their appeal',()=> {
+  linkProvideYourContactDetails().should('exist');
+  statusProvideYourContactDetails().should('exist');
+  linkTellAboutTheAppealSite().should('exist');
+  statusTellAboutTheAppealSite().should('exist');
+  linkUploadDocsFromPlanningApplication().should('exist');
+  statusUploadDocsFromPlanningApplication().should('exist');
+  linkUploadDocsForYourAppeal().should('exist');
+  statusUploadDocsForYourAppeal().should('exist');
+  linkCheckYourAnswers().should('exist');
+  statusCheckYourAnswers().should('exist');
 })
 Then('when a section has been completed they are able to see what has been completed or incompleted',()=> {
-
+  applicationStatusText().should('exist');
+  applicationStatusDetailedText().should('exist');
 })
 

--- a/packages/e2e-tests/cypress/support/full-planning/appeals-service/page-objects/appeal-form-task-list-po.js
+++ b/packages/e2e-tests/cypress/support/full-planning/appeals-service/page-objects/appeal-form-task-list-po.js
@@ -1,9 +1,15 @@
-export const pageHeadingTaskListH2 = () => cy.findAllByText("Appeal Complete/incomplete");
-//You have completed 0 of 5 tasks.
+export const applicationStatusText = () => cy.get('[data-cy=application-status]');
+//status text for You have completed 0 of 5 tasks
+export const applicationStatusDetailedText = () => cy.get('[data-cy=application-status-detailed]');
+export const linkProvideYourContactDetails = () => cy.get('[data-cy=contactDetailsSection]');
+export const statusProvideYourContactDetails = () => cy.get('[data-cy=task-list-item-contactDetailsSection] > .govuk-tag');
+export const linkTellAboutTheAppealSite = () => cy.get('[data-cy=aboutAppealSiteSection]');
+export const statusTellAboutTheAppealSite = () => cy.get('[data-cy=task-list-item-aboutAppealSiteSection] > .govuk-tag');
+export const linkUploadDocsFromPlanningApplication = () => cy.get('[data-cy=task-list-item-planningApplicationDocumentsSection] > .govuk-tag');
+export const statusUploadDocsFromPlanningApplication = () => cy.get('[data-cy=task-list-item-planningApplicationDocumentsSection] > .govuk-tag');
+export const linkUploadDocsForYourAppeal = () => cy.get('[data-cy=appealDocumentsSection]');
+export const statusUploadDocsForYourAppeal = () => cy.get('[data-cy=task-list-item-appealDocumentsSection] > .govuk-tag');
+export const linkCheckYourAnswers = () => cy.get('[data-cy=submitYourAppealSection]')
+export const statusCheckYourAnswers = () => cy.get('[data-cy=task-list-item-submitYourAppealSection] > .govuk-tag');
 
-export const linkProvideYourContactDetails = cy.findByText('Provide your contact details');
-export const linkTellAboutTheAppealSite = cy.findByText('Tell us about the appeal site');
-export const linkUploadDocsFromPlanningApplication = cy.findByText('Upload documents from your planning application');
-export const linkUploadDocsForYourAppeal = cy.findByText('Upload documents for your appeal');
-export const linkCheckYourAnswers = cy.findByText('Check your answers and submit your appeal');
 


### PR DESCRIPTION
adding cypress test for full planning task list page

## AS-4027-main ticket
<!-- Add the number from the Jira board -->
https://pins-ds.atlassian.net/browse/AS-4187

## Description of change
Add cypress tests

## Checklist
<!-- Put an `x` in all the boxes that apply: -->
- [ ] Requires infrastructure changes
- [ ] If adding or remove environment variables (e.g. in `docker-compose.yaml`) then I have updated the appropriate Helm chart
- [ ] I have updated the documentation accordingly
- [ X] My commit history in this PR is linear
- [ ] New features have tests
- [ ] Breaking change (team conversation required)

## Important

Please do not merge from `master` (please only [rebase](https://github.com/foundry4/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
