### PR TITLE
feat: add e2e tests for check your answers page in full planning

### DIFF
--- a/packages/e2e-tests/cypress/cucumber-json/appeal-submission-appeal-site-address.cucumber.json
+++ b/packages/e2e-tests/cypress/cucumber-json/appeal-submission-appeal-site-address.cucumber.json
@@ -1,0 +1,1122 @@
+[
+  {
+    "description": "  I need to provide the appeal site address, so that all parties know which site the appeal is against.\n  Note: This feature describes behaviour for a newly created appeal",
+    "keyword": "Feature",
+    "name": "Appellant provides the Appeal Site Address",
+    "line": 1,
+    "id": "appellant-provides-the-appeal-site-address",
+    "tags": [],
+    "uri": "appeal-submission-appeal-site-address.feature",
+    "elements": [
+      {
+        "id": "appellant-provides-the-appeal-site-address;section-status-update---valid-appeal-site-address",
+        "keyword": "Scenario",
+        "line": 5,
+        "name": "Section status update - valid appeal site address",
+        "tags": [],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 6,
+            "name": "appeal site address is requested",
+            "result": {
+              "status": "passed",
+              "duration": 2292000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 7,
+            "name": "valid appeal site address is submitted",
+            "result": {
+              "status": "passed",
+              "duration": 4183000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 8,
+            "name": "Address of the appeal site section is \"COMPLETED\"",
+            "result": {
+              "status": "passed",
+              "duration": 1121000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "appellant-provides-the-appeal-site-address;section-status-update---invalid-appeal-site-address",
+        "keyword": "Scenario",
+        "line": 10,
+        "name": "Section status update - invalid appeal site address",
+        "tags": [],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 11,
+            "name": "appeal site address is requested",
+            "result": {
+              "status": "passed",
+              "duration": 1711000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 12,
+            "name": "invalid appeal site address is submitted",
+            "result": {
+              "status": "passed",
+              "duration": 4366000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 13,
+            "name": "Address of the appeal site section is \"NOT STARTED\"",
+            "result": {
+              "status": "passed",
+              "duration": 1184000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "appellant-provides-the-appeal-site-address;prospective-appellant-submits-a-valid-appeal-site-address",
+        "keyword": "Scenario",
+        "line": 23,
+        "name": "Prospective Appellant submits a valid appeal site address",
+        "tags": [
+          {
+            "name": "@as-2483",
+            "line": 15
+          }
+        ],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 17,
+            "name": "the user is prompted for the site address",
+            "result": {
+              "status": "passed",
+              "duration": 2383000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 18,
+            "name": "the user provides their appeal site address as \"1 Taylor Road\" and \"Clifton\" and \"Bristol\" and \"South Glos\" and \"BS8 1TG\"",
+            "result": {
+              "status": "passed",
+              "duration": 4379000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 19,
+            "name": "the user is able to continue with the provided address",
+            "result": {
+              "status": "passed",
+              "duration": 17000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "And ",
+            "line": 20,
+            "name": "the user can see that their appeal has been updated with the provided site address as \"1 Taylor Road\" and \"Clifton\" and \"Bristol\" and \"South Glos\" and \"BS8 1TG\"",
+            "result": {
+              "status": "passed",
+              "duration": 2500000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "appellant-provides-the-appeal-site-address;prospective-appellant-submits-a-valid-appeal-site-address",
+        "keyword": "Scenario",
+        "line": 24,
+        "name": "Prospective Appellant submits a valid appeal site address",
+        "tags": [
+          {
+            "name": "@as-2483",
+            "line": 15
+          }
+        ],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 17,
+            "name": "the user is prompted for the site address",
+            "result": {
+              "status": "passed",
+              "duration": 2811000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 18,
+            "name": "the user provides their appeal site address as \"2 Taylor Road\" and \"\" and \"\" and \"\" and \"M1 1AA\"",
+            "result": {
+              "status": "passed",
+              "duration": 3774000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 19,
+            "name": "the user is able to continue with the provided address",
+            "result": {
+              "status": "passed",
+              "duration": 20000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "And ",
+            "line": 20,
+            "name": "the user can see that their appeal has been updated with the provided site address as \"2 Taylor Road\" and \"\" and \"\" and \"\" and \"M1 1AA\"",
+            "result": {
+              "status": "passed",
+              "duration": 2659000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "appellant-provides-the-appeal-site-address;prospective-appellant-submits-a-valid-appeal-site-address",
+        "keyword": "Scenario",
+        "line": 25,
+        "name": "Prospective Appellant submits a valid appeal site address",
+        "tags": [
+          {
+            "name": "@as-2483",
+            "line": 15
+          }
+        ],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 17,
+            "name": "the user is prompted for the site address",
+            "result": {
+              "status": "passed",
+              "duration": 2550000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 18,
+            "name": "the user provides their appeal site address as \"4 Taylor Road\" and \"\" and \"Bristol\" and \"South Glos\" and \"M60 1NW\"",
+            "result": {
+              "status": "passed",
+              "duration": 4273000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 19,
+            "name": "the user is able to continue with the provided address",
+            "result": {
+              "status": "passed",
+              "duration": 26000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "And ",
+            "line": 20,
+            "name": "the user can see that their appeal has been updated with the provided site address as \"4 Taylor Road\" and \"\" and \"Bristol\" and \"South Glos\" and \"M60 1NW\"",
+            "result": {
+              "status": "passed",
+              "duration": 2642000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "appellant-provides-the-appeal-site-address;prospective-appellant-submits-a-valid-appeal-site-address",
+        "keyword": "Scenario",
+        "line": 26,
+        "name": "Prospective Appellant submits a valid appeal site address",
+        "tags": [
+          {
+            "name": "@as-2483",
+            "line": 15
+          }
+        ],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 17,
+            "name": "the user is prompted for the site address",
+            "result": {
+              "status": "passed",
+              "duration": 2708000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 18,
+            "name": "the user provides their appeal site address as \"5 Taylor Road\" and \"Clifton\" and \"\" and \"South Glos\" and \"DN55 1PT\"",
+            "result": {
+              "status": "passed",
+              "duration": 3928000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 19,
+            "name": "the user is able to continue with the provided address",
+            "result": {
+              "status": "passed",
+              "duration": 15000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "And ",
+            "line": 20,
+            "name": "the user can see that their appeal has been updated with the provided site address as \"5 Taylor Road\" and \"Clifton\" and \"\" and \"South Glos\" and \"DN55 1PT\"",
+            "result": {
+              "status": "passed",
+              "duration": 2729000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "appellant-provides-the-appeal-site-address;prospective-appellant-submits-a-valid-appeal-site-address",
+        "keyword": "Scenario",
+        "line": 27,
+        "name": "Prospective Appellant submits a valid appeal site address",
+        "tags": [
+          {
+            "name": "@as-2483",
+            "line": 15
+          }
+        ],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 17,
+            "name": "the user is prompted for the site address",
+            "result": {
+              "status": "passed",
+              "duration": 2409000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 18,
+            "name": "the user provides their appeal site address as \"5 Taylor Road\" and \"Clifton\" and \"Bristol\" and \"\" and \"DN55 1PT\"",
+            "result": {
+              "status": "passed",
+              "duration": 4081000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 19,
+            "name": "the user is able to continue with the provided address",
+            "result": {
+              "status": "passed",
+              "duration": 25000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "And ",
+            "line": 20,
+            "name": "the user can see that their appeal has been updated with the provided site address as \"5 Taylor Road\" and \"Clifton\" and \"Bristol\" and \"\" and \"DN55 1PT\"",
+            "result": {
+              "status": "passed",
+              "duration": 2580000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "appellant-provides-the-appeal-site-address;prospective-appellant-submits-an-appeal-site-address-without-mandatory-information",
+        "keyword": "Scenario",
+        "line": 37,
+        "name": "Prospective Appellant submits an appeal site address without mandatory information",
+        "tags": [
+          {
+            "name": "@as-2483",
+            "line": 29
+          }
+        ],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 31,
+            "name": "the user is prompted for the site address",
+            "result": {
+              "status": "passed",
+              "duration": 2916000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 32,
+            "name": "the user provides their appeal site address as \"\" and \"\" and \"\" and \"South Glos\" and \"W1A 1HQ\"",
+            "result": {
+              "status": "passed",
+              "duration": 4148000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 33,
+            "name": "the user is informed that they cannot continue with the provided address because \"Address Line 1 is required\"",
+            "result": {
+              "status": "passed",
+              "duration": 149000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "And ",
+            "line": 34,
+            "name": "the user can see that their appeal has not been updated with the provided address",
+            "result": {
+              "status": "passed",
+              "duration": 2092000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "appellant-provides-the-appeal-site-address;prospective-appellant-submits-an-appeal-site-address-without-mandatory-information",
+        "keyword": "Scenario",
+        "line": 38,
+        "name": "Prospective Appellant submits an appeal site address without mandatory information",
+        "tags": [
+          {
+            "name": "@as-2483",
+            "line": 29
+          }
+        ],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 31,
+            "name": "the user is prompted for the site address",
+            "result": {
+              "status": "passed",
+              "duration": 2846000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 32,
+            "name": "the user provides their appeal site address as \"aaa\" and \"\" and \"\" and \"\" and \"\"",
+            "result": {
+              "status": "passed",
+              "duration": 3880000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 33,
+            "name": "the user is informed that they cannot continue with the provided address because \"Postcode is required\"",
+            "result": {
+              "status": "passed",
+              "duration": 78000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "And ",
+            "line": 34,
+            "name": "the user can see that their appeal has not been updated with the provided address",
+            "result": {
+              "status": "passed",
+              "duration": 2546000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "appellant-provides-the-appeal-site-address;prospective-appellant-fails-to-provide-any-address-information",
+        "keyword": "Scenario",
+        "line": 41,
+        "name": "Prospective appellant fails to provide any address information",
+        "tags": [
+          {
+            "name": "@as-1680",
+            "line": 40
+          },
+          {
+            "name": "@as-2483",
+            "line": 40
+          }
+        ],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 42,
+            "name": "the user is prompted for the site address",
+            "result": {
+              "status": "passed",
+              "duration": 2307000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 43,
+            "name": "the user provides their appeal site address as \"\" and \"\" and \"\" and \"\" and \"\"",
+            "result": {
+              "status": "passed",
+              "duration": 3981000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 44,
+            "name": "the user is informed that \"Address Line 1 is required\"",
+            "result": {
+              "status": "passed",
+              "duration": 80000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "And ",
+            "line": 45,
+            "name": "the user is informed that \"Postcode is required\"",
+            "result": {
+              "status": "passed",
+              "duration": 72000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "appellant-provides-the-appeal-site-address;prospective-appellant-fails-to-provide-first-address-line-and-postcode",
+        "keyword": "Scenario",
+        "line": 47,
+        "name": "Prospective appellant fails to provide first address line and Postcode",
+        "tags": [],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 48,
+            "name": "the user is prompted for the site address",
+            "result": {
+              "status": "passed",
+              "duration": 2736000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 49,
+            "name": "the user provides their appeal site address as \"\" and \"\" and \"\" and \"South Glos\" and \"\"",
+            "result": {
+              "status": "passed",
+              "duration": 4280000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 50,
+            "name": "the user is informed that \"Address Line 1 is required\"",
+            "result": {
+              "status": "passed",
+              "duration": 74000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "And ",
+            "line": 51,
+            "name": "the user is informed that \"Postcode is required\"",
+            "result": {
+              "status": "passed",
+              "duration": 65000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "appellant-provides-the-appeal-site-address;prospective-appellant-provides-address-data-that-exceeds-the-maximum-length-constraint-for-each-field",
+        "keyword": "Scenario",
+        "line": 61,
+        "name": "Prospective appellant provides address data that exceeds the maximum length constraint for each field",
+        "tags": [
+          {
+            "name": "@as-2483",
+            "line": 53
+          }
+        ],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 55,
+            "name": "the user is prompted for the site address",
+            "result": {
+              "status": "passed",
+              "duration": 2380000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 56,
+            "name": "the user provides a value which is too long - \"Address Line 1\" : 61",
+            "result": {
+              "status": "passed",
+              "duration": 4032000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 57,
+            "name": "the user is informed that they cannot continue with the provided address because \"Address Line 1 has a limit of 60 characters\"",
+            "result": {
+              "status": "passed",
+              "duration": 78000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "And ",
+            "line": 58,
+            "name": "the user can see that their appeal has not been updated with the provided address",
+            "result": {
+              "status": "passed",
+              "duration": 2264000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "appellant-provides-the-appeal-site-address;prospective-appellant-provides-address-data-that-exceeds-the-maximum-length-constraint-for-each-field",
+        "keyword": "Scenario",
+        "line": 62,
+        "name": "Prospective appellant provides address data that exceeds the maximum length constraint for each field",
+        "tags": [
+          {
+            "name": "@as-2483",
+            "line": 53
+          }
+        ],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 55,
+            "name": "the user is prompted for the site address",
+            "result": {
+              "status": "passed",
+              "duration": 2707000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 56,
+            "name": "the user provides a value which is too long - \"Address Line 2\" : 61",
+            "result": {
+              "status": "passed",
+              "duration": 4301000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 57,
+            "name": "the user is informed that they cannot continue with the provided address because \"Address Line 2 has a limit of 60 characters\"",
+            "result": {
+              "status": "passed",
+              "duration": 61000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "And ",
+            "line": 58,
+            "name": "the user can see that their appeal has not been updated with the provided address",
+            "result": {
+              "status": "passed",
+              "duration": 2574000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "appellant-provides-the-appeal-site-address;prospective-appellant-provides-address-data-that-exceeds-the-maximum-length-constraint-for-each-field",
+        "keyword": "Scenario",
+        "line": 63,
+        "name": "Prospective appellant provides address data that exceeds the maximum length constraint for each field",
+        "tags": [
+          {
+            "name": "@as-2483",
+            "line": 53
+          }
+        ],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 55,
+            "name": "the user is prompted for the site address",
+            "result": {
+              "status": "passed",
+              "duration": 2846000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 56,
+            "name": "the user provides a value which is too long - \"Town or City\" : 61",
+            "result": {
+              "status": "passed",
+              "duration": 3715000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 57,
+            "name": "the user is informed that they cannot continue with the provided address because \"Town or City has a limit of 60 characters\"",
+            "result": {
+              "status": "passed",
+              "duration": 63000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "And ",
+            "line": 58,
+            "name": "the user can see that their appeal has not been updated with the provided address",
+            "result": {
+              "status": "passed",
+              "duration": 2546000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "appellant-provides-the-appeal-site-address;prospective-appellant-provides-address-data-that-exceeds-the-maximum-length-constraint-for-each-field",
+        "keyword": "Scenario",
+        "line": 64,
+        "name": "Prospective appellant provides address data that exceeds the maximum length constraint for each field",
+        "tags": [
+          {
+            "name": "@as-2483",
+            "line": 53
+          }
+        ],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 55,
+            "name": "the user is prompted for the site address",
+            "result": {
+              "status": "passed",
+              "duration": 2431000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 56,
+            "name": "the user provides a value which is too long - \"County\" : 61",
+            "result": {
+              "status": "passed",
+              "duration": 4051000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 57,
+            "name": "the user is informed that they cannot continue with the provided address because \"County has a limit of 60 characters\"",
+            "result": {
+              "status": "passed",
+              "duration": 77000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "And ",
+            "line": 58,
+            "name": "the user can see that their appeal has not been updated with the provided address",
+            "result": {
+              "status": "passed",
+              "duration": 2781000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "appellant-provides-the-appeal-site-address;prospective-appellant-provides-address-data-that-exceeds-the-maximum-length-constraint-for-each-field",
+        "keyword": "Scenario",
+        "line": 65,
+        "name": "Prospective appellant provides address data that exceeds the maximum length constraint for each field",
+        "tags": [
+          {
+            "name": "@as-2483",
+            "line": 53
+          }
+        ],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 55,
+            "name": "the user is prompted for the site address",
+            "result": {
+              "status": "passed",
+              "duration": 2723000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 56,
+            "name": "the user provides a value which is too long - \"Postcode\" : 9",
+            "result": {
+              "status": "passed",
+              "duration": 3345000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 57,
+            "name": "the user is informed that they cannot continue with the provided address because \"Postcode has a limit of 8 characters\"",
+            "result": {
+              "status": "passed",
+              "duration": 91000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "And ",
+            "line": 58,
+            "name": "the user can see that their appeal has not been updated with the provided address",
+            "result": {
+              "status": "passed",
+              "duration": 2541000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "appellant-provides-the-appeal-site-address;prospective-appellant-provides-address-data-that-exceeds-the-maximum-length-constraint-for-multiple-fields",
+        "keyword": "Scenario",
+        "line": 68,
+        "name": "Prospective appellant provides address data that exceeds the maximum length constraint for multiple fields",
+        "tags": [
+          {
+            "name": "@as-2483",
+            "line": 67
+          }
+        ],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 69,
+            "name": "the user is prompted for the site address",
+            "result": {
+              "status": "passed",
+              "duration": 3236000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 70,
+            "name": "the user provides values that are too long for Address Line 1, Address Line 2, Town or City, County and Postcode",
+            "result": {
+              "status": "passed",
+              "duration": 10203000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 71,
+            "name": "the user is informed that \"Address Line 1 has a limit of 60 characters\"",
+            "result": {
+              "status": "passed",
+              "duration": 68000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "And ",
+            "line": 72,
+            "name": "the user is informed that \"Address Line 2 has a limit of 60 characters\"",
+            "result": {
+              "status": "passed",
+              "duration": 63000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "And ",
+            "line": 73,
+            "name": "the user is informed that \"Town or City has a limit of 60 characters\"",
+            "result": {
+              "status": "passed",
+              "duration": 56000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "And ",
+            "line": 74,
+            "name": "the user is informed that \"County has a limit of 60 characters\"",
+            "result": {
+              "status": "passed",
+              "duration": 59000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "And ",
+            "line": 75,
+            "name": "the user is informed that \"Postcode has a limit of 8 characters\"",
+            "result": {
+              "status": "passed",
+              "duration": 56000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "And ",
+            "line": 76,
+            "name": "the user can see that their appeal has not been updated with the provided address",
+            "result": {
+              "status": "passed",
+              "duration": 2445000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "appellant-provides-the-appeal-site-address;prospective-appellant-provides-invalid-address-data-with-some-missing-fields-and-others-that-exceed-the-maximum-length-constraint",
+        "keyword": "Scenario",
+        "line": 79,
+        "name": "Prospective appellant provides invalid address data with some missing fields and others that exceed the maximum length constraint",
+        "tags": [
+          {
+            "name": "@as-2483",
+            "line": 78
+          }
+        ],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 80,
+            "name": "the user is prompted for the site address",
+            "result": {
+              "status": "passed",
+              "duration": 2163000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 81,
+            "name": "the user provides values that are too long for Address Line 2 and Town or City and provides no other data",
+            "result": {
+              "status": "passed",
+              "duration": 5945000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 82,
+            "name": "the user is informed that \"Address Line 1 is required\"",
+            "result": {
+              "status": "passed",
+              "duration": 67000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "And ",
+            "line": 83,
+            "name": "the user is informed that \"Address Line 2 has a limit of 60 characters\"",
+            "result": {
+              "status": "passed",
+              "duration": 71000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "And ",
+            "line": 84,
+            "name": "the user is informed that \"Town or City has a limit of 60 characters\"",
+            "result": {
+              "status": "passed",
+              "duration": 97000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "And ",
+            "line": 85,
+            "name": "the user is informed that \"Postcode is required\"",
+            "result": {
+              "status": "passed",
+              "duration": 128000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "And ",
+            "line": 86,
+            "name": "the user can see that their appeal has not been updated with the provided address",
+            "result": {
+              "status": "passed",
+              "duration": 2570000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "appellant-provides-the-appeal-site-address;prospective-appellant-provides-address-data-with-invalid-postcode",
+        "keyword": "Scenario",
+        "line": 94,
+        "name": "Prospective appellant provides address data with invalid Postcode",
+        "tags": [],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 89,
+            "name": "the user is prompted for the site address",
+            "result": {
+              "status": "passed",
+              "duration": 2930000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 90,
+            "name": "the user provides their appeal site address with postcode as \"ZXAS SS\"",
+            "result": {
+              "status": "passed",
+              "duration": 2924000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 91,
+            "name": "the user is informed that they cannot continue with the provided address because \"Postcodes can't be all letters\"",
+            "result": {
+              "status": "passed",
+              "duration": 54000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "appellant-provides-the-appeal-site-address;prospective-appellant-provides-address-data-with-invalid-postcode",
+        "keyword": "Scenario",
+        "line": 95,
+        "name": "Prospective appellant provides address data with invalid Postcode",
+        "tags": [],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 89,
+            "name": "the user is prompted for the site address",
+            "result": {
+              "status": "passed",
+              "duration": 2553000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 90,
+            "name": "the user provides their appeal site address with postcode as \"1RG 4AX\"",
+            "result": {
+              "status": "passed",
+              "duration": 2943000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 91,
+            "name": "the user is informed that they cannot continue with the provided address because \"Postcodes should begin with a letter\"",
+            "result": {
+              "status": "passed",
+              "duration": 86000000
+            }
+          }
+        ]
+      }
+    ]
+  }
+]

--- a/packages/e2e-tests/cypress/cucumber-json/appeal-submission-appeal-site-ownership.cucumber.json
+++ b/packages/e2e-tests/cypress/cucumber-json/appeal-submission-appeal-site-ownership.cucumber.json
@@ -1,0 +1,483 @@
+[
+  {
+    "description": "  Prospective appellant asked to notify the owners of the appeal site where necessary\n  Note: This feature describes behaviour for a newly created appeal",
+    "keyword": "Feature",
+    "name": "Prospective Appellant provides the Appeal Site Ownership",
+    "line": 1,
+    "id": "prospective-appellant-provides-the-appeal-site-ownership",
+    "tags": [],
+    "uri": "appeal-submission-appeal-site-ownership.feature",
+    "elements": [
+      {
+        "id": "prospective-appellant-provides-the-appeal-site-ownership;no-confirmation-of-ownership-of-the-whole-site-provided",
+        "keyword": "Scenario",
+        "line": 5,
+        "name": "No confirmation of ownership of the whole site provided",
+        "tags": [],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 6,
+            "name": "the site ownership is presented for the first time",
+            "result": {
+              "status": "passed",
+              "duration": 1674000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 7,
+            "name": "no confirmation is provided that the whole site is owned",
+            "result": {
+              "status": "passed",
+              "duration": 2101000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 8,
+            "name": "confirmation of whole site ownership is requested",
+            "result": {
+              "status": "passed",
+              "duration": 1502000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "And ",
+            "line": 9,
+            "name": "Ownership of the appeal site section is \"NOT STARTED\"",
+            "result": {
+              "status": "passed",
+              "duration": 1713000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "prospective-appellant-provides-the-appeal-site-ownership;confirmation-that-the-whole-site-is-owned",
+        "keyword": "Scenario",
+        "line": 11,
+        "name": "Confirmation that the whole site is owned",
+        "tags": [],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 12,
+            "name": "the site ownership is presented for the first time",
+            "result": {
+              "status": "passed",
+              "duration": 1368000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 13,
+            "name": "it is confirmed that the whole site is owned",
+            "result": {
+              "status": "passed",
+              "duration": 2452000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 14,
+            "name": "a request to confirm access to the site is presented",
+            "result": {
+              "status": "passed",
+              "duration": 20000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "And ",
+            "line": 15,
+            "name": "the site is updated to be wholly owned on the appeal",
+            "result": {
+              "status": "passed",
+              "duration": 3366000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "And ",
+            "line": 16,
+            "name": "Ownership of the appeal site section is \"COMPLETED\"",
+            "result": {
+              "status": "passed",
+              "duration": 1576000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "prospective-appellant-provides-the-appeal-site-ownership;confirmation-that-the-whole-site-is-not-owned",
+        "keyword": "Scenario",
+        "line": 18,
+        "name": "Confirmation that the whole site is not owned",
+        "tags": [],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 19,
+            "name": "the site ownership is presented for the first time",
+            "result": {
+              "status": "passed",
+              "duration": 1584000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 20,
+            "name": "it is confirmed that the whole site is not owned",
+            "result": {
+              "status": "passed",
+              "duration": 2120000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 21,
+            "name": "a request to notify additional owners is presented",
+            "result": {
+              "status": "passed",
+              "duration": 29000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "And ",
+            "line": 22,
+            "name": "the site is updated to not be wholly owned on the appeal",
+            "result": {
+              "status": "passed",
+              "duration": 1775000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "And ",
+            "line": 23,
+            "name": "Ownership of the appeal site section is \"IN PROGRESS\"",
+            "result": {
+              "status": "passed",
+              "duration": 1596000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "prospective-appellant-provides-the-appeal-site-ownership;no-confirmation-of-additional-site-owners-notification",
+        "keyword": "Scenario",
+        "line": 25,
+        "name": "No confirmation of additional site owners notification",
+        "tags": [],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 26,
+            "name": "confirmation of additional site owners notification is requested",
+            "result": {
+              "status": "passed",
+              "duration": 7052000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 27,
+            "name": "no confirmation of notification of additional site owners is provided",
+            "result": {
+              "status": "passed",
+              "duration": 2185000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 28,
+            "name": "confirmation of notification of additional site owners is requested",
+            "result": {
+              "status": "passed",
+              "duration": 1740000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "And ",
+            "line": 29,
+            "name": "Ownership of the appeal site section is \"IN PROGRESS\"",
+            "result": {
+              "status": "passed",
+              "duration": 1805000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "prospective-appellant-provides-the-appeal-site-ownership;confirmation-that-additional-site-owners-have-been-notified",
+        "keyword": "Scenario",
+        "line": 31,
+        "name": "Confirmation that additional site owners have been notified",
+        "tags": [],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 32,
+            "name": "confirmation of additional site owners notification is requested",
+            "result": {
+              "status": "passed",
+              "duration": 7612000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 33,
+            "name": "it is confirmed that additional site owners have been notified",
+            "result": {
+              "status": "passed",
+              "duration": 2637000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 34,
+            "name": "a request to confirm access to the site is presented",
+            "result": {
+              "status": "passed",
+              "duration": 23000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "And ",
+            "line": 35,
+            "name": "the site is updated so that other owners been notified on the appeal",
+            "result": {
+              "status": "passed",
+              "duration": 1855000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "And ",
+            "line": 36,
+            "name": "Ownership of the appeal site section is \"COMPLETED\"",
+            "result": {
+              "status": "passed",
+              "duration": 1733000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "prospective-appellant-provides-the-appeal-site-ownership;confirmation-that-additional-site-owners-have-not-been-notified",
+        "keyword": "Scenario",
+        "line": 38,
+        "name": "Confirmation that additional site owners have not been notified",
+        "tags": [],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 39,
+            "name": "confirmation of additional site owners notification is requested",
+            "result": {
+              "status": "passed",
+              "duration": 7858000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 40,
+            "name": "it is confirmed that additional site owners have not been notified",
+            "result": {
+              "status": "passed",
+              "duration": 2289000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 41,
+            "name": "a request to confirm access to the site is presented",
+            "result": {
+              "status": "passed",
+              "duration": 17000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "And ",
+            "line": 42,
+            "name": "the site is updated to not be wholly owned on the appeal",
+            "result": {
+              "status": "passed",
+              "duration": 1635000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "And ",
+            "line": 43,
+            "name": "the site is updated so that other owners have not been notified on the appeal",
+            "result": {
+              "status": "passed",
+              "duration": 1966000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "And ",
+            "line": 44,
+            "name": "Ownership of the appeal site section is \"COMPLETED\"",
+            "result": {
+              "status": "passed",
+              "duration": 1768000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "prospective-appellant-provides-the-appeal-site-ownership;confirmation-that-the-whole-site-is-owned-when-previously-identified-as-not-owned",
+        "keyword": "Scenario",
+        "line": 46,
+        "name": "Confirmation that the whole site is owned when previously identified as not owned",
+        "tags": [],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 47,
+            "name": "the whole site had previously been confirmed as not owned",
+            "result": {
+              "status": "passed",
+              "duration": 5334000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 48,
+            "name": "it is confirmed that the whole site is owned",
+            "result": {
+              "status": "passed",
+              "duration": 2457000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 49,
+            "name": "a request to notify additional owners is not presented",
+            "result": {
+              "status": "passed",
+              "duration": 19000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "And ",
+            "line": 50,
+            "name": "the site is updated to be wholly owned on the appeal",
+            "result": {
+              "status": "passed",
+              "duration": 3811000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "And ",
+            "line": 51,
+            "name": "Ownership of the appeal site section is \"COMPLETED\"",
+            "result": {
+              "status": "passed",
+              "duration": 1519000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "prospective-appellant-provides-the-appeal-site-ownership;confirmation-that-the-whole-site-is-not-owned-when-previously-identified-as-owned",
+        "keyword": "Scenario",
+        "line": 53,
+        "name": "Confirmation that the whole site is not owned when previously identified as owned",
+        "tags": [],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 54,
+            "name": "the whole site had previously been confirmed as owned",
+            "result": {
+              "status": "passed",
+              "duration": 5824000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 55,
+            "name": "it is confirmed that the whole site is not owned",
+            "result": {
+              "status": "passed",
+              "duration": 2495000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 56,
+            "name": "a request to notify additional owners is presented",
+            "result": {
+              "status": "passed",
+              "duration": 14000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "And ",
+            "line": 57,
+            "name": "the site is updated to not be wholly owned on the appeal",
+            "result": {
+              "status": "passed",
+              "duration": 1802000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "And ",
+            "line": 58,
+            "name": "Ownership of the appeal site section is \"IN PROGRESS\"",
+            "result": {
+              "status": "passed",
+              "duration": 1755000000
+            }
+          }
+        ]
+      }
+    ]
+  }
+]

--- a/packages/e2e-tests/cypress/cucumber-json/appeal-submission-confirmation.cucumber.json
+++ b/packages/e2e-tests/cypress/cucumber-json/appeal-submission-confirmation.cucumber.json
@@ -1,0 +1,98 @@
+[
+  {
+    "description": "  The confirmation page must display the feedback link and its header has no back buttons",
+    "keyword": "Feature",
+    "name": "Confirmation page feature",
+    "line": 1,
+    "id": "confirmation-page-feature",
+    "tags": [],
+    "uri": "appeal-submission-confirmation.feature",
+    "elements": [
+      {
+        "id": "confirmation-page-feature;required-link-is-present",
+        "keyword": "Scenario",
+        "line": 5,
+        "name": "Required link is present",
+        "tags": [
+          {
+            "name": "@as-2264",
+            "line": 4
+          }
+        ],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 6,
+            "name": "an appeal exists",
+            "result": {
+              "status": "passed",
+              "duration": 77173000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 7,
+            "name": "the appeal confirmation is presented",
+            "result": {
+              "status": "passed",
+              "duration": 4521000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 8,
+            "name": "the required link is displayed in the page body",
+            "result": {
+              "status": "passed",
+              "duration": 256000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "confirmation-page-feature;the-back-button-is-not-present",
+        "keyword": "Scenario",
+        "line": 10,
+        "name": "The back button is not present",
+        "tags": [],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 11,
+            "name": "an appeal exists",
+            "result": {
+              "status": "passed",
+              "duration": 74556000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 12,
+            "name": "the appeal confirmation is presented",
+            "result": {
+              "status": "passed",
+              "duration": 3827000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 13,
+            "name": "the back button is not displayed",
+            "result": {
+              "status": "passed",
+              "duration": 19000000
+            }
+          }
+        ]
+      }
+    ]
+  }
+]

--- a/packages/e2e-tests/cypress/cucumber-json/appeal-submission-creation-of-submission-information-file.cucumber.json
+++ b/packages/e2e-tests/cypress/cucumber-json/appeal-submission-creation-of-submission-information-file.cucumber.json
@@ -1,0 +1,72 @@
+[
+  {
+    "description": "  As a Planning Inspectorate case worker\n  I want a human readable file containing the appellant’s appeal submission information, at point of submission\n  So that I have all the information collected during the appeal submission that was not explicitly passed to Horizon",
+    "keyword": "Feature",
+    "name": "Appeal Submission - Creation of submission information file",
+    "line": 1,
+    "id": "appeal-submission---creation-of-submission-information-file",
+    "tags": [],
+    "uri": "appeal-submission-creation-of-submission-information-file.feature",
+    "elements": [
+      {
+        "id": "appeal-submission---creation-of-submission-information-file;summary-of-submission",
+        "keyword": "Scenario",
+        "line": 8,
+        "name": "Summary of submission",
+        "tags": [
+          {
+            "name": "@as-101",
+            "line": 7
+          },
+          {
+            "name": "@as-1441",
+            "line": 7
+          }
+        ],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 9,
+            "name": "a prospective appellant has provided valid appeal information",
+            "result": {
+              "status": "passed",
+              "duration": 76499000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 10,
+            "name": "the appeal is submitted",
+            "result": {
+              "status": "passed",
+              "duration": 4217000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 11,
+            "name": "a submission information file is created",
+            "result": {
+              "status": "passed",
+              "duration": 2850000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "And ",
+            "line": 12,
+            "name": "the cookie banner does not exist",
+            "result": {
+              "status": "passed",
+              "duration": 51000000
+            }
+          }
+        ]
+      }
+    ]
+  }
+]

--- a/packages/e2e-tests/cypress/cucumber-json/appeal-submission-more-than-one-appeal.cucumber.json
+++ b/packages/e2e-tests/cypress/cucumber-json/appeal-submission-more-than-one-appeal.cucumber.json
@@ -1,0 +1,119 @@
+[
+  {
+    "description": "  I need to be able to submit more than one appeal\n  So that I can create all the appeals I need",
+    "keyword": "Feature",
+    "name": "As an appellant or agent using the appeals service",
+    "line": 1,
+    "id": "as-an-appellant-or-agent-using-the-appeals-service",
+    "tags": [],
+    "uri": "appeal-submission-more-than-one-appeal.feature",
+    "elements": [
+      {
+        "id": "as-an-appellant-or-agent-using-the-appeals-service;ac1:-appellant-to-be-able-to-create-more-than-1-appeal",
+        "keyword": "Scenario",
+        "line": 6,
+        "name": "AC1: Appellant to be able to create more than 1 appeal",
+        "tags": [
+          {
+            "name": "@smoketest",
+            "line": 5
+          },
+          {
+            "name": "@as-1517",
+            "line": 5
+          },
+          {
+            "name": "@ac1",
+            "line": 5
+          }
+        ],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 7,
+            "name": "an appellant has successfully submitted an appeal",
+            "result": {
+              "status": "passed",
+              "duration": 41395000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 8,
+            "name": "the appellant starts a new appeal",
+            "result": {
+              "status": "passed",
+              "duration": 3428000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 9,
+            "name": "the appellant is able to create a new appeal without any error message",
+            "result": {
+              "status": "passed",
+              "duration": 1604000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "as-an-appellant-or-agent-using-the-appeals-service;ac2:-agent-to-be-able-to-create-more-than-1-appeal",
+        "keyword": "Scenario",
+        "line": 12,
+        "name": "AC2: Agent to be able to create more than 1 appeal",
+        "tags": [
+          {
+            "name": "@smoketest",
+            "line": 11
+          },
+          {
+            "name": "@as-1517",
+            "line": 11
+          },
+          {
+            "name": "@ac2",
+            "line": 11
+          }
+        ],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 13,
+            "name": "an agent has successfully submitted an appeal",
+            "result": {
+              "status": "passed",
+              "duration": 34967000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 14,
+            "name": "the agent starts a new appeal",
+            "result": {
+              "status": "passed",
+              "duration": 3142000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 15,
+            "name": "the agent is able to create a new appeal without any error message",
+            "result": {
+              "status": "passed",
+              "duration": 1683000000
+            }
+          }
+        ]
+      }
+    ]
+  }
+]

--- a/packages/e2e-tests/cypress/cucumber-json/appeal-submission-save-and-continue-navigation-about-you.cucumber.json
+++ b/packages/e2e-tests/cypress/cucumber-json/appeal-submission-save-and-continue-navigation-about-you.cucumber.json
@@ -1,0 +1,198 @@
+[
+  {
+    "description": "    As a prospective appellant, I want to be taken through the submission process efficiently\n    so that I do not get confused.\n    This feature file covers the navigation between the About You section to the task-list\n    The navigation does not depend on the status of a sub-section",
+    "keyword": "Feature",
+    "name": "Appeal Submission Save and Continue Navigation - About You",
+    "line": 2,
+    "id": "appeal-submission-save-and-continue-navigation---about-you",
+    "tags": [
+      {
+        "name": "@UI-ONLY",
+        "line": 1
+      }
+    ],
+    "uri": "appeal-submission-save-and-continue-navigation-about-you.feature",
+    "elements": [
+      {
+        "id": "appeal-submission-save-and-continue-navigation---about-you;navigation---is-original-applicant",
+        "keyword": "Scenario",
+        "line": 8,
+        "name": "Navigation - Is original applicant",
+        "tags": [
+          {
+            "name": "@UI-ONLY",
+            "line": 1
+          }
+        ],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 9,
+            "name": "the \"Who are you\" is presented",
+            "result": {
+              "status": "passed",
+              "duration": 1850000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 10,
+            "name": "the \"Who are you\" is submitted with valid values",
+            "result": {
+              "status": "passed",
+              "duration": 2389000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 11,
+            "name": "the user is navigated to \"Your details\"",
+            "result": {
+              "status": "passed",
+              "duration": 31000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "appeal-submission-save-and-continue-navigation---about-you;navigation---your-details-for-original-applicant",
+        "keyword": "Scenario",
+        "line": 13,
+        "name": "Navigation - Your details for original applicant",
+        "tags": [
+          {
+            "name": "@UI-ONLY",
+            "line": 1
+          }
+        ],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 14,
+            "name": "the \"Your details\" is presented for an original applicant",
+            "result": {
+              "status": "passed",
+              "duration": 3336000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 15,
+            "name": "the \"Your details\" is submitted with valid values",
+            "result": {
+              "status": "passed",
+              "duration": 2952000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 16,
+            "name": "the user is navigated to \"Appeal tasks\"",
+            "result": {
+              "status": "passed",
+              "duration": 19000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "appeal-submission-save-and-continue-navigation---about-you;navigation---not-the-original-applicant",
+        "keyword": "Scenario",
+        "line": 18,
+        "name": "Navigation - Not the original applicant",
+        "tags": [
+          {
+            "name": "@UI-ONLY",
+            "line": 1
+          }
+        ],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 19,
+            "name": "the \"Your details\" is presented for not the original applicant",
+            "result": {
+              "status": "passed",
+              "duration": 3167000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 20,
+            "name": "the \"Your details\" is submitted with valid values",
+            "result": {
+              "status": "passed",
+              "duration": 1945000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 21,
+            "name": "the user is navigated to \"Applicant name\"",
+            "result": {
+              "status": "passed",
+              "duration": 22000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "appeal-submission-save-and-continue-navigation---about-you;navigation---applicant-name---not-the-original-applicant",
+        "keyword": "Scenario",
+        "line": 23,
+        "name": "Navigation - Applicant name - not the original applicant",
+        "tags": [
+          {
+            "name": "@UI-ONLY",
+            "line": 1
+          }
+        ],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 24,
+            "name": "the \"Applicant name\" is presented",
+            "result": {
+              "status": "passed",
+              "duration": 2126000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 25,
+            "name": "the \"Applicant name\" is submitted with valid values",
+            "result": {
+              "status": "passed",
+              "duration": 2258000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 26,
+            "name": "the user is navigated to \"Appeal tasks\"",
+            "result": {
+              "status": "passed",
+              "duration": 28000000
+            }
+          }
+        ]
+      }
+    ]
+  }
+]

--- a/packages/e2e-tests/cypress/cucumber-json/appeal-submission-save-and-continue-navigation-appeal-site.cucumber.json
+++ b/packages/e2e-tests/cypress/cucumber-json/appeal-submission-save-and-continue-navigation-appeal-site.cucumber.json
@@ -1,0 +1,423 @@
+[
+  {
+    "description": "As a prospective appellant, I want to be taken through the submission process efficiently\nso that I do not get confused.\nThis feature file covers the navigation between the About-the-appeal-site to the task-list\nThe navigation does not depend on the status of a sub-section",
+    "keyword": "Feature",
+    "name": "Appeal Submission Save and Continue Navigation - About the appeal site",
+    "line": 2,
+    "id": "appeal-submission-save-and-continue-navigation---about-the-appeal-site",
+    "tags": [
+      {
+        "name": "@UI-ONLY",
+        "line": 1
+      }
+    ],
+    "uri": "appeal-submission-save-and-continue-navigation-appeal-site.feature",
+    "elements": [
+      {
+        "id": "appeal-submission-save-and-continue-navigation---about-the-appeal-site;navigation---about-the-appeal-site",
+        "keyword": "Scenario",
+        "line": 8,
+        "name": "Navigation - About the appeal site",
+        "tags": [
+          {
+            "name": "@UI-ONLY",
+            "line": 1
+          }
+        ],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 9,
+            "name": "the \"Site location\" is presented",
+            "result": {
+              "status": "passed",
+              "duration": 2621000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 10,
+            "name": "the \"Site location\" is submitted with valid values",
+            "result": {
+              "status": "passed",
+              "duration": 3435000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 11,
+            "name": "the user is navigated to \"Site ownership\"",
+            "result": {
+              "status": "passed",
+              "duration": 29000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "appeal-submission-save-and-continue-navigation---about-the-appeal-site;navigation---site-ownership-with-yes-selected",
+        "keyword": "Scenario",
+        "line": 13,
+        "name": "Navigation - Site ownership with YES selected",
+        "tags": [
+          {
+            "name": "@UI-ONLY",
+            "line": 1
+          }
+        ],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 14,
+            "name": "the \"Site ownership\" is presented",
+            "result": {
+              "status": "passed",
+              "duration": 1551000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 15,
+            "name": "the \"Site ownership\" is submitted with a YES value",
+            "result": {
+              "status": "passed",
+              "duration": 1537000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 16,
+            "name": "the user is navigated to \"Site access\"",
+            "result": {
+              "status": "passed",
+              "duration": 27000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "appeal-submission-save-and-continue-navigation---about-the-appeal-site;navigation---site-ownership-with-no-selected",
+        "keyword": "Scenario",
+        "line": 18,
+        "name": "Navigation - Site ownership with NO selected",
+        "tags": [
+          {
+            "name": "@UI-ONLY",
+            "line": 1
+          }
+        ],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 19,
+            "name": "the \"Site ownership\" is presented",
+            "result": {
+              "status": "passed",
+              "duration": 1192000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 20,
+            "name": "the \"Site ownership\" is submitted with a NO value",
+            "result": {
+              "status": "passed",
+              "duration": 1448000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 21,
+            "name": "the user is navigated to \"Site ownership certb\"",
+            "result": {
+              "status": "passed",
+              "duration": 25000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "appeal-submission-save-and-continue-navigation---about-the-appeal-site;navigation---site-ownership-certb-with-yes-selected",
+        "keyword": "Scenario",
+        "line": 23,
+        "name": "Navigation - Site ownership certb with YES selected",
+        "tags": [
+          {
+            "name": "@UI-ONLY",
+            "line": 1
+          }
+        ],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 24,
+            "name": "the \"Site ownership\" is not wholly owned",
+            "result": {
+              "status": "passed",
+              "duration": 2728000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 25,
+            "name": "the \"Site ownership certb\" is submitted with a YES value",
+            "result": {
+              "status": "passed",
+              "duration": 1666000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 26,
+            "name": "the user is navigated to \"Site access\"",
+            "result": {
+              "status": "passed",
+              "duration": 26000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "appeal-submission-save-and-continue-navigation---about-the-appeal-site;navigation---site-ownership-certb-with-no-selected",
+        "keyword": "Scenario",
+        "line": 28,
+        "name": "Navigation - Site ownership certb with NO selected",
+        "tags": [
+          {
+            "name": "@UI-ONLY",
+            "line": 1
+          }
+        ],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 29,
+            "name": "the \"Site ownership\" is not wholly owned",
+            "result": {
+              "status": "passed",
+              "duration": 2817000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 30,
+            "name": "the \"Site ownership certb\" is submitted with a NO value",
+            "result": {
+              "status": "passed",
+              "duration": 1684000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 31,
+            "name": "the user is navigated to \"Site access\"",
+            "result": {
+              "status": "passed",
+              "duration": 17000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "appeal-submission-save-and-continue-navigation---about-the-appeal-site;navigation---site-access-with-yes-selected",
+        "keyword": "Scenario",
+        "line": 33,
+        "name": "Navigation - Site access with YES selected",
+        "tags": [
+          {
+            "name": "@UI-ONLY",
+            "line": 1
+          }
+        ],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 34,
+            "name": "the \"Site access\" is presented",
+            "result": {
+              "status": "passed",
+              "duration": 1423000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 35,
+            "name": "the \"Site access\" is submitted with a YES value",
+            "result": {
+              "status": "passed",
+              "duration": 1695000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 36,
+            "name": "the user is navigated to \"Site safety\"",
+            "result": {
+              "status": "passed",
+              "duration": 16000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "appeal-submission-save-and-continue-navigation---about-the-appeal-site;navigation---site-access-with-no-selected",
+        "keyword": "Scenario",
+        "line": 38,
+        "name": "Navigation - Site access with NO selected",
+        "tags": [
+          {
+            "name": "@UI-ONLY",
+            "line": 1
+          }
+        ],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 39,
+            "name": "the \"Site access\" is presented",
+            "result": {
+              "status": "passed",
+              "duration": 1230000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 40,
+            "name": "the \"Site access\" is submitted with a NO value and text about how access is restricted",
+            "result": {
+              "status": "passed",
+              "duration": 2048000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 41,
+            "name": "the user is navigated to \"Site safety\"",
+            "result": {
+              "status": "passed",
+              "duration": 16000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "appeal-submission-save-and-continue-navigation---about-the-appeal-site;navigation---site-access-safety-with-yes-selected",
+        "keyword": "Scenario",
+        "line": 43,
+        "name": "Navigation - Site access safety with YES selected",
+        "tags": [
+          {
+            "name": "@UI-ONLY",
+            "line": 1
+          }
+        ],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 44,
+            "name": "the \"Site safety\" is presented",
+            "result": {
+              "status": "passed",
+              "duration": 1338000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 45,
+            "name": "the \"Site safety\" is submitted with a YES value and text about health and safety concerns",
+            "result": {
+              "status": "passed",
+              "duration": 1411000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 46,
+            "name": "the user is navigated to \"Appeal tasks\"",
+            "result": {
+              "status": "passed",
+              "duration": 27000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "appeal-submission-save-and-continue-navigation---about-the-appeal-site;navigation---site-access-safety-with-no-selected",
+        "keyword": "Scenario",
+        "line": 48,
+        "name": "Navigation - Site access safety with NO selected",
+        "tags": [
+          {
+            "name": "@UI-ONLY",
+            "line": 1
+          }
+        ],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 49,
+            "name": "the \"Site safety\" is presented",
+            "result": {
+              "status": "passed",
+              "duration": 1352000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 50,
+            "name": "the \"Site safety\" is submitted with a NO value",
+            "result": {
+              "status": "passed",
+              "duration": 2297000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 51,
+            "name": "the user is navigated to \"Appeal tasks\"",
+            "result": {
+              "status": "passed",
+              "duration": 22000000
+            }
+          }
+        ]
+      }
+    ]
+  }
+]

--- a/packages/e2e-tests/cypress/cucumber-json/appeal-submission-save-and-continue-navigation-planning-application.cucumber.json
+++ b/packages/e2e-tests/cypress/cucumber-json/appeal-submission-save-and-continue-navigation-planning-application.cucumber.json
@@ -1,0 +1,153 @@
+[
+  {
+    "description": "As a prospective appellant, I want to be taken through the submission process efficiently\nso that I do not get confused.\nThis feature file covers the navigation between the Planning Application section to the task-list\nThe navigation does not depend on the status of a sub-section",
+    "keyword": "Feature",
+    "name": "Appeal Submission Save and Continue Navigation - About the Original Planning Application",
+    "line": 2,
+    "id": "appeal-submission-save-and-continue-navigation---about-the-original-planning-application",
+    "tags": [
+      {
+        "name": "@UI-ONLY",
+        "line": 1
+      }
+    ],
+    "uri": "appeal-submission-save-and-continue-navigation-planning-application.feature",
+    "elements": [
+      {
+        "id": "appeal-submission-save-and-continue-navigation---about-the-original-planning-application;navigation---planning-application-number",
+        "keyword": "Scenario",
+        "line": 8,
+        "name": "Navigation - Planning Application number",
+        "tags": [
+          {
+            "name": "@UI-ONLY",
+            "line": 1
+          }
+        ],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 9,
+            "name": "the \"Application number\" is presented",
+            "result": {
+              "status": "passed",
+              "duration": 2131000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 10,
+            "name": "the \"Application number\" is submitted with valid values",
+            "result": {
+              "status": "passed",
+              "duration": 1776000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 11,
+            "name": "the user is navigated to \"Upload application\"",
+            "result": {
+              "status": "passed",
+              "duration": 26000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "appeal-submission-save-and-continue-navigation---about-the-original-planning-application;navigation---upload-application",
+        "keyword": "Scenario",
+        "line": 13,
+        "name": "Navigation - Upload application",
+        "tags": [
+          {
+            "name": "@UI-ONLY",
+            "line": 1
+          }
+        ],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 14,
+            "name": "the \"Upload application\" is presented",
+            "result": {
+              "status": "passed",
+              "duration": 738000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 15,
+            "name": "the \"Upload application\" is submitted with valid values",
+            "result": {
+              "status": "passed",
+              "duration": 812000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 16,
+            "name": "the user is navigated to \"Upload decision letter\"",
+            "result": {
+              "status": "passed",
+              "duration": 11000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "appeal-submission-save-and-continue-navigation---about-the-original-planning-application;navigation---upload-decision-letter",
+        "keyword": "Scenario",
+        "line": 18,
+        "name": "Navigation - Upload decision letter",
+        "tags": [
+          {
+            "name": "@UI-ONLY",
+            "line": 1
+          }
+        ],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 19,
+            "name": "the \"Upload decision letter\" is presented",
+            "result": {
+              "status": "passed",
+              "duration": 548000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 20,
+            "name": "the \"Upload decision letter\" is submitted with valid values",
+            "result": {
+              "status": "passed",
+              "duration": 844000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 21,
+            "name": "the user is navigated to \"Appeal tasks\"",
+            "result": {
+              "status": "passed",
+              "duration": 6000000
+            }
+          }
+        ]
+      }
+    ]
+  }
+]

--- a/packages/e2e-tests/cypress/cucumber-json/appeal-submission-save-and-continue-navigation-your-appeal.cucumber.json
+++ b/packages/e2e-tests/cypress/cucumber-json/appeal-submission-save-and-continue-navigation-your-appeal.cucumber.json
@@ -1,0 +1,108 @@
+[
+  {
+    "description": "As a prospective appellant, I want to be taken through the submission process efficiently\nso that I do not get confused.\nThis feature file covers the navigation between the Your appeal section to the task-list\nThe navigation does not depend on the status of a sub-section",
+    "keyword": "Feature",
+    "name": "Appeal Submission Save and Continue Navigation - Your appeal",
+    "line": 2,
+    "id": "appeal-submission-save-and-continue-navigation---your-appeal",
+    "tags": [
+      {
+        "name": "@UI-ONLY",
+        "line": 1
+      }
+    ],
+    "uri": "appeal-submission-save-and-continue-navigation-your-appeal.feature",
+    "elements": [
+      {
+        "id": "appeal-submission-save-and-continue-navigation---your-appeal;navigation---your-appeal",
+        "keyword": "Scenario",
+        "line": 8,
+        "name": "Navigation - Your appeal",
+        "tags": [
+          {
+            "name": "@UI-ONLY",
+            "line": 1
+          }
+        ],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 9,
+            "name": "the \"Appeal statement\" is presented",
+            "result": {
+              "status": "passed",
+              "duration": 1195000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 10,
+            "name": "the \"Appeal statement\" is submitted with valid values",
+            "result": {
+              "status": "passed",
+              "duration": 1127000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 11,
+            "name": "the user is navigated to \"Supporting documents\"",
+            "result": {
+              "status": "passed",
+              "duration": 17000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "appeal-submission-save-and-continue-navigation---your-appeal;navigation---supporting-documents",
+        "keyword": "Scenario",
+        "line": 13,
+        "name": "Navigation - Supporting documents",
+        "tags": [
+          {
+            "name": "@UI-ONLY",
+            "line": 1
+          }
+        ],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 14,
+            "name": "the \"Supporting documents\" is presented",
+            "result": {
+              "status": "passed",
+              "duration": 1305000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 15,
+            "name": "the \"Supporting documents\" is submitted with valid values",
+            "result": {
+              "status": "passed",
+              "duration": 1364000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 16,
+            "name": "the user is navigated to \"Appeal tasks\"",
+            "result": {
+              "status": "passed",
+              "duration": 16000000
+            }
+          }
+        ]
+      }
+    ]
+  }
+]

--- a/packages/e2e-tests/cypress/cucumber-json/appeal-submission-site-health-and-safety-issues.cucumber.json
+++ b/packages/e2e-tests/cypress/cucumber-json/appeal-submission-site-health-and-safety-issues.cucumber.json
@@ -1,0 +1,613 @@
+[
+  {
+    "description": "  As an Inspector I need to understand if there are any H&S concerns at the appeal site\n  so that I can plan my site visit accordingly.\n  Note: This feature describes behaviour for a newly created appeal",
+    "keyword": "Feature",
+    "name": "Appellant submission - Health and safety issues",
+    "line": 1,
+    "id": "appellant-submission---health-and-safety-issues",
+    "tags": [],
+    "uri": "appeal-submission-site-health-and-safety-issues.feature",
+    "elements": [
+      {
+        "id": "appellant-submission---health-and-safety-issues;opportunity-to-provide-health-and-safety-issues-is-presented",
+        "keyword": "Scenario",
+        "line": 6,
+        "name": "Opportunity to provide health and safety issues is presented",
+        "tags": [],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 7,
+            "name": "the status of the appeal section is displayed",
+            "result": {
+              "status": "passed",
+              "duration": 550000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 8,
+            "name": "health and safety issues is accessed",
+            "result": {
+              "status": "passed",
+              "duration": 522000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 9,
+            "name": "the opportunity to provide health and safety issues is presented",
+            "result": {
+              "status": "passed",
+              "duration": 495000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "And ",
+            "line": 10,
+            "name": "Health and Safety issues section is \"NOT STARTED\"",
+            "result": {
+              "status": "passed",
+              "duration": 404000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "appellant-submission---health-and-safety-issues;opportunity-to-provide-health-and-safety-issues-is-presented-showing-no-issues",
+        "keyword": "Scenario",
+        "line": 12,
+        "name": "Opportunity to provide health and safety issues is presented showing no issues",
+        "tags": [],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 13,
+            "name": "the status of the appeal section is displayed with no health and safety issues previously reported",
+            "result": {
+              "status": "passed",
+              "duration": 1836000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 14,
+            "name": "health and safety issues is accessed",
+            "result": {
+              "status": "passed",
+              "duration": 900000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 15,
+            "name": "no health and safety issues is presented",
+            "result": {
+              "status": "passed",
+              "duration": 750000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "And ",
+            "line": 16,
+            "name": "Health and Safety issues section is \"COMPLETED\"",
+            "result": {
+              "status": "passed",
+              "duration": 651000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "appellant-submission---health-and-safety-issues;opportunity-to-provide-health-and-safety-issues-is-presented-showing-issues-and-concerns",
+        "keyword": "Scenario",
+        "line": 18,
+        "name": "Opportunity to provide health and safety issues is presented showing issues and concerns",
+        "tags": [],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 19,
+            "name": "the status of the appeal section is displayed with some health and safety issues previously reported",
+            "result": {
+              "status": "passed",
+              "duration": 3167000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 20,
+            "name": "health and safety issues is accessed",
+            "result": {
+              "status": "passed",
+              "duration": 665000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 21,
+            "name": "health and safety issues along with concerns is presented",
+            "result": {
+              "status": "passed",
+              "duration": 749000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "And ",
+            "line": 22,
+            "name": "Health and Safety issues section is \"COMPLETED\"",
+            "result": {
+              "status": "passed",
+              "duration": 932000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "appellant-submission---health-and-safety-issues;confirmation-of-health-and-safety-issues-not-provided",
+        "keyword": "Scenario",
+        "line": 24,
+        "name": "Confirmation of health and safety issues not provided",
+        "tags": [],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 25,
+            "name": "confirmation of health and safety issues is requested",
+            "result": {
+              "status": "passed",
+              "duration": 818000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 26,
+            "name": "no confirmation of health and safety issues is provided",
+            "result": {
+              "status": "passed",
+              "duration": 870000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 27,
+            "name": "appeal is not updated because confirmation of health and safety issues is required",
+            "result": {
+              "status": "passed",
+              "duration": 817000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "And ",
+            "line": 28,
+            "name": "Health and Safety issues section is \"NOT STARTED\"",
+            "result": {
+              "status": "passed",
+              "duration": 700000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "appellant-submission---health-and-safety-issues;confirmation-provided-of-health-and-safety-issues-exceeds-character-limit",
+        "keyword": "Scenario",
+        "line": 30,
+        "name": "Confirmation provided of health and safety issues-Exceeds character limit",
+        "tags": [],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 31,
+            "name": "confirmation of health and safety issues is requested",
+            "result": {
+              "status": "passed",
+              "duration": 714000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 32,
+            "name": "confirmation of health and safety issues is provided along with concerns exceeding the limit",
+            "result": {
+              "status": "passed",
+              "duration": 5184000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 33,
+            "name": "appeal is not updated because the health and safety concerns exceed the limit",
+            "result": {
+              "status": "passed",
+              "duration": 1064000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "And ",
+            "line": 34,
+            "name": "Health and Safety issues section is \"NOT STARTED\"",
+            "result": {
+              "status": "passed",
+              "duration": 1160000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "appellant-submission---health-and-safety-issues;health-and-safety-issues-present-but-concerns-not-provided",
+        "keyword": "Scenario",
+        "line": 36,
+        "name": "Health and safety issues present but concerns not provided",
+        "tags": [],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 37,
+            "name": "confirmation of health and safety issues is requested",
+            "result": {
+              "status": "passed",
+              "duration": 821000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 38,
+            "name": "confirmation of health and safety issues is provided without concerns",
+            "result": {
+              "status": "passed",
+              "duration": 873000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 39,
+            "name": "appeal is not updated because health and safety concerns are required",
+            "result": {
+              "status": "passed",
+              "duration": 781000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "And ",
+            "line": 40,
+            "name": "Health and Safety issues section is \"NOT STARTED\"",
+            "result": {
+              "status": "passed",
+              "duration": 1331000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "appellant-submission---health-and-safety-issues;confirmation-provided-of-health-and-safety-concerns",
+        "keyword": "Scenario",
+        "line": 42,
+        "name": "Confirmation provided of health and safety concerns",
+        "tags": [],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 43,
+            "name": "confirmation of health and safety issues is requested",
+            "result": {
+              "status": "passed",
+              "duration": 1267000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 44,
+            "name": "confirmation of health and safety issues is provided along with concerns",
+            "result": {
+              "status": "passed",
+              "duration": 2246000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 45,
+            "name": "appeal is updated with health and safety issues and concerns and the appeal tasks are presented",
+            "result": {
+              "status": "passed",
+              "duration": 2758000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "And ",
+            "line": 46,
+            "name": "Health and Safety issues section is \"COMPLETED\"",
+            "result": {
+              "status": "passed",
+              "duration": 696000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "appellant-submission---health-and-safety-issues;confirmation-provided-no-health-and-safety-issues",
+        "keyword": "Scenario",
+        "line": 48,
+        "name": "Confirmation provided no health and safety issues",
+        "tags": [],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 49,
+            "name": "confirmation of health and safety issues is requested",
+            "result": {
+              "status": "passed",
+              "duration": 910000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 50,
+            "name": "confirmation of no health and safety issues is provided",
+            "result": {
+              "status": "passed",
+              "duration": 1078000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 51,
+            "name": "appeal is updated with no health and safety issues and the appeal tasks are presented",
+            "result": {
+              "status": "passed",
+              "duration": 3249000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "And ",
+            "line": 52,
+            "name": "Health and Safety issues section is \"COMPLETED\"",
+            "result": {
+              "status": "passed",
+              "duration": 690000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "appellant-submission---health-and-safety-issues;confirmation-indicated-with-health-and-safety-issues-update-the-appeal-with-no-health-and-safety-issues",
+        "keyword": "Scenario",
+        "line": 54,
+        "name": "Confirmation indicated with health and safety issues-update the appeal with no health and safety issues",
+        "tags": [],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 55,
+            "name": "health and safety issues along with concerns have been indicated",
+            "result": {
+              "status": "passed",
+              "duration": 1523000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 56,
+            "name": "confirmation of no health and safety issues is provided",
+            "result": {
+              "status": "passed",
+              "duration": 1704000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 57,
+            "name": "appeal is updated with no health and safety issues and the appeal tasks are presented",
+            "result": {
+              "status": "passed",
+              "duration": 4539000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "And ",
+            "line": 58,
+            "name": "Health and Safety issues section is \"COMPLETED\"",
+            "result": {
+              "status": "passed",
+              "duration": 1003000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "appellant-submission---health-and-safety-issues;confirmation-indicated-with-no-health-and-safety-issues-update-the-appeal-with-health-and-safety-issues",
+        "keyword": "Scenario",
+        "line": 60,
+        "name": "Confirmation indicated with no health and safety issues-update the appeal with health and safety issues",
+        "tags": [],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 61,
+            "name": "no health and safety concerns have been indicated",
+            "result": {
+              "status": "passed",
+              "duration": 1339000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 62,
+            "name": "confirmation of health and safety issues is provided along with concerns",
+            "result": {
+              "status": "passed",
+              "duration": 2459000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 63,
+            "name": "appeal is updated with health and safety issues and concerns and the appeal tasks are presented",
+            "result": {
+              "status": "passed",
+              "duration": 3436000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "And ",
+            "line": 64,
+            "name": "Health and Safety issues section is \"COMPLETED\"",
+            "result": {
+              "status": "passed",
+              "duration": 1284000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "appellant-submission---health-and-safety-issues;confirmation-provided-with-no-health-and-safety-issues-replace-the-present-selection-of-health-and-safety-concerns",
+        "keyword": "Scenario",
+        "line": 66,
+        "name": "Confirmation provided with no health and safety issues-replace the present selection of health and safety concerns",
+        "tags": [],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 67,
+            "name": "health and safety issues and concerns previously indicated followed by an indication of no issues",
+            "result": {
+              "status": "passed",
+              "duration": 3798000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 68,
+            "name": "health and safety issues are indicated",
+            "result": {
+              "status": "passed",
+              "duration": 103000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 69,
+            "name": "health and safety issues along with concerns are presented",
+            "result": {
+              "status": "passed",
+              "duration": 19000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "And ",
+            "line": 70,
+            "name": "Health and Safety issues section is \"COMPLETED\"",
+            "result": {
+              "status": "passed",
+              "duration": 761000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "appellant-submission---health-and-safety-issues;confirmation-provided-with-health-and-safety-concerns-replace-the-present-selection-of-no-health-and-safety-issues",
+        "keyword": "Scenario",
+        "line": 72,
+        "name": "Confirmation provided with health and safety concerns-replace the present selection of no health and safety issues",
+        "tags": [],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 73,
+            "name": "health and safety issues along with concerns have been provided",
+            "result": {
+              "status": "passed",
+              "duration": 3738000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 74,
+            "name": "confirmation of no health and safety issues is provided",
+            "result": {
+              "status": "passed",
+              "duration": 817000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 75,
+            "name": "appeal is updated with no health and safety issues and the appeal tasks are presented",
+            "result": {
+              "status": "passed",
+              "duration": 1940000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "And ",
+            "line": 76,
+            "name": "Health and Safety issues section is \"COMPLETED\"",
+            "result": {
+              "status": "passed",
+              "duration": 659000000
+            }
+          }
+        ]
+      }
+    ]
+  }
+]

--- a/packages/e2e-tests/cypress/cucumber-json/appeal-submission-system-test-borough-council-lpa.cucumber.json
+++ b/packages/e2e-tests/cypress/cucumber-json/appeal-submission-system-test-borough-council-lpa.cucumber.json
@@ -1,0 +1,58 @@
+[
+  {
+    "description": "  To be able to verify the deployment of the application to production we need the ability\n   to submit an appeal and create a case for it in Horizon with no negative impact",
+    "keyword": "Feature",
+    "name": "Submit an appeal using the System Test Borough Council LPA",
+    "line": 1,
+    "id": "submit-an-appeal-using-the-system-test-borough-council-lpa",
+    "tags": [],
+    "uri": "appeal-submission-system-test-borough-council-lpa.feature",
+    "elements": [
+      {
+        "id": "submit-an-appeal-using-the-system-test-borough-council-lpa;appeal-submission-using-the-system-test-borough-council-lpa-as-local-planning-department",
+        "keyword": "Scenario",
+        "line": 6,
+        "name": "Appeal submission using the System Test Borough Council LPA as local planning department",
+        "tags": [
+          {
+            "name": "@as-1576",
+            "line": 5
+          }
+        ],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 7,
+            "name": "an appeal is ready to be submitted with System Test Borough Council LPA",
+            "result": {
+              "status": "passed",
+              "duration": 32902000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 8,
+            "name": "the declaration is agreed",
+            "result": {
+              "status": "passed",
+              "duration": 2045000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 9,
+            "name": "the submission confirmation is presented",
+            "result": {
+              "status": "passed",
+              "duration": 218000000
+            }
+          }
+        ]
+      }
+    ]
+  }
+]

--- a/packages/e2e-tests/cypress/cucumber-json/appeal-submission-tasklist-planningApplicationForm.cucumber.json
+++ b/packages/e2e-tests/cypress/cucumber-json/appeal-submission-tasklist-planningApplicationForm.cucumber.json
@@ -1,0 +1,52 @@
+[
+  {
+    "keyword": "Feature",
+    "name": "User chooses to provide their appeal submission document",
+    "line": 1,
+    "id": "user-chooses-to-provide-their-appeal-submission-document",
+    "tags": [],
+    "uri": "appeal-submission-tasklist-planningApplicationForm.feature",
+    "elements": [
+      {
+        "id": "user-chooses-to-provide-their-appeal-submission-document;the-user-needs-to-provide-their-appeal-submission-document",
+        "keyword": "Scenario",
+        "line": 3,
+        "name": "The user needs to provide their appeal submission document",
+        "tags": [],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 4,
+            "name": "the user checks the status of their appeal",
+            "result": {
+              "status": "passed",
+              "duration": 1201000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 5,
+            "name": "the user selects to upload their appeal submission document",
+            "result": {
+              "status": "passed",
+              "duration": 647000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 6,
+            "name": "the user should be presented with opportunity to upload their appeal submission document",
+            "result": {
+              "status": "passed",
+              "duration": 19000000
+            }
+          }
+        ]
+      }
+    ]
+  }
+]

--- a/packages/e2e-tests/cypress/cucumber-json/appeal-submission-tasklist-planningApplicationNumber.cucumber.json
+++ b/packages/e2e-tests/cypress/cucumber-json/appeal-submission-tasklist-planningApplicationNumber.cucumber.json
@@ -1,0 +1,52 @@
+[
+  {
+    "keyword": "Feature",
+    "name": "User chooses to provide their planning application number",
+    "line": 1,
+    "id": "user-chooses-to-provide-their-planning-application-number",
+    "tags": [],
+    "uri": "appeal-submission-tasklist-planningApplicationNumber.feature",
+    "elements": [
+      {
+        "id": "user-chooses-to-provide-their-planning-application-number;the-user-needs-to-provide-their-planning-application-number",
+        "keyword": "Scenario",
+        "line": 3,
+        "name": "The user needs to provide their planning application number",
+        "tags": [],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 4,
+            "name": "the user checks the status of their appeal",
+            "result": {
+              "status": "passed",
+              "duration": 1070000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 5,
+            "name": "the user selects to provide their planning application number",
+            "result": {
+              "status": "passed",
+              "duration": 719000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 6,
+            "name": "the user should be presented with opportunity to provide their planning application number",
+            "result": {
+              "status": "passed",
+              "duration": 24000000
+            }
+          }
+        ]
+      }
+    ]
+  }
+]

--- a/packages/e2e-tests/cypress/cucumber-json/appeal-submission-tasklist.cucumber.json
+++ b/packages/e2e-tests/cypress/cucumber-json/appeal-submission-tasklist.cucumber.json
@@ -1,0 +1,1293 @@
+[
+  {
+    "description": "  As a prospective appellant I want to clearly see which sections of the\n  appeal submission I have completed, so that I do not waste my time checking.\n\n  Initially all the tasks are \"NOT STARTED\", once the appellant has provided required information they are \"COMPLETED\"\n  Some tasks could be multi steps and if not all steps are completed, then the task is considered \"IN PROGRESS\"\n\n  The \"Check your answer\" task state should be \"CANNOT START YET\" until all mandatory tasks are \"COMPLETED\"",
+    "keyword": "Feature",
+    "name": "Task lists",
+    "line": 1,
+    "id": "task-lists",
+    "tags": [],
+    "uri": "appeal-submission-tasklist.feature",
+    "elements": [
+      {
+        "id": "task-lists;when-the-tasks-are-presented,-then-they-should-able-to-be-selected",
+        "keyword": "Scenario",
+        "line": 15,
+        "name": "When the tasks are presented, then they should able to be selected",
+        "tags": [],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 11,
+            "name": "the appeal tasks are presented",
+            "result": {
+              "status": "passed",
+              "duration": 834000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "And ",
+            "line": 12,
+            "name": "the task \"About you - Your details\" is available for selection",
+            "result": {
+              "status": "passed",
+              "duration": 22000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "task-lists;when-the-tasks-are-presented,-then-they-should-able-to-be-selected",
+        "keyword": "Scenario",
+        "line": 16,
+        "name": "When the tasks are presented, then they should able to be selected",
+        "tags": [],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 11,
+            "name": "the appeal tasks are presented",
+            "result": {
+              "status": "passed",
+              "duration": 847000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "And ",
+            "line": 12,
+            "name": "the task \"Planning application - Application number\" is available for selection",
+            "result": {
+              "status": "passed",
+              "duration": 15000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "task-lists;when-the-tasks-are-presented,-then-they-should-able-to-be-selected",
+        "keyword": "Scenario",
+        "line": 17,
+        "name": "When the tasks are presented, then they should able to be selected",
+        "tags": [],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 11,
+            "name": "the appeal tasks are presented",
+            "result": {
+              "status": "passed",
+              "duration": 1144000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "And ",
+            "line": 12,
+            "name": "the task \"Planning application - Upload application\" is available for selection",
+            "result": {
+              "status": "passed",
+              "duration": 34000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "task-lists;when-the-tasks-are-presented,-then-they-should-able-to-be-selected",
+        "keyword": "Scenario",
+        "line": 18,
+        "name": "When the tasks are presented, then they should able to be selected",
+        "tags": [],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 11,
+            "name": "the appeal tasks are presented",
+            "result": {
+              "status": "passed",
+              "duration": 962000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "And ",
+            "line": 12,
+            "name": "the task \"Planning application - Upload decision letter\" is available for selection",
+            "result": {
+              "status": "passed",
+              "duration": 22000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "task-lists;when-the-tasks-are-presented,-then-they-should-able-to-be-selected",
+        "keyword": "Scenario",
+        "line": 19,
+        "name": "When the tasks are presented, then they should able to be selected",
+        "tags": [],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 11,
+            "name": "the appeal tasks are presented",
+            "result": {
+              "status": "passed",
+              "duration": 803000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "And ",
+            "line": 12,
+            "name": "the task \"Your appeal - Appeal statement\" is available for selection",
+            "result": {
+              "status": "passed",
+              "duration": 18000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "task-lists;when-the-tasks-are-presented,-then-they-should-able-to-be-selected",
+        "keyword": "Scenario",
+        "line": 20,
+        "name": "When the tasks are presented, then they should able to be selected",
+        "tags": [],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 11,
+            "name": "the appeal tasks are presented",
+            "result": {
+              "status": "passed",
+              "duration": 772000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "And ",
+            "line": 12,
+            "name": "the task \"Your appeal - Supporting documents\" is available for selection",
+            "result": {
+              "status": "passed",
+              "duration": 16000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "task-lists;when-the-tasks-are-presented,-then-they-should-able-to-be-selected",
+        "keyword": "Scenario",
+        "line": 21,
+        "name": "When the tasks are presented, then they should able to be selected",
+        "tags": [],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 11,
+            "name": "the appeal tasks are presented",
+            "result": {
+              "status": "passed",
+              "duration": 1026000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "And ",
+            "line": 12,
+            "name": "the task \"Appeal site - Site location\" is available for selection",
+            "result": {
+              "status": "passed",
+              "duration": 32000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "task-lists;when-the-tasks-are-presented,-then-they-should-able-to-be-selected",
+        "keyword": "Scenario",
+        "line": 22,
+        "name": "When the tasks are presented, then they should able to be selected",
+        "tags": [],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 11,
+            "name": "the appeal tasks are presented",
+            "result": {
+              "status": "passed",
+              "duration": 1790000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "And ",
+            "line": 12,
+            "name": "the task \"Appeal site - Site ownership\" is available for selection",
+            "result": {
+              "status": "passed",
+              "duration": 78000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "task-lists;when-the-tasks-are-presented,-then-they-should-able-to-be-selected",
+        "keyword": "Scenario",
+        "line": 23,
+        "name": "When the tasks are presented, then they should able to be selected",
+        "tags": [],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 11,
+            "name": "the appeal tasks are presented",
+            "result": {
+              "status": "passed",
+              "duration": 1302000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "And ",
+            "line": 12,
+            "name": "the task \"Appeal site - Site access\" is available for selection",
+            "result": {
+              "status": "passed",
+              "duration": 40000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "task-lists;when-the-tasks-are-presented,-then-they-should-able-to-be-selected",
+        "keyword": "Scenario",
+        "line": 24,
+        "name": "When the tasks are presented, then they should able to be selected",
+        "tags": [],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 11,
+            "name": "the appeal tasks are presented",
+            "result": {
+              "status": "passed",
+              "duration": 1401000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "And ",
+            "line": 12,
+            "name": "the task \"Appeal site - Site safety\" is available for selection",
+            "result": {
+              "status": "passed",
+              "duration": 71000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "task-lists;when-the-appeal-is-not-started,-then-the-tasks-are-in-\"not-started\"-state",
+        "keyword": "Scenario",
+        "line": 33,
+        "name": "When the appeal is not started, then the tasks are in \"NOT STARTED\" state",
+        "tags": [],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 28,
+            "name": "the \"About you - Your details\" part of the appeal is not started",
+            "result": {
+              "status": "passed",
+              "duration": 164000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 29,
+            "name": "the appeal tasks are presented",
+            "result": {
+              "status": "passed",
+              "duration": 1215000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 30,
+            "name": "the state for \"About you - Your details\" is displayed to be \"NOT STARTED\"",
+            "result": {
+              "status": "passed",
+              "duration": 32000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "task-lists;when-the-appeal-is-not-started,-then-the-tasks-are-in-\"not-started\"-state",
+        "keyword": "Scenario",
+        "line": 34,
+        "name": "When the appeal is not started, then the tasks are in \"NOT STARTED\" state",
+        "tags": [],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 28,
+            "name": "the \"Planning application - Application number\" part of the appeal is not started",
+            "result": {
+              "status": "passed",
+              "duration": 81000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 29,
+            "name": "the appeal tasks are presented",
+            "result": {
+              "status": "passed",
+              "duration": 808000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 30,
+            "name": "the state for \"Planning application - Application number\" is displayed to be \"NOT STARTED\"",
+            "result": {
+              "status": "passed",
+              "duration": 20000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "task-lists;when-the-appeal-is-not-started,-then-the-tasks-are-in-\"not-started\"-state",
+        "keyword": "Scenario",
+        "line": 35,
+        "name": "When the appeal is not started, then the tasks are in \"NOT STARTED\" state",
+        "tags": [],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 28,
+            "name": "the \"Planning application - Upload application\" part of the appeal is not started",
+            "result": {
+              "status": "passed",
+              "duration": 62000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 29,
+            "name": "the appeal tasks are presented",
+            "result": {
+              "status": "passed",
+              "duration": 717000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 30,
+            "name": "the state for \"Planning application - Upload application\" is displayed to be \"NOT STARTED\"",
+            "result": {
+              "status": "passed",
+              "duration": 18000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "task-lists;when-the-appeal-is-not-started,-then-the-tasks-are-in-\"not-started\"-state",
+        "keyword": "Scenario",
+        "line": 36,
+        "name": "When the appeal is not started, then the tasks are in \"NOT STARTED\" state",
+        "tags": [],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 28,
+            "name": "the \"Planning application - Upload decision letter\" part of the appeal is not started",
+            "result": {
+              "status": "passed",
+              "duration": 58000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 29,
+            "name": "the appeal tasks are presented",
+            "result": {
+              "status": "passed",
+              "duration": 727000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 30,
+            "name": "the state for \"Planning application - Upload decision letter\" is displayed to be \"NOT STARTED\"",
+            "result": {
+              "status": "passed",
+              "duration": 12000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "task-lists;when-the-appeal-is-not-started,-then-the-tasks-are-in-\"not-started\"-state",
+        "keyword": "Scenario",
+        "line": 37,
+        "name": "When the appeal is not started, then the tasks are in \"NOT STARTED\" state",
+        "tags": [],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 28,
+            "name": "the \"Your appeal - Appeal statement\" part of the appeal is not started",
+            "result": {
+              "status": "passed",
+              "duration": 49000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 29,
+            "name": "the appeal tasks are presented",
+            "result": {
+              "status": "passed",
+              "duration": 656000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 30,
+            "name": "the state for \"Your appeal - Appeal statement\" is displayed to be \"NOT STARTED\"",
+            "result": {
+              "status": "passed",
+              "duration": 12000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "task-lists;when-the-appeal-is-not-started,-then-the-tasks-are-in-\"not-started\"-state",
+        "keyword": "Scenario",
+        "line": 38,
+        "name": "When the appeal is not started, then the tasks are in \"NOT STARTED\" state",
+        "tags": [],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 28,
+            "name": "the \"Your appeal - Supporting documents\" part of the appeal is not started",
+            "result": {
+              "status": "passed",
+              "duration": 55000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 29,
+            "name": "the appeal tasks are presented",
+            "result": {
+              "status": "passed",
+              "duration": 684000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 30,
+            "name": "the state for \"Your appeal - Supporting documents\" is displayed to be \"NOT STARTED\"",
+            "result": {
+              "status": "passed",
+              "duration": 13000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "task-lists;when-the-appeal-is-not-started,-then-the-tasks-are-in-\"not-started\"-state",
+        "keyword": "Scenario",
+        "line": 39,
+        "name": "When the appeal is not started, then the tasks are in \"NOT STARTED\" state",
+        "tags": [],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 28,
+            "name": "the \"Appeal site - Site location\" part of the appeal is not started",
+            "result": {
+              "status": "passed",
+              "duration": 49000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 29,
+            "name": "the appeal tasks are presented",
+            "result": {
+              "status": "passed",
+              "duration": 652000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 30,
+            "name": "the state for \"Appeal site - Site location\" is displayed to be \"NOT STARTED\"",
+            "result": {
+              "status": "passed",
+              "duration": 13000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "task-lists;when-the-appeal-is-not-started,-then-the-tasks-are-in-\"not-started\"-state",
+        "keyword": "Scenario",
+        "line": 40,
+        "name": "When the appeal is not started, then the tasks are in \"NOT STARTED\" state",
+        "tags": [],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 28,
+            "name": "the \"Appeal site - Site ownership\" part of the appeal is not started",
+            "result": {
+              "status": "passed",
+              "duration": 50000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 29,
+            "name": "the appeal tasks are presented",
+            "result": {
+              "status": "passed",
+              "duration": 626000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 30,
+            "name": "the state for \"Appeal site - Site ownership\" is displayed to be \"NOT STARTED\"",
+            "result": {
+              "status": "passed",
+              "duration": 17000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "task-lists;when-the-appeal-is-not-started,-then-the-tasks-are-in-\"not-started\"-state",
+        "keyword": "Scenario",
+        "line": 41,
+        "name": "When the appeal is not started, then the tasks are in \"NOT STARTED\" state",
+        "tags": [],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 28,
+            "name": "the \"Appeal site - Site access\" part of the appeal is not started",
+            "result": {
+              "status": "passed",
+              "duration": 54000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 29,
+            "name": "the appeal tasks are presented",
+            "result": {
+              "status": "passed",
+              "duration": 656000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 30,
+            "name": "the state for \"Appeal site - Site access\" is displayed to be \"NOT STARTED\"",
+            "result": {
+              "status": "passed",
+              "duration": 13000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "task-lists;when-the-appeal-is-not-started,-then-the-tasks-are-in-\"not-started\"-state",
+        "keyword": "Scenario",
+        "line": 42,
+        "name": "When the appeal is not started, then the tasks are in \"NOT STARTED\" state",
+        "tags": [],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 28,
+            "name": "the \"Appeal site - Site safety\" part of the appeal is not started",
+            "result": {
+              "status": "passed",
+              "duration": 61000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 29,
+            "name": "the appeal tasks are presented",
+            "result": {
+              "status": "passed",
+              "duration": 788000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 30,
+            "name": "the state for \"Appeal site - Site safety\" is displayed to be \"NOT STARTED\"",
+            "result": {
+              "status": "passed",
+              "duration": 20000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "task-lists;when-the-appeal-is-completed,-then-the-tasks-are-in-\"completed\"-state",
+        "keyword": "Scenario",
+        "line": 50,
+        "name": "When the appeal is completed, then the tasks are in \"COMPLETED\" state",
+        "tags": [],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 45,
+            "name": "the \"About you - Your details\" part of the appeal are completed",
+            "result": {
+              "status": "passed",
+              "duration": 3386000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 46,
+            "name": "the appeal tasks are presented",
+            "result": {
+              "status": "passed",
+              "duration": 700000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 47,
+            "name": "the state for \"About you - Your details\" is displayed to be \"COMPLETED\"",
+            "result": {
+              "status": "passed",
+              "duration": 18000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "task-lists;when-the-appeal-is-completed,-then-the-tasks-are-in-\"completed\"-state",
+        "keyword": "Scenario",
+        "line": 51,
+        "name": "When the appeal is completed, then the tasks are in \"COMPLETED\" state",
+        "tags": [],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 45,
+            "name": "the \"Planning application - Application number\" part of the appeal are completed",
+            "result": {
+              "status": "passed",
+              "duration": 1784000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 46,
+            "name": "the appeal tasks are presented",
+            "result": {
+              "status": "passed",
+              "duration": 651000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 47,
+            "name": "the state for \"Planning application - Application number\" is displayed to be \"COMPLETED\"",
+            "result": {
+              "status": "passed",
+              "duration": 17000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "task-lists;when-the-appeal-is-completed,-then-the-tasks-are-in-\"completed\"-state",
+        "keyword": "Scenario",
+        "line": 52,
+        "name": "When the appeal is completed, then the tasks are in \"COMPLETED\" state",
+        "tags": [],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 45,
+            "name": "the \"Planning application - Upload application\" part of the appeal are completed",
+            "result": {
+              "status": "passed",
+              "duration": 1490000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 46,
+            "name": "the appeal tasks are presented",
+            "result": {
+              "status": "passed",
+              "duration": 643000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 47,
+            "name": "the state for \"Planning application - Upload application\" is displayed to be \"COMPLETED\"",
+            "result": {
+              "status": "passed",
+              "duration": 13000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "task-lists;when-the-appeal-is-completed,-then-the-tasks-are-in-\"completed\"-state",
+        "keyword": "Scenario",
+        "line": 53,
+        "name": "When the appeal is completed, then the tasks are in \"COMPLETED\" state",
+        "tags": [],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 45,
+            "name": "the \"Planning application - Upload decision letter\" part of the appeal are completed",
+            "result": {
+              "status": "passed",
+              "duration": 1443000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 46,
+            "name": "the appeal tasks are presented",
+            "result": {
+              "status": "passed",
+              "duration": 675000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 47,
+            "name": "the state for \"Planning application - Upload decision letter\" is displayed to be \"COMPLETED\"",
+            "result": {
+              "status": "passed",
+              "duration": 13000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "task-lists;when-the-appeal-is-completed,-then-the-tasks-are-in-\"completed\"-state",
+        "keyword": "Scenario",
+        "line": 54,
+        "name": "When the appeal is completed, then the tasks are in \"COMPLETED\" state",
+        "tags": [],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 45,
+            "name": "the \"Your appeal - Appeal statement\" part of the appeal are completed",
+            "result": {
+              "status": "passed",
+              "duration": 2012000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 46,
+            "name": "the appeal tasks are presented",
+            "result": {
+              "status": "passed",
+              "duration": 666000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 47,
+            "name": "the state for \"Your appeal - Appeal statement\" is displayed to be \"COMPLETED\"",
+            "result": {
+              "status": "passed",
+              "duration": 19000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "task-lists;when-the-appeal-is-completed,-then-the-tasks-are-in-\"completed\"-state",
+        "keyword": "Scenario",
+        "line": 55,
+        "name": "When the appeal is completed, then the tasks are in \"COMPLETED\" state",
+        "tags": [],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 45,
+            "name": "the \"Your appeal - Supporting documents\" part of the appeal are completed",
+            "result": {
+              "status": "passed",
+              "duration": 4948000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 46,
+            "name": "the appeal tasks are presented",
+            "result": {
+              "status": "passed",
+              "duration": 847000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 47,
+            "name": "the state for \"Your appeal - Supporting documents\" is displayed to be \"COMPLETED\"",
+            "result": {
+              "status": "passed",
+              "duration": 33000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "task-lists;when-the-appeal-is-completed,-then-the-tasks-are-in-\"completed\"-state",
+        "keyword": "Scenario",
+        "line": 56,
+        "name": "When the appeal is completed, then the tasks are in \"COMPLETED\" state",
+        "tags": [],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 45,
+            "name": "the \"Appeal site - Site location\" part of the appeal are completed",
+            "result": {
+              "status": "passed",
+              "duration": 2922000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 46,
+            "name": "the appeal tasks are presented",
+            "result": {
+              "status": "passed",
+              "duration": 566000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 47,
+            "name": "the state for \"Appeal site - Site location\" is displayed to be \"COMPLETED\"",
+            "result": {
+              "status": "passed",
+              "duration": 12000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "task-lists;when-the-appeal-is-completed,-then-the-tasks-are-in-\"completed\"-state",
+        "keyword": "Scenario",
+        "line": 57,
+        "name": "When the appeal is completed, then the tasks are in \"COMPLETED\" state",
+        "tags": [],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 45,
+            "name": "the \"Appeal site - Site ownership\" part of the appeal are completed",
+            "result": {
+              "status": "passed",
+              "duration": 1669000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 46,
+            "name": "the appeal tasks are presented",
+            "result": {
+              "status": "passed",
+              "duration": 711000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 47,
+            "name": "the state for \"Appeal site - Site ownership\" is displayed to be \"COMPLETED\"",
+            "result": {
+              "status": "passed",
+              "duration": 26000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "task-lists;when-the-appeal-is-completed,-then-the-tasks-are-in-\"completed\"-state",
+        "keyword": "Scenario",
+        "line": 58,
+        "name": "When the appeal is completed, then the tasks are in \"COMPLETED\" state",
+        "tags": [],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 45,
+            "name": "the \"Appeal site - Site access\" part of the appeal are completed",
+            "result": {
+              "status": "passed",
+              "duration": 1724000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 46,
+            "name": "the appeal tasks are presented",
+            "result": {
+              "status": "passed",
+              "duration": 635000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 47,
+            "name": "the state for \"Appeal site - Site access\" is displayed to be \"COMPLETED\"",
+            "result": {
+              "status": "passed",
+              "duration": 21000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "task-lists;when-the-appeal-is-completed,-then-the-tasks-are-in-\"completed\"-state",
+        "keyword": "Scenario",
+        "line": 59,
+        "name": "When the appeal is completed, then the tasks are in \"COMPLETED\" state",
+        "tags": [],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 45,
+            "name": "the \"Appeal site - Site safety\" part of the appeal are completed",
+            "result": {
+              "status": "passed",
+              "duration": 1584000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 46,
+            "name": "the appeal tasks are presented",
+            "result": {
+              "status": "passed",
+              "duration": 601000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 47,
+            "name": "the state for \"Appeal site - Site safety\" is displayed to be \"COMPLETED\"",
+            "result": {
+              "status": "passed",
+              "duration": 16000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "task-lists;when-the-tasks-are-started-but-not-completed,-then-there-are-in-\"in-progress\"-state",
+        "keyword": "Scenario",
+        "line": 67,
+        "name": "When the tasks are started but not completed, then there are in \"IN PROGRESS\" state",
+        "tags": [],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 62,
+            "name": "the \"About you - Your details\" part of the appeal is started but not completed",
+            "result": {
+              "status": "passed",
+              "duration": 2626000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 63,
+            "name": "the appeal tasks are presented",
+            "result": {
+              "status": "passed",
+              "duration": 578000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 64,
+            "name": "the state for \"About you - Your details\" is displayed to be \"IN PROGRESS\"",
+            "result": {
+              "status": "passed",
+              "duration": 15000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "task-lists;when-the-tasks-are-started-but-not-completed,-then-there-are-in-\"in-progress\"-state",
+        "keyword": "Scenario",
+        "line": 68,
+        "name": "When the tasks are started but not completed, then there are in \"IN PROGRESS\" state",
+        "tags": [],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 62,
+            "name": "the \"Appeal site - Site ownership\" part of the appeal is started but not completed",
+            "result": {
+              "status": "passed",
+              "duration": 1440000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 63,
+            "name": "the appeal tasks are presented",
+            "result": {
+              "status": "passed",
+              "duration": 700000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 64,
+            "name": "the state for \"Appeal site - Site ownership\" is displayed to be \"IN PROGRESS\"",
+            "result": {
+              "status": "passed",
+              "duration": 17000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "task-lists;when-mandatory-tasks-are-not-completed,-then-check-your-answers-task-is-not-available",
+        "keyword": "Scenario",
+        "line": 70,
+        "name": "When mandatory tasks are not completed, then Check your answers task is not available",
+        "tags": [],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 71,
+            "name": "mandatory tasks are not completed",
+            "result": {
+              "status": "passed",
+              "duration": 60000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 72,
+            "name": "the appeal tasks are presented",
+            "result": {
+              "status": "passed",
+              "duration": 675000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 73,
+            "name": "the state for \"Appeal submit - Check your answers\" is displayed to be \"CANNOT START YET\"",
+            "result": {
+              "status": "passed",
+              "duration": 20000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "And ",
+            "line": 74,
+            "name": "the task \"Appeal submit - Check your answers\" is not available for selection",
+            "result": {
+              "status": "passed",
+              "duration": 23000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "task-lists;when-mandatory-tasks-are-completed,-then-check-your-answers-task-is-available",
+        "keyword": "Scenario",
+        "line": 76,
+        "name": "When mandatory tasks are completed, then Check your answers task is available",
+        "tags": [],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 77,
+            "name": "mandatory tasks are completed",
+            "result": {
+              "status": "passed",
+              "duration": 18875000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 78,
+            "name": "the appeal tasks are presented",
+            "result": {
+              "status": "passed",
+              "duration": 637000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 79,
+            "name": "the state for \"Appeal submit - Check your answers\" is displayed to be \"NOT STARTED\"",
+            "result": {
+              "status": "passed",
+              "duration": 42000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "And ",
+            "line": 80,
+            "name": "the task \"Appeal submit - Check your answers\" is available for selection",
+            "result": {
+              "status": "passed",
+              "duration": 44000000
+            }
+          }
+        ]
+      }
+    ]
+  }
+]

--- a/packages/e2e-tests/cypress/cucumber-json/appeal-submission-to-horizon-other-appellant-submission-scenarios.cucumber.json
+++ b/packages/e2e-tests/cypress/cucumber-json/appeal-submission-to-horizon-other-appellant-submission-scenarios.cucumber.json
@@ -1,0 +1,268 @@
+[
+  {
+    "description": "As a case officer\nI want an appeal to include details about site ownership and access\nso that I can book an appropriate site visit with a Planning Inspector and site owner",
+    "keyword": "Feature",
+    "name": "Appeal submission to Horizon - other Appellant submission scenarios",
+    "line": 2,
+    "id": "appeal-submission-to-horizon---other-appellant-submission-scenarios",
+    "tags": [
+      {
+        "name": "@wip",
+        "line": 1
+      }
+    ],
+    "uri": "appeal-submission-to-horizon-other-appellant-submission-scenarios.feature",
+    "elements": [
+      {
+        "id": "appeal-submission-to-horizon---other-appellant-submission-scenarios;ac1.1-appeal-information-submitted-where-the-whole-site-can-be-seen-from-a-public-road",
+        "keyword": "Scenario",
+        "line": 9,
+        "name": "AC1.1 Appeal information submitted where the whole site can be seen from a public road",
+        "tags": [
+          {
+            "name": "@wip",
+            "line": 1
+          },
+          {
+            "name": "@as-105",
+            "line": 8
+          },
+          {
+            "name": "@as-105-ac1.1",
+            "line": 8
+          }
+        ],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 10,
+            "name": "a prospective appellant has provided appeal information where the whole site can be seen",
+            "result": {
+              "status": "skipped"
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 11,
+            "name": "the appeal is submitted",
+            "result": {
+              "status": "skipped"
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 12,
+            "name": "a case is created for a case officer where an inspector does not require site access",
+            "result": {
+              "status": "skipped"
+            }
+          }
+        ]
+      },
+      {
+        "id": "appeal-submission-to-horizon---other-appellant-submission-scenarios;ac1.2-appeal-information-submitted-where-the-whole-site-cannot-be-seen-from-a-public-road",
+        "keyword": "Scenario",
+        "line": 15,
+        "name": "AC1.2 Appeal information submitted where the whole site cannot be seen from a public road",
+        "tags": [
+          {
+            "name": "@wip",
+            "line": 1
+          },
+          {
+            "name": "@as-105",
+            "line": 14
+          },
+          {
+            "name": "@as-105-ac1.2",
+            "line": 14
+          }
+        ],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 16,
+            "name": "a prospective appellant has provided appeal information where the whole site cannot be seen",
+            "result": {
+              "status": "skipped"
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 17,
+            "name": "the appeal is submitted",
+            "result": {
+              "status": "skipped"
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 18,
+            "name": "a case is created for a case officer where an inspector requires site access",
+            "result": {
+              "status": "skipped"
+            }
+          }
+        ]
+      },
+      {
+        "id": "appeal-submission-to-horizon---other-appellant-submission-scenarios;ac2.2-appellant-is-the-owner-of-the-whole-site",
+        "keyword": "Scenario",
+        "line": 21,
+        "name": "AC2.2 Appellant is the owner of the whole site",
+        "tags": [
+          {
+            "name": "@wip",
+            "line": 1
+          },
+          {
+            "name": "@as-105",
+            "line": 20
+          },
+          {
+            "name": "@as-105-ac2.1",
+            "line": 20
+          }
+        ],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 22,
+            "name": "a prospective appellant has provided appeal information where they own the whole site",
+            "result": {
+              "status": "skipped"
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 23,
+            "name": "the appeal is submitted",
+            "result": {
+              "status": "skipped"
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 24,
+            "name": "a case is created for a case officer with Certificate A",
+            "result": {
+              "status": "skipped"
+            }
+          }
+        ]
+      },
+      {
+        "id": "appeal-submission-to-horizon---other-appellant-submission-scenarios;ac2.2a-appellant-is-not-the-owner-of-the-whole-site---has-informed-owner",
+        "keyword": "Scenario",
+        "line": 27,
+        "name": "AC2.2a Appellant is not the owner of the whole site - has informed owner",
+        "tags": [
+          {
+            "name": "@wip",
+            "line": 1
+          },
+          {
+            "name": "@as-105",
+            "line": 26
+          },
+          {
+            "name": "@as-105-ac2.2a",
+            "line": 26
+          }
+        ],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 28,
+            "name": "a prospective appellant has provided appeal information where they do not own the whole site while confirming owner has been informed",
+            "result": {
+              "status": "skipped"
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 29,
+            "name": "the appeal is submitted",
+            "result": {
+              "status": "skipped"
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 30,
+            "name": "a case without Certificate A is created for a case officer while recording that owner has been informed",
+            "result": {
+              "status": "skipped"
+            }
+          }
+        ]
+      },
+      {
+        "id": "appeal-submission-to-horizon---other-appellant-submission-scenarios;ac2.2b-appellant-is-not-the-owner-of-the-whole-site---has-not-informed-owner",
+        "keyword": "Scenario",
+        "line": 33,
+        "name": "AC2.2b Appellant is not the owner of the whole site - has not informed owner",
+        "tags": [
+          {
+            "name": "@wip",
+            "line": 1
+          },
+          {
+            "name": "@as-105",
+            "line": 32
+          },
+          {
+            "name": "@as-105-ac2.2b",
+            "line": 32
+          }
+        ],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 34,
+            "name": "a prospective appellant has provided appeal information where they do not own the whole site while confirming owner has not been informed",
+            "result": {
+              "status": "skipped"
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 35,
+            "name": "the appeal is submitted",
+            "result": {
+              "status": "skipped"
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 36,
+            "name": "a case without Certificate A is created for a case officer while recording that owner has not been informed",
+            "result": {
+              "status": "skipped"
+            }
+          }
+        ]
+      }
+    ]
+  }
+]

--- a/packages/e2e-tests/cypress/cucumber-json/appeal-submission-to-horizon-with-documents.cucumber.json
+++ b/packages/e2e-tests/cypress/cucumber-json/appeal-submission-to-horizon-with-documents.cucumber.json
@@ -1,0 +1,69 @@
+[
+  {
+    "description": "  As a case worker\n  I want to view the documents associated to an appeal\n  So that I can review them",
+    "keyword": "Feature",
+    "name": "Appeal submission to Horizon - providing all documentation",
+    "line": 2,
+    "id": "appeal-submission-to-horizon---providing-all-documentation",
+    "tags": [
+      {
+        "name": "@wip",
+        "line": 1
+      }
+    ],
+    "uri": "appeal-submission-to-horizon-with-documents.feature",
+    "elements": [
+      {
+        "id": "appeal-submission-to-horizon---providing-all-documentation;appeal-documentation-submitted-for-case-workers-to-view",
+        "keyword": "Scenario",
+        "line": 8,
+        "name": "Appeal documentation submitted for case workers to view",
+        "tags": [
+          {
+            "name": "@wip",
+            "line": 1
+          }
+        ],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 9,
+            "name": "documents have been provided as part of an appeal",
+            "result": {
+              "status": "skipped"
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 10,
+            "name": "the appeal is submitted",
+            "result": {
+              "status": "skipped"
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 11,
+            "name": "the associated documents will be available for the case worker to review",
+            "result": {
+              "status": "skipped"
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "And ",
+            "line": 12,
+            "name": "an email notification is sent",
+            "result": {
+              "status": "skipped"
+            }
+          }
+        ]
+      }
+    ]
+  }
+]

--- a/packages/e2e-tests/cypress/cucumber-json/appeal-submission-to-horizon.cucumber.json
+++ b/packages/e2e-tests/cypress/cucumber-json/appeal-submission-to-horizon.cucumber.json
@@ -1,0 +1,218 @@
+[
+  {
+    "description": "  As a Planning Inspectorate case worker\n  I want an appeal case published in Horizon\n  so that I am able to manage the appeal",
+    "keyword": "Feature",
+    "name": "Appeal submission to Horizon - create case for appellant",
+    "line": 2,
+    "id": "appeal-submission-to-horizon---create-case-for-appellant",
+    "tags": [
+      {
+        "name": "@wip",
+        "line": 1
+      }
+    ],
+    "uri": "appeal-submission-to-horizon.feature",
+    "elements": [
+      {
+        "id": "appeal-submission-to-horizon---create-case-for-appellant;appeal-information-submitted-by-an-appellant",
+        "keyword": "Scenario",
+        "line": 9,
+        "name": "Appeal information submitted by an Appellant",
+        "tags": [
+          {
+            "name": "@wip",
+            "line": 1
+          },
+          {
+            "name": "@ucd-831",
+            "line": 8
+          },
+          {
+            "name": "@ucd-831-ac1",
+            "line": 8
+          }
+        ],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 10,
+            "name": "a prospective appellant has provided appeal information",
+            "result": {
+              "status": "skipped"
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 11,
+            "name": "the appeal is submitted",
+            "result": {
+              "status": "skipped"
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 12,
+            "name": "a case is created for the appellant",
+            "result": {
+              "status": "skipped"
+            }
+          }
+        ]
+      },
+      {
+        "id": "appeal-submission-to-horizon---create-case-for-appellant;appeal-information-submitted-by-an-agent",
+        "keyword": "Scenario",
+        "line": 15,
+        "name": "Appeal information submitted by an Agent",
+        "tags": [
+          {
+            "name": "@wip",
+            "line": 1
+          },
+          {
+            "name": "@as-102",
+            "line": 14
+          },
+          {
+            "name": "@as-102-ac1",
+            "line": 14
+          }
+        ],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 16,
+            "name": "an agent has provided appeal information",
+            "result": {
+              "status": "skipped"
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 17,
+            "name": "the appeal is submitted",
+            "result": {
+              "status": "skipped"
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 18,
+            "name": "a case is created for the appellant and the agent",
+            "result": {
+              "status": "skipped"
+            }
+          }
+        ]
+      },
+      {
+        "id": "appeal-submission-to-horizon---create-case-for-appellant;lpa-receives-notification-of-a-new-appeal---appellant",
+        "keyword": "Scenario",
+        "line": 21,
+        "name": "LPA receives notification of a new appeal - appellant",
+        "tags": [
+          {
+            "name": "@wip",
+            "line": 1
+          },
+          {
+            "name": "@as-1864",
+            "line": 20
+          },
+          {
+            "name": "@as-1864-ac1-1",
+            "line": 20
+          }
+        ],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 22,
+            "name": "a prospective appellant has provided appeal information",
+            "result": {
+              "status": "skipped"
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 23,
+            "name": "the appeal is submitted",
+            "result": {
+              "status": "skipped"
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 24,
+            "name": "the LPA will receive an email notification of the appeal",
+            "result": {
+              "status": "skipped"
+            }
+          }
+        ]
+      },
+      {
+        "id": "appeal-submission-to-horizon---create-case-for-appellant;lpa-receives-notification-of-a-new-appeal---agent",
+        "keyword": "Scenario",
+        "line": 27,
+        "name": "LPA receives notification of a new appeal - agent",
+        "tags": [
+          {
+            "name": "@wip",
+            "line": 1
+          },
+          {
+            "name": "@as-1864",
+            "line": 26
+          },
+          {
+            "name": "@as-1864-ac1-2",
+            "line": 26
+          }
+        ],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 28,
+            "name": "an agent has provided appeal information",
+            "result": {
+              "status": "skipped"
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 29,
+            "name": "the appeal is submitted",
+            "result": {
+              "status": "skipped"
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 30,
+            "name": "the LPA will receive an email notification of the appeal",
+            "result": {
+              "status": "skipped"
+            }
+          }
+        ]
+      }
+    ]
+  }
+]

--- a/packages/e2e-tests/cypress/cucumber-json/appeal-submisssion-email-notification.cucumber.json
+++ b/packages/e2e-tests/cypress/cucumber-json/appeal-submisssion-email-notification.cucumber.json
@@ -1,0 +1,93 @@
+[
+  {
+    "description": "  As an appellant/agent\n  I want to receive confirmation of my appeal by email\n  So that I have a copy for my records",
+    "keyword": "Feature",
+    "name": "Send email notification",
+    "line": 1,
+    "id": "send-email-notification",
+    "tags": [],
+    "uri": "appeal-submisssion-email-notification.feature",
+    "elements": [
+      {
+        "id": "send-email-notification;send-email-confirmation-to-appellant",
+        "keyword": "Scenario",
+        "line": 6,
+        "name": "Send email confirmation to appellant",
+        "tags": [],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 7,
+            "name": "an appellant has prepared an appeal",
+            "result": {
+              "status": "passed",
+              "duration": 41244000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 8,
+            "name": "the appeal is submitted",
+            "result": {
+              "status": "passed",
+              "duration": 2542000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 9,
+            "name": "a confirmation email containing a link to the your-planning-appeal page is sent to the appellant",
+            "result": {
+              "status": "passed",
+              "duration": 148000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "send-email-notification;send-email-confirmation-to-agent",
+        "keyword": "Scenario",
+        "line": 11,
+        "name": "Send email confirmation to agent",
+        "tags": [],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 12,
+            "name": "an agent has prepared an appeal",
+            "result": {
+              "status": "passed",
+              "duration": 30633000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 13,
+            "name": "the appeal is submitted",
+            "result": {
+              "status": "passed",
+              "duration": 1882000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 14,
+            "name": "a confirmation email containing a link to the your-planning-appeal page is sent to the agent",
+            "result": {
+              "status": "passed",
+              "duration": 124000000
+            }
+          }
+        ]
+      }
+    ]
+  }
+]

--- a/packages/e2e-tests/cypress/cucumber-json/appellant-confirms-declaration.cucumber.json
+++ b/packages/e2e-tests/cypress/cucumber-json/appellant-confirms-declaration.cucumber.json
@@ -1,0 +1,107 @@
+[
+  {
+    "keyword": "Feature",
+    "name": "Declaration must be agreed before a submission can be made",
+    "line": 2,
+    "id": "declaration-must-be-agreed-before-a-submission-can-be-made",
+    "tags": [
+      {
+        "name": "@UI-ONLY",
+        "line": 1
+      }
+    ],
+    "uri": "appellant-confirms-declaration.feature",
+    "elements": [
+      {
+        "id": "declaration-must-be-agreed-before-a-submission-can-be-made;prospective-appellant-does-not-agree-to-the-declaration",
+        "keyword": "Scenario",
+        "line": 4,
+        "name": "Prospective appellant does not agree to the declaration",
+        "tags": [
+          {
+            "name": "@UI-ONLY",
+            "line": 1
+          }
+        ],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 5,
+            "name": "an appeal is ready to be submitted",
+            "result": {
+              "status": "passed",
+              "duration": 36211000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 6,
+            "name": "the declaration is not agreed",
+            "result": {
+              "status": "passed",
+              "duration": 1778000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 7,
+            "name": "no submission confirmation is presented",
+            "result": {
+              "status": "passed",
+              "duration": 154000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "declaration-must-be-agreed-before-a-submission-can-be-made;prospective-appellant-agree-to-the-declaration",
+        "keyword": "Scenario",
+        "line": 9,
+        "name": "Prospective appellant agree to the declaration",
+        "tags": [
+          {
+            "name": "@UI-ONLY",
+            "line": 1
+          }
+        ],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 10,
+            "name": "an appeal is ready to be submitted",
+            "result": {
+              "status": "passed",
+              "duration": 26184000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 11,
+            "name": "the declaration is agreed",
+            "result": {
+              "status": "passed",
+              "duration": 1817000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 12,
+            "name": "the submission confirmation is presented",
+            "result": {
+              "status": "passed",
+              "duration": 290000000
+            }
+          }
+        ]
+      }
+    ]
+  }
+]

--- a/packages/e2e-tests/cypress/cucumber-json/appellant-submission-check-your-answers-ac2.cucumber.json
+++ b/packages/e2e-tests/cypress/cucumber-json/appellant-submission-check-your-answers-ac2.cucumber.json
@@ -1,0 +1,572 @@
+[
+  {
+    "keyword": "Feature",
+    "name": "A user checks their answers and wants to submit their appeal",
+    "line": 1,
+    "id": "a-user-checks-their-answers-and-wants-to-submit-their-appeal",
+    "tags": [],
+    "uri": "appellant-submission-check-your-answers-ac2.feature",
+    "elements": [
+      {
+        "id": "a-user-checks-their-answers-and-wants-to-submit-their-appeal;ac2a---accessing-an-appeal-section-from-check-your-answers",
+        "keyword": "Scenario",
+        "line": 9,
+        "name": "AC2a - Accessing an appeal section from check your answers",
+        "tags": [],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 4,
+            "name": "the check your answers page is displayed for Person Appealing is Original Applicant",
+            "result": {
+              "status": "passed",
+              "duration": 35863000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 5,
+            "name": "section \"About you - Who are you Section\" is accessed",
+            "result": {
+              "status": "passed",
+              "duration": 847000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 6,
+            "name": "the \"About you - Who are you Section\" is displayed",
+            "result": {
+              "status": "passed",
+              "duration": 18000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "a-user-checks-their-answers-and-wants-to-submit-their-appeal;ac2a---accessing-an-appeal-section-from-check-your-answers",
+        "keyword": "Scenario",
+        "line": 10,
+        "name": "AC2a - Accessing an appeal section from check your answers",
+        "tags": [],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 4,
+            "name": "the check your answers page is displayed for Person Appealing is Original Applicant",
+            "result": {
+              "status": "passed",
+              "duration": 26324000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 5,
+            "name": "section \"About you - Your details Section\" is accessed",
+            "result": {
+              "status": "passed",
+              "duration": 649000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 6,
+            "name": "the \"About you - Your details Section\" is displayed",
+            "result": {
+              "status": "passed",
+              "duration": 13000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "a-user-checks-their-answers-and-wants-to-submit-their-appeal;ac2a---accessing-an-appeal-section-from-check-your-answers",
+        "keyword": "Scenario",
+        "line": 11,
+        "name": "AC2a - Accessing an appeal section from check your answers",
+        "tags": [],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 4,
+            "name": "the check your answers page is displayed for Person Appealing is Original Applicant",
+            "result": {
+              "status": "passed",
+              "duration": 29884000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 5,
+            "name": "section \"Planning application - Application number\" is accessed",
+            "result": {
+              "status": "passed",
+              "duration": 858000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 6,
+            "name": "the \"Planning application - Application number\" is displayed",
+            "result": {
+              "status": "passed",
+              "duration": 24000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "a-user-checks-their-answers-and-wants-to-submit-their-appeal;ac2a---accessing-an-appeal-section-from-check-your-answers",
+        "keyword": "Scenario",
+        "line": 12,
+        "name": "AC2a - Accessing an appeal section from check your answers",
+        "tags": [],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 4,
+            "name": "the check your answers page is displayed for Person Appealing is Original Applicant",
+            "result": {
+              "status": "passed",
+              "duration": 28289000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 5,
+            "name": "section \"Planning application - Upload application\" is accessed",
+            "result": {
+              "status": "passed",
+              "duration": 605000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 6,
+            "name": "the \"Planning application - Upload application\" is displayed",
+            "result": {
+              "status": "passed",
+              "duration": 9000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "a-user-checks-their-answers-and-wants-to-submit-their-appeal;ac2a---accessing-an-appeal-section-from-check-your-answers",
+        "keyword": "Scenario",
+        "line": 13,
+        "name": "AC2a - Accessing an appeal section from check your answers",
+        "tags": [],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 4,
+            "name": "the check your answers page is displayed for Person Appealing is Original Applicant",
+            "result": {
+              "status": "passed",
+              "duration": 28092000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 5,
+            "name": "section \"Planning application - Upload decision letter\" is accessed",
+            "result": {
+              "status": "passed",
+              "duration": 565000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 6,
+            "name": "the \"Planning application - Upload decision letter\" is displayed",
+            "result": {
+              "status": "passed",
+              "duration": 11000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "a-user-checks-their-answers-and-wants-to-submit-their-appeal;ac2a---accessing-an-appeal-section-from-check-your-answers",
+        "keyword": "Scenario",
+        "line": 14,
+        "name": "AC2a - Accessing an appeal section from check your answers",
+        "tags": [],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 4,
+            "name": "the check your answers page is displayed for Person Appealing is Original Applicant",
+            "result": {
+              "status": "passed",
+              "duration": 35299000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 5,
+            "name": "section \"Your appeal - Appeal statement\" is accessed",
+            "result": {
+              "status": "passed",
+              "duration": 1000000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 6,
+            "name": "the \"Your appeal - Appeal statement\" is displayed",
+            "result": {
+              "status": "passed",
+              "duration": 32000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "a-user-checks-their-answers-and-wants-to-submit-their-appeal;ac2a---accessing-an-appeal-section-from-check-your-answers",
+        "keyword": "Scenario",
+        "line": 15,
+        "name": "AC2a - Accessing an appeal section from check your answers",
+        "tags": [],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 4,
+            "name": "the check your answers page is displayed for Person Appealing is Original Applicant",
+            "result": {
+              "status": "passed",
+              "duration": 28522000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 5,
+            "name": "section \"Your appeal - Supporting documents\" is accessed",
+            "result": {
+              "status": "passed",
+              "duration": 687000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 6,
+            "name": "the \"Your appeal - Supporting documents\" is displayed",
+            "result": {
+              "status": "passed",
+              "duration": 11000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "a-user-checks-their-answers-and-wants-to-submit-their-appeal;ac2a---accessing-an-appeal-section-from-check-your-answers",
+        "keyword": "Scenario",
+        "line": 16,
+        "name": "AC2a - Accessing an appeal section from check your answers",
+        "tags": [],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 4,
+            "name": "the check your answers page is displayed for Person Appealing is Original Applicant",
+            "result": {
+              "status": "passed",
+              "duration": 28026000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 5,
+            "name": "section \"Appeal site - Site location\" is accessed",
+            "result": {
+              "status": "passed",
+              "duration": 869000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 6,
+            "name": "the \"Appeal site - Site location\" is displayed",
+            "result": {
+              "status": "passed",
+              "duration": 6000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "a-user-checks-their-answers-and-wants-to-submit-their-appeal;ac2a---accessing-an-appeal-section-from-check-your-answers",
+        "keyword": "Scenario",
+        "line": 17,
+        "name": "AC2a - Accessing an appeal section from check your answers",
+        "tags": [],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 4,
+            "name": "the check your answers page is displayed for Person Appealing is Original Applicant",
+            "result": {
+              "status": "passed",
+              "duration": 28341000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 5,
+            "name": "section \"Appeal site - Site ownership\" is accessed",
+            "result": {
+              "status": "passed",
+              "duration": 827000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 6,
+            "name": "the \"Appeal site - Site ownership\" is displayed",
+            "result": {
+              "status": "passed",
+              "duration": 14000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "a-user-checks-their-answers-and-wants-to-submit-their-appeal;ac2a---accessing-an-appeal-section-from-check-your-answers",
+        "keyword": "Scenario",
+        "line": 18,
+        "name": "AC2a - Accessing an appeal section from check your answers",
+        "tags": [],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 4,
+            "name": "the check your answers page is displayed for Person Appealing is Original Applicant",
+            "result": {
+              "status": "passed",
+              "duration": 28871000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 5,
+            "name": "section \"Appeal site - Site access\" is accessed",
+            "result": {
+              "status": "passed",
+              "duration": 796000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 6,
+            "name": "the \"Appeal site - Site access\" is displayed",
+            "result": {
+              "status": "passed",
+              "duration": 11000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "a-user-checks-their-answers-and-wants-to-submit-their-appeal;ac2a---accessing-an-appeal-section-from-check-your-answers",
+        "keyword": "Scenario",
+        "line": 19,
+        "name": "AC2a - Accessing an appeal section from check your answers",
+        "tags": [],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 4,
+            "name": "the check your answers page is displayed for Person Appealing is Original Applicant",
+            "result": {
+              "status": "passed",
+              "duration": 28841000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 5,
+            "name": "section \"Appeal site - Site safety\" is accessed",
+            "result": {
+              "status": "passed",
+              "duration": 750000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 6,
+            "name": "the \"Appeal site - Site safety\" is displayed",
+            "result": {
+              "status": "passed",
+              "duration": 8000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "a-user-checks-their-answers-and-wants-to-submit-their-appeal;ac2b---accessing-an-appeal-section-from-check-your-answers",
+        "keyword": "Scenario",
+        "line": 27,
+        "name": "AC2b - Accessing an appeal section from check your answers",
+        "tags": [],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 22,
+            "name": "the check your answers page is displayed for Person Appealing is not Original Applicant",
+            "result": {
+              "status": "passed",
+              "duration": 38201000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 23,
+            "name": "section \"About you - Who are you Section\" is accessed",
+            "result": {
+              "status": "passed",
+              "duration": 947000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 24,
+            "name": "the \"About you - Who are you Section\" is displayed",
+            "result": {
+              "status": "passed",
+              "duration": 18000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "a-user-checks-their-answers-and-wants-to-submit-their-appeal;ac2b---accessing-an-appeal-section-from-check-your-answers",
+        "keyword": "Scenario",
+        "line": 28,
+        "name": "AC2b - Accessing an appeal section from check your answers",
+        "tags": [],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 22,
+            "name": "the check your answers page is displayed for Person Appealing is not Original Applicant",
+            "result": {
+              "status": "passed",
+              "duration": 41580000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 23,
+            "name": "section \"About you - Your details Section\" is accessed",
+            "result": {
+              "status": "passed",
+              "duration": 974000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 24,
+            "name": "the \"About you - Your details Section\" is displayed",
+            "result": {
+              "status": "passed",
+              "duration": 16000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "a-user-checks-their-answers-and-wants-to-submit-their-appeal;ac2b---accessing-an-appeal-section-from-check-your-answers",
+        "keyword": "Scenario",
+        "line": 29,
+        "name": "AC2b - Accessing an appeal section from check your answers",
+        "tags": [],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 22,
+            "name": "the check your answers page is displayed for Person Appealing is not Original Applicant",
+            "result": {
+              "status": "passed",
+              "duration": 43867000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 23,
+            "name": "section \"About you - Appealing of behalf of Section\" is accessed",
+            "result": {
+              "status": "passed",
+              "duration": 907000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 24,
+            "name": "the \"About you - Appealing of behalf of Section\" is displayed",
+            "result": {
+              "status": "passed",
+              "duration": 16000000
+            }
+          }
+        ]
+      }
+    ]
+  }
+]

--- a/packages/e2e-tests/cypress/cucumber-json/appellant-submission-check-your-answers-ac3.cucumber.json
+++ b/packages/e2e-tests/cypress/cucumber-json/appellant-submission-check-your-answers-ac3.cucumber.json
@@ -1,0 +1,172 @@
+[
+  {
+    "keyword": "Feature",
+    "name": "A user checks their answers and wants to submit their appeal",
+    "line": 1,
+    "id": "a-user-checks-their-answers-and-wants-to-submit-their-appeal",
+    "tags": [],
+    "uri": "appellant-submission-check-your-answers-ac3.feature",
+    "elements": [
+      {
+        "id": "a-user-checks-their-answers-and-wants-to-submit-their-appeal;ac3a---presenting-updated-sections-on-your-appeal---about-you",
+        "keyword": "Scenario",
+        "line": 3,
+        "name": "AC3a - Presenting updated sections on your appeal - About you",
+        "tags": [],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 4,
+            "name": "changes are made for About you section",
+            "result": {
+              "status": "passed",
+              "duration": 38156000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 5,
+            "name": "Check Your Answers is presented",
+            "result": {
+              "status": "passed",
+              "duration": 991000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 6,
+            "name": "the updated values for About you section are displayed",
+            "result": {
+              "status": "passed",
+              "duration": 219000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "a-user-checks-their-answers-and-wants-to-submit-their-appeal;ac3b---presenting-updated-sections-on-your-appeal---about-the-original-planning-application",
+        "keyword": "Scenario",
+        "line": 8,
+        "name": "AC3b - Presenting updated sections on your appeal - About the original planning application",
+        "tags": [],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 9,
+            "name": "changes are made for About the original planning application section",
+            "result": {
+              "status": "passed",
+              "duration": 32167000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 10,
+            "name": "Check Your Answers is presented",
+            "result": {
+              "status": "passed",
+              "duration": 718000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 11,
+            "name": "the updated values for About the original planning application section are displayed",
+            "result": {
+              "status": "passed",
+              "duration": 38000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "a-user-checks-their-answers-and-wants-to-submit-their-appeal;ac3c---presenting-updated-sections-on-your-appeal---about-your-appeal",
+        "keyword": "Scenario",
+        "line": 13,
+        "name": "AC3c - Presenting updated sections on your appeal - About your appeal",
+        "tags": [],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 14,
+            "name": "changes are made for About your appeal section",
+            "result": {
+              "status": "passed",
+              "duration": 29473000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 15,
+            "name": "Check Your Answers is presented",
+            "result": {
+              "status": "passed",
+              "duration": 739000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 16,
+            "name": "the updated values for About your appeal section are displayed",
+            "result": {
+              "status": "passed",
+              "duration": 36000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "a-user-checks-their-answers-and-wants-to-submit-their-appeal;ac3d---presenting-updated-sections-on-your-appeal---visiting-the-appeal-site",
+        "keyword": "Scenario",
+        "line": 18,
+        "name": "AC3d - Presenting updated sections on your appeal - Visiting the appeal site",
+        "tags": [],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 19,
+            "name": "changes are made for Visiting the appeal site section",
+            "result": {
+              "status": "passed",
+              "duration": 36443000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 20,
+            "name": "Check Your Answers is presented",
+            "result": {
+              "status": "passed",
+              "duration": 680000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 21,
+            "name": "the updated values for Visiting the appeal site section are displayed",
+            "result": {
+              "status": "passed",
+              "duration": 48000000
+            }
+          }
+        ]
+      }
+    ]
+  }
+]

--- a/packages/e2e-tests/cypress/cucumber-json/appellant-submission-check-your-answers-ac4.cucumber.json
+++ b/packages/e2e-tests/cypress/cucumber-json/appellant-submission-check-your-answers-ac4.cucumber.json
@@ -1,0 +1,92 @@
+[
+  {
+    "keyword": "Feature",
+    "name": "A user checks their answers and wants to submit their appeal",
+    "line": 1,
+    "id": "a-user-checks-their-answers-and-wants-to-submit-their-appeal",
+    "tags": [],
+    "uri": "appellant-submission-check-your-answers-ac4.feature",
+    "elements": [
+      {
+        "id": "a-user-checks-their-answers-and-wants-to-submit-their-appeal;ac4a---multiple-document-upload-section---multiple-documents-are-correctly-displayed",
+        "keyword": "Scenario",
+        "line": 3,
+        "name": "AC4a - Multiple document upload section - multiple documents are correctly displayed",
+        "tags": [],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 4,
+            "name": "the appeal has more than one other documents",
+            "result": {
+              "status": "passed",
+              "duration": 43120000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 5,
+            "name": "Check Your Answers is presented",
+            "result": {
+              "status": "passed",
+              "duration": 1196000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 6,
+            "name": "the multiple other documents are correctly displayed",
+            "result": {
+              "status": "passed",
+              "duration": 296000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "a-user-checks-their-answers-and-wants-to-submit-their-appeal;ac4b---multiple-document-upload-section---absence-of-document-is-correctly-displayed",
+        "keyword": "Scenario",
+        "line": 8,
+        "name": "AC4b - Multiple document upload section - absence of document is correctly displayed",
+        "tags": [],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 9,
+            "name": "the appeal has no other documents",
+            "result": {
+              "status": "passed",
+              "duration": 28618000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 10,
+            "name": "Check Your Answers is presented",
+            "result": {
+              "status": "passed",
+              "duration": 758000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 11,
+            "name": "the absence of other document is correctly displayed",
+            "result": {
+              "status": "passed",
+              "duration": 17000000
+            }
+          }
+        ]
+      }
+    ]
+  }
+]

--- a/packages/e2e-tests/cypress/cucumber-json/appellant-submission-check-your-answers-ac5.cucumber.json
+++ b/packages/e2e-tests/cypress/cucumber-json/appellant-submission-check-your-answers-ac5.cucumber.json
@@ -1,0 +1,57 @@
+[
+  {
+    "keyword": "Feature",
+    "name": "A user checks their answers and wants to submit their appeal",
+    "line": 1,
+    "id": "a-user-checks-their-answers-and-wants-to-submit-their-appeal",
+    "tags": [],
+    "uri": "appellant-submission-check-your-answers-ac5.feature",
+    "elements": [
+      {
+        "id": "a-user-checks-their-answers-and-wants-to-submit-their-appeal;other-owner-notification-question-is-displayed-when-the-appellant/agent-does-not-own-whole-site",
+        "keyword": "Scenario",
+        "line": 4,
+        "name": "other owner notification question is displayed when the Appellant/agent does not own whole site",
+        "tags": [
+          {
+            "name": "@AS-121",
+            "line": 3
+          }
+        ],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 5,
+            "name": "an agent or appellant is reviewing their answers and they do not wholly own the site",
+            "result": {
+              "status": "passed",
+              "duration": 35863000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 6,
+            "name": "Check Your Answers is presented",
+            "result": {
+              "status": "passed",
+              "duration": 1166000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 7,
+            "name": "the answer for other owner notification is displayed with a change link",
+            "result": {
+              "status": "passed",
+              "duration": 63000000
+            }
+          }
+        ]
+      }
+    ]
+  }
+]

--- a/packages/e2e-tests/cypress/cucumber-json/appellant-submission-check-your-answers-ac6.cucumber.json
+++ b/packages/e2e-tests/cypress/cucumber-json/appellant-submission-check-your-answers-ac6.cucumber.json
@@ -1,0 +1,57 @@
+[
+  {
+    "keyword": "Feature",
+    "name": "A user checks their answers and wants to submit their appeal",
+    "line": 1,
+    "id": "a-user-checks-their-answers-and-wants-to-submit-their-appeal",
+    "tags": [],
+    "uri": "appellant-submission-check-your-answers-ac6.feature",
+    "elements": [
+      {
+        "id": "a-user-checks-their-answers-and-wants-to-submit-their-appeal;other-owner-notification-question-is-not-displayed-when-the-appellant/agent-does-own-whole-site",
+        "keyword": "Scenario",
+        "line": 4,
+        "name": "other owner notification question is not displayed when the Appellant/agent does own whole site",
+        "tags": [
+          {
+            "name": "@AS-121",
+            "line": 3
+          }
+        ],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 5,
+            "name": "an agent or appellant is reviewing their answers and they wholly own the site",
+            "result": {
+              "status": "passed",
+              "duration": 37813000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 6,
+            "name": "Check Your Answers is presented",
+            "result": {
+              "status": "passed",
+              "duration": 1063000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 7,
+            "name": "the answer for other owner notification is not displayed",
+            "result": {
+              "status": "passed",
+              "duration": 67000000
+            }
+          }
+        ]
+      }
+    ]
+  }
+]

--- a/packages/e2e-tests/cypress/cucumber-json/appellant-submission-check-your-answers-ac9.cucumber.json
+++ b/packages/e2e-tests/cypress/cucumber-json/appellant-submission-check-your-answers-ac9.cucumber.json
@@ -1,0 +1,67 @@
+[
+  {
+    "keyword": "Feature",
+    "name": "A user checks their answers and wants to submit their appeal",
+    "line": 1,
+    "id": "a-user-checks-their-answers-and-wants-to-submit-their-appeal",
+    "tags": [],
+    "uri": "appellant-submission-check-your-answers-ac9.feature",
+    "elements": [
+      {
+        "id": "a-user-checks-their-answers-and-wants-to-submit-their-appeal;change-link-navigates-to-the-other-owner-notification-page",
+        "keyword": "Scenario",
+        "line": 4,
+        "name": "Change link navigates to the other owner notification page",
+        "tags": [
+          {
+            "name": "@AS-121",
+            "line": 3
+          }
+        ],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 5,
+            "name": "an agent or appellant has provided information where they have not informed the other owners",
+            "result": {
+              "status": "passed",
+              "duration": 41649000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 6,
+            "name": "Check Your Answers is presented",
+            "result": {
+              "status": "passed",
+              "duration": 1115000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "And ",
+            "line": 7,
+            "name": "agent or appellant decide to change their other owner notification answer from no to yes",
+            "result": {
+              "status": "passed",
+              "duration": 2981000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 8,
+            "name": "the positive answer for other owner notification is displayed with a change link",
+            "result": {
+              "status": "passed",
+              "duration": 68000000
+            }
+          }
+        ]
+      }
+    ]
+  }
+]

--- a/packages/e2e-tests/cypress/cucumber-json/appellant-submission-check-your-answers.cucumber.json
+++ b/packages/e2e-tests/cypress/cucumber-json/appellant-submission-check-your-answers.cucumber.json
@@ -1,0 +1,92 @@
+[
+  {
+    "keyword": "Feature",
+    "name": "A user checks their answers and wants to submit their appeal",
+    "line": 1,
+    "id": "a-user-checks-their-answers-and-wants-to-submit-their-appeal",
+    "tags": [],
+    "uri": "appellant-submission-check-your-answers.feature",
+    "elements": [
+      {
+        "id": "a-user-checks-their-answers-and-wants-to-submit-their-appeal;the-user-has-valid-data-and-wants-to-submit-their-appeal",
+        "keyword": "Scenario",
+        "line": 3,
+        "name": "The user has valid data and wants to submit their appeal",
+        "tags": [],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 4,
+            "name": "the user is presented with the answers they had provided",
+            "result": {
+              "status": "passed",
+              "duration": 27403000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 5,
+            "name": "the user confirms their answers",
+            "result": {
+              "status": "passed",
+              "duration": 648000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 6,
+            "name": "the user should be presented with the Terms and Conditions of the service",
+            "result": {
+              "status": "passed",
+              "duration": 23000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "a-user-checks-their-answers-and-wants-to-submit-their-appeal;ac1---accessing-check-your-answers-from-the-task-list",
+        "keyword": "Scenario",
+        "line": 8,
+        "name": "AC1 - Accessing check your answers from the task list",
+        "tags": [],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 9,
+            "name": "the completed task list page is displayed",
+            "result": {
+              "status": "passed",
+              "duration": 32684000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 10,
+            "name": "Check Your Answers is accessed",
+            "result": {
+              "status": "passed",
+              "duration": 962000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 11,
+            "name": "the appeal information is presented",
+            "result": {
+              "status": "passed",
+              "duration": 2849000000
+            }
+          }
+        ]
+      }
+    ]
+  }
+]

--- a/packages/e2e-tests/cypress/cucumber-json/appellant-submission-decision-letter.cucumber.json
+++ b/packages/e2e-tests/cypress/cucumber-json/appellant-submission-decision-letter.cucumber.json
@@ -1,0 +1,627 @@
+[
+  {
+    "description": "  As an appellant\n  I need to be informed when I need to upload my decision letter\n  So that I complete my appeal correctly\n\n  An appeal must include an uploaded decision letter file.\n  Valid decision letter files must:\n  * be one of the white-listed types (doc, docx, pdf, tif, tiff, jpg, jpeg and png) and\n  * not exceed a size limit.\n  The latest successfully uploaded decision letter file replaces any previously uploaded file.",
+    "keyword": "Feature",
+    "name": "Appellant submission - decision letter",
+    "line": 1,
+    "id": "appellant-submission---decision-letter",
+    "tags": [],
+    "uri": "appellant-submission-decision-letter.feature",
+    "elements": [
+      {
+        "id": "appellant-submission---decision-letter;prospective-applicant-do-not-upload-a-decision-letter-file",
+        "keyword": "Scenario",
+        "line": 14,
+        "name": "Prospective applicant do not upload a decision letter file",
+        "tags": [
+          {
+            "name": "@as-119",
+            "line": 13
+          },
+          {
+            "name": "@ac-1-1",
+            "line": 13
+          },
+          {
+            "name": "@as-1677",
+            "line": 13
+          }
+        ],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 15,
+            "name": "user did not previously submitted a decision letter file",
+            "result": {
+              "status": "passed",
+              "duration": 96000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 16,
+            "name": "user does not submit a decision letter file",
+            "result": {
+              "status": "passed",
+              "duration": 1598000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 17,
+            "name": "user is informed that he needs to upload a decision letter file",
+            "result": {
+              "status": "passed",
+              "duration": 34000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "appellant-submission---decision-letter;prospective-applicant-do-not-upload-a-planning-application-file",
+        "keyword": "Scenario",
+        "line": 20,
+        "name": "Prospective applicant do not upload a planning application file",
+        "tags": [
+          {
+            "name": "@as-119",
+            "line": 19
+          },
+          {
+            "name": "@ac-1-2",
+            "line": 19
+          }
+        ],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 21,
+            "name": "user has previously submitted a decision letter file \"appeal-statement-valid.pdf\"",
+            "result": {
+              "status": "passed",
+              "duration": 1768000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 22,
+            "name": "user does not submit a decision letter file",
+            "result": {
+              "status": "passed",
+              "duration": 1687000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 23,
+            "name": "decision letter file \"appeal-statement-valid.pdf\" is submitted and user can proceed",
+            "result": {
+              "status": "passed",
+              "duration": 739000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "appellant-submission---decision-letter;prospective-appellant-submits-valid-decision-letter-file",
+        "keyword": "Scenario",
+        "line": 31,
+        "name": "Prospective appellant submits valid decision letter file",
+        "tags": [
+          {
+            "name": "@as-119",
+            "line": 25
+          },
+          {
+            "name": "@ac-2",
+            "line": 25
+          }
+        ],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 27,
+            "name": "user submits a decision letter file \"appeal-statement-valid.doc\"",
+            "result": {
+              "status": "passed",
+              "duration": 1381000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 28,
+            "name": "decision letter file \"appeal-statement-valid.doc\" is submitted and user can proceed",
+            "result": {
+              "status": "passed",
+              "duration": 519000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "appellant-submission---decision-letter;prospective-appellant-submits-valid-decision-letter-file",
+        "keyword": "Scenario",
+        "line": 32,
+        "name": "Prospective appellant submits valid decision letter file",
+        "tags": [
+          {
+            "name": "@as-119",
+            "line": 25
+          },
+          {
+            "name": "@ac-2",
+            "line": 25
+          }
+        ],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 27,
+            "name": "user submits a decision letter file \"appeal-statement-valid.docx\"",
+            "result": {
+              "status": "passed",
+              "duration": 1468000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 28,
+            "name": "decision letter file \"appeal-statement-valid.docx\" is submitted and user can proceed",
+            "result": {
+              "status": "passed",
+              "duration": 568000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "appellant-submission---decision-letter;prospective-appellant-submits-valid-decision-letter-file",
+        "keyword": "Scenario",
+        "line": 33,
+        "name": "Prospective appellant submits valid decision letter file",
+        "tags": [
+          {
+            "name": "@as-119",
+            "line": 25
+          },
+          {
+            "name": "@ac-2",
+            "line": 25
+          }
+        ],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 27,
+            "name": "user submits a decision letter file \"appeal-statement-valid.pdf\"",
+            "result": {
+              "status": "passed",
+              "duration": 1892000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 28,
+            "name": "decision letter file \"appeal-statement-valid.pdf\" is submitted and user can proceed",
+            "result": {
+              "status": "passed",
+              "duration": 734000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "appellant-submission---decision-letter;prospective-appellant-submits-valid-decision-letter-file",
+        "keyword": "Scenario",
+        "line": 34,
+        "name": "Prospective appellant submits valid decision letter file",
+        "tags": [
+          {
+            "name": "@as-119",
+            "line": 25
+          },
+          {
+            "name": "@ac-2",
+            "line": 25
+          }
+        ],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 27,
+            "name": "user submits a decision letter file \"appeal-statement-valid.tif\"",
+            "result": {
+              "status": "passed",
+              "duration": 4435000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 28,
+            "name": "decision letter file \"appeal-statement-valid.tif\" is submitted and user can proceed",
+            "result": {
+              "status": "passed",
+              "duration": 607000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "appellant-submission---decision-letter;prospective-appellant-submits-valid-decision-letter-file",
+        "keyword": "Scenario",
+        "line": 35,
+        "name": "Prospective appellant submits valid decision letter file",
+        "tags": [
+          {
+            "name": "@as-119",
+            "line": 25
+          },
+          {
+            "name": "@ac-2",
+            "line": 25
+          }
+        ],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 27,
+            "name": "user submits a decision letter file \"appeal-statement-valid.tiff\"",
+            "result": {
+              "status": "passed",
+              "duration": 3979000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 28,
+            "name": "decision letter file \"appeal-statement-valid.tiff\" is submitted and user can proceed",
+            "result": {
+              "status": "passed",
+              "duration": 671000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "appellant-submission---decision-letter;prospective-appellant-submits-valid-decision-letter-file",
+        "keyword": "Scenario",
+        "line": 36,
+        "name": "Prospective appellant submits valid decision letter file",
+        "tags": [
+          {
+            "name": "@as-119",
+            "line": 25
+          },
+          {
+            "name": "@ac-2",
+            "line": 25
+          }
+        ],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 27,
+            "name": "user submits a decision letter file \"appeal-statement-valid.jpg\"",
+            "result": {
+              "status": "passed",
+              "duration": 2205000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 28,
+            "name": "decision letter file \"appeal-statement-valid.jpg\" is submitted and user can proceed",
+            "result": {
+              "status": "passed",
+              "duration": 586000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "appellant-submission---decision-letter;prospective-appellant-submits-valid-decision-letter-file",
+        "keyword": "Scenario",
+        "line": 37,
+        "name": "Prospective appellant submits valid decision letter file",
+        "tags": [
+          {
+            "name": "@as-119",
+            "line": 25
+          },
+          {
+            "name": "@ac-2",
+            "line": 25
+          }
+        ],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 27,
+            "name": "user submits a decision letter file \"appeal-statement-valid.jpeg\"",
+            "result": {
+              "status": "passed",
+              "duration": 1285000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 28,
+            "name": "decision letter file \"appeal-statement-valid.jpeg\" is submitted and user can proceed",
+            "result": {
+              "status": "passed",
+              "duration": 521000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "appellant-submission---decision-letter;prospective-appellant-submits-valid-decision-letter-file",
+        "keyword": "Scenario",
+        "line": 38,
+        "name": "Prospective appellant submits valid decision letter file",
+        "tags": [
+          {
+            "name": "@as-119",
+            "line": 25
+          },
+          {
+            "name": "@ac-2",
+            "line": 25
+          }
+        ],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 27,
+            "name": "user submits a decision letter file \"appeal-statement-valid.png\"",
+            "result": {
+              "status": "passed",
+              "duration": 1297000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 28,
+            "name": "decision letter file \"appeal-statement-valid.png\" is submitted and user can proceed",
+            "result": {
+              "status": "passed",
+              "duration": 537000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "appellant-submission---decision-letter;prospective-appellant-submits-valid-decision-letter-file-replaces-previous-file",
+        "keyword": "Scenario",
+        "line": 42,
+        "name": "Prospective appellant submits valid decision letter file replaces previous file",
+        "tags": [],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 43,
+            "name": "user has previously submitted a decision letter file \"appeal-statement-valid.pdf\"",
+            "result": {
+              "status": "passed",
+              "duration": 1336000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 44,
+            "name": "user submits a decision letter file \"appeal-statement-valid.doc\"",
+            "result": {
+              "status": "passed",
+              "duration": 1206000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 45,
+            "name": "user can see that the decision letter file \"appeal-statement-valid.doc\" \"is\" submitted",
+            "result": {
+              "status": "passed",
+              "duration": 1265000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "appellant-submission---decision-letter;prospective-appellant-submits-invalid-decision-letter-file-does-not-replace-previous-file",
+        "keyword": "Scenario",
+        "line": 54,
+        "name": "Prospective appellant submits invalid decision letter file does not replace previous file",
+        "tags": [],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 48,
+            "name": "user has previously submitted a decision letter file \"appeal-statement-valid.pdf\"",
+            "result": {
+              "status": "passed",
+              "duration": 1548000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 49,
+            "name": "user submits a decision letter file \"appeal-statement-invalid-wrong-type.csv\"",
+            "result": {
+              "status": "passed",
+              "duration": 1115000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 50,
+            "name": "user is informed that the decision letter file is not submitted because \"file type is invalid\"",
+            "result": {
+              "status": "passed",
+              "duration": 22000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "And ",
+            "line": 51,
+            "name": "user can see that the decision letter file \"appeal-statement-valid.pdf\" \"is\" submitted",
+            "result": {
+              "status": "passed",
+              "duration": 1007000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "appellant-submission---decision-letter;prospective-appellant-submits-invalid-decision-letter-file",
+        "keyword": "Scenario",
+        "line": 62,
+        "name": "Prospective appellant submits invalid decision letter file",
+        "tags": [],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 58,
+            "name": "user submits a decision letter file \"appeal-statement-invalid-wrong-type.csv\"",
+            "result": {
+              "status": "passed",
+              "duration": 1194000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 59,
+            "name": "user is informed that the decision letter file is not submitted because \"file type is invalid\"",
+            "result": {
+              "status": "passed",
+              "duration": 24000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "appellant-submission---decision-letter;prospective-appellant-successfully-submits-valid-decision-letter-file-followed-by-invalid-file-that-is-rejected-before-successfully-submitting-another-valid-file",
+        "keyword": "Scenario",
+        "line": 71,
+        "name": "Prospective appellant successfully submits valid decision letter file followed by invalid file that is rejected before successfully submitting another valid file",
+        "tags": [],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 66,
+            "name": "user has previously submitted a valid decision letter file \"appeal-statement-valid.pdf\" followed by an invalid file \"appeal-statement-invalid-wrong-type.csv\" that was rejected because \"file type is invalid\"",
+            "result": {
+              "status": "passed",
+              "duration": 2480000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 67,
+            "name": "user submits a decision letter file \"appeal-statement-valid.doc\"",
+            "result": {
+              "status": "passed",
+              "duration": 1227000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 68,
+            "name": "user can see that the decision letter file \"appeal-statement-valid.doc\" \"is\" submitted",
+            "result": {
+              "status": "passed",
+              "duration": 1028000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "appellant-submission---decision-letter;prospective-appellant-successfully-submits-valid-decision-letter-file-followed-by-invalid-file-that-is-rejected-before-proceeding-without-selecting-a-new-file",
+        "keyword": "Scenario",
+        "line": 80,
+        "name": "Prospective appellant successfully submits valid decision letter file followed by invalid file that is rejected before proceeding without selecting a new file",
+        "tags": [],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 75,
+            "name": "user has previously submitted a valid decision letter file \"appeal-statement-valid.doc\" followed by an invalid file \"appeal-statement-invalid-wrong-type.csv\" that was rejected because \"file type is invalid\"",
+            "result": {
+              "status": "passed",
+              "duration": 2571000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 76,
+            "name": "user does not submit a decision letter file",
+            "result": {
+              "status": "passed",
+              "duration": 1120000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 77,
+            "name": "user can see that the decision letter file \"appeal-statement-valid.doc\" \"is\" submitted",
+            "result": {
+              "status": "passed",
+              "duration": 1043000000
+            }
+          }
+        ]
+      }
+    ]
+  }
+]

--- a/packages/e2e-tests/cypress/cucumber-json/appellant-submission-footer.cucumber.json
+++ b/packages/e2e-tests/cypress/cucumber-json/appellant-submission-footer.cucumber.json
@@ -1,0 +1,1373 @@
+[
+  {
+    "description": "  Each of the Eligibility and Appellant Submission webpages must display links to the following:\n  * Terms and conditions\n  * Privacy",
+    "keyword": "Feature",
+    "name": "Common links in footer section",
+    "line": 1,
+    "id": "common-links-in-footer-section",
+    "tags": [],
+    "uri": "appellant-submission-footer.feature",
+    "elements": [
+      {
+        "id": "common-links-in-footer-section;required-links-in-footer-are-present",
+        "keyword": "Scenario",
+        "line": 12,
+        "name": "Required links in footer are present",
+        "tags": [],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 7,
+            "name": "an appeal is being made",
+            "result": {
+              "status": "passed",
+              "duration": 179000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 8,
+            "name": "the \"Start your appeal\" page is presented",
+            "result": {
+              "status": "passed",
+              "duration": 992000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 9,
+            "name": "the required links are displayed",
+            "result": {
+              "status": "passed",
+              "duration": 105000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "common-links-in-footer-section;required-links-in-footer-are-present",
+        "keyword": "Scenario",
+        "line": 13,
+        "name": "Required links in footer are present",
+        "tags": [],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 7,
+            "name": "an appeal is being made",
+            "result": {
+              "status": "passed",
+              "duration": 70000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 8,
+            "name": "the \"Eligibility - House holder planning permission\" page is presented",
+            "result": {
+              "status": "passed",
+              "duration": 733000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 9,
+            "name": "the required links are displayed",
+            "result": {
+              "status": "passed",
+              "duration": 66000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "common-links-in-footer-section;required-links-in-footer-are-present",
+        "keyword": "Scenario",
+        "line": 14,
+        "name": "Required links in footer are present",
+        "tags": [],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 7,
+            "name": "an appeal is being made",
+            "result": {
+              "status": "passed",
+              "duration": 65000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 8,
+            "name": "the \"Eligibility - Householder planning permission out\" page is presented",
+            "result": {
+              "status": "passed",
+              "duration": 510000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 9,
+            "name": "the required links are displayed",
+            "result": {
+              "status": "passed",
+              "duration": 73000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "common-links-in-footer-section;required-links-in-footer-are-present",
+        "keyword": "Scenario",
+        "line": 15,
+        "name": "Required links in footer are present",
+        "tags": [],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 7,
+            "name": "an appeal is being made",
+            "result": {
+              "status": "passed",
+              "duration": 72000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 8,
+            "name": "the \"Eligibility - Granted Or Refused Permission\" page is presented",
+            "result": {
+              "status": "passed",
+              "duration": 566000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 9,
+            "name": "the required links are displayed",
+            "result": {
+              "status": "passed",
+              "duration": 53000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "common-links-in-footer-section;required-links-in-footer-are-present",
+        "keyword": "Scenario",
+        "line": 16,
+        "name": "Required links in footer are present",
+        "tags": [],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 7,
+            "name": "an appeal is being made",
+            "result": {
+              "status": "passed",
+              "duration": 42000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 8,
+            "name": "the \"Eligibility - Granted Or Refused Permission Out\" page is presented",
+            "result": {
+              "status": "passed",
+              "duration": 493000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 9,
+            "name": "the required links are displayed",
+            "result": {
+              "status": "passed",
+              "duration": 61000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "common-links-in-footer-section;required-links-in-footer-are-present",
+        "keyword": "Scenario",
+        "line": 17,
+        "name": "Required links in footer are present",
+        "tags": [],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 7,
+            "name": "an appeal is being made",
+            "result": {
+              "status": "passed",
+              "duration": 45000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 8,
+            "name": "the \"Eligibility - No decision on Permission\" page is presented",
+            "result": {
+              "status": "passed",
+              "duration": 472000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 9,
+            "name": "the required links are displayed",
+            "result": {
+              "status": "passed",
+              "duration": 60000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "common-links-in-footer-section;required-links-in-footer-are-present",
+        "keyword": "Scenario",
+        "line": 18,
+        "name": "Required links in footer are present",
+        "tags": [],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 7,
+            "name": "an appeal is being made",
+            "result": {
+              "status": "passed",
+              "duration": 40000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 8,
+            "name": "the \"Eligibility - Decision date\" page is presented",
+            "result": {
+              "status": "passed",
+              "duration": 795000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 9,
+            "name": "the required links are displayed",
+            "result": {
+              "status": "passed",
+              "duration": 79000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "common-links-in-footer-section;required-links-in-footer-are-present",
+        "keyword": "Scenario",
+        "line": 19,
+        "name": "Required links in footer are present",
+        "tags": [],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 7,
+            "name": "an appeal is being made",
+            "result": {
+              "status": "passed",
+              "duration": 44000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 8,
+            "name": "the \"Eligibility - Decision date expired\" page is presented",
+            "result": {
+              "status": "passed",
+              "duration": 926000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 9,
+            "name": "the required links are displayed",
+            "result": {
+              "status": "passed",
+              "duration": 37000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "common-links-in-footer-section;required-links-in-footer-are-present",
+        "keyword": "Scenario",
+        "line": 20,
+        "name": "Required links in footer are present",
+        "tags": [],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 7,
+            "name": "an appeal is being made",
+            "result": {
+              "status": "passed",
+              "duration": 33000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 8,
+            "name": "the \"Eligibility - Planning department\" page is presented",
+            "result": {
+              "status": "passed",
+              "duration": 669000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 9,
+            "name": "the required links are displayed",
+            "result": {
+              "status": "passed",
+              "duration": 69000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "common-links-in-footer-section;required-links-in-footer-are-present",
+        "keyword": "Scenario",
+        "line": 21,
+        "name": "Required links in footer are present",
+        "tags": [],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 7,
+            "name": "an appeal is being made",
+            "result": {
+              "status": "passed",
+              "duration": 44000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 8,
+            "name": "the \"Eligibility - Planning department out\" page is presented",
+            "result": {
+              "status": "passed",
+              "duration": 487000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 9,
+            "name": "the required links are displayed",
+            "result": {
+              "status": "passed",
+              "duration": 82000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "common-links-in-footer-section;required-links-in-footer-are-present",
+        "keyword": "Scenario",
+        "line": 22,
+        "name": "Required links in footer are present",
+        "tags": [],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 7,
+            "name": "an appeal is being made",
+            "result": {
+              "status": "passed",
+              "duration": 45000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 8,
+            "name": "the \"Enforcement - Notice\" page is presented",
+            "result": {
+              "status": "passed",
+              "duration": 692000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 9,
+            "name": "the required links are displayed",
+            "result": {
+              "status": "passed",
+              "duration": 54000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "common-links-in-footer-section;required-links-in-footer-are-present",
+        "keyword": "Scenario",
+        "line": 23,
+        "name": "Required links in footer are present",
+        "tags": [],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 7,
+            "name": "an appeal is being made",
+            "result": {
+              "status": "passed",
+              "duration": 41000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 8,
+            "name": "the \"Enforcement - Notice out\" page is presented",
+            "result": {
+              "status": "passed",
+              "duration": 537000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 9,
+            "name": "the required links are displayed",
+            "result": {
+              "status": "passed",
+              "duration": 53000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "common-links-in-footer-section;required-links-in-footer-are-present",
+        "keyword": "Scenario",
+        "line": 24,
+        "name": "Required links in footer are present",
+        "tags": [],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 7,
+            "name": "an appeal is being made",
+            "result": {
+              "status": "passed",
+              "duration": 43000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 8,
+            "name": "the \"Eligibility - Listed building\" page is presented",
+            "result": {
+              "status": "passed",
+              "duration": 692000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 9,
+            "name": "the required links are displayed",
+            "result": {
+              "status": "passed",
+              "duration": 73000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "common-links-in-footer-section;required-links-in-footer-are-present",
+        "keyword": "Scenario",
+        "line": 25,
+        "name": "Required links in footer are present",
+        "tags": [],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 7,
+            "name": "an appeal is being made",
+            "result": {
+              "status": "passed",
+              "duration": 41000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 8,
+            "name": "the \"Eligibility - Listed building out\" page is presented",
+            "result": {
+              "status": "passed",
+              "duration": 457000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 9,
+            "name": "the required links are displayed",
+            "result": {
+              "status": "passed",
+              "duration": 59000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "common-links-in-footer-section;required-links-in-footer-are-present",
+        "keyword": "Scenario",
+        "line": 26,
+        "name": "Required links in footer are present",
+        "tags": [],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 7,
+            "name": "an appeal is being made",
+            "result": {
+              "status": "passed",
+              "duration": 44000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 8,
+            "name": "the \"Eligibility - Costs\" page is presented",
+            "result": {
+              "status": "passed",
+              "duration": 665000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 9,
+            "name": "the required links are displayed",
+            "result": {
+              "status": "passed",
+              "duration": 61000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "common-links-in-footer-section;required-links-in-footer-are-present",
+        "keyword": "Scenario",
+        "line": 27,
+        "name": "Required links in footer are present",
+        "tags": [],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 7,
+            "name": "an appeal is being made",
+            "result": {
+              "status": "passed",
+              "duration": 45000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 8,
+            "name": "the \"Eligibility - Costs out\" page is presented",
+            "result": {
+              "status": "passed",
+              "duration": 473000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 9,
+            "name": "the required links are displayed",
+            "result": {
+              "status": "passed",
+              "duration": 53000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "common-links-in-footer-section;required-links-in-footer-are-present",
+        "keyword": "Scenario",
+        "line": 28,
+        "name": "Required links in footer are present",
+        "tags": [],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 7,
+            "name": "an appeal is being made",
+            "result": {
+              "status": "passed",
+              "duration": 50000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 8,
+            "name": "the \"Eligibility - Appeal statement info\" page is presented",
+            "result": {
+              "status": "passed",
+              "duration": 495000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 9,
+            "name": "the required links are displayed",
+            "result": {
+              "status": "passed",
+              "duration": 54000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "common-links-in-footer-section;required-links-in-footer-are-present",
+        "keyword": "Scenario",
+        "line": 29,
+        "name": "Required links in footer are present",
+        "tags": [],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 7,
+            "name": "an appeal is being made",
+            "result": {
+              "status": "passed",
+              "duration": 39000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 8,
+            "name": "the \"Appellant submission - Appeal tasks\" page is presented",
+            "result": {
+              "status": "passed",
+              "duration": 644000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 9,
+            "name": "the required links are displayed",
+            "result": {
+              "status": "passed",
+              "duration": 64000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "common-links-in-footer-section;required-links-in-footer-are-present",
+        "keyword": "Scenario",
+        "line": 30,
+        "name": "Required links in footer are present",
+        "tags": [],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 7,
+            "name": "an appeal is being made",
+            "result": {
+              "status": "passed",
+              "duration": 43000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 8,
+            "name": "the \"Appellant submission - Your details - Who are you\" page is presented",
+            "result": {
+              "status": "passed",
+              "duration": 590000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 9,
+            "name": "the required links are displayed",
+            "result": {
+              "status": "passed",
+              "duration": 56000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "common-links-in-footer-section;required-links-in-footer-are-present",
+        "keyword": "Scenario",
+        "line": 31,
+        "name": "Required links in footer are present",
+        "tags": [],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 7,
+            "name": "an appeal is being made",
+            "result": {
+              "status": "passed",
+              "duration": 77000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 8,
+            "name": "the \"Appellant submission - Your details - Your details\" page is presented",
+            "result": {
+              "status": "passed",
+              "duration": 657000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 9,
+            "name": "the required links are displayed",
+            "result": {
+              "status": "passed",
+              "duration": 62000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "common-links-in-footer-section;required-links-in-footer-are-present",
+        "keyword": "Scenario",
+        "line": 32,
+        "name": "Required links in footer are present",
+        "tags": [],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 7,
+            "name": "an appeal is being made",
+            "result": {
+              "status": "passed",
+              "duration": 38000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 8,
+            "name": "the \"Appellant submission - Your details - Applicant name\" page is presented",
+            "result": {
+              "status": "passed",
+              "duration": 604000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 9,
+            "name": "the required links are displayed",
+            "result": {
+              "status": "passed",
+              "duration": 53000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "common-links-in-footer-section;required-links-in-footer-are-present",
+        "keyword": "Scenario",
+        "line": 33,
+        "name": "Required links in footer are present",
+        "tags": [],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 7,
+            "name": "an appeal is being made",
+            "result": {
+              "status": "passed",
+              "duration": 44000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 8,
+            "name": "the \"Appellant submission - Planning application - Application number\" page is presented",
+            "result": {
+              "status": "passed",
+              "duration": 987000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 9,
+            "name": "the required links are displayed",
+            "result": {
+              "status": "passed",
+              "duration": 48000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "common-links-in-footer-section;required-links-in-footer-are-present",
+        "keyword": "Scenario",
+        "line": 34,
+        "name": "Required links in footer are present",
+        "tags": [],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 7,
+            "name": "an appeal is being made",
+            "result": {
+              "status": "passed",
+              "duration": 39000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 8,
+            "name": "the \"Appellant submission - Planning application - Upload application\" page is presented",
+            "result": {
+              "status": "passed",
+              "duration": 537000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 9,
+            "name": "the required links are displayed",
+            "result": {
+              "status": "passed",
+              "duration": 77000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "common-links-in-footer-section;required-links-in-footer-are-present",
+        "keyword": "Scenario",
+        "line": 35,
+        "name": "Required links in footer are present",
+        "tags": [],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 7,
+            "name": "an appeal is being made",
+            "result": {
+              "status": "passed",
+              "duration": 42000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 8,
+            "name": "the \"Appellant submission - Planning application - Upload decision letter\" page is presented",
+            "result": {
+              "status": "passed",
+              "duration": 632000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 9,
+            "name": "the required links are displayed",
+            "result": {
+              "status": "passed",
+              "duration": 54000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "common-links-in-footer-section;required-links-in-footer-are-present",
+        "keyword": "Scenario",
+        "line": 36,
+        "name": "Required links in footer are present",
+        "tags": [],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 7,
+            "name": "an appeal is being made",
+            "result": {
+              "status": "passed",
+              "duration": 37000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 8,
+            "name": "the \"Appellant submission - Your appeal - Appeal statement\" page is presented",
+            "result": {
+              "status": "passed",
+              "duration": 626000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 9,
+            "name": "the required links are displayed",
+            "result": {
+              "status": "passed",
+              "duration": 66000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "common-links-in-footer-section;required-links-in-footer-are-present",
+        "keyword": "Scenario",
+        "line": 37,
+        "name": "Required links in footer are present",
+        "tags": [],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 7,
+            "name": "an appeal is being made",
+            "result": {
+              "status": "passed",
+              "duration": 41000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 8,
+            "name": "the \"Appellant submission - Your appeal - Supporting documents\" page is presented",
+            "result": {
+              "status": "passed",
+              "duration": 691000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 9,
+            "name": "the required links are displayed",
+            "result": {
+              "status": "passed",
+              "duration": 73000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "common-links-in-footer-section;required-links-in-footer-are-present",
+        "keyword": "Scenario",
+        "line": 38,
+        "name": "Required links in footer are present",
+        "tags": [],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 7,
+            "name": "an appeal is being made",
+            "result": {
+              "status": "passed",
+              "duration": 45000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 8,
+            "name": "the \"Appellant submission - Appeal site - Site location\" page is presented",
+            "result": {
+              "status": "passed",
+              "duration": 777000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 9,
+            "name": "the required links are displayed",
+            "result": {
+              "status": "passed",
+              "duration": 50000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "common-links-in-footer-section;required-links-in-footer-are-present",
+        "keyword": "Scenario",
+        "line": 39,
+        "name": "Required links in footer are present",
+        "tags": [],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 7,
+            "name": "an appeal is being made",
+            "result": {
+              "status": "passed",
+              "duration": 42000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 8,
+            "name": "the \"Appellant submission - Appeal site - Site ownership\" page is presented",
+            "result": {
+              "status": "passed",
+              "duration": 744000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 9,
+            "name": "the required links are displayed",
+            "result": {
+              "status": "passed",
+              "duration": 58000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "common-links-in-footer-section;required-links-in-footer-are-present",
+        "keyword": "Scenario",
+        "line": 40,
+        "name": "Required links in footer are present",
+        "tags": [],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 7,
+            "name": "an appeal is being made",
+            "result": {
+              "status": "passed",
+              "duration": 42000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 8,
+            "name": "the \"Appellant submission - Appeal site - Site ownership certb\" page is presented",
+            "result": {
+              "status": "passed",
+              "duration": 712000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 9,
+            "name": "the required links are displayed",
+            "result": {
+              "status": "passed",
+              "duration": 52000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "common-links-in-footer-section;required-links-in-footer-are-present",
+        "keyword": "Scenario",
+        "line": 41,
+        "name": "Required links in footer are present",
+        "tags": [],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 7,
+            "name": "an appeal is being made",
+            "result": {
+              "status": "passed",
+              "duration": 41000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 8,
+            "name": "the \"Appellant submission - Appeal site - Site access\" page is presented",
+            "result": {
+              "status": "passed",
+              "duration": 731000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 9,
+            "name": "the required links are displayed",
+            "result": {
+              "status": "passed",
+              "duration": 53000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "common-links-in-footer-section;required-links-in-footer-are-present",
+        "keyword": "Scenario",
+        "line": 42,
+        "name": "Required links in footer are present",
+        "tags": [],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 7,
+            "name": "an appeal is being made",
+            "result": {
+              "status": "passed",
+              "duration": 54000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 8,
+            "name": "the \"Appellant submission - Appeal site - Site safety\" page is presented",
+            "result": {
+              "status": "passed",
+              "duration": 688000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 9,
+            "name": "the required links are displayed",
+            "result": {
+              "status": "passed",
+              "duration": 56000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "common-links-in-footer-section;required-links-in-footer-are-present",
+        "keyword": "Scenario",
+        "line": 43,
+        "name": "Required links in footer are present",
+        "tags": [],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 7,
+            "name": "an appeal is being made",
+            "result": {
+              "status": "passed",
+              "duration": 40000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 8,
+            "name": "the \"Appellant submission - Check your answers\" page is presented",
+            "result": {
+              "status": "passed",
+              "duration": 711000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 9,
+            "name": "the required links are displayed",
+            "result": {
+              "status": "passed",
+              "duration": 61000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "common-links-in-footer-section;required-links-in-footer-are-present",
+        "keyword": "Scenario",
+        "line": 44,
+        "name": "Required links in footer are present",
+        "tags": [],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 7,
+            "name": "an appeal is being made",
+            "result": {
+              "status": "passed",
+              "duration": 41000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 8,
+            "name": "the \"Appeal submission - Declaration\" page is presented",
+            "result": {
+              "status": "passed",
+              "duration": 662000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 9,
+            "name": "the required links are displayed",
+            "result": {
+              "status": "passed",
+              "duration": 59000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "common-links-in-footer-section;required-links-in-footer-are-present",
+        "keyword": "Scenario",
+        "line": 45,
+        "name": "Required links in footer are present",
+        "tags": [],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 7,
+            "name": "an appeal is being made",
+            "result": {
+              "status": "passed",
+              "duration": 44000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 8,
+            "name": "the \"Appeal submission - Confirmation\" page is presented",
+            "result": {
+              "status": "passed",
+              "duration": 900000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 9,
+            "name": "the required links are displayed",
+            "result": {
+              "status": "passed",
+              "duration": 55000000
+            }
+          }
+        ]
+      }
+    ]
+  }
+]

--- a/packages/e2e-tests/cypress/cucumber-json/appellant-submission-header.cucumber.json
+++ b/packages/e2e-tests/cypress/cucumber-json/appellant-submission-header.cucumber.json
@@ -1,0 +1,2463 @@
+[
+  {
+    "description": "  Each of the Eligibility and Appellant Submission webpages must display link to feedback page",
+    "keyword": "Feature",
+    "name": "Common link in header section",
+    "line": 1,
+    "id": "common-link-in-header-section",
+    "tags": [],
+    "uri": "appellant-submission-header.feature",
+    "elements": [
+      {
+        "id": "common-link-in-header-section;required-link-in-header-is-present",
+        "keyword": "Scenario",
+        "line": 11,
+        "name": "Required link in header is present",
+        "tags": [
+          {
+            "name": "@as-2264",
+            "line": 4
+          }
+        ],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 6,
+            "name": "an appeal is being made",
+            "result": {
+              "status": "passed",
+              "duration": 144000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 7,
+            "name": "the \"Start your appeal\" page is presented",
+            "result": {
+              "status": "passed",
+              "duration": 1012000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 8,
+            "name": "the required header link is displayed",
+            "result": {
+              "status": "passed",
+              "duration": 151000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "common-link-in-header-section;required-link-in-header-is-present",
+        "keyword": "Scenario",
+        "line": 12,
+        "name": "Required link in header is present",
+        "tags": [
+          {
+            "name": "@as-2264",
+            "line": 4
+          }
+        ],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 6,
+            "name": "an appeal is being made",
+            "result": {
+              "status": "passed",
+              "duration": 91000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 7,
+            "name": "the \"Eligibility - House holder planning permission\" page is presented",
+            "result": {
+              "status": "passed",
+              "duration": 752000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 8,
+            "name": "the required header link is displayed",
+            "result": {
+              "status": "passed",
+              "duration": 125000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "common-link-in-header-section;required-link-in-header-is-present",
+        "keyword": "Scenario",
+        "line": 13,
+        "name": "Required link in header is present",
+        "tags": [
+          {
+            "name": "@as-2264",
+            "line": 4
+          }
+        ],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 6,
+            "name": "an appeal is being made",
+            "result": {
+              "status": "passed",
+              "duration": 99000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 7,
+            "name": "the \"Eligibility - Householder planning permission out\" page is presented",
+            "result": {
+              "status": "passed",
+              "duration": 541000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 8,
+            "name": "the required header link is displayed",
+            "result": {
+              "status": "passed",
+              "duration": 141000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "common-link-in-header-section;required-link-in-header-is-present",
+        "keyword": "Scenario",
+        "line": 14,
+        "name": "Required link in header is present",
+        "tags": [
+          {
+            "name": "@as-2264",
+            "line": 4
+          }
+        ],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 6,
+            "name": "an appeal is being made",
+            "result": {
+              "status": "passed",
+              "duration": 62000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 7,
+            "name": "the \"Eligibility - Granted Or Refused Permission\" page is presented",
+            "result": {
+              "status": "passed",
+              "duration": 818000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 8,
+            "name": "the required header link is displayed",
+            "result": {
+              "status": "passed",
+              "duration": 135000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "common-link-in-header-section;required-link-in-header-is-present",
+        "keyword": "Scenario",
+        "line": 15,
+        "name": "Required link in header is present",
+        "tags": [
+          {
+            "name": "@as-2264",
+            "line": 4
+          }
+        ],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 6,
+            "name": "an appeal is being made",
+            "result": {
+              "status": "passed",
+              "duration": 70000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 7,
+            "name": "the \"Eligibility - Granted Or Refused Permission Out\" page is presented",
+            "result": {
+              "status": "passed",
+              "duration": 740000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 8,
+            "name": "the required header link is displayed",
+            "result": {
+              "status": "passed",
+              "duration": 137000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "common-link-in-header-section;required-link-in-header-is-present",
+        "keyword": "Scenario",
+        "line": 16,
+        "name": "Required link in header is present",
+        "tags": [
+          {
+            "name": "@as-2264",
+            "line": 4
+          }
+        ],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 6,
+            "name": "an appeal is being made",
+            "result": {
+              "status": "passed",
+              "duration": 82000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 7,
+            "name": "the \"Eligibility - No decision on Permission\" page is presented",
+            "result": {
+              "status": "passed",
+              "duration": 591000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 8,
+            "name": "the required header link is displayed",
+            "result": {
+              "status": "passed",
+              "duration": 128000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "common-link-in-header-section;required-link-in-header-is-present",
+        "keyword": "Scenario",
+        "line": 17,
+        "name": "Required link in header is present",
+        "tags": [
+          {
+            "name": "@as-2264",
+            "line": 4
+          }
+        ],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 6,
+            "name": "an appeal is being made",
+            "result": {
+              "status": "passed",
+              "duration": 128000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 7,
+            "name": "the \"Eligibility - Decision date\" page is presented",
+            "result": {
+              "status": "passed",
+              "duration": 1232000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 8,
+            "name": "the required header link is displayed",
+            "result": {
+              "status": "passed",
+              "duration": 165000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "common-link-in-header-section;required-link-in-header-is-present",
+        "keyword": "Scenario",
+        "line": 18,
+        "name": "Required link in header is present",
+        "tags": [
+          {
+            "name": "@as-2264",
+            "line": 4
+          }
+        ],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 6,
+            "name": "an appeal is being made",
+            "result": {
+              "status": "passed",
+              "duration": 67000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 7,
+            "name": "the \"Eligibility - Decision date expired\" page is presented",
+            "result": {
+              "status": "passed",
+              "duration": 569000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 8,
+            "name": "the required header link is displayed",
+            "result": {
+              "status": "passed",
+              "duration": 122000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "common-link-in-header-section;required-link-in-header-is-present",
+        "keyword": "Scenario",
+        "line": 19,
+        "name": "Required link in header is present",
+        "tags": [
+          {
+            "name": "@as-2264",
+            "line": 4
+          }
+        ],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 6,
+            "name": "an appeal is being made",
+            "result": {
+              "status": "passed",
+              "duration": 59000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 7,
+            "name": "the \"Eligibility - Planning department\" page is presented",
+            "result": {
+              "status": "passed",
+              "duration": 684000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 8,
+            "name": "the required header link is displayed",
+            "result": {
+              "status": "passed",
+              "duration": 130000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "common-link-in-header-section;required-link-in-header-is-present",
+        "keyword": "Scenario",
+        "line": 20,
+        "name": "Required link in header is present",
+        "tags": [
+          {
+            "name": "@as-2264",
+            "line": 4
+          }
+        ],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 6,
+            "name": "an appeal is being made",
+            "result": {
+              "status": "passed",
+              "duration": 52000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 7,
+            "name": "the \"Eligibility - Planning department out\" page is presented",
+            "result": {
+              "status": "passed",
+              "duration": 489000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 8,
+            "name": "the required header link is displayed",
+            "result": {
+              "status": "passed",
+              "duration": 122000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "common-link-in-header-section;required-link-in-header-is-present",
+        "keyword": "Scenario",
+        "line": 21,
+        "name": "Required link in header is present",
+        "tags": [
+          {
+            "name": "@as-2264",
+            "line": 4
+          }
+        ],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 6,
+            "name": "an appeal is being made",
+            "result": {
+              "status": "passed",
+              "duration": 45000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 7,
+            "name": "the \"Enforcement - Notice\" page is presented",
+            "result": {
+              "status": "passed",
+              "duration": 675000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 8,
+            "name": "the required header link is displayed",
+            "result": {
+              "status": "passed",
+              "duration": 121000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "common-link-in-header-section;required-link-in-header-is-present",
+        "keyword": "Scenario",
+        "line": 22,
+        "name": "Required link in header is present",
+        "tags": [
+          {
+            "name": "@as-2264",
+            "line": 4
+          }
+        ],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 6,
+            "name": "an appeal is being made",
+            "result": {
+              "status": "passed",
+              "duration": 42000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 7,
+            "name": "the \"Enforcement - Notice out\" page is presented",
+            "result": {
+              "status": "passed",
+              "duration": 524000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 8,
+            "name": "the required header link is displayed",
+            "result": {
+              "status": "passed",
+              "duration": 126000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "common-link-in-header-section;required-link-in-header-is-present",
+        "keyword": "Scenario",
+        "line": 23,
+        "name": "Required link in header is present",
+        "tags": [
+          {
+            "name": "@as-2264",
+            "line": 4
+          }
+        ],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 6,
+            "name": "an appeal is being made",
+            "result": {
+              "status": "passed",
+              "duration": 42000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 7,
+            "name": "the \"Eligibility - Listed building\" page is presented",
+            "result": {
+              "status": "passed",
+              "duration": 570000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 8,
+            "name": "the required header link is displayed",
+            "result": {
+              "status": "passed",
+              "duration": 117000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "common-link-in-header-section;required-link-in-header-is-present",
+        "keyword": "Scenario",
+        "line": 24,
+        "name": "Required link in header is present",
+        "tags": [
+          {
+            "name": "@as-2264",
+            "line": 4
+          }
+        ],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 6,
+            "name": "an appeal is being made",
+            "result": {
+              "status": "passed",
+              "duration": 38000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 7,
+            "name": "the \"Eligibility - Listed building out\" page is presented",
+            "result": {
+              "status": "passed",
+              "duration": 502000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 8,
+            "name": "the required header link is displayed",
+            "result": {
+              "status": "passed",
+              "duration": 130000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "common-link-in-header-section;required-link-in-header-is-present",
+        "keyword": "Scenario",
+        "line": 25,
+        "name": "Required link in header is present",
+        "tags": [
+          {
+            "name": "@as-2264",
+            "line": 4
+          }
+        ],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 6,
+            "name": "an appeal is being made",
+            "result": {
+              "status": "passed",
+              "duration": 48000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 7,
+            "name": "the \"Eligibility - Costs\" page is presented",
+            "result": {
+              "status": "passed",
+              "duration": 635000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 8,
+            "name": "the required header link is displayed",
+            "result": {
+              "status": "passed",
+              "duration": 118000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "common-link-in-header-section;required-link-in-header-is-present",
+        "keyword": "Scenario",
+        "line": 26,
+        "name": "Required link in header is present",
+        "tags": [
+          {
+            "name": "@as-2264",
+            "line": 4
+          }
+        ],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 6,
+            "name": "an appeal is being made",
+            "result": {
+              "status": "passed",
+              "duration": 46000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 7,
+            "name": "the \"Eligibility - Costs out\" page is presented",
+            "result": {
+              "status": "passed",
+              "duration": 854000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 8,
+            "name": "the required header link is displayed",
+            "result": {
+              "status": "passed",
+              "duration": 150000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "common-link-in-header-section;required-link-in-header-is-present",
+        "keyword": "Scenario",
+        "line": 27,
+        "name": "Required link in header is present",
+        "tags": [
+          {
+            "name": "@as-2264",
+            "line": 4
+          }
+        ],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 6,
+            "name": "an appeal is being made",
+            "result": {
+              "status": "passed",
+              "duration": 112000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 7,
+            "name": "the \"Eligibility - Appeal statement info\" page is presented",
+            "result": {
+              "status": "passed",
+              "duration": 915000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 8,
+            "name": "the required header link is displayed",
+            "result": {
+              "status": "passed",
+              "duration": 134000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "common-link-in-header-section;required-link-in-header-is-present",
+        "keyword": "Scenario",
+        "line": 28,
+        "name": "Required link in header is present",
+        "tags": [
+          {
+            "name": "@as-2264",
+            "line": 4
+          }
+        ],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 6,
+            "name": "an appeal is being made",
+            "result": {
+              "status": "passed",
+              "duration": 60000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 7,
+            "name": "the \"Appellant submission - Appeal tasks\" page is presented",
+            "result": {
+              "status": "passed",
+              "duration": 723000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 8,
+            "name": "the required header link is displayed",
+            "result": {
+              "status": "passed",
+              "duration": 123000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "common-link-in-header-section;required-link-in-header-is-present",
+        "keyword": "Scenario",
+        "line": 29,
+        "name": "Required link in header is present",
+        "tags": [
+          {
+            "name": "@as-2264",
+            "line": 4
+          }
+        ],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 6,
+            "name": "an appeal is being made",
+            "result": {
+              "status": "passed",
+              "duration": 52000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 7,
+            "name": "the \"Appellant submission - Your details - Who are you\" page is presented",
+            "result": {
+              "status": "passed",
+              "duration": 644000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 8,
+            "name": "the required header link is displayed",
+            "result": {
+              "status": "passed",
+              "duration": 121000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "common-link-in-header-section;required-link-in-header-is-present",
+        "keyword": "Scenario",
+        "line": 30,
+        "name": "Required link in header is present",
+        "tags": [
+          {
+            "name": "@as-2264",
+            "line": 4
+          }
+        ],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 6,
+            "name": "an appeal is being made",
+            "result": {
+              "status": "passed",
+              "duration": 46000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 7,
+            "name": "the \"Appellant submission - Your details - Your details\" page is presented",
+            "result": {
+              "status": "passed",
+              "duration": 633000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 8,
+            "name": "the required header link is displayed",
+            "result": {
+              "status": "passed",
+              "duration": 121000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "common-link-in-header-section;required-link-in-header-is-present",
+        "keyword": "Scenario",
+        "line": 31,
+        "name": "Required link in header is present",
+        "tags": [
+          {
+            "name": "@as-2264",
+            "line": 4
+          }
+        ],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 6,
+            "name": "an appeal is being made",
+            "result": {
+              "status": "passed",
+              "duration": 93000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 7,
+            "name": "the \"Appellant submission - Your details - Applicant name\" page is presented",
+            "result": {
+              "status": "passed",
+              "duration": 513000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 8,
+            "name": "the required header link is displayed",
+            "result": {
+              "status": "passed",
+              "duration": 125000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "common-link-in-header-section;required-link-in-header-is-present",
+        "keyword": "Scenario",
+        "line": 32,
+        "name": "Required link in header is present",
+        "tags": [
+          {
+            "name": "@as-2264",
+            "line": 4
+          }
+        ],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 6,
+            "name": "an appeal is being made",
+            "result": {
+              "status": "passed",
+              "duration": 42000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 7,
+            "name": "the \"Appellant submission - Planning application - Application number\" page is presented",
+            "result": {
+              "status": "passed",
+              "duration": 582000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 8,
+            "name": "the required header link is displayed",
+            "result": {
+              "status": "passed",
+              "duration": 120000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "common-link-in-header-section;required-link-in-header-is-present",
+        "keyword": "Scenario",
+        "line": 33,
+        "name": "Required link in header is present",
+        "tags": [
+          {
+            "name": "@as-2264",
+            "line": 4
+          }
+        ],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 6,
+            "name": "an appeal is being made",
+            "result": {
+              "status": "passed",
+              "duration": 74000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 7,
+            "name": "the \"Appellant submission - Planning application - Upload application\" page is presented",
+            "result": {
+              "status": "passed",
+              "duration": 549000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 8,
+            "name": "the required header link is displayed",
+            "result": {
+              "status": "passed",
+              "duration": 115000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "common-link-in-header-section;required-link-in-header-is-present",
+        "keyword": "Scenario",
+        "line": 34,
+        "name": "Required link in header is present",
+        "tags": [
+          {
+            "name": "@as-2264",
+            "line": 4
+          }
+        ],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 6,
+            "name": "an appeal is being made",
+            "result": {
+              "status": "passed",
+              "duration": 44000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 7,
+            "name": "the \"Appellant submission - Planning application - Upload decision letter\" page is presented",
+            "result": {
+              "status": "passed",
+              "duration": 595000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 8,
+            "name": "the required header link is displayed",
+            "result": {
+              "status": "passed",
+              "duration": 131000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "common-link-in-header-section;required-link-in-header-is-present",
+        "keyword": "Scenario",
+        "line": 35,
+        "name": "Required link in header is present",
+        "tags": [
+          {
+            "name": "@as-2264",
+            "line": 4
+          }
+        ],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 6,
+            "name": "an appeal is being made",
+            "result": {
+              "status": "passed",
+              "duration": 95000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 7,
+            "name": "the \"Appellant submission - Your appeal - Appeal statement\" page is presented",
+            "result": {
+              "status": "passed",
+              "duration": 572000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 8,
+            "name": "the required header link is displayed",
+            "result": {
+              "status": "passed",
+              "duration": 133000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "common-link-in-header-section;required-link-in-header-is-present",
+        "keyword": "Scenario",
+        "line": 36,
+        "name": "Required link in header is present",
+        "tags": [
+          {
+            "name": "@as-2264",
+            "line": 4
+          }
+        ],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 6,
+            "name": "an appeal is being made",
+            "result": {
+              "status": "passed",
+              "duration": 70000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 7,
+            "name": "the \"Appellant submission - Your appeal - Supporting documents\" page is presented",
+            "result": {
+              "status": "passed",
+              "duration": 600000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 8,
+            "name": "the required header link is displayed",
+            "result": {
+              "status": "passed",
+              "duration": 130000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "common-link-in-header-section;required-link-in-header-is-present",
+        "keyword": "Scenario",
+        "line": 37,
+        "name": "Required link in header is present",
+        "tags": [
+          {
+            "name": "@as-2264",
+            "line": 4
+          }
+        ],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 6,
+            "name": "an appeal is being made",
+            "result": {
+              "status": "passed",
+              "duration": 59000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 7,
+            "name": "the \"Appellant submission - Appeal site - Site location\" page is presented",
+            "result": {
+              "status": "passed",
+              "duration": 720000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 8,
+            "name": "the required header link is displayed",
+            "result": {
+              "status": "passed",
+              "duration": 119000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "common-link-in-header-section;required-link-in-header-is-present",
+        "keyword": "Scenario",
+        "line": 38,
+        "name": "Required link in header is present",
+        "tags": [
+          {
+            "name": "@as-2264",
+            "line": 4
+          }
+        ],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 6,
+            "name": "an appeal is being made",
+            "result": {
+              "status": "passed",
+              "duration": 47000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 7,
+            "name": "the \"Appellant submission - Appeal site - Site ownership\" page is presented",
+            "result": {
+              "status": "passed",
+              "duration": 584000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 8,
+            "name": "the required header link is displayed",
+            "result": {
+              "status": "passed",
+              "duration": 121000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "common-link-in-header-section;required-link-in-header-is-present",
+        "keyword": "Scenario",
+        "line": 39,
+        "name": "Required link in header is present",
+        "tags": [
+          {
+            "name": "@as-2264",
+            "line": 4
+          }
+        ],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 6,
+            "name": "an appeal is being made",
+            "result": {
+              "status": "passed",
+              "duration": 54000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 7,
+            "name": "the \"Appellant submission - Appeal site - Site ownership certb\" page is presented",
+            "result": {
+              "status": "passed",
+              "duration": 594000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 8,
+            "name": "the required header link is displayed",
+            "result": {
+              "status": "passed",
+              "duration": 118000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "common-link-in-header-section;required-link-in-header-is-present",
+        "keyword": "Scenario",
+        "line": 40,
+        "name": "Required link in header is present",
+        "tags": [
+          {
+            "name": "@as-2264",
+            "line": 4
+          }
+        ],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 6,
+            "name": "an appeal is being made",
+            "result": {
+              "status": "passed",
+              "duration": 53000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 7,
+            "name": "the \"Appellant submission - Appeal site - Site access\" page is presented",
+            "result": {
+              "status": "passed",
+              "duration": 630000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 8,
+            "name": "the required header link is displayed",
+            "result": {
+              "status": "passed",
+              "duration": 116000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "common-link-in-header-section;required-link-in-header-is-present",
+        "keyword": "Scenario",
+        "line": 41,
+        "name": "Required link in header is present",
+        "tags": [
+          {
+            "name": "@as-2264",
+            "line": 4
+          }
+        ],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 6,
+            "name": "an appeal is being made",
+            "result": {
+              "status": "passed",
+              "duration": 51000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 7,
+            "name": "the \"Appellant submission - Appeal site - Site safety\" page is presented",
+            "result": {
+              "status": "passed",
+              "duration": 595000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 8,
+            "name": "the required header link is displayed",
+            "result": {
+              "status": "passed",
+              "duration": 120000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "common-link-in-header-section;required-link-in-header-is-present",
+        "keyword": "Scenario",
+        "line": 42,
+        "name": "Required link in header is present",
+        "tags": [
+          {
+            "name": "@as-2264",
+            "line": 4
+          }
+        ],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 6,
+            "name": "an appeal is being made",
+            "result": {
+              "status": "passed",
+              "duration": 42000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 7,
+            "name": "the \"Appellant submission - Check your answers\" page is presented",
+            "result": {
+              "status": "passed",
+              "duration": 611000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 8,
+            "name": "the required header link is displayed",
+            "result": {
+              "status": "passed",
+              "duration": 124000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "common-link-in-header-section;required-link-in-header-is-present",
+        "keyword": "Scenario",
+        "line": 43,
+        "name": "Required link in header is present",
+        "tags": [
+          {
+            "name": "@as-2264",
+            "line": 4
+          }
+        ],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 6,
+            "name": "an appeal is being made",
+            "result": {
+              "status": "passed",
+              "duration": 49000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 7,
+            "name": "the \"Appeal submission - Declaration\" page is presented",
+            "result": {
+              "status": "passed",
+              "duration": 556000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 8,
+            "name": "the required header link is displayed",
+            "result": {
+              "status": "passed",
+              "duration": 118000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "common-link-in-header-section;required-link-in-header-is-present",
+        "keyword": "Scenario",
+        "line": 44,
+        "name": "Required link in header is present",
+        "tags": [
+          {
+            "name": "@as-2264",
+            "line": 4
+          }
+        ],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 6,
+            "name": "an appeal is being made",
+            "result": {
+              "status": "passed",
+              "duration": 45000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 7,
+            "name": "the \"Appeal submission - Confirmation\" page is presented",
+            "result": {
+              "status": "passed",
+              "duration": 512000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 8,
+            "name": "the required header link is displayed",
+            "result": {
+              "status": "passed",
+              "duration": 127000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "common-link-in-header-section;required-back-button-is-present",
+        "keyword": "Scenario",
+        "line": 52,
+        "name": "Required back button is present",
+        "tags": [],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 47,
+            "name": "an appeal is being made",
+            "result": {
+              "status": "passed",
+              "duration": 51000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 48,
+            "name": "the \"Eligibility - House holder planning permission\" page is presented",
+            "result": {
+              "status": "passed",
+              "duration": 614000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 49,
+            "name": "the back button is displayed",
+            "result": {
+              "status": "passed",
+              "duration": 12000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "common-link-in-header-section;required-back-button-is-present",
+        "keyword": "Scenario",
+        "line": 53,
+        "name": "Required back button is present",
+        "tags": [],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 47,
+            "name": "an appeal is being made",
+            "result": {
+              "status": "passed",
+              "duration": 55000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 48,
+            "name": "the \"Eligibility - Granted Or Refused Permission\" page is presented",
+            "result": {
+              "status": "passed",
+              "duration": 642000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 49,
+            "name": "the back button is displayed",
+            "result": {
+              "status": "passed",
+              "duration": 17000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "common-link-in-header-section;required-back-button-is-present",
+        "keyword": "Scenario",
+        "line": 54,
+        "name": "Required back button is present",
+        "tags": [],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 47,
+            "name": "an appeal is being made",
+            "result": {
+              "status": "passed",
+              "duration": 70000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 48,
+            "name": "the \"Eligibility - Decision date\" page is presented",
+            "result": {
+              "status": "passed",
+              "duration": 778000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 49,
+            "name": "the back button is displayed",
+            "result": {
+              "status": "passed",
+              "duration": 12000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "common-link-in-header-section;required-back-button-is-present",
+        "keyword": "Scenario",
+        "line": 55,
+        "name": "Required back button is present",
+        "tags": [],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 47,
+            "name": "an appeal is being made",
+            "result": {
+              "status": "passed",
+              "duration": 51000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 48,
+            "name": "the \"Eligibility - Planning department\" page is presented",
+            "result": {
+              "status": "passed",
+              "duration": 698000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 49,
+            "name": "the back button is displayed",
+            "result": {
+              "status": "passed",
+              "duration": 13000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "common-link-in-header-section;required-back-button-is-present",
+        "keyword": "Scenario",
+        "line": 56,
+        "name": "Required back button is present",
+        "tags": [],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 47,
+            "name": "an appeal is being made",
+            "result": {
+              "status": "passed",
+              "duration": 61000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 48,
+            "name": "the \"Enforcement - Notice\" page is presented",
+            "result": {
+              "status": "passed",
+              "duration": 656000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 49,
+            "name": "the back button is displayed",
+            "result": {
+              "status": "passed",
+              "duration": 10000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "common-link-in-header-section;required-back-button-is-present",
+        "keyword": "Scenario",
+        "line": 57,
+        "name": "Required back button is present",
+        "tags": [],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 47,
+            "name": "an appeal is being made",
+            "result": {
+              "status": "passed",
+              "duration": 52000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 48,
+            "name": "the \"Eligibility - Listed building\" page is presented",
+            "result": {
+              "status": "passed",
+              "duration": 669000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 49,
+            "name": "the back button is displayed",
+            "result": {
+              "status": "passed",
+              "duration": 14000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "common-link-in-header-section;required-back-button-is-present",
+        "keyword": "Scenario",
+        "line": 58,
+        "name": "Required back button is present",
+        "tags": [],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 47,
+            "name": "an appeal is being made",
+            "result": {
+              "status": "passed",
+              "duration": 67000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 48,
+            "name": "the \"Eligibility - Costs\" page is presented",
+            "result": {
+              "status": "passed",
+              "duration": 624000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 49,
+            "name": "the back button is displayed",
+            "result": {
+              "status": "passed",
+              "duration": 11000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "common-link-in-header-section;required-back-button-is-present",
+        "keyword": "Scenario",
+        "line": 59,
+        "name": "Required back button is present",
+        "tags": [],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 47,
+            "name": "an appeal is being made",
+            "result": {
+              "status": "passed",
+              "duration": 52000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 48,
+            "name": "the \"Eligibility - Appeal statement info\" page is presented",
+            "result": {
+              "status": "passed",
+              "duration": 492000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 49,
+            "name": "the back button is displayed",
+            "result": {
+              "status": "passed",
+              "duration": 15000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "common-link-in-header-section;required-back-button-is-present",
+        "keyword": "Scenario",
+        "line": 60,
+        "name": "Required back button is present",
+        "tags": [],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 47,
+            "name": "an appeal is being made",
+            "result": {
+              "status": "passed",
+              "duration": 50000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 48,
+            "name": "the \"Appellant submission - Your details - Who are you\" page is presented",
+            "result": {
+              "status": "passed",
+              "duration": 676000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 49,
+            "name": "the back button is displayed",
+            "result": {
+              "status": "passed",
+              "duration": 12000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "common-link-in-header-section;required-back-button-is-present",
+        "keyword": "Scenario",
+        "line": 61,
+        "name": "Required back button is present",
+        "tags": [],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 47,
+            "name": "an appeal is being made",
+            "result": {
+              "status": "passed",
+              "duration": 64000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 48,
+            "name": "the \"Appellant submission - Your details - Your details\" page is presented",
+            "result": {
+              "status": "passed",
+              "duration": 643000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 49,
+            "name": "the back button is displayed",
+            "result": {
+              "status": "passed",
+              "duration": 11000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "common-link-in-header-section;required-back-button-is-present",
+        "keyword": "Scenario",
+        "line": 62,
+        "name": "Required back button is present",
+        "tags": [],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 47,
+            "name": "an appeal is being made",
+            "result": {
+              "status": "passed",
+              "duration": 68000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 48,
+            "name": "the \"Appellant submission - Your details - Applicant name\" page is presented",
+            "result": {
+              "status": "passed",
+              "duration": 607000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 49,
+            "name": "the back button is displayed",
+            "result": {
+              "status": "passed",
+              "duration": 13000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "common-link-in-header-section;required-back-button-is-present",
+        "keyword": "Scenario",
+        "line": 63,
+        "name": "Required back button is present",
+        "tags": [],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 47,
+            "name": "an appeal is being made",
+            "result": {
+              "status": "passed",
+              "duration": 56000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 48,
+            "name": "the \"Appellant submission - Planning application - Application number\" page is presented",
+            "result": {
+              "status": "passed",
+              "duration": 669000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 49,
+            "name": "the back button is displayed",
+            "result": {
+              "status": "passed",
+              "duration": 16000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "common-link-in-header-section;required-back-button-is-present",
+        "keyword": "Scenario",
+        "line": 64,
+        "name": "Required back button is present",
+        "tags": [],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 47,
+            "name": "an appeal is being made",
+            "result": {
+              "status": "passed",
+              "duration": 74000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 48,
+            "name": "the \"Appellant submission - Planning application - Upload application\" page is presented",
+            "result": {
+              "status": "passed",
+              "duration": 722000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 49,
+            "name": "the back button is displayed",
+            "result": {
+              "status": "passed",
+              "duration": 13000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "common-link-in-header-section;required-back-button-is-present",
+        "keyword": "Scenario",
+        "line": 65,
+        "name": "Required back button is present",
+        "tags": [],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 47,
+            "name": "an appeal is being made",
+            "result": {
+              "status": "passed",
+              "duration": 72000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 48,
+            "name": "the \"Appellant submission - Planning application - Upload decision letter\" page is presented",
+            "result": {
+              "status": "passed",
+              "duration": 545000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 49,
+            "name": "the back button is displayed",
+            "result": {
+              "status": "passed",
+              "duration": 10000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "common-link-in-header-section;required-back-button-is-present",
+        "keyword": "Scenario",
+        "line": 66,
+        "name": "Required back button is present",
+        "tags": [],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 47,
+            "name": "an appeal is being made",
+            "result": {
+              "status": "passed",
+              "duration": 45000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 48,
+            "name": "the \"Appellant submission - Your appeal - Appeal statement\" page is presented",
+            "result": {
+              "status": "passed",
+              "duration": 657000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 49,
+            "name": "the back button is displayed",
+            "result": {
+              "status": "passed",
+              "duration": 10000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "common-link-in-header-section;required-back-button-is-present",
+        "keyword": "Scenario",
+        "line": 67,
+        "name": "Required back button is present",
+        "tags": [],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 47,
+            "name": "an appeal is being made",
+            "result": {
+              "status": "passed",
+              "duration": 50000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 48,
+            "name": "the \"Appellant submission - Your appeal - Supporting documents\" page is presented",
+            "result": {
+              "status": "passed",
+              "duration": 663000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 49,
+            "name": "the back button is displayed",
+            "result": {
+              "status": "passed",
+              "duration": 11000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "common-link-in-header-section;required-back-button-is-present",
+        "keyword": "Scenario",
+        "line": 68,
+        "name": "Required back button is present",
+        "tags": [],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 47,
+            "name": "an appeal is being made",
+            "result": {
+              "status": "passed",
+              "duration": 59000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 48,
+            "name": "the \"Appellant submission - Appeal site - Site location\" page is presented",
+            "result": {
+              "status": "passed",
+              "duration": 800000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 49,
+            "name": "the back button is displayed",
+            "result": {
+              "status": "passed",
+              "duration": 8000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "common-link-in-header-section;required-back-button-is-present",
+        "keyword": "Scenario",
+        "line": 69,
+        "name": "Required back button is present",
+        "tags": [],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 47,
+            "name": "an appeal is being made",
+            "result": {
+              "status": "passed",
+              "duration": 68000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 48,
+            "name": "the \"Appellant submission - Appeal site - Site ownership\" page is presented",
+            "result": {
+              "status": "passed",
+              "duration": 652000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 49,
+            "name": "the back button is displayed",
+            "result": {
+              "status": "passed",
+              "duration": 12000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "common-link-in-header-section;required-back-button-is-present",
+        "keyword": "Scenario",
+        "line": 70,
+        "name": "Required back button is present",
+        "tags": [],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 47,
+            "name": "an appeal is being made",
+            "result": {
+              "status": "passed",
+              "duration": 48000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 48,
+            "name": "the \"Appellant submission - Appeal site - Site ownership certb\" page is presented",
+            "result": {
+              "status": "passed",
+              "duration": 676000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 49,
+            "name": "the back button is displayed",
+            "result": {
+              "status": "passed",
+              "duration": 10000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "common-link-in-header-section;required-back-button-is-present",
+        "keyword": "Scenario",
+        "line": 71,
+        "name": "Required back button is present",
+        "tags": [],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 47,
+            "name": "an appeal is being made",
+            "result": {
+              "status": "passed",
+              "duration": 67000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 48,
+            "name": "the \"Appellant submission - Appeal site - Site access\" page is presented",
+            "result": {
+              "status": "passed",
+              "duration": 770000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 49,
+            "name": "the back button is displayed",
+            "result": {
+              "status": "passed",
+              "duration": 11000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "common-link-in-header-section;required-back-button-is-present",
+        "keyword": "Scenario",
+        "line": 72,
+        "name": "Required back button is present",
+        "tags": [],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 47,
+            "name": "an appeal is being made",
+            "result": {
+              "status": "passed",
+              "duration": 63000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 48,
+            "name": "the \"Appellant submission - Appeal site - Site safety\" page is presented",
+            "result": {
+              "status": "passed",
+              "duration": 682000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 49,
+            "name": "the back button is displayed",
+            "result": {
+              "status": "passed",
+              "duration": 12000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "common-link-in-header-section;required-back-button-is-present",
+        "keyword": "Scenario",
+        "line": 73,
+        "name": "Required back button is present",
+        "tags": [],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 47,
+            "name": "an appeal is being made",
+            "result": {
+              "status": "passed",
+              "duration": 55000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 48,
+            "name": "the \"Appellant submission - Check your answers\" page is presented",
+            "result": {
+              "status": "passed",
+              "duration": 630000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 49,
+            "name": "the back button is displayed",
+            "result": {
+              "status": "passed",
+              "duration": 12000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "common-link-in-header-section;required-back-button-is-present",
+        "keyword": "Scenario",
+        "line": 74,
+        "name": "Required back button is present",
+        "tags": [],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 47,
+            "name": "an appeal is being made",
+            "result": {
+              "status": "passed",
+              "duration": 60000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 48,
+            "name": "the \"Appeal submission - Declaration\" page is presented",
+            "result": {
+              "status": "passed",
+              "duration": 676000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 49,
+            "name": "the back button is displayed",
+            "result": {
+              "status": "passed",
+              "duration": 10000000
+            }
+          }
+        ]
+      }
+    ]
+  }
+]

--- a/packages/e2e-tests/cypress/cucumber-json/appellant-submission-planning-application-number.cucumber.json
+++ b/packages/e2e-tests/cypress/cucumber-json/appellant-submission-planning-application-number.cucumber.json
@@ -1,0 +1,292 @@
+[
+  {
+    "keyword": "Feature",
+    "name": "Appellant submits a planning application reference number so that the planning inspectorate can refer to their appeal",
+    "line": 1,
+    "id": "appellant-submits-a-planning-application-reference-number-so-that-the-planning-inspectorate-can-refer-to-their-appeal",
+    "tags": [],
+    "uri": "appellant-submission-planning-application-number.feature",
+    "elements": [
+      {
+        "id": "appellant-submits-a-planning-application-reference-number-so-that-the-planning-inspectorate-can-refer-to-their-appeal;prospective-appellant-provides-a-valid-planning-application-number",
+        "keyword": "Scenario",
+        "line": 3,
+        "name": "Prospective appellant provides a valid planning application number",
+        "tags": [],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 4,
+            "name": "user has not previously provided a planning application number",
+            "result": {
+              "status": "passed",
+              "duration": 924000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 5,
+            "name": "the user provides a planning application number \"ValidNumber/12345\"",
+            "result": {
+              "status": "passed",
+              "duration": 1430000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 6,
+            "name": "the planning application number in the appeal will be \"ValidNumber/12345\"",
+            "result": {
+              "status": "passed",
+              "duration": 465000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "appellant-submits-a-planning-application-reference-number-so-that-the-planning-inspectorate-can-refer-to-their-appeal;prospective-appellant-provides-an-invalid-planning-application-number",
+        "keyword": "Scenario",
+        "line": 16,
+        "name": "Prospective appellant provides an invalid planning application number",
+        "tags": [],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 9,
+            "name": "user has not previously provided a planning application number",
+            "result": {
+              "status": "passed",
+              "duration": 476000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 10,
+            "name": "the user provides a planning application number \"\"",
+            "result": {
+              "status": "passed",
+              "duration": 999000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 11,
+            "name": "the user is informed that the application number is not valid because \"mandatory field\"",
+            "result": {
+              "status": "passed",
+              "duration": 18000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "And ",
+            "line": 12,
+            "name": "the appeal is not updated with the provided planning application number",
+            "result": {
+              "status": "passed",
+              "duration": 366000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "appellant-submits-a-planning-application-reference-number-so-that-the-planning-inspectorate-can-refer-to-their-appeal;prospective-appellant-provides-an-invalid-planning-application-number",
+        "keyword": "Scenario",
+        "line": 17,
+        "name": "Prospective appellant provides an invalid planning application number",
+        "tags": [],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 9,
+            "name": "user has not previously provided a planning application number",
+            "result": {
+              "status": "passed",
+              "duration": 435000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 10,
+            "name": "the user provides a planning application number \"1234567890123456789012345678901\"",
+            "result": {
+              "status": "passed",
+              "duration": 1435000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 11,
+            "name": "the user is informed that the application number is not valid because \"exceeds max characters\"",
+            "result": {
+              "status": "passed",
+              "duration": 12000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "And ",
+            "line": 12,
+            "name": "the appeal is not updated with the provided planning application number",
+            "result": {
+              "status": "passed",
+              "duration": 372000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "appellant-submits-a-planning-application-reference-number-so-that-the-planning-inspectorate-can-refer-to-their-appeal;prospective-appellant-provides-a-valid-planning-application-number-that-replaces-previous-value",
+        "keyword": "Scenario",
+        "line": 19,
+        "name": "Prospective appellant provides a valid planning application number that replaces previous value",
+        "tags": [],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 20,
+            "name": "user has previously provided a planning application number \"FirstNumber/12345\"",
+            "result": {
+              "status": "passed",
+              "duration": 1299000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 21,
+            "name": "the user provides a planning application number \"SecondNumber/54321\"",
+            "result": {
+              "status": "passed",
+              "duration": 1286000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 22,
+            "name": "the planning application number in the appeal will be \"SecondNumber/54321\"",
+            "result": {
+              "status": "passed",
+              "duration": 572000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "appellant-submits-a-planning-application-reference-number-so-that-the-planning-inspectorate-can-refer-to-their-appeal;prospective-appellant-provides-an-invalid-planning-application-number-that-does-not-replace-previous-value",
+        "keyword": "Scenario",
+        "line": 32,
+        "name": "Prospective appellant provides an invalid planning application number that does not replace previous value",
+        "tags": [],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 25,
+            "name": "user has previously provided a planning application number \"FirstNumber/12345\"",
+            "result": {
+              "status": "passed",
+              "duration": 1838000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 26,
+            "name": "the user provides a planning application number \"\"",
+            "result": {
+              "status": "passed",
+              "duration": 1311000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 27,
+            "name": "the user is informed that the application number is not valid because \"mandatory field\"",
+            "result": {
+              "status": "passed",
+              "duration": 24000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "And ",
+            "line": 28,
+            "name": "the planning application number in the appeal will be \"FirstNumber/12345\"",
+            "result": {
+              "status": "passed",
+              "duration": 531000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "appellant-submits-a-planning-application-reference-number-so-that-the-planning-inspectorate-can-refer-to-their-appeal;prospective-appellant-provides-an-invalid-planning-application-number-that-does-not-replace-previous-value",
+        "keyword": "Scenario",
+        "line": 33,
+        "name": "Prospective appellant provides an invalid planning application number that does not replace previous value",
+        "tags": [],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 25,
+            "name": "user has previously provided a planning application number \"FirstNumber/12345\"",
+            "result": {
+              "status": "passed",
+              "duration": 1451000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 26,
+            "name": "the user provides a planning application number \"1234567890123456789012345678901\"",
+            "result": {
+              "status": "passed",
+              "duration": 1520000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 27,
+            "name": "the user is informed that the application number is not valid because \"exceeds max characters\"",
+            "result": {
+              "status": "passed",
+              "duration": 17000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "And ",
+            "line": 28,
+            "name": "the planning application number in the appeal will be \"FirstNumber/12345\"",
+            "result": {
+              "status": "passed",
+              "duration": 491000000
+            }
+          }
+        ]
+      }
+    ]
+  }
+]

--- a/packages/e2e-tests/cypress/cucumber-json/appellant-submission-supporting-documents.cucumber.json
+++ b/packages/e2e-tests/cypress/cucumber-json/appellant-submission-supporting-documents.cucumber.json
@@ -1,0 +1,743 @@
+[
+  {
+    "description": "  An appeal can include zero to many uploaded supporting documents.\n  Valid supporting documents files must:\n  * be one of the white-listed types (doc, docx, pdf, tif, tiff, jpg, jpeg and png) and\n  * not exceed a size limit.\n  Multiple supporting documents file can been added at the same time.\n  A valid uploaded document submitted is added to any previously submitted file.",
+    "keyword": "Feature",
+    "name": "Appellant submission - Supporting documents",
+    "line": 1,
+    "id": "appellant-submission---supporting-documents",
+    "tags": [],
+    "uri": "appellant-submission-supporting-documents.feature",
+    "elements": [
+      {
+        "id": "appellant-submission---supporting-documents;when-no-document-is-uploaded,-then-the-appeal-is-not-updated",
+        "keyword": "Scenario",
+        "line": 10,
+        "name": "When no document is uploaded, then the appeal is not updated",
+        "tags": [],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 11,
+            "name": "the supporting document page is displayed",
+            "result": {
+              "status": "passed",
+              "duration": 2932000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 12,
+            "name": "no document is uploaded",
+            "result": {
+              "status": "passed",
+              "duration": 163000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 13,
+            "name": "no document are submitted",
+            "result": {
+              "status": "passed",
+              "duration": 1813000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "appellant-submission---supporting-documents;ac3.1:-when-no-new-document-is-uploaded,-then-previous-documents-uploaded-remains-unaltered",
+        "keyword": "Scenario",
+        "line": 15,
+        "name": "AC3.1: When no new document is uploaded, then previous documents uploaded remains unaltered",
+        "tags": [],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 16,
+            "name": "supporting document \"appeal-statement-valid.pdf\" being submitted",
+            "result": {
+              "status": "passed",
+              "duration": 5462000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 17,
+            "name": "no document is uploaded",
+            "result": {
+              "status": "passed",
+              "duration": 2321000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 18,
+            "name": "document \"appeal-statement-valid.pdf\" is submitted",
+            "result": {
+              "status": "passed",
+              "duration": 2714000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "appellant-submission---supporting-documents;ac1:-when-a-valid-document-is-uploaded,-then-it-is-successfully-submitted",
+        "keyword": "Scenario",
+        "line": 26,
+        "name": "AC1: When a valid document is uploaded, then it is successfully submitted",
+        "tags": [],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 21,
+            "name": "the supporting document page is displayed",
+            "result": {
+              "status": "passed",
+              "duration": 1587000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 22,
+            "name": "a valid document \"appeal-statement-valid.doc\" is uploaded",
+            "result": {
+              "status": "passed",
+              "duration": 1935000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 23,
+            "name": "document \"appeal-statement-valid.doc\" is submitted",
+            "result": {
+              "status": "passed",
+              "duration": 1332000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "appellant-submission---supporting-documents;ac1:-when-a-valid-document-is-uploaded,-then-it-is-successfully-submitted",
+        "keyword": "Scenario",
+        "line": 27,
+        "name": "AC1: When a valid document is uploaded, then it is successfully submitted",
+        "tags": [],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 21,
+            "name": "the supporting document page is displayed",
+            "result": {
+              "status": "passed",
+              "duration": 1304000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 22,
+            "name": "a valid document \"appeal-statement-valid.docx\" is uploaded",
+            "result": {
+              "status": "passed",
+              "duration": 7242000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 23,
+            "name": "document \"appeal-statement-valid.docx\" is submitted",
+            "result": {
+              "status": "passed",
+              "duration": 2848000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "appellant-submission---supporting-documents;ac1:-when-a-valid-document-is-uploaded,-then-it-is-successfully-submitted",
+        "keyword": "Scenario",
+        "line": 28,
+        "name": "AC1: When a valid document is uploaded, then it is successfully submitted",
+        "tags": [],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 21,
+            "name": "the supporting document page is displayed",
+            "result": {
+              "status": "passed",
+              "duration": 8132000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 22,
+            "name": "a valid document \"appeal-statement-valid.pdf\" is uploaded",
+            "result": {
+              "status": "passed",
+              "duration": 1751000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 23,
+            "name": "document \"appeal-statement-valid.pdf\" is submitted",
+            "result": {
+              "status": "passed",
+              "duration": 1416000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "appellant-submission---supporting-documents;ac1:-when-a-valid-document-is-uploaded,-then-it-is-successfully-submitted",
+        "keyword": "Scenario",
+        "line": 29,
+        "name": "AC1: When a valid document is uploaded, then it is successfully submitted",
+        "tags": [],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 21,
+            "name": "the supporting document page is displayed",
+            "result": {
+              "status": "passed",
+              "duration": 1130000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 22,
+            "name": "a valid document \"appeal-statement-valid.tif\" is uploaded",
+            "result": {
+              "status": "passed",
+              "duration": 7965000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 23,
+            "name": "document \"appeal-statement-valid.tif\" is submitted",
+            "result": {
+              "status": "passed",
+              "duration": 1305000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "appellant-submission---supporting-documents;ac1:-when-a-valid-document-is-uploaded,-then-it-is-successfully-submitted",
+        "keyword": "Scenario",
+        "line": 30,
+        "name": "AC1: When a valid document is uploaded, then it is successfully submitted",
+        "tags": [],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 21,
+            "name": "the supporting document page is displayed",
+            "result": {
+              "status": "passed",
+              "duration": 1720000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 22,
+            "name": "a valid document \"appeal-statement-valid.tiff\" is uploaded",
+            "result": {
+              "status": "passed",
+              "duration": 6173000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 23,
+            "name": "document \"appeal-statement-valid.tiff\" is submitted",
+            "result": {
+              "status": "passed",
+              "duration": 1499000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "appellant-submission---supporting-documents;ac1:-when-a-valid-document-is-uploaded,-then-it-is-successfully-submitted",
+        "keyword": "Scenario",
+        "line": 31,
+        "name": "AC1: When a valid document is uploaded, then it is successfully submitted",
+        "tags": [],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 21,
+            "name": "the supporting document page is displayed",
+            "result": {
+              "status": "passed",
+              "duration": 1624000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 22,
+            "name": "a valid document \"appeal-statement-valid.jpg\" is uploaded",
+            "result": {
+              "status": "passed",
+              "duration": 1765000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 23,
+            "name": "document \"appeal-statement-valid.jpg\" is submitted",
+            "result": {
+              "status": "passed",
+              "duration": 1500000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "appellant-submission---supporting-documents;ac1:-when-a-valid-document-is-uploaded,-then-it-is-successfully-submitted",
+        "keyword": "Scenario",
+        "line": 32,
+        "name": "AC1: When a valid document is uploaded, then it is successfully submitted",
+        "tags": [],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 21,
+            "name": "the supporting document page is displayed",
+            "result": {
+              "status": "passed",
+              "duration": 1703000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 22,
+            "name": "a valid document \"appeal-statement-valid.jpeg\" is uploaded",
+            "result": {
+              "status": "passed",
+              "duration": 1769000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 23,
+            "name": "document \"appeal-statement-valid.jpeg\" is submitted",
+            "result": {
+              "status": "passed",
+              "duration": 1203000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "appellant-submission---supporting-documents;ac1:-when-a-valid-document-is-uploaded,-then-it-is-successfully-submitted",
+        "keyword": "Scenario",
+        "line": 33,
+        "name": "AC1: When a valid document is uploaded, then it is successfully submitted",
+        "tags": [],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 21,
+            "name": "the supporting document page is displayed",
+            "result": {
+              "status": "passed",
+              "duration": 1474000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 22,
+            "name": "a valid document \"appeal-statement-valid.png\" is uploaded",
+            "result": {
+              "status": "passed",
+              "duration": 1637000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 23,
+            "name": "document \"appeal-statement-valid.png\" is submitted",
+            "result": {
+              "status": "passed",
+              "duration": 1514000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "appellant-submission---supporting-documents;ac3:-when-a-valid-document-is-uploaded,--they-it's-added-to-existing-documents",
+        "keyword": "Scenario",
+        "line": 36,
+        "name": "AC3: When a valid document is uploaded,  they it's added to existing documents",
+        "tags": [],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 37,
+            "name": "supporting document \"appeal-statement-valid.pdf\" being submitted",
+            "result": {
+              "status": "passed",
+              "duration": 8130000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 38,
+            "name": "a valid document \"appeal-statement-valid.doc\" is uploaded",
+            "result": {
+              "status": "passed",
+              "duration": 4592000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 39,
+            "name": "both document \"appeal-statement-valid.pdf\" and \"appeal-statement-valid.doc\" are submitted",
+            "result": {
+              "status": "passed",
+              "duration": 7191000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "appellant-submission---supporting-documents;ac2:-when-an-invalid-document-is-uploaded,-then-the-submission-is-denied",
+        "keyword": "Scenario",
+        "line": 47,
+        "name": "AC2: When an invalid document is uploaded, then the submission is denied",
+        "tags": [],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 42,
+            "name": "the supporting document page is displayed",
+            "result": {
+              "status": "passed",
+              "duration": 1500000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 43,
+            "name": "an invalid document \"appeal-statement-invalid-wrong-type.csv\" is uploaded",
+            "result": {
+              "status": "passed",
+              "duration": 2178000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 44,
+            "name": "document \"appeal-statement-invalid-wrong-type.csv\" is not submitted because \"file type is invalid\"",
+            "result": {
+              "status": "passed",
+              "duration": 151000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "appellant-submission---supporting-documents;ac4:-when-an-invalid-document-is-uploaded,-then-previous-documents-uploaded-remains-unaltered",
+        "keyword": "Scenario",
+        "line": 57,
+        "name": "AC4: When an invalid document is uploaded, then previous documents uploaded remains unaltered",
+        "tags": [],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 51,
+            "name": "supporting document \"appeal-statement-valid.pdf\" being submitted",
+            "result": {
+              "status": "passed",
+              "duration": 3382000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 52,
+            "name": "an invalid document \"appeal-statement-invalid-wrong-type.csv\" is uploaded",
+            "result": {
+              "status": "passed",
+              "duration": 1940000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 53,
+            "name": "document \"appeal-statement-invalid-wrong-type.csv\" is not submitted because \"file type is invalid\"",
+            "result": {
+              "status": "passed",
+              "duration": 159000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "And ",
+            "line": 54,
+            "name": "document \"appeal-statement-valid.pdf\" is submitted",
+            "result": {
+              "status": "passed",
+              "duration": 1182000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "appellant-submission---supporting-documents;when-multiple-valid-documents-simultaneously-uploaded,-then-they-are-successfully-submitted",
+        "keyword": "Scenario",
+        "line": 60,
+        "name": "When multiple valid documents simultaneously uploaded, then they are successfully submitted",
+        "tags": [],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 61,
+            "name": "the supporting document page is displayed",
+            "result": {
+              "status": "passed",
+              "duration": 1825000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 62,
+            "name": "multiple valid documents are uploaded simultaneously",
+            "result": {
+              "status": "passed",
+              "duration": 10346000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 63,
+            "name": "all the documents are submitted",
+            "result": {
+              "status": "passed",
+              "duration": 2572000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "appellant-submission---supporting-documents;when-multiple-valid-documents-simultaneously-uploaded,-they-are-added-to-existing-documents",
+        "keyword": "Scenario",
+        "line": 65,
+        "name": "When multiple valid documents simultaneously uploaded, they are added to existing documents",
+        "tags": [],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 66,
+            "name": "multiple documents were previously submitted",
+            "result": {
+              "status": "passed",
+              "duration": 3597000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 67,
+            "name": "multiple valid documents are uploaded simultaneously",
+            "result": {
+              "status": "passed",
+              "duration": 7308000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 68,
+            "name": "the documents are added to the previous ones",
+            "result": {
+              "status": "passed",
+              "duration": 5345000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "appellant-submission---supporting-documents;when-multiple-invalid-documents-are-uploaded,-then-all-of-them-are-denied-submission",
+        "keyword": "Scenario",
+        "line": 70,
+        "name": "When multiple invalid documents are uploaded, then all of them are denied submission",
+        "tags": [],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 71,
+            "name": "the supporting document page is displayed",
+            "result": {
+              "status": "passed",
+              "duration": 1452000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 72,
+            "name": "multiple invalid documents are uploaded simultaneously",
+            "result": {
+              "status": "passed",
+              "duration": 1573000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 73,
+            "name": "none of them is submitted",
+            "result": {
+              "status": "passed",
+              "duration": 1593000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "appellant-submission---supporting-documents;when-a-mix-of-valid-and-invalid-documents-is-uploaded,-then-only-valid-files-are-submitted",
+        "keyword": "Scenario",
+        "line": 76,
+        "name": "When a mix of valid and invalid documents is uploaded, then only valid files are submitted",
+        "tags": [],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 77,
+            "name": "the supporting document page is displayed",
+            "result": {
+              "status": "passed",
+              "duration": 1696000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 78,
+            "name": "mix of valid and invalid documents are uploaded simultaneously",
+            "result": {
+              "status": "passed",
+              "duration": 4928000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 79,
+            "name": "only valid document are submitted",
+            "result": {
+              "status": "passed",
+              "duration": 3290000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "appellant-submission---supporting-documents;when-multiple-valid-documents-are-uploaded-after-some-documents-being-denied,-they-are-added-to-existing-documents",
+        "keyword": "Scenario",
+        "line": 81,
+        "name": "When multiple valid documents are uploaded after some documents being denied, they are added to existing documents",
+        "tags": [],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 82,
+            "name": "multiple valid and invalid documents were previously uploaded",
+            "result": {
+              "status": "passed",
+              "duration": 4124000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 83,
+            "name": "multiple valid documents are uploaded simultaneously",
+            "result": {
+              "status": "passed",
+              "duration": 6434000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 84,
+            "name": "the documents are added to the previous ones",
+            "result": {
+              "status": "passed",
+              "duration": 3406000000
+            }
+          }
+        ]
+      }
+    ]
+  }
+]

--- a/packages/e2e-tests/cypress/cucumber-json/appellant-submission-upload-application.cucumber.json
+++ b/packages/e2e-tests/cypress/cucumber-json/appellant-submission-upload-application.cucumber.json
@@ -1,0 +1,654 @@
+[
+  {
+    "description": "  As an appellant\n  I need to be informed when I need to upload my planning application form\n  So that I complete my appeal correctly\n\n  An appeal must include an uploaded planning application file.\n  Valid planning application files must:\n  * be one of the white-listed types (doc, docx, pdf, tif, tiff, jpg, jpeg and png) and\n  * not exceed a size limit.\n  The latest successfully uploaded planning application file replaces any previously uploaded file.",
+    "keyword": "Feature",
+    "name": "Planning Application file submission",
+    "line": 1,
+    "id": "planning-application-file-submission",
+    "tags": [],
+    "uri": "appellant-submission-upload-application.feature",
+    "elements": [
+      {
+        "id": "planning-application-file-submission;prospective-applicant-do-not-upload-a-planning-application-file",
+        "keyword": "Scenario",
+        "line": 20,
+        "name": "Prospective applicant do not upload a planning application file",
+        "tags": [
+          {
+            "name": "@as-118",
+            "line": 19
+          },
+          {
+            "name": "@ac-1-2",
+            "line": 19
+          }
+        ],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 21,
+            "name": "user has previously submitted a planning application file \"appeal-statement-valid.pdf\"",
+            "result": {
+              "status": "passed",
+              "duration": 2759000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 22,
+            "name": "user does not submit a planning application file",
+            "result": {
+              "status": "passed",
+              "duration": 2357000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 23,
+            "name": "application file \"appeal-statement-valid.pdf\" is submitted and user can proceed",
+            "result": {
+              "status": "passed",
+              "duration": 1179000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "planning-application-file-submission;prospective-appellant-submits-valid-planning-application-file",
+        "keyword": "Scenario",
+        "line": 32,
+        "name": "Prospective appellant submits valid planning application file",
+        "tags": [
+          {
+            "name": "@as-118",
+            "line": 25
+          },
+          {
+            "name": "@ac-2",
+            "line": 25
+          }
+        ],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 27,
+            "name": "user did not previously submitted a planning application file",
+            "result": {
+              "status": "passed",
+              "duration": 72000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 28,
+            "name": "user submits a planning application file \"appeal-statement-valid.doc\"",
+            "result": {
+              "status": "passed",
+              "duration": 2475000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 29,
+            "name": "application file \"appeal-statement-valid.doc\" is submitted and user can proceed",
+            "result": {
+              "status": "passed",
+              "duration": 1139000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "planning-application-file-submission;prospective-appellant-submits-valid-planning-application-file",
+        "keyword": "Scenario",
+        "line": 33,
+        "name": "Prospective appellant submits valid planning application file",
+        "tags": [
+          {
+            "name": "@as-118",
+            "line": 25
+          },
+          {
+            "name": "@ac-2",
+            "line": 25
+          }
+        ],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 27,
+            "name": "user did not previously submitted a planning application file",
+            "result": {
+              "status": "passed",
+              "duration": 61000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 28,
+            "name": "user submits a planning application file \"appeal-statement-valid.docx\"",
+            "result": {
+              "status": "passed",
+              "duration": 2308000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 29,
+            "name": "application file \"appeal-statement-valid.docx\" is submitted and user can proceed",
+            "result": {
+              "status": "passed",
+              "duration": 1230000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "planning-application-file-submission;prospective-appellant-submits-valid-planning-application-file",
+        "keyword": "Scenario",
+        "line": 34,
+        "name": "Prospective appellant submits valid planning application file",
+        "tags": [
+          {
+            "name": "@as-118",
+            "line": 25
+          },
+          {
+            "name": "@ac-2",
+            "line": 25
+          }
+        ],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 27,
+            "name": "user did not previously submitted a planning application file",
+            "result": {
+              "status": "passed",
+              "duration": 111000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 28,
+            "name": "user submits a planning application file \"appeal-statement-valid.pdf\"",
+            "result": {
+              "status": "passed",
+              "duration": 2273000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 29,
+            "name": "application file \"appeal-statement-valid.pdf\" is submitted and user can proceed",
+            "result": {
+              "status": "passed",
+              "duration": 1225000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "planning-application-file-submission;prospective-appellant-submits-valid-planning-application-file",
+        "keyword": "Scenario",
+        "line": 35,
+        "name": "Prospective appellant submits valid planning application file",
+        "tags": [
+          {
+            "name": "@as-118",
+            "line": 25
+          },
+          {
+            "name": "@ac-2",
+            "line": 25
+          }
+        ],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 27,
+            "name": "user did not previously submitted a planning application file",
+            "result": {
+              "status": "passed",
+              "duration": 110000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 28,
+            "name": "user submits a planning application file \"appeal-statement-valid.tif\"",
+            "result": {
+              "status": "passed",
+              "duration": 6982000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 29,
+            "name": "application file \"appeal-statement-valid.tif\" is submitted and user can proceed",
+            "result": {
+              "status": "passed",
+              "duration": 1216000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "planning-application-file-submission;prospective-appellant-submits-valid-planning-application-file",
+        "keyword": "Scenario",
+        "line": 36,
+        "name": "Prospective appellant submits valid planning application file",
+        "tags": [
+          {
+            "name": "@as-118",
+            "line": 25
+          },
+          {
+            "name": "@ac-2",
+            "line": 25
+          }
+        ],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 27,
+            "name": "user did not previously submitted a planning application file",
+            "result": {
+              "status": "passed",
+              "duration": 132000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 28,
+            "name": "user submits a planning application file \"appeal-statement-valid.tiff\"",
+            "result": {
+              "status": "passed",
+              "duration": 6253000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 29,
+            "name": "application file \"appeal-statement-valid.tiff\" is submitted and user can proceed",
+            "result": {
+              "status": "passed",
+              "duration": 1264000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "planning-application-file-submission;prospective-appellant-submits-valid-planning-application-file",
+        "keyword": "Scenario",
+        "line": 37,
+        "name": "Prospective appellant submits valid planning application file",
+        "tags": [
+          {
+            "name": "@as-118",
+            "line": 25
+          },
+          {
+            "name": "@ac-2",
+            "line": 25
+          }
+        ],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 27,
+            "name": "user did not previously submitted a planning application file",
+            "result": {
+              "status": "passed",
+              "duration": 141000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 28,
+            "name": "user submits a planning application file \"appeal-statement-valid.jpg\"",
+            "result": {
+              "status": "passed",
+              "duration": 2324000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 29,
+            "name": "application file \"appeal-statement-valid.jpg\" is submitted and user can proceed",
+            "result": {
+              "status": "passed",
+              "duration": 1195000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "planning-application-file-submission;prospective-appellant-submits-valid-planning-application-file",
+        "keyword": "Scenario",
+        "line": 38,
+        "name": "Prospective appellant submits valid planning application file",
+        "tags": [
+          {
+            "name": "@as-118",
+            "line": 25
+          },
+          {
+            "name": "@ac-2",
+            "line": 25
+          }
+        ],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 27,
+            "name": "user did not previously submitted a planning application file",
+            "result": {
+              "status": "passed",
+              "duration": 263000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 28,
+            "name": "user submits a planning application file \"appeal-statement-valid.jpeg\"",
+            "result": {
+              "status": "passed",
+              "duration": 2491000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 29,
+            "name": "application file \"appeal-statement-valid.jpeg\" is submitted and user can proceed",
+            "result": {
+              "status": "passed",
+              "duration": 1084000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "planning-application-file-submission;prospective-appellant-submits-valid-planning-application-file",
+        "keyword": "Scenario",
+        "line": 39,
+        "name": "Prospective appellant submits valid planning application file",
+        "tags": [
+          {
+            "name": "@as-118",
+            "line": 25
+          },
+          {
+            "name": "@ac-2",
+            "line": 25
+          }
+        ],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 27,
+            "name": "user did not previously submitted a planning application file",
+            "result": {
+              "status": "passed",
+              "duration": 93000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 28,
+            "name": "user submits a planning application file \"appeal-statement-valid.png\"",
+            "result": {
+              "status": "passed",
+              "duration": 2506000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 29,
+            "name": "application file \"appeal-statement-valid.png\" is submitted and user can proceed",
+            "result": {
+              "status": "passed",
+              "duration": 1210000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "planning-application-file-submission;prospective-appellant-submits-valid-planning-application-file-replaces-previous-file",
+        "keyword": "Scenario",
+        "line": 42,
+        "name": "Prospective appellant submits valid planning application file replaces previous file",
+        "tags": [],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 43,
+            "name": "user has previously submitted a planning application file \"appeal-statement-valid.pdf\"",
+            "result": {
+              "status": "passed",
+              "duration": 2431000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 44,
+            "name": "user submits a planning application file \"appeal-statement-valid.doc\"",
+            "result": {
+              "status": "passed",
+              "duration": 2568000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 45,
+            "name": "user can see that the planning application file \"appeal-statement-valid.doc\" \"is\" submitted",
+            "result": {
+              "status": "passed",
+              "duration": 2684000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "planning-application-file-submission;prospective-appellant-submits-invalid-planning-application-file-does-not-replace-previous-file",
+        "keyword": "Scenario",
+        "line": 54,
+        "name": "Prospective appellant submits invalid planning application file does not replace previous file",
+        "tags": [],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 48,
+            "name": "user has previously submitted a planning application file \"appeal-statement-valid.pdf\"",
+            "result": {
+              "status": "passed",
+              "duration": 2288000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 49,
+            "name": "user submits a planning application file \"appeal-statement-invalid-wrong-type.csv\"",
+            "result": {
+              "status": "passed",
+              "duration": 2301000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 50,
+            "name": "user is informed that the planning application file is not submitted because \"file type is invalid\"",
+            "result": {
+              "status": "passed",
+              "duration": 161000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "And ",
+            "line": 51,
+            "name": "user can see that the planning application file \"appeal-statement-valid.pdf\" \"is\" submitted",
+            "result": {
+              "status": "passed",
+              "duration": 2083000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "planning-application-file-submission;prospective-appellant-submits-invalid-planning-application-file",
+        "keyword": "Scenario",
+        "line": 63,
+        "name": "Prospective appellant submits invalid planning application file",
+        "tags": [],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 59,
+            "name": "user submits a planning application file \"appeal-statement-invalid-wrong-type.csv\"",
+            "result": {
+              "status": "passed",
+              "duration": 2554000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 60,
+            "name": "user is informed that the planning application file is not submitted because \"file type is invalid\"",
+            "result": {
+              "status": "passed",
+              "duration": 134000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "planning-application-file-submission;prospective-appellant-successfully-submits-valid-planning-application-file-followed-by-invalid-file-that-is-rejected-before-successfully-submitting-another-valid-file",
+        "keyword": "Scenario",
+        "line": 73,
+        "name": "Prospective appellant successfully submits valid planning application file followed by invalid file that is rejected before successfully submitting another valid file",
+        "tags": [],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 68,
+            "name": "user has previously submitted a valid planning application file \"appeal-statement-valid.pdf\" followed by an invalid file \"appeal-statement-invalid-wrong-type.csv\" that was rejected because \"file type is invalid\"",
+            "result": {
+              "status": "passed",
+              "duration": 5193000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 69,
+            "name": "user submits a planning application file \"appeal-statement-valid.doc\"",
+            "result": {
+              "status": "passed",
+              "duration": 2255000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 70,
+            "name": "user can see that the planning application file \"appeal-statement-valid.doc\" \"is\" submitted",
+            "result": {
+              "status": "passed",
+              "duration": 2205000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "planning-application-file-submission;prospective-appellant-successfully-submits-valid-planning-application-file-followed-by-invalid-file-that-is-rejected-before-proceeding-without-selecting-a-new-file",
+        "keyword": "Scenario",
+        "line": 82,
+        "name": "Prospective appellant successfully submits valid planning application file followed by invalid file that is rejected before proceeding without selecting a new file",
+        "tags": [],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 77,
+            "name": "user has previously submitted a valid planning application file \"appeal-statement-valid.doc\" followed by an invalid file \"appeal-statement-invalid-wrong-type.csv\" that was rejected because \"file type is invalid\"",
+            "result": {
+              "status": "passed",
+              "duration": 5596000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 78,
+            "name": "user does not submit a planning application file",
+            "result": {
+              "status": "passed",
+              "duration": 2433000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 79,
+            "name": "user can see that the planning application file \"appeal-statement-valid.doc\" \"is\" submitted",
+            "result": {
+              "status": "passed",
+              "duration": 2231000000
+            }
+          }
+        ]
+      }
+    ]
+  }
+]

--- a/packages/e2e-tests/cypress/cucumber-json/appellant-submission-your-details-applicant-name.cucumber.json
+++ b/packages/e2e-tests/cypress/cucumber-json/appellant-submission-your-details-applicant-name.cucumber.json
@@ -1,0 +1,383 @@
+[
+  {
+    "description": "  Note: This feature describes behaviour for a newly created appeal",
+    "keyword": "Feature",
+    "name": "Name of original applicant",
+    "line": 2,
+    "id": "name-of-original-applicant",
+    "tags": [
+      {
+        "name": "@smoketest",
+        "line": 1
+      }
+    ],
+    "uri": "appellant-submission-your-details-applicant-name.feature",
+    "elements": [
+      {
+        "id": "name-of-original-applicant;valid-name",
+        "keyword": "Scenario",
+        "line": 5,
+        "name": "Valid name",
+        "tags": [
+          {
+            "name": "@smoketest",
+            "line": 1
+          }
+        ],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 6,
+            "name": "appeal is made on behalf of another applicant",
+            "result": {
+              "status": "passed",
+              "duration": 7032000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 7,
+            "name": "original applicant name is submitted",
+            "result": {
+              "status": "passed",
+              "duration": 2550000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 8,
+            "name": "appeal tasks are presented",
+            "result": {
+              "status": "passed",
+              "duration": 39000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "And ",
+            "line": 9,
+            "name": "appeal is updated with the original applicant",
+            "result": {
+              "status": "passed",
+              "duration": 2031000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "And ",
+            "line": 10,
+            "name": "Your Details section is \"COMPLETED\"",
+            "result": {
+              "status": "passed",
+              "duration": 1314000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "name-of-original-applicant;invalid-name",
+        "keyword": "Scenario",
+        "line": 21,
+        "name": "Invalid name",
+        "tags": [
+          {
+            "name": "@smoketest",
+            "line": 1
+          }
+        ],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 13,
+            "name": "appeal is made on behalf of another applicant",
+            "result": {
+              "status": "passed",
+              "duration": 7633000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 14,
+            "name": "original applicant name \"\" is submitted",
+            "result": {
+              "status": "passed",
+              "duration": 2742000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 15,
+            "name": "original applicant value \"\" is invalid because \"name missing\"",
+            "result": {
+              "status": "passed",
+              "duration": 97000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "And ",
+            "line": 16,
+            "name": "applicant name is presented",
+            "result": {
+              "status": "passed",
+              "duration": 24000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "And ",
+            "line": 17,
+            "name": "appeal is not updated with the original applicant \"\"",
+            "result": {
+              "status": "passed",
+              "duration": 1078000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "And ",
+            "line": 18,
+            "name": "Your Details section is \"IN PROGRESS\"",
+            "result": {
+              "status": "passed",
+              "duration": 1047000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "name-of-original-applicant;invalid-name",
+        "keyword": "Scenario",
+        "line": 22,
+        "name": "Invalid name",
+        "tags": [
+          {
+            "name": "@smoketest",
+            "line": 1
+          }
+        ],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 13,
+            "name": "appeal is made on behalf of another applicant",
+            "result": {
+              "status": "passed",
+              "duration": 5211000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 14,
+            "name": "original applicant name \"A\" is submitted",
+            "result": {
+              "status": "passed",
+              "duration": 1943000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 15,
+            "name": "original applicant value \"A\" is invalid because \"name outside size constraints\"",
+            "result": {
+              "status": "passed",
+              "duration": 24000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "And ",
+            "line": 16,
+            "name": "applicant name is presented",
+            "result": {
+              "status": "passed",
+              "duration": 7000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "And ",
+            "line": 17,
+            "name": "appeal is not updated with the original applicant \"A\"",
+            "result": {
+              "status": "passed",
+              "duration": 1210000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "And ",
+            "line": 18,
+            "name": "Your Details section is \"IN PROGRESS\"",
+            "result": {
+              "status": "passed",
+              "duration": 1322000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "name-of-original-applicant;invalid-name",
+        "keyword": "Scenario",
+        "line": 23,
+        "name": "Invalid name",
+        "tags": [
+          {
+            "name": "@smoketest",
+            "line": 1
+          }
+        ],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 13,
+            "name": "appeal is made on behalf of another applicant",
+            "result": {
+              "status": "passed",
+              "duration": 5224000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 14,
+            "name": "original applicant name \"Invalid name because it is eighty-one characters long  abcdefghijklmnopqrstuvwxyz\" is submitted",
+            "result": {
+              "status": "passed",
+              "duration": 3713000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 15,
+            "name": "original applicant value \"Invalid name because it is eighty-one characters long  abcdefghijklmnopqrstuvwxyz\" is invalid because \"name outside size constraints\"",
+            "result": {
+              "status": "passed",
+              "duration": 90000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "And ",
+            "line": 16,
+            "name": "applicant name is presented",
+            "result": {
+              "status": "passed",
+              "duration": 24000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "And ",
+            "line": 17,
+            "name": "appeal is not updated with the original applicant \"Invalid name because it is eighty-one characters long  abcdefghijklmnopqrstuvwxyz\"",
+            "result": {
+              "status": "passed",
+              "duration": 1508000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "And ",
+            "line": 18,
+            "name": "Your Details section is \"IN PROGRESS\"",
+            "result": {
+              "status": "passed",
+              "duration": 1055000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "name-of-original-applicant;invalid-name",
+        "keyword": "Scenario",
+        "line": 24,
+        "name": "Invalid name",
+        "tags": [
+          {
+            "name": "@smoketest",
+            "line": 1
+          }
+        ],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 13,
+            "name": "appeal is made on behalf of another applicant",
+            "result": {
+              "status": "passed",
+              "duration": 7788000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 14,
+            "name": "original applicant name \"Invalid name with prohibited characters *3(/+\" is submitted",
+            "result": {
+              "status": "passed",
+              "duration": 3493000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 15,
+            "name": "original applicant value \"Invalid name with prohibited characters *3(/+\" is invalid because \"name with prohibited characters\"",
+            "result": {
+              "status": "passed",
+              "duration": 74000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "And ",
+            "line": 16,
+            "name": "applicant name is presented",
+            "result": {
+              "status": "passed",
+              "duration": 16000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "And ",
+            "line": 17,
+            "name": "appeal is not updated with the original applicant \"Invalid name with prohibited characters *3(/+\"",
+            "result": {
+              "status": "passed",
+              "duration": 815000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "And ",
+            "line": 18,
+            "name": "Your Details section is \"IN PROGRESS\"",
+            "result": {
+              "status": "passed",
+              "duration": 766000000
+            }
+          }
+        ]
+      }
+    ]
+  }
+]

--- a/packages/e2e-tests/cypress/cucumber-json/appellant-submission-your-details-who-are-you.cucumber.json
+++ b/packages/e2e-tests/cypress/cucumber-json/appellant-submission-your-details-who-are-you.cucumber.json
@@ -1,0 +1,217 @@
+[
+  {
+    "description": "  Note: This feature describes behaviour for a newly created appeal",
+    "keyword": "Feature",
+    "name": "Confirmation of original applicant",
+    "line": 2,
+    "id": "confirmation-of-original-applicant",
+    "tags": [
+      {
+        "name": "@smoketest",
+        "line": 1
+      }
+    ],
+    "uri": "appellant-submission-your-details-who-are-you.feature",
+    "elements": [
+      {
+        "id": "confirmation-of-original-applicant;no-confirmation",
+        "keyword": "Scenario",
+        "line": 6,
+        "name": "No confirmation",
+        "tags": [
+          {
+            "name": "@smoketest",
+            "line": 1
+          },
+          {
+            "name": "@as-1672",
+            "line": 5
+          }
+        ],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 7,
+            "name": "confirmation of whether appellant is original applicant is requested",
+            "result": {
+              "status": "passed",
+              "duration": 1811000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 8,
+            "name": "confirmation about original applicant is not provided",
+            "result": {
+              "status": "passed",
+              "duration": 1091000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 9,
+            "name": "original applicant status is presented",
+            "result": {
+              "status": "passed",
+              "duration": 79000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "And ",
+            "line": 10,
+            "name": "appeal is not updated because confirmation of original applicant status is required",
+            "result": {
+              "status": "passed",
+              "duration": 106000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "And ",
+            "line": 11,
+            "name": "Your Details section is \"NOT STARTED\"",
+            "result": {
+              "status": "passed",
+              "duration": 806000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "confirmation-of-original-applicant;confirmation-provided---is-original-applicant",
+        "keyword": "Scenario",
+        "line": 13,
+        "name": "Confirmation provided - is original applicant",
+        "tags": [
+          {
+            "name": "@smoketest",
+            "line": 1
+          }
+        ],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 14,
+            "name": "confirmation of whether appellant is original applicant is requested",
+            "result": {
+              "status": "passed",
+              "duration": 942000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 15,
+            "name": "confirmation provided that appellant is original applicant",
+            "result": {
+              "status": "passed",
+              "duration": 1623000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 16,
+            "name": "name and email are presented",
+            "result": {
+              "status": "passed",
+              "duration": 12000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "And ",
+            "line": 17,
+            "name": "appeal is updated to show appellant is original applicant",
+            "result": {
+              "status": "passed",
+              "duration": 1303000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "And ",
+            "line": 18,
+            "name": "Your Details section is \"IN PROGRESS\"",
+            "result": {
+              "status": "passed",
+              "duration": 1288000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "confirmation-of-original-applicant;confirmation-provided---is-not-original-applicant",
+        "keyword": "Scenario",
+        "line": 20,
+        "name": "Confirmation provided - is not original applicant",
+        "tags": [
+          {
+            "name": "@smoketest",
+            "line": 1
+          }
+        ],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 21,
+            "name": "confirmation of whether appellant is original applicant is requested",
+            "result": {
+              "status": "passed",
+              "duration": 1238000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 22,
+            "name": "confirmation provided that appellant is not original applicant",
+            "result": {
+              "status": "passed",
+              "duration": 3400000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 23,
+            "name": "name and email are presented",
+            "result": {
+              "status": "passed",
+              "duration": 16000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "And ",
+            "line": 24,
+            "name": "appeal is updated to show appellant is not original applicant",
+            "result": {
+              "status": "passed",
+              "duration": 1397000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "And ",
+            "line": 25,
+            "name": "Your Details section is \"IN PROGRESS\"",
+            "result": {
+              "status": "passed",
+              "duration": 1265000000
+            }
+          }
+        ]
+      }
+    ]
+  }
+]

--- a/packages/e2e-tests/cypress/cucumber-json/appellant-submission-your-details-your-details-first-submissison.cucumber.json
+++ b/packages/e2e-tests/cypress/cucumber-json/appellant-submission-your-details-your-details-first-submissison.cucumber.json
@@ -1,0 +1,1754 @@
+[
+  {
+    "description": "  Note: This feature describes behaviour for a newly created appeal",
+    "keyword": "Feature",
+    "name": "Name and email provided for the first time",
+    "line": 2,
+    "id": "name-and-email-provided-for-the-first-time",
+    "tags": [
+      {
+        "name": "@smoketest",
+        "line": 1
+      }
+    ],
+    "uri": "appellant-submission-your-details-your-details-first-submissison.feature",
+    "elements": [
+      {
+        "id": "name-and-email-provided-for-the-first-time;section-status-update---original-applicant---valid-name-and-email",
+        "keyword": "Scenario",
+        "line": 5,
+        "name": "Section status update - original applicant - valid name and email",
+        "tags": [
+          {
+            "name": "@smoketest",
+            "line": 1
+          }
+        ],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 6,
+            "name": "name and email are requested where appellant is the original applicant",
+            "result": {
+              "status": "passed",
+              "duration": 5558000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 7,
+            "name": "new valid name and email are submitted",
+            "result": {
+              "status": "passed",
+              "duration": 4676000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 8,
+            "name": "Your Details section is \"COMPLETED\"",
+            "result": {
+              "status": "passed",
+              "duration": 1063000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "name-and-email-provided-for-the-first-time;section-status-update---original-applicant---invalid-name-and-email",
+        "keyword": "Scenario",
+        "line": 10,
+        "name": "Section status update - original applicant - invalid name and email",
+        "tags": [
+          {
+            "name": "@smoketest",
+            "line": 1
+          }
+        ],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 11,
+            "name": "name and email are requested where appellant is the original applicant",
+            "result": {
+              "status": "passed",
+              "duration": 5618000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 12,
+            "name": "new invalid name and email are submitted",
+            "result": {
+              "status": "passed",
+              "duration": 4418000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 13,
+            "name": "Your Details section is \"IN PROGRESS\"",
+            "result": {
+              "status": "passed",
+              "duration": 1171000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "name-and-email-provided-for-the-first-time;section-status-update---not-original-applicant---valid-name-and-email",
+        "keyword": "Scenario",
+        "line": 15,
+        "name": "Section status update - not original applicant - valid name and email",
+        "tags": [
+          {
+            "name": "@smoketest",
+            "line": 1
+          }
+        ],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 16,
+            "name": "name and email are requested where appellant is not the original applicant",
+            "result": {
+              "status": "passed",
+              "duration": 3938000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 17,
+            "name": "new valid name and email are submitted",
+            "result": {
+              "status": "passed",
+              "duration": 4064000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 18,
+            "name": "Your Details section is \"IN PROGRESS\"",
+            "result": {
+              "status": "passed",
+              "duration": 1041000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "name-and-email-provided-for-the-first-time;section-status-update---not-original-applicant---invalid-name-and-email",
+        "keyword": "Scenario",
+        "line": 20,
+        "name": "Section status update - not original applicant - invalid name and email",
+        "tags": [
+          {
+            "name": "@smoketest",
+            "line": 1
+          }
+        ],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 21,
+            "name": "name and email are requested where appellant is not the original applicant",
+            "result": {
+              "status": "passed",
+              "duration": 4317000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 22,
+            "name": "new invalid name and email are submitted",
+            "result": {
+              "status": "passed",
+              "duration": 3544000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 23,
+            "name": "Your Details section is \"IN PROGRESS\"",
+            "result": {
+              "status": "passed",
+              "duration": 1304000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "name-and-email-provided-for-the-first-time;valid-name-and-email---original-applicant",
+        "keyword": "Scenario",
+        "line": 32,
+        "name": "Valid name and email - original applicant",
+        "tags": [
+          {
+            "name": "@smoketest",
+            "line": 1
+          }
+        ],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 26,
+            "name": "name and email are requested where appellant is the original applicant",
+            "result": {
+              "status": "passed",
+              "duration": 2654000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 27,
+            "name": "\"Good\" and \"abc@mail.com\" are submitted",
+            "result": {
+              "status": "passed",
+              "duration": 2392000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 28,
+            "name": "appeal tasks are presented",
+            "result": {
+              "status": "passed",
+              "duration": 17000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "And ",
+            "line": 29,
+            "name": "appeal is updated with \"Good\" and \"abc@mail.com\"",
+            "result": {
+              "status": "passed",
+              "duration": 874000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "name-and-email-provided-for-the-first-time;valid-name-and-email---original-applicant",
+        "keyword": "Scenario",
+        "line": 33,
+        "name": "Valid name and email - original applicant",
+        "tags": [
+          {
+            "name": "@smoketest",
+            "line": 1
+          }
+        ],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 26,
+            "name": "name and email are requested where appellant is the original applicant",
+            "result": {
+              "status": "passed",
+              "duration": 4327000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 27,
+            "name": "\"Good Name\" and \"abc.def@mail.fr\" are submitted",
+            "result": {
+              "status": "passed",
+              "duration": 3551000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 28,
+            "name": "appeal tasks are presented",
+            "result": {
+              "status": "passed",
+              "duration": 38000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "And ",
+            "line": 29,
+            "name": "appeal is updated with \"Good Name\" and \"abc.def@mail.fr\"",
+            "result": {
+              "status": "passed",
+              "duration": 1059000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "name-and-email-provided-for-the-first-time;valid-name-and-email---original-applicant",
+        "keyword": "Scenario",
+        "line": 34,
+        "name": "Valid name and email - original applicant",
+        "tags": [
+          {
+            "name": "@smoketest",
+            "line": 1
+          }
+        ],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 26,
+            "name": "name and email are requested where appellant is the original applicant",
+            "result": {
+              "status": "passed",
+              "duration": 3843000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 27,
+            "name": "\"Good-Name\" and \"abc_def@mail.com\" are submitted",
+            "result": {
+              "status": "passed",
+              "duration": 3220000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 28,
+            "name": "appeal tasks are presented",
+            "result": {
+              "status": "passed",
+              "duration": 14000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "And ",
+            "line": 29,
+            "name": "appeal is updated with \"Good-Name\" and \"abc_def@mail.com\"",
+            "result": {
+              "status": "passed",
+              "duration": 1128000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "name-and-email-provided-for-the-first-time;valid-name-and-email---original-applicant",
+        "keyword": "Scenario",
+        "line": 35,
+        "name": "Valid name and email - original applicant",
+        "tags": [
+          {
+            "name": "@smoketest",
+            "line": 1
+          }
+        ],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 26,
+            "name": "name and email are requested where appellant is the original applicant",
+            "result": {
+              "status": "passed",
+              "duration": 4091000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 27,
+            "name": "\"Also' Good\" and \"abc.def2@mail.com\" are submitted",
+            "result": {
+              "status": "passed",
+              "duration": 4493000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 28,
+            "name": "appeal tasks are presented",
+            "result": {
+              "status": "passed",
+              "duration": 14000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "And ",
+            "line": 29,
+            "name": "appeal is updated with \"Also' Good\" and \"abc.def2@mail.com\"",
+            "result": {
+              "status": "passed",
+              "duration": 1161000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "name-and-email-provided-for-the-first-time;valid-name-and-email---original-applicant",
+        "keyword": "Scenario",
+        "line": 36,
+        "name": "Valid name and email - original applicant",
+        "tags": [
+          {
+            "name": "@smoketest",
+            "line": 1
+          }
+        ],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 26,
+            "name": "name and email are requested where appellant is the original applicant",
+            "result": {
+              "status": "passed",
+              "duration": 4058000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 27,
+            "name": "\"Valid name because it is eighty characters long ----- abcdefghijklmnopqrstuvwxyz\" and \"abc.def2@mail.com\" are submitted",
+            "result": {
+              "status": "passed",
+              "duration": 5847000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 28,
+            "name": "appeal tasks are presented",
+            "result": {
+              "status": "passed",
+              "duration": 35000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "And ",
+            "line": 29,
+            "name": "appeal is updated with \"Valid name because it is eighty characters long ----- abcdefghijklmnopqrstuvwxyz\" and \"abc.def2@mail.com\"",
+            "result": {
+              "status": "passed",
+              "duration": 1277000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "name-and-email-provided-for-the-first-time;valid-name-and-email---not-original-applicant",
+        "keyword": "Scenario",
+        "line": 38,
+        "name": "Valid name and email - not original applicant",
+        "tags": [
+          {
+            "name": "@smoketest",
+            "line": 1
+          }
+        ],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 39,
+            "name": "name and email are requested where appellant is not the original applicant",
+            "result": {
+              "status": "passed",
+              "duration": 8132000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "And ",
+            "line": 40,
+            "name": "confirmation provided that appellant is not original applicant",
+            "result": {
+              "status": "passed",
+              "duration": 2598000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 41,
+            "name": "new valid name and email are submitted",
+            "result": {
+              "status": "passed",
+              "duration": 3282000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 42,
+            "name": "applicant name is presented",
+            "result": {
+              "status": "passed",
+              "duration": 48000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "And ",
+            "line": 43,
+            "name": "appeal is updated with new valid name and email",
+            "result": {
+              "status": "passed",
+              "duration": 1082000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "name-and-email-provided-for-the-first-time;invalid-name-and-valid-email",
+        "keyword": "Scenario",
+        "line": 54,
+        "name": "Invalid name and valid email",
+        "tags": [
+          {
+            "name": "@smoketest",
+            "line": 1
+          },
+          {
+            "name": "@as-1673",
+            "line": 45
+          }
+        ],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 47,
+            "name": "name and email are requested",
+            "result": {
+              "status": "passed",
+              "duration": 1707000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 48,
+            "name": "\"\" and \"valid@email.com\" are submitted",
+            "result": {
+              "status": "passed",
+              "duration": 3464000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 49,
+            "name": "name \"\" is invalid because \"name missing\"",
+            "result": {
+              "status": "passed",
+              "duration": 78000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "And ",
+            "line": 50,
+            "name": "name and email are presented",
+            "result": {
+              "status": "passed",
+              "duration": 22000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "And ",
+            "line": 51,
+            "name": "appeal is not updated",
+            "result": {
+              "status": "passed",
+              "duration": 1536000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "name-and-email-provided-for-the-first-time;invalid-name-and-valid-email",
+        "keyword": "Scenario",
+        "line": 55,
+        "name": "Invalid name and valid email",
+        "tags": [
+          {
+            "name": "@smoketest",
+            "line": 1
+          },
+          {
+            "name": "@as-1673",
+            "line": 45
+          }
+        ],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 47,
+            "name": "name and email are requested",
+            "result": {
+              "status": "passed",
+              "duration": 1354000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 48,
+            "name": "\"A\" and \"valid@email.com\" are submitted",
+            "result": {
+              "status": "passed",
+              "duration": 4961000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 49,
+            "name": "name \"A\" is invalid because \"name outside size constraints\"",
+            "result": {
+              "status": "passed",
+              "duration": 116000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "And ",
+            "line": 50,
+            "name": "name and email are presented",
+            "result": {
+              "status": "passed",
+              "duration": 25000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "And ",
+            "line": 51,
+            "name": "appeal is not updated",
+            "result": {
+              "status": "passed",
+              "duration": 2560000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "name-and-email-provided-for-the-first-time;invalid-name-and-valid-email",
+        "keyword": "Scenario",
+        "line": 56,
+        "name": "Invalid name and valid email",
+        "tags": [
+          {
+            "name": "@smoketest",
+            "line": 1
+          },
+          {
+            "name": "@as-1673",
+            "line": 45
+          }
+        ],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 47,
+            "name": "name and email are requested",
+            "result": {
+              "status": "passed",
+              "duration": 1705000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 48,
+            "name": "\"Invalid name because it is eighty-one characters long  abcdefghijklmnopqrstuvwxyz\" and \"valid@email.com\" are submitted",
+            "result": {
+              "status": "passed",
+              "duration": 4185000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 49,
+            "name": "name \"Invalid name because it is eighty-one characters long  abcdefghijklmnopqrstuvwxyz\" is invalid because \"name outside size constraints\"",
+            "result": {
+              "status": "passed",
+              "duration": 65000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "And ",
+            "line": 50,
+            "name": "name and email are presented",
+            "result": {
+              "status": "passed",
+              "duration": 9000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "And ",
+            "line": 51,
+            "name": "appeal is not updated",
+            "result": {
+              "status": "passed",
+              "duration": 897000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "name-and-email-provided-for-the-first-time;invalid-name-and-valid-email",
+        "keyword": "Scenario",
+        "line": 57,
+        "name": "Invalid name and valid email",
+        "tags": [
+          {
+            "name": "@smoketest",
+            "line": 1
+          },
+          {
+            "name": "@as-1673",
+            "line": 45
+          }
+        ],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 47,
+            "name": "name and email are requested",
+            "result": {
+              "status": "passed",
+              "duration": 2059000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 48,
+            "name": "\"Invalid name with prohibited characters *3(/+\" and \"valid@email.com\" are submitted",
+            "result": {
+              "status": "passed",
+              "duration": 6011000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 49,
+            "name": "name \"Invalid name with prohibited characters *3(/+\" is invalid because \"name with prohibited characters\"",
+            "result": {
+              "status": "passed",
+              "duration": 129000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "And ",
+            "line": 50,
+            "name": "name and email are presented",
+            "result": {
+              "status": "passed",
+              "duration": 162000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "And ",
+            "line": 51,
+            "name": "appeal is not updated",
+            "result": {
+              "status": "passed",
+              "duration": 1542000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "name-and-email-provided-for-the-first-time;valid-name-and-invalid-email",
+        "keyword": "Scenario",
+        "line": 67,
+        "name": "Valid name and invalid email",
+        "tags": [
+          {
+            "name": "@smoketest",
+            "line": 1
+          }
+        ],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 60,
+            "name": "name and email are requested",
+            "result": {
+              "status": "passed",
+              "duration": 1823000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 61,
+            "name": "\"Valid Name\" and \"\" are submitted",
+            "result": {
+              "status": "passed",
+              "duration": 3617000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 62,
+            "name": "email \"\" is invalid because \"email missing\"",
+            "result": {
+              "status": "passed",
+              "duration": 81000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "And ",
+            "line": 63,
+            "name": "name and email are presented",
+            "result": {
+              "status": "passed",
+              "duration": 25000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "And ",
+            "line": 64,
+            "name": "appeal is not updated",
+            "result": {
+              "status": "passed",
+              "duration": 1159000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "name-and-email-provided-for-the-first-time;valid-name-and-invalid-email",
+        "keyword": "Scenario",
+        "line": 68,
+        "name": "Valid name and invalid email",
+        "tags": [
+          {
+            "name": "@smoketest",
+            "line": 1
+          }
+        ],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 60,
+            "name": "name and email are requested",
+            "result": {
+              "status": "passed",
+              "duration": 941000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 61,
+            "name": "\"Valid Name\" and \"invalid email\" are submitted",
+            "result": {
+              "status": "passed",
+              "duration": 2389000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 62,
+            "name": "email \"invalid email\" is invalid because \"email invalid\"",
+            "result": {
+              "status": "passed",
+              "duration": 31000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "And ",
+            "line": 63,
+            "name": "name and email are presented",
+            "result": {
+              "status": "passed",
+              "duration": 10000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "And ",
+            "line": 64,
+            "name": "appeal is not updated",
+            "result": {
+              "status": "passed",
+              "duration": 964000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "name-and-email-provided-for-the-first-time;valid-name-and-invalid-email",
+        "keyword": "Scenario",
+        "line": 69,
+        "name": "Valid name and invalid email",
+        "tags": [
+          {
+            "name": "@smoketest",
+            "line": 1
+          }
+        ],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 60,
+            "name": "name and email are requested",
+            "result": {
+              "status": "passed",
+              "duration": 2067000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 61,
+            "name": "\"Valid Name\" and \"abc-@mail.com\" are submitted",
+            "result": {
+              "status": "passed",
+              "duration": 3549000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 62,
+            "name": "email \"abc-@mail.com\" is invalid because \"email invalid\"",
+            "result": {
+              "status": "passed",
+              "duration": 80000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "And ",
+            "line": 63,
+            "name": "name and email are presented",
+            "result": {
+              "status": "passed",
+              "duration": 22000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "And ",
+            "line": 64,
+            "name": "appeal is not updated",
+            "result": {
+              "status": "passed",
+              "duration": 1086000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "name-and-email-provided-for-the-first-time;valid-name-and-invalid-email",
+        "keyword": "Scenario",
+        "line": 70,
+        "name": "Valid name and invalid email",
+        "tags": [
+          {
+            "name": "@smoketest",
+            "line": 1
+          }
+        ],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 60,
+            "name": "name and email are requested",
+            "result": {
+              "status": "passed",
+              "duration": 1200000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 61,
+            "name": "\"Valid Name\" and \"abc..def@mail.com\" are submitted",
+            "result": {
+              "status": "passed",
+              "duration": 3164000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 62,
+            "name": "email \"abc..def@mail.com\" is invalid because \"email invalid\"",
+            "result": {
+              "status": "passed",
+              "duration": 81000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "And ",
+            "line": 63,
+            "name": "name and email are presented",
+            "result": {
+              "status": "passed",
+              "duration": 20000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "And ",
+            "line": 64,
+            "name": "appeal is not updated",
+            "result": {
+              "status": "passed",
+              "duration": 1026000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "name-and-email-provided-for-the-first-time;valid-name-and-invalid-email",
+        "keyword": "Scenario",
+        "line": 71,
+        "name": "Valid name and invalid email",
+        "tags": [
+          {
+            "name": "@smoketest",
+            "line": 1
+          }
+        ],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 60,
+            "name": "name and email are requested",
+            "result": {
+              "status": "passed",
+              "duration": 2868000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 61,
+            "name": "\"Valid Name\" and \".abc@mail.com\" are submitted",
+            "result": {
+              "status": "passed",
+              "duration": 3114000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 62,
+            "name": "email \".abc@mail.com\" is invalid because \"email invalid\"",
+            "result": {
+              "status": "passed",
+              "duration": 63000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "And ",
+            "line": 63,
+            "name": "name and email are presented",
+            "result": {
+              "status": "passed",
+              "duration": 14000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "And ",
+            "line": 64,
+            "name": "appeal is not updated",
+            "result": {
+              "status": "passed",
+              "duration": 1011000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "name-and-email-provided-for-the-first-time;valid-name-and-invalid-email",
+        "keyword": "Scenario",
+        "line": 72,
+        "name": "Valid name and invalid email",
+        "tags": [
+          {
+            "name": "@smoketest",
+            "line": 1
+          }
+        ],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 60,
+            "name": "name and email are requested",
+            "result": {
+              "status": "passed",
+              "duration": 2354000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 61,
+            "name": "\"Valid Name\" and \"abc#def@mail.com\" are submitted",
+            "result": {
+              "status": "passed",
+              "duration": 3932000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 62,
+            "name": "email \"abc#def@mail.com\" is invalid because \"email invalid\"",
+            "result": {
+              "status": "passed",
+              "duration": 146000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "And ",
+            "line": 63,
+            "name": "name and email are presented",
+            "result": {
+              "status": "passed",
+              "duration": 28000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "And ",
+            "line": 64,
+            "name": "appeal is not updated",
+            "result": {
+              "status": "passed",
+              "duration": 2488000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "name-and-email-provided-for-the-first-time;valid-name-and-invalid-email",
+        "keyword": "Scenario",
+        "line": 73,
+        "name": "Valid name and invalid email",
+        "tags": [
+          {
+            "name": "@smoketest",
+            "line": 1
+          }
+        ],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 60,
+            "name": "name and email are requested",
+            "result": {
+              "status": "passed",
+              "duration": 1739000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 61,
+            "name": "\"Valid Name\" and \"abc=@mail.com\" are submitted",
+            "result": {
+              "status": "passed",
+              "duration": 5078000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 62,
+            "name": "email \"abc=@mail.com\" is invalid because \"email invalid\"",
+            "result": {
+              "status": "passed",
+              "duration": 92000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "And ",
+            "line": 63,
+            "name": "name and email are presented",
+            "result": {
+              "status": "passed",
+              "duration": 16000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "And ",
+            "line": 64,
+            "name": "appeal is not updated",
+            "result": {
+              "status": "passed",
+              "duration": 1463000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "name-and-email-provided-for-the-first-time;valid-name-and-invalid-email",
+        "keyword": "Scenario",
+        "line": 74,
+        "name": "Valid name and invalid email",
+        "tags": [
+          {
+            "name": "@smoketest",
+            "line": 1
+          }
+        ],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 60,
+            "name": "name and email are requested",
+            "result": {
+              "status": "passed",
+              "duration": 1761000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 61,
+            "name": "\"Valid Name\" and \"abc@mail.c\" are submitted",
+            "result": {
+              "status": "passed",
+              "duration": 4050000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 62,
+            "name": "email \"abc@mail.c\" is invalid because \"email invalid\"",
+            "result": {
+              "status": "passed",
+              "duration": 86000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "And ",
+            "line": 63,
+            "name": "name and email are presented",
+            "result": {
+              "status": "passed",
+              "duration": 26000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "And ",
+            "line": 64,
+            "name": "appeal is not updated",
+            "result": {
+              "status": "passed",
+              "duration": 1432000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "name-and-email-provided-for-the-first-time;valid-name-and-invalid-email",
+        "keyword": "Scenario",
+        "line": 75,
+        "name": "Valid name and invalid email",
+        "tags": [
+          {
+            "name": "@smoketest",
+            "line": 1
+          }
+        ],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 60,
+            "name": "name and email are requested",
+            "result": {
+              "status": "passed",
+              "duration": 1774000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 61,
+            "name": "\"Valid Name\" and \"abc.def@mail#archive.com\" are submitted",
+            "result": {
+              "status": "passed",
+              "duration": 4219000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 62,
+            "name": "email \"abc.def@mail#archive.com\" is invalid because \"email invalid\"",
+            "result": {
+              "status": "passed",
+              "duration": 77000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "And ",
+            "line": 63,
+            "name": "name and email are presented",
+            "result": {
+              "status": "passed",
+              "duration": 22000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "And ",
+            "line": 64,
+            "name": "appeal is not updated",
+            "result": {
+              "status": "passed",
+              "duration": 2108000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "name-and-email-provided-for-the-first-time;valid-name-and-invalid-email",
+        "keyword": "Scenario",
+        "line": 76,
+        "name": "Valid name and invalid email",
+        "tags": [
+          {
+            "name": "@smoketest",
+            "line": 1
+          }
+        ],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 60,
+            "name": "name and email are requested",
+            "result": {
+              "status": "passed",
+              "duration": 1459000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 61,
+            "name": "\"Valid Name\" and \"abc#def@mail\" are submitted",
+            "result": {
+              "status": "passed",
+              "duration": 3669000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 62,
+            "name": "email \"abc#def@mail\" is invalid because \"email invalid\"",
+            "result": {
+              "status": "passed",
+              "duration": 56000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "And ",
+            "line": 63,
+            "name": "name and email are presented",
+            "result": {
+              "status": "passed",
+              "duration": 9000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "And ",
+            "line": 64,
+            "name": "appeal is not updated",
+            "result": {
+              "status": "passed",
+              "duration": 1533000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "name-and-email-provided-for-the-first-time;valid-name-and-invalid-email",
+        "keyword": "Scenario",
+        "line": 77,
+        "name": "Valid name and invalid email",
+        "tags": [
+          {
+            "name": "@smoketest",
+            "line": 1
+          }
+        ],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 60,
+            "name": "name and email are requested",
+            "result": {
+              "status": "passed",
+              "duration": 2364000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 61,
+            "name": "\"Valid Name\" and \"abc#def@mail..com\" are submitted",
+            "result": {
+              "status": "passed",
+              "duration": 4244000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 62,
+            "name": "email \"abc#def@mail..com\" is invalid because \"email invalid\"",
+            "result": {
+              "status": "passed",
+              "duration": 88000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "And ",
+            "line": 63,
+            "name": "name and email are presented",
+            "result": {
+              "status": "passed",
+              "duration": 16000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "And ",
+            "line": 64,
+            "name": "appeal is not updated",
+            "result": {
+              "status": "passed",
+              "duration": 1337000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "name-and-email-provided-for-the-first-time;invalid-name-and-invalid-email",
+        "keyword": "Scenario",
+        "line": 88,
+        "name": "Invalid name and invalid email",
+        "tags": [
+          {
+            "name": "@smoketest",
+            "line": 1
+          }
+        ],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 80,
+            "name": "name and email are requested",
+            "result": {
+              "status": "passed",
+              "duration": 1342000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 81,
+            "name": "\"\" and \"\" are submitted",
+            "result": {
+              "status": "passed",
+              "duration": 2183000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 82,
+            "name": "name \"\" is invalid because \"name missing\"",
+            "result": {
+              "status": "passed",
+              "duration": 64000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "And ",
+            "line": 83,
+            "name": "email \"\" is invalid because \"email missing\"",
+            "result": {
+              "status": "passed",
+              "duration": 60000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "And ",
+            "line": 84,
+            "name": "name and email are presented",
+            "result": {
+              "status": "passed",
+              "duration": 14000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "And ",
+            "line": 85,
+            "name": "appeal is not updated",
+            "result": {
+              "status": "passed",
+              "duration": 1020000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "name-and-email-provided-for-the-first-time;invalid-name-and-invalid-email",
+        "keyword": "Scenario",
+        "line": 89,
+        "name": "Invalid name and invalid email",
+        "tags": [
+          {
+            "name": "@smoketest",
+            "line": 1
+          }
+        ],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 80,
+            "name": "name and email are requested",
+            "result": {
+              "status": "passed",
+              "duration": 893000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 81,
+            "name": "\"A\" and \"invalid email\" are submitted",
+            "result": {
+              "status": "passed",
+              "duration": 2136000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 82,
+            "name": "name \"A\" is invalid because \"name outside size constraints\"",
+            "result": {
+              "status": "passed",
+              "duration": 43000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "And ",
+            "line": 83,
+            "name": "email \"invalid email\" is invalid because \"email invalid\"",
+            "result": {
+              "status": "passed",
+              "duration": 32000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "And ",
+            "line": 84,
+            "name": "name and email are presented",
+            "result": {
+              "status": "passed",
+              "duration": 5000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "And ",
+            "line": 85,
+            "name": "appeal is not updated",
+            "result": {
+              "status": "passed",
+              "duration": 764000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "name-and-email-provided-for-the-first-time;invalid-name-and-invalid-email",
+        "keyword": "Scenario",
+        "line": 90,
+        "name": "Invalid name and invalid email",
+        "tags": [
+          {
+            "name": "@smoketest",
+            "line": 1
+          }
+        ],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 80,
+            "name": "name and email are requested",
+            "result": {
+              "status": "passed",
+              "duration": 835000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 81,
+            "name": "\"Invalid name with prohibited characters *3(/+\" and \"\" are submitted",
+            "result": {
+              "status": "passed",
+              "duration": 4145000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 82,
+            "name": "name \"Invalid name with prohibited characters *3(/+\" is invalid because \"name with prohibited characters\"",
+            "result": {
+              "status": "passed",
+              "duration": 94000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "And ",
+            "line": 83,
+            "name": "email \"\" is invalid because \"email missing\"",
+            "result": {
+              "status": "passed",
+              "duration": 113000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "And ",
+            "line": 84,
+            "name": "name and email are presented",
+            "result": {
+              "status": "passed",
+              "duration": 19000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "And ",
+            "line": 85,
+            "name": "appeal is not updated",
+            "result": {
+              "status": "passed",
+              "duration": 1512000000
+            }
+          }
+        ]
+      }
+    ]
+  }
+]

--- a/packages/e2e-tests/cypress/cucumber-json/appellant-submission-your-details-your-details-previously-submitted.cucumber.json
+++ b/packages/e2e-tests/cypress/cucumber-json/appellant-submission-your-details-your-details-previously-submitted.cucumber.json
@@ -1,0 +1,1754 @@
+[
+  {
+    "description": "  Note: This feature describes behaviour for a newly created appeal",
+    "keyword": "Feature",
+    "name": "Name and email provided after being previously provided",
+    "line": 2,
+    "id": "name-and-email-provided-after-being-previously-provided",
+    "tags": [
+      {
+        "name": "@smoketest",
+        "line": 1
+      }
+    ],
+    "uri": "appellant-submission-your-details-your-details-previously-submitted.feature",
+    "elements": [
+      {
+        "id": "name-and-email-provided-after-being-previously-provided;section-status-update---original-applicant---valid-name-and-email",
+        "keyword": "Scenario",
+        "line": 5,
+        "name": "Section status update - original applicant - valid name and email",
+        "tags": [
+          {
+            "name": "@smoketest",
+            "line": 1
+          }
+        ],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 6,
+            "name": "name and email are requested again where appellant is the original applicant",
+            "result": {
+              "status": "passed",
+              "duration": 10688000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 7,
+            "name": "new valid name and email are submitted",
+            "result": {
+              "status": "passed",
+              "duration": 5212000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 8,
+            "name": "Your Details section is \"COMPLETED\"",
+            "result": {
+              "status": "passed",
+              "duration": 1635000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "name-and-email-provided-after-being-previously-provided;section-status-update---original-applicant---invalid-name-and-email",
+        "keyword": "Scenario",
+        "line": 10,
+        "name": "Section status update - original applicant - invalid name and email",
+        "tags": [
+          {
+            "name": "@smoketest",
+            "line": 1
+          }
+        ],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 11,
+            "name": "name and email are requested again where appellant is the original applicant",
+            "result": {
+              "status": "passed",
+              "duration": 8475000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 12,
+            "name": "new invalid name and email are submitted",
+            "result": {
+              "status": "passed",
+              "duration": 4089000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 13,
+            "name": "Your Details section is \"COMPLETED\"",
+            "result": {
+              "status": "passed",
+              "duration": 901000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "name-and-email-provided-after-being-previously-provided;section-status-update---not-original-applicant---valid-name-and-email",
+        "keyword": "Scenario",
+        "line": 15,
+        "name": "Section status update - not original applicant - valid name and email",
+        "tags": [
+          {
+            "name": "@smoketest",
+            "line": 1
+          }
+        ],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 16,
+            "name": "name and email are requested again where appellant is not the original applicant",
+            "result": {
+              "status": "passed",
+              "duration": 7589000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 17,
+            "name": "new valid name and email are submitted",
+            "result": {
+              "status": "passed",
+              "duration": 3515000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 18,
+            "name": "Your Details section is \"IN PROGRESS\"",
+            "result": {
+              "status": "passed",
+              "duration": 1007000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "name-and-email-provided-after-being-previously-provided;section-status-update---not-original-applicant---invalid-name-and-email",
+        "keyword": "Scenario",
+        "line": 20,
+        "name": "Section status update - not original applicant - invalid name and email",
+        "tags": [
+          {
+            "name": "@smoketest",
+            "line": 1
+          }
+        ],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 21,
+            "name": "name and email are requested again where appellant is not the original applicant",
+            "result": {
+              "status": "passed",
+              "duration": 7380000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 22,
+            "name": "new invalid name and email are submitted",
+            "result": {
+              "status": "passed",
+              "duration": 5205000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 23,
+            "name": "Your Details section is \"IN PROGRESS\"",
+            "result": {
+              "status": "passed",
+              "duration": 1560000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "name-and-email-provided-after-being-previously-provided;valid-name-and-email---original-applicant",
+        "keyword": "Scenario",
+        "line": 32,
+        "name": "Valid name and email - original applicant",
+        "tags": [
+          {
+            "name": "@smoketest",
+            "line": 1
+          }
+        ],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 26,
+            "name": "name and email are requested again where appellant is the original applicant",
+            "result": {
+              "status": "passed",
+              "duration": 9223000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 27,
+            "name": "\"Good\" and \"abc@mail.com\" are submitted",
+            "result": {
+              "status": "passed",
+              "duration": 4249000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 28,
+            "name": "appeal tasks are presented",
+            "result": {
+              "status": "passed",
+              "duration": 39000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "And ",
+            "line": 29,
+            "name": "appeal is updated with \"Good\" and \"abc@mail.com\"",
+            "result": {
+              "status": "passed",
+              "duration": 1188000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "name-and-email-provided-after-being-previously-provided;valid-name-and-email---original-applicant",
+        "keyword": "Scenario",
+        "line": 33,
+        "name": "Valid name and email - original applicant",
+        "tags": [
+          {
+            "name": "@smoketest",
+            "line": 1
+          }
+        ],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 26,
+            "name": "name and email are requested again where appellant is the original applicant",
+            "result": {
+              "status": "passed",
+              "duration": 8854000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 27,
+            "name": "\"Good Name\" and \"abc.def@mail.fr\" are submitted",
+            "result": {
+              "status": "passed",
+              "duration": 4400000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 28,
+            "name": "appeal tasks are presented",
+            "result": {
+              "status": "passed",
+              "duration": 36000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "And ",
+            "line": 29,
+            "name": "appeal is updated with \"Good Name\" and \"abc.def@mail.fr\"",
+            "result": {
+              "status": "passed",
+              "duration": 1402000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "name-and-email-provided-after-being-previously-provided;valid-name-and-email---original-applicant",
+        "keyword": "Scenario",
+        "line": 34,
+        "name": "Valid name and email - original applicant",
+        "tags": [
+          {
+            "name": "@smoketest",
+            "line": 1
+          }
+        ],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 26,
+            "name": "name and email are requested again where appellant is the original applicant",
+            "result": {
+              "status": "passed",
+              "duration": 6541000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 27,
+            "name": "\"Good-Name\" and \"abc_def@mail.com\" are submitted",
+            "result": {
+              "status": "passed",
+              "duration": 3709000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 28,
+            "name": "appeal tasks are presented",
+            "result": {
+              "status": "passed",
+              "duration": 13000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "And ",
+            "line": 29,
+            "name": "appeal is updated with \"Good-Name\" and \"abc_def@mail.com\"",
+            "result": {
+              "status": "passed",
+              "duration": 669000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "name-and-email-provided-after-being-previously-provided;valid-name-and-email---original-applicant",
+        "keyword": "Scenario",
+        "line": 35,
+        "name": "Valid name and email - original applicant",
+        "tags": [
+          {
+            "name": "@smoketest",
+            "line": 1
+          }
+        ],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 26,
+            "name": "name and email are requested again where appellant is the original applicant",
+            "result": {
+              "status": "passed",
+              "duration": 6442000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 27,
+            "name": "\"Also' Good\" and \"abc.def2@mail.com\" are submitted",
+            "result": {
+              "status": "passed",
+              "duration": 4906000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 28,
+            "name": "appeal tasks are presented",
+            "result": {
+              "status": "passed",
+              "duration": 19000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "And ",
+            "line": 29,
+            "name": "appeal is updated with \"Also' Good\" and \"abc.def2@mail.com\"",
+            "result": {
+              "status": "passed",
+              "duration": 1653000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "name-and-email-provided-after-being-previously-provided;valid-name-and-email---original-applicant",
+        "keyword": "Scenario",
+        "line": 36,
+        "name": "Valid name and email - original applicant",
+        "tags": [
+          {
+            "name": "@smoketest",
+            "line": 1
+          }
+        ],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 26,
+            "name": "name and email are requested again where appellant is the original applicant",
+            "result": {
+              "status": "passed",
+              "duration": 9240000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 27,
+            "name": "\"Valid name because it is eighty characters long ----- abcdefghijklmnopqrstuvwxyz\" and \"abc.def2@mail.com\" are submitted",
+            "result": {
+              "status": "passed",
+              "duration": 5303000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 28,
+            "name": "appeal tasks are presented",
+            "result": {
+              "status": "passed",
+              "duration": 18000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "And ",
+            "line": 29,
+            "name": "appeal is updated with \"Valid name because it is eighty characters long ----- abcdefghijklmnopqrstuvwxyz\" and \"abc.def2@mail.com\"",
+            "result": {
+              "status": "passed",
+              "duration": 2083000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "name-and-email-provided-after-being-previously-provided;valid-name-and-email---not-original-applicant",
+        "keyword": "Scenario",
+        "line": 38,
+        "name": "Valid name and email - not original applicant",
+        "tags": [
+          {
+            "name": "@smoketest",
+            "line": 1
+          }
+        ],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 39,
+            "name": "name and email are requested again where appellant is not the original applicant",
+            "result": {
+              "status": "passed",
+              "duration": 8146000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "And ",
+            "line": 40,
+            "name": "confirmation provided that appellant is not original applicant",
+            "result": {
+              "status": "passed",
+              "duration": 3156000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 41,
+            "name": "new valid name and email are submitted",
+            "result": {
+              "status": "passed",
+              "duration": 2832000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 42,
+            "name": "applicant name is presented",
+            "result": {
+              "status": "passed",
+              "duration": 15000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "And ",
+            "line": 43,
+            "name": "appeal is updated with new valid name and email",
+            "result": {
+              "status": "passed",
+              "duration": 754000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "name-and-email-provided-after-being-previously-provided;invalid-name-and-valid-email",
+        "keyword": "Scenario",
+        "line": 54,
+        "name": "Invalid name and valid email",
+        "tags": [
+          {
+            "name": "@smoketest",
+            "line": 1
+          },
+          {
+            "name": "@as-1673",
+            "line": 45
+          }
+        ],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 47,
+            "name": "name and email are requested again",
+            "result": {
+              "status": "passed",
+              "duration": 3392000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 48,
+            "name": "\"\" and \"valid@email.com\" are submitted",
+            "result": {
+              "status": "passed",
+              "duration": 2318000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 49,
+            "name": "name \"\" is invalid because \"name missing\"",
+            "result": {
+              "status": "passed",
+              "duration": 71000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "And ",
+            "line": 50,
+            "name": "name and email are presented",
+            "result": {
+              "status": "passed",
+              "duration": 13000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "And ",
+            "line": 51,
+            "name": "appeal is not updated again",
+            "result": {
+              "status": "passed",
+              "duration": 776000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "name-and-email-provided-after-being-previously-provided;invalid-name-and-valid-email",
+        "keyword": "Scenario",
+        "line": 55,
+        "name": "Invalid name and valid email",
+        "tags": [
+          {
+            "name": "@smoketest",
+            "line": 1
+          },
+          {
+            "name": "@as-1673",
+            "line": 45
+          }
+        ],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 47,
+            "name": "name and email are requested again",
+            "result": {
+              "status": "passed",
+              "duration": 3120000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 48,
+            "name": "\"A\" and \"valid@email.com\" are submitted",
+            "result": {
+              "status": "passed",
+              "duration": 2114000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 49,
+            "name": "name \"A\" is invalid because \"name outside size constraints\"",
+            "result": {
+              "status": "passed",
+              "duration": 26000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "And ",
+            "line": 50,
+            "name": "name and email are presented",
+            "result": {
+              "status": "passed",
+              "duration": 8000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "And ",
+            "line": 51,
+            "name": "appeal is not updated again",
+            "result": {
+              "status": "passed",
+              "duration": 833000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "name-and-email-provided-after-being-previously-provided;invalid-name-and-valid-email",
+        "keyword": "Scenario",
+        "line": 56,
+        "name": "Invalid name and valid email",
+        "tags": [
+          {
+            "name": "@smoketest",
+            "line": 1
+          },
+          {
+            "name": "@as-1673",
+            "line": 45
+          }
+        ],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 47,
+            "name": "name and email are requested again",
+            "result": {
+              "status": "passed",
+              "duration": 3325000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 48,
+            "name": "\"Invalid name because it is eighty-one characters long  abcdefghijklmnopqrstuvwxyz\" and \"valid@email.com\" are submitted",
+            "result": {
+              "status": "passed",
+              "duration": 3595000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 49,
+            "name": "name \"Invalid name because it is eighty-one characters long  abcdefghijklmnopqrstuvwxyz\" is invalid because \"name outside size constraints\"",
+            "result": {
+              "status": "passed",
+              "duration": 60000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "And ",
+            "line": 50,
+            "name": "name and email are presented",
+            "result": {
+              "status": "passed",
+              "duration": 14000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "And ",
+            "line": 51,
+            "name": "appeal is not updated again",
+            "result": {
+              "status": "passed",
+              "duration": 826000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "name-and-email-provided-after-being-previously-provided;invalid-name-and-valid-email",
+        "keyword": "Scenario",
+        "line": 57,
+        "name": "Invalid name and valid email",
+        "tags": [
+          {
+            "name": "@smoketest",
+            "line": 1
+          },
+          {
+            "name": "@as-1673",
+            "line": 45
+          }
+        ],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 47,
+            "name": "name and email are requested again",
+            "result": {
+              "status": "passed",
+              "duration": 3035000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 48,
+            "name": "\"Invalid name with prohibited characters *3(/+\" and \"valid@email.com\" are submitted",
+            "result": {
+              "status": "passed",
+              "duration": 2622000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 49,
+            "name": "name \"Invalid name with prohibited characters *3(/+\" is invalid because \"name with prohibited characters\"",
+            "result": {
+              "status": "passed",
+              "duration": 29000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "And ",
+            "line": 50,
+            "name": "name and email are presented",
+            "result": {
+              "status": "passed",
+              "duration": 9000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "And ",
+            "line": 51,
+            "name": "appeal is not updated again",
+            "result": {
+              "status": "passed",
+              "duration": 721000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "name-and-email-provided-after-being-previously-provided;valid-name-and-invalid-email",
+        "keyword": "Scenario",
+        "line": 67,
+        "name": "Valid name and invalid email",
+        "tags": [
+          {
+            "name": "@smoketest",
+            "line": 1
+          }
+        ],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 60,
+            "name": "name and email are requested again",
+            "result": {
+              "status": "passed",
+              "duration": 3488000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 61,
+            "name": "\"Valid Name\" and \"\" are submitted",
+            "result": {
+              "status": "passed",
+              "duration": 2277000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 62,
+            "name": "email \"\" is invalid because \"email missing\"",
+            "result": {
+              "status": "passed",
+              "duration": 47000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "And ",
+            "line": 63,
+            "name": "name and email are presented",
+            "result": {
+              "status": "passed",
+              "duration": 10000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "And ",
+            "line": 64,
+            "name": "appeal is not updated again",
+            "result": {
+              "status": "passed",
+              "duration": 1219000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "name-and-email-provided-after-being-previously-provided;valid-name-and-invalid-email",
+        "keyword": "Scenario",
+        "line": 68,
+        "name": "Valid name and invalid email",
+        "tags": [
+          {
+            "name": "@smoketest",
+            "line": 1
+          }
+        ],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 60,
+            "name": "name and email are requested again",
+            "result": {
+              "status": "passed",
+              "duration": 4319000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 61,
+            "name": "\"Valid Name\" and \"invalid email\" are submitted",
+            "result": {
+              "status": "passed",
+              "duration": 2383000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 62,
+            "name": "email \"invalid email\" is invalid because \"email invalid\"",
+            "result": {
+              "status": "passed",
+              "duration": 108000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "And ",
+            "line": 63,
+            "name": "name and email are presented",
+            "result": {
+              "status": "passed",
+              "duration": 26000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "And ",
+            "line": 64,
+            "name": "appeal is not updated again",
+            "result": {
+              "status": "passed",
+              "duration": 1792000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "name-and-email-provided-after-being-previously-provided;valid-name-and-invalid-email",
+        "keyword": "Scenario",
+        "line": 69,
+        "name": "Valid name and invalid email",
+        "tags": [
+          {
+            "name": "@smoketest",
+            "line": 1
+          }
+        ],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 60,
+            "name": "name and email are requested again",
+            "result": {
+              "status": "passed",
+              "duration": 5851000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 61,
+            "name": "\"Valid Name\" and \"abc-@mail.com\" are submitted",
+            "result": {
+              "status": "passed",
+              "duration": 3534000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 62,
+            "name": "email \"abc-@mail.com\" is invalid because \"email invalid\"",
+            "result": {
+              "status": "passed",
+              "duration": 83000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "And ",
+            "line": 63,
+            "name": "name and email are presented",
+            "result": {
+              "status": "passed",
+              "duration": 25000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "And ",
+            "line": 64,
+            "name": "appeal is not updated again",
+            "result": {
+              "status": "passed",
+              "duration": 1828000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "name-and-email-provided-after-being-previously-provided;valid-name-and-invalid-email",
+        "keyword": "Scenario",
+        "line": 70,
+        "name": "Valid name and invalid email",
+        "tags": [
+          {
+            "name": "@smoketest",
+            "line": 1
+          }
+        ],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 60,
+            "name": "name and email are requested again",
+            "result": {
+              "status": "passed",
+              "duration": 3977000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 61,
+            "name": "\"Valid Name\" and \"abc..def@mail.com\" are submitted",
+            "result": {
+              "status": "passed",
+              "duration": 3715000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 62,
+            "name": "email \"abc..def@mail.com\" is invalid because \"email invalid\"",
+            "result": {
+              "status": "passed",
+              "duration": 69000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "And ",
+            "line": 63,
+            "name": "name and email are presented",
+            "result": {
+              "status": "passed",
+              "duration": 14000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "And ",
+            "line": 64,
+            "name": "appeal is not updated again",
+            "result": {
+              "status": "passed",
+              "duration": 1303000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "name-and-email-provided-after-being-previously-provided;valid-name-and-invalid-email",
+        "keyword": "Scenario",
+        "line": 71,
+        "name": "Valid name and invalid email",
+        "tags": [
+          {
+            "name": "@smoketest",
+            "line": 1
+          }
+        ],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 60,
+            "name": "name and email are requested again",
+            "result": {
+              "status": "passed",
+              "duration": 4974000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 61,
+            "name": "\"Valid Name\" and \".abc@mail.com\" are submitted",
+            "result": {
+              "status": "passed",
+              "duration": 3188000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 62,
+            "name": "email \".abc@mail.com\" is invalid because \"email invalid\"",
+            "result": {
+              "status": "passed",
+              "duration": 94000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "And ",
+            "line": 63,
+            "name": "name and email are presented",
+            "result": {
+              "status": "passed",
+              "duration": 19000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "And ",
+            "line": 64,
+            "name": "appeal is not updated again",
+            "result": {
+              "status": "passed",
+              "duration": 1661000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "name-and-email-provided-after-being-previously-provided;valid-name-and-invalid-email",
+        "keyword": "Scenario",
+        "line": 72,
+        "name": "Valid name and invalid email",
+        "tags": [
+          {
+            "name": "@smoketest",
+            "line": 1
+          }
+        ],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 60,
+            "name": "name and email are requested again",
+            "result": {
+              "status": "passed",
+              "duration": 4711000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 61,
+            "name": "\"Valid Name\" and \"abc#def@mail.com\" are submitted",
+            "result": {
+              "status": "passed",
+              "duration": 4112000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 62,
+            "name": "email \"abc#def@mail.com\" is invalid because \"email invalid\"",
+            "result": {
+              "status": "passed",
+              "duration": 120000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "And ",
+            "line": 63,
+            "name": "name and email are presented",
+            "result": {
+              "status": "passed",
+              "duration": 26000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "And ",
+            "line": 64,
+            "name": "appeal is not updated again",
+            "result": {
+              "status": "passed",
+              "duration": 1056000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "name-and-email-provided-after-being-previously-provided;valid-name-and-invalid-email",
+        "keyword": "Scenario",
+        "line": 73,
+        "name": "Valid name and invalid email",
+        "tags": [
+          {
+            "name": "@smoketest",
+            "line": 1
+          }
+        ],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 60,
+            "name": "name and email are requested again",
+            "result": {
+              "status": "passed",
+              "duration": 5117000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 61,
+            "name": "\"Valid Name\" and \"abc=@mail.com\" are submitted",
+            "result": {
+              "status": "passed",
+              "duration": 2907000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 62,
+            "name": "email \"abc=@mail.com\" is invalid because \"email invalid\"",
+            "result": {
+              "status": "passed",
+              "duration": 73000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "And ",
+            "line": 63,
+            "name": "name and email are presented",
+            "result": {
+              "status": "passed",
+              "duration": 20000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "And ",
+            "line": 64,
+            "name": "appeal is not updated again",
+            "result": {
+              "status": "passed",
+              "duration": 1256000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "name-and-email-provided-after-being-previously-provided;valid-name-and-invalid-email",
+        "keyword": "Scenario",
+        "line": 74,
+        "name": "Valid name and invalid email",
+        "tags": [
+          {
+            "name": "@smoketest",
+            "line": 1
+          }
+        ],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 60,
+            "name": "name and email are requested again",
+            "result": {
+              "status": "passed",
+              "duration": 4140000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 61,
+            "name": "\"Valid Name\" and \"abc@mail.c\" are submitted",
+            "result": {
+              "status": "passed",
+              "duration": 2652000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 62,
+            "name": "email \"abc@mail.c\" is invalid because \"email invalid\"",
+            "result": {
+              "status": "passed",
+              "duration": 63000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "And ",
+            "line": 63,
+            "name": "name and email are presented",
+            "result": {
+              "status": "passed",
+              "duration": 15000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "And ",
+            "line": 64,
+            "name": "appeal is not updated again",
+            "result": {
+              "status": "passed",
+              "duration": 898000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "name-and-email-provided-after-being-previously-provided;valid-name-and-invalid-email",
+        "keyword": "Scenario",
+        "line": 75,
+        "name": "Valid name and invalid email",
+        "tags": [
+          {
+            "name": "@smoketest",
+            "line": 1
+          }
+        ],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 60,
+            "name": "name and email are requested again",
+            "result": {
+              "status": "passed",
+              "duration": 4917000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 61,
+            "name": "\"Valid Name\" and \"abc.def@mail#archive.com\" are submitted",
+            "result": {
+              "status": "passed",
+              "duration": 4361000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 62,
+            "name": "email \"abc.def@mail#archive.com\" is invalid because \"email invalid\"",
+            "result": {
+              "status": "passed",
+              "duration": 326000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "And ",
+            "line": 63,
+            "name": "name and email are presented",
+            "result": {
+              "status": "passed",
+              "duration": 19000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "And ",
+            "line": 64,
+            "name": "appeal is not updated again",
+            "result": {
+              "status": "passed",
+              "duration": 1822000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "name-and-email-provided-after-being-previously-provided;valid-name-and-invalid-email",
+        "keyword": "Scenario",
+        "line": 76,
+        "name": "Valid name and invalid email",
+        "tags": [
+          {
+            "name": "@smoketest",
+            "line": 1
+          }
+        ],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 60,
+            "name": "name and email are requested again",
+            "result": {
+              "status": "passed",
+              "duration": 6594000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 61,
+            "name": "\"Valid Name\" and \"abc#def@mail\" are submitted",
+            "result": {
+              "status": "passed",
+              "duration": 3413000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 62,
+            "name": "email \"abc#def@mail\" is invalid because \"email invalid\"",
+            "result": {
+              "status": "passed",
+              "duration": 76000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "And ",
+            "line": 63,
+            "name": "name and email are presented",
+            "result": {
+              "status": "passed",
+              "duration": 24000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "And ",
+            "line": 64,
+            "name": "appeal is not updated again",
+            "result": {
+              "status": "passed",
+              "duration": 1292000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "name-and-email-provided-after-being-previously-provided;valid-name-and-invalid-email",
+        "keyword": "Scenario",
+        "line": 77,
+        "name": "Valid name and invalid email",
+        "tags": [
+          {
+            "name": "@smoketest",
+            "line": 1
+          }
+        ],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 60,
+            "name": "name and email are requested again",
+            "result": {
+              "status": "passed",
+              "duration": 5372000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 61,
+            "name": "\"Valid Name\" and \"abc#def@mail..com\" are submitted",
+            "result": {
+              "status": "passed",
+              "duration": 2697000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 62,
+            "name": "email \"abc#def@mail..com\" is invalid because \"email invalid\"",
+            "result": {
+              "status": "passed",
+              "duration": 54000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "And ",
+            "line": 63,
+            "name": "name and email are presented",
+            "result": {
+              "status": "passed",
+              "duration": 9000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "And ",
+            "line": 64,
+            "name": "appeal is not updated again",
+            "result": {
+              "status": "passed",
+              "duration": 772000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "name-and-email-provided-after-being-previously-provided;invalid-name-and-invalid-email",
+        "keyword": "Scenario",
+        "line": 88,
+        "name": "Invalid name and invalid email",
+        "tags": [
+          {
+            "name": "@smoketest",
+            "line": 1
+          }
+        ],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 80,
+            "name": "name and email are requested again",
+            "result": {
+              "status": "passed",
+              "duration": 5018000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 81,
+            "name": "\"\" and \"\" are submitted",
+            "result": {
+              "status": "passed",
+              "duration": 3701000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 82,
+            "name": "name \"\" is invalid because \"name missing\"",
+            "result": {
+              "status": "passed",
+              "duration": 63000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "And ",
+            "line": 83,
+            "name": "email \"\" is invalid because \"email missing\"",
+            "result": {
+              "status": "passed",
+              "duration": 103000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "And ",
+            "line": 84,
+            "name": "name and email are presented",
+            "result": {
+              "status": "passed",
+              "duration": 21000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "And ",
+            "line": 85,
+            "name": "appeal is not updated again",
+            "result": {
+              "status": "passed",
+              "duration": 1651000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "name-and-email-provided-after-being-previously-provided;invalid-name-and-invalid-email",
+        "keyword": "Scenario",
+        "line": 89,
+        "name": "Invalid name and invalid email",
+        "tags": [
+          {
+            "name": "@smoketest",
+            "line": 1
+          }
+        ],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 80,
+            "name": "name and email are requested again",
+            "result": {
+              "status": "passed",
+              "duration": 5451000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 81,
+            "name": "\"A\" and \"invalid email\" are submitted",
+            "result": {
+              "status": "passed",
+              "duration": 4247000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 82,
+            "name": "name \"A\" is invalid because \"name outside size constraints\"",
+            "result": {
+              "status": "passed",
+              "duration": 82000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "And ",
+            "line": 83,
+            "name": "email \"invalid email\" is invalid because \"email invalid\"",
+            "result": {
+              "status": "passed",
+              "duration": 157000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "And ",
+            "line": 84,
+            "name": "name and email are presented",
+            "result": {
+              "status": "passed",
+              "duration": 39000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "And ",
+            "line": 85,
+            "name": "appeal is not updated again",
+            "result": {
+              "status": "passed",
+              "duration": 1687000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "name-and-email-provided-after-being-previously-provided;invalid-name-and-invalid-email",
+        "keyword": "Scenario",
+        "line": 90,
+        "name": "Invalid name and invalid email",
+        "tags": [
+          {
+            "name": "@smoketest",
+            "line": 1
+          }
+        ],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 80,
+            "name": "name and email are requested again",
+            "result": {
+              "status": "passed",
+              "duration": 5621000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 81,
+            "name": "\"Invalid name with prohibited characters *3(/+\" and \"\" are submitted",
+            "result": {
+              "status": "passed",
+              "duration": 4563000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 82,
+            "name": "name \"Invalid name with prohibited characters *3(/+\" is invalid because \"name with prohibited characters\"",
+            "result": {
+              "status": "passed",
+              "duration": 110000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "And ",
+            "line": 83,
+            "name": "email \"\" is invalid because \"email missing\"",
+            "result": {
+              "status": "passed",
+              "duration": 92000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "And ",
+            "line": 84,
+            "name": "name and email are presented",
+            "result": {
+              "status": "passed",
+              "duration": 23000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "And ",
+            "line": 85,
+            "name": "appeal is not updated again",
+            "result": {
+              "status": "passed",
+              "duration": 1418000000
+            }
+          }
+        ]
+      }
+    ]
+  }
+]

--- a/packages/e2e-tests/cypress/cucumber-json/back-link.cucumber.json
+++ b/packages/e2e-tests/cypress/cucumber-json/back-link.cucumber.json
@@ -1,0 +1,613 @@
+[
+  {
+    "description": "  As an appellant creating an appeal\n  I need to be able to navigate back to my previous page within the appeal service\n  So that I can change or review my previous answer",
+    "keyword": "Feature",
+    "name": "Back link",
+    "line": 1,
+    "id": "back-link",
+    "tags": [],
+    "uri": "back-link.feature",
+    "elements": [
+      {
+        "id": "back-link;appellant-or-agent-can-navigate-back-to-previous-page-when-javascript-is-turned-off---eligiblity",
+        "keyword": "Scenario",
+        "line": 7,
+        "name": "Appellant or agent can navigate back to previous page when javascript is turned off - eligiblity",
+        "tags": [
+          {
+            "name": "@as-115",
+            "line": 6
+          },
+          {
+            "name": "@as-115-1-1",
+            "line": 6
+          }
+        ],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 8,
+            "name": "an appellant or agent is checking their eligibility with JavaScript disabled",
+            "result": {
+              "status": "passed",
+              "duration": 2114000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 9,
+            "name": "they navigate forwards within the eligibility steps",
+            "result": {
+              "status": "passed",
+              "duration": 11994000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 10,
+            "name": "they will be able to navigate back to the previous page within the eligibility steps",
+            "result": {
+              "status": "passed",
+              "duration": 6610000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "back-link;appellant-or-agent-can-navigate-back-to-previous-page-when-javascript-is-turned-off---appeal",
+        "keyword": "Scenario",
+        "line": 13,
+        "name": "Appellant or agent can navigate back to previous page when javascript is turned off - appeal",
+        "tags": [
+          {
+            "name": "@as-115",
+            "line": 12
+          },
+          {
+            "name": "@as-115-1-2",
+            "line": 12
+          }
+        ],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 14,
+            "name": "an appellant or agent is creating an appeal with JavaScript disabled",
+            "result": {
+              "status": "passed",
+              "duration": 2300000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 15,
+            "name": "they navigate forwards within the appeal steps",
+            "result": {
+              "status": "passed",
+              "duration": 7993000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 16,
+            "name": "they will be able to navigate back to the previous page within the appeal steps",
+            "result": {
+              "status": "passed",
+              "duration": 5989000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "back-link;appellant-or-agent-can-navigate-back-to-previous-page-when-javascript-is-turned-off---appeal-back-to-task-list",
+        "keyword": "Scenario",
+        "line": 19,
+        "name": "Appellant or agent can navigate back to previous page when javascript is turned off - appeal back to task list",
+        "tags": [
+          {
+            "name": "@as-115",
+            "line": 18
+          },
+          {
+            "name": "@as-115-1-3",
+            "line": 18
+          },
+          {
+            "name": "@as-115-5",
+            "line": 18
+          }
+        ],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 20,
+            "name": "an appellant or agent is on the task list with JavaScript disabled",
+            "result": {
+              "status": "passed",
+              "duration": 1228000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 21,
+            "name": "they provide details about the original planning application",
+            "result": {
+              "status": "passed",
+              "duration": 5575000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 22,
+            "name": "they will be able to navigate back from the original planning application steps to the task list",
+            "result": {
+              "status": "passed",
+              "duration": 4108000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "back-link;appellant-or-agent-can-navigate-back-to-previous-page-when-javascript-is-turned-off---check-your-answers",
+        "keyword": "Scenario",
+        "line": 25,
+        "name": "Appellant or agent can navigate back to previous page when javascript is turned off - check your answers",
+        "tags": [
+          {
+            "name": "@as-115",
+            "line": 24
+          },
+          {
+            "name": "@as-115-1-4",
+            "line": 24
+          },
+          {
+            "name": "@as-115-6",
+            "line": 24
+          }
+        ],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 26,
+            "name": "an appellant or agent is on check your answers with JavaScript disabled",
+            "result": {
+              "status": "passed",
+              "duration": 1761000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 27,
+            "name": "they alter details about visiting the appeal site",
+            "result": {
+              "status": "passed",
+              "duration": 4577000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 28,
+            "name": "they will be able to navigate back from the visiting the appeal site steps to check your answers",
+            "result": {
+              "status": "passed",
+              "duration": 3947000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "back-link;appellant-or-agent-can-navigate-back-to-previous-page-when-javascript-is-enabled---eligiblity",
+        "keyword": "Scenario",
+        "line": 31,
+        "name": "Appellant or agent can navigate back to previous page when javascript is enabled - eligiblity",
+        "tags": [
+          {
+            "name": "@as-115",
+            "line": 30
+          },
+          {
+            "name": "@as-115-1-5",
+            "line": 30
+          }
+        ],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 32,
+            "name": "an appellant or agent is checking their eligibility with JavaScript enabled",
+            "result": {
+              "status": "passed",
+              "duration": 1414000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 33,
+            "name": "they navigate forwards within the eligibility steps",
+            "result": {
+              "status": "passed",
+              "duration": 8480000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 34,
+            "name": "they will be able to navigate back to the previous page within the eligibility steps",
+            "result": {
+              "status": "passed",
+              "duration": 5784000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "back-link;appellant-or-agent-can-navigate-back-to-previous-page-when-javascript-is-enabled---appeal",
+        "keyword": "Scenario",
+        "line": 37,
+        "name": "Appellant or agent can navigate back to previous page when javascript is enabled - appeal",
+        "tags": [
+          {
+            "name": "@as-115",
+            "line": 36
+          },
+          {
+            "name": "@as-115-1-6",
+            "line": 36
+          }
+        ],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 38,
+            "name": "an appellant or agent is creating an appeal with JavaScript enabled",
+            "result": {
+              "status": "passed",
+              "duration": 1699000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 39,
+            "name": "they navigate forwards within the appeal steps",
+            "result": {
+              "status": "passed",
+              "duration": 7120000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 40,
+            "name": "they will be able to navigate back to the previous page within the appeal steps",
+            "result": {
+              "status": "passed",
+              "duration": 5698000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "back-link;appellant-or-agent-can-navigate-back-to-previous-page-when-javascript-is-enabled---appeal-back-to-task-list",
+        "keyword": "Scenario",
+        "line": 43,
+        "name": "Appellant or agent can navigate back to previous page when javascript is enabled - appeal back to task list",
+        "tags": [
+          {
+            "name": "@as-115",
+            "line": 42
+          },
+          {
+            "name": "@as-115-1-7",
+            "line": 42
+          },
+          {
+            "name": "@as-115-5",
+            "line": 42
+          }
+        ],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 44,
+            "name": "an appellant or agent is on the task list with JavaScript enabled",
+            "result": {
+              "status": "passed",
+              "duration": 1801000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 45,
+            "name": "they provide details about the original planning application",
+            "result": {
+              "status": "passed",
+              "duration": 6243000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 46,
+            "name": "they will be able to navigate back from the original planning application steps to the task list",
+            "result": {
+              "status": "passed",
+              "duration": 4443000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "back-link;appellant-or-agent-can-navigate-back-to-previous-page-when-javascript-is-enabled---check-your-answers",
+        "keyword": "Scenario",
+        "line": 49,
+        "name": "Appellant or agent can navigate back to previous page when javascript is enabled - check your answers",
+        "tags": [
+          {
+            "name": "@as-115",
+            "line": 48
+          },
+          {
+            "name": "@as-115-1-8",
+            "line": 48
+          },
+          {
+            "name": "@as-115-6",
+            "line": 48
+          }
+        ],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 50,
+            "name": "an appellant or agent is on check your answers with JavaScript enabled",
+            "result": {
+              "status": "passed",
+              "duration": 1520000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 51,
+            "name": "they alter details about visiting the appeal site",
+            "result": {
+              "status": "passed",
+              "duration": 5248000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 52,
+            "name": "they will be able to navigate back from the visiting the appeal site steps to check your answers",
+            "result": {
+              "status": "passed",
+              "duration": 4529000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "back-link;when-an-error-occurred-on-the-previous-page-using-the-‘back’-link-will-return-to-that-page-without-an-error-being-displayed",
+        "keyword": "Scenario",
+        "line": 55,
+        "name": "When an error occurred on the previous page using the ‘Back’ link will return to that page without an error being displayed",
+        "tags": [
+          {
+            "name": "@as-115",
+            "line": 54
+          },
+          {
+            "name": "@as-115-2",
+            "line": 54
+          }
+        ],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 56,
+            "name": "an appellant or agent had an error on the previous page",
+            "result": {
+              "status": "passed",
+              "duration": 6392000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 57,
+            "name": "the appellant or agent uses the back link",
+            "result": {
+              "status": "passed",
+              "duration": 1463000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 58,
+            "name": "the page will be displayed without the error",
+            "result": {
+              "status": "passed",
+              "duration": 49000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "back-link;when-an-error-occurs-on-the-current-page-using-the-'back'-link-will-return-to-the-previous-page-without-refreshing-the-current-page",
+        "keyword": "Scenario",
+        "line": 61,
+        "name": "When an error occurs on the current page using the 'Back' link will return to the previous page without refreshing the current page",
+        "tags": [
+          {
+            "name": "@as-115",
+            "line": 60
+          },
+          {
+            "name": "@as-115-3",
+            "line": 60
+          }
+        ],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 62,
+            "name": "an appellant or agent has an error on the current page",
+            "result": {
+              "status": "passed",
+              "duration": 2642000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 63,
+            "name": "the appellant or agent selects to go back",
+            "result": {
+              "status": "passed",
+              "duration": 1514000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 64,
+            "name": "the previous page will be displayed without the current page being refreshed",
+            "result": {
+              "status": "passed",
+              "duration": 25000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "back-link;when-the-previous-page-was-not-in-the-appeal-service.-it-will-go-back-to-the-service-‘start'-page￼",
+        "keyword": "Scenario",
+        "line": 67,
+        "name": "When the previous page was not in the appeal service. It will go back to the service ‘Start' page￼",
+        "tags": [
+          {
+            "name": "@as-115",
+            "line": 66
+          },
+          {
+            "name": "@as-115-4",
+            "line": 66
+          }
+        ],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 68,
+            "name": "an appellant or Agent didn’t come from a previous page in the service",
+            "result": {
+              "status": "passed",
+              "duration": 1983000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 69,
+            "name": "the appellant or agent selects to go back",
+            "result": {
+              "status": "passed",
+              "duration": 1170000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 70,
+            "name": "they will be taken to the ‘Start’ page of the service",
+            "result": {
+              "status": "passed",
+              "duration": 20000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "back-link;we-do-not-display-a-back-button-on-the-service-'start'-page",
+        "keyword": "Scenario",
+        "line": 73,
+        "name": "We do not display a back button on the service 'Start' page",
+        "tags": [
+          {
+            "name": "@as-115",
+            "line": 72
+          }
+        ],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 74,
+            "name": "an appellant or Agent visits the ‘Start’ page of the service",
+            "result": {
+              "status": "passed",
+              "duration": 1235000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 75,
+            "name": "the appellant or agent wishes to go back",
+            "result": {
+              "status": "passed",
+              "duration": 18000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 76,
+            "name": "they must use breadcrumbs or browser back button",
+            "result": {
+              "status": "passed",
+              "duration": 35000000
+            }
+          }
+        ]
+      }
+    ]
+  }
+]

--- a/packages/e2e-tests/cypress/cucumber-json/check-your-answers.cucumber.json
+++ b/packages/e2e-tests/cypress/cucumber-json/check-your-answers.cucumber.json
@@ -1,0 +1,173 @@
+[
+  {
+    "description": "  I want to be able to review and change my answers\n  So that my appeal is accurate",
+    "keyword": "Feature",
+    "name": "As an Appellant/Agent",
+    "line": 1,
+    "id": "as-an-appellant/agent",
+    "tags": [],
+    "uri": "check-your-answers.feature",
+    "elements": [
+      {
+        "id": "as-an-appellant/agent;appellant-has-provided-their-appeal-details-and-is-ready-to-check-their-answers-before-they-submit-their-appeal",
+        "keyword": "Scenario",
+        "line": 6,
+        "name": "Appellant has provided their appeal details and is ready to check their answers before they submit their appeal",
+        "tags": [],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 7,
+            "name": "the appellant is on the 'Appeal a planning decision' page",
+            "result": {
+              "status": "passed",
+              "duration": 1266000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 8,
+            "name": "they click on 'Check your answers and submit your appeal' link",
+            "result": {
+              "status": "passed",
+              "duration": 1440000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 9,
+            "name": "the information they have inputted will be displayed",
+            "result": {
+              "status": "passed",
+              "duration": 138000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "as-an-appellant/agent;agent-has-provided-their-appeal-details-and-is-ready-to-check-their-answers-before-they-submit-their-appeal",
+        "keyword": "Scenario",
+        "line": 11,
+        "name": "Agent has provided their appeal details and is ready to check their answers before they submit their appeal",
+        "tags": [],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 12,
+            "name": "the agent is on the 'Appeal a planning decision' page",
+            "result": {
+              "status": "passed",
+              "duration": 1747000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 13,
+            "name": "they click on 'Check your answers and submit your appeal' link",
+            "result": {
+              "status": "passed",
+              "duration": 1673000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 14,
+            "name": "the information they have inputted will be displayed",
+            "result": {
+              "status": "passed",
+              "duration": 136000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "as-an-appellant/agent;agent-or-appellant-select-the-back-link",
+        "keyword": "Scenario",
+        "line": 23,
+        "name": "Agent or Appellant select the back link",
+        "tags": [],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 17,
+            "name": "the 'agent' is on the 'Check your answers' page",
+            "result": {
+              "status": "passed",
+              "duration": 3414000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 18,
+            "name": "they select the 'Back' link",
+            "result": {
+              "status": "passed",
+              "duration": 1396000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 19,
+            "name": "the 'agent' is on the 'Appeal a planning decision' page",
+            "result": {
+              "status": "passed",
+              "duration": 18000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "as-an-appellant/agent;agent-or-appellant-select-the-back-link",
+        "keyword": "Scenario",
+        "line": 24,
+        "name": "Agent or Appellant select the back link",
+        "tags": [],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 17,
+            "name": "the 'appellant' is on the 'Check your answers' page",
+            "result": {
+              "status": "passed",
+              "duration": 3110000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 18,
+            "name": "they select the 'Back' link",
+            "result": {
+              "status": "passed",
+              "duration": 1619000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 19,
+            "name": "the 'appellant' is on the 'Appeal a planning decision' page",
+            "result": {
+              "status": "passed",
+              "duration": 16000000
+            }
+          }
+        ]
+      }
+    ]
+  }
+]

--- a/packages/e2e-tests/cypress/cucumber-json/cookie-consent-view-preferences-with-javascript-enabled.cucumber.json
+++ b/packages/e2e-tests/cypress/cucumber-json/cookie-consent-view-preferences-with-javascript-enabled.cucumber.json
@@ -1,0 +1,62 @@
+[
+  {
+    "description": "  As a PO for the appeals service\n  I want the service users to be able to view their cookie preferences\n  So that the service adheres to the latest cookie legislation",
+    "keyword": "Feature",
+    "name": "Cookie Consent - View Preferences with JavaScript enabled",
+    "line": 1,
+    "id": "cookie-consent---view-preferences-with-javascript-enabled",
+    "tags": [],
+    "uri": "cookie-consent-view-preferences-with-javascript-enabled.feature",
+    "elements": [
+      {
+        "id": "cookie-consent---view-preferences-with-javascript-enabled;cookie-information",
+        "keyword": "Scenario",
+        "line": 8,
+        "name": "Cookie information",
+        "tags": [
+          {
+            "name": "@as-100",
+            "line": 7
+          },
+          {
+            "name": "@as-100-1",
+            "line": 7
+          }
+        ],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 9,
+            "name": "a user has elected to manage their cookie preference",
+            "result": {
+              "status": "passed",
+              "duration": 1635000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 10,
+            "name": "the user views the Cookie Preferences service",
+            "result": {
+              "status": "passed",
+              "duration": 669000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 11,
+            "name": "the user is provided information of what task each cookie is performing",
+            "result": {
+              "status": "passed",
+              "duration": 190000000
+            }
+          }
+        ]
+      }
+    ]
+  }
+]

--- a/packages/e2e-tests/cypress/cucumber-json/cookie-consent-view-preferences-without-javascript-enabled.cucumber.json
+++ b/packages/e2e-tests/cypress/cucumber-json/cookie-consent-view-preferences-without-javascript-enabled.cucumber.json
@@ -1,0 +1,63 @@
+[
+  {
+    "description": "  As a user of the appeal service\n  I need to be informed of cookies and the impact of javascript\n  So that I can enable the cookies if I want to",
+    "keyword": "Feature",
+    "name": "Cookie Consent - View Preferences without JavaScript enabled",
+    "line": 1,
+    "id": "cookie-consent---view-preferences-without-javascript-enabled",
+    "tags": [],
+    "uri": "cookie-consent-view-preferences-without-javascript-enabled.feature",
+    "elements": [
+      {
+        "id": "cookie-consent---view-preferences-without-javascript-enabled;make-the-content-of-the-cookie-preference-page-specific-to-the-use-of-javascript-when-the-user-has-javascript-turned-off",
+        "keyword": "Scenario",
+        "line": 8,
+        "name": "Make the content of the Cookie preference page specific to the use of Javascript when the user has Javascript turned off",
+        "tags": [
+          {
+            "name": "@as-1351",
+            "line": 7
+          },
+          {
+            "name": "@as-1351-1",
+            "line": 7
+          }
+        ],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 9,
+            "name": "a user has elected to manage their cookie preference without JavaScript enabled",
+            "result": {
+              "status": "passed",
+              "duration": 6345000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 10,
+            "name": "the user views the Cookie Preferences service page",
+            "result": {
+              "status": "passed",
+              "duration": 1104000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 11,
+            "name": "the page content will mention about cookies requiring Javascript to be turned on",
+            "result": {
+              "status": "failed",
+              "duration": 4095000000,
+              "error_message": "AssertionError: Timed out retrying after 4000ms: expected '<h1.govuk-heading-l.cookie-settings__no-js.govuk-!-display-none>' to be 'visible'\n\nThis element `<h1.govuk-heading-l.cookie-settings__no-js.govuk-!-display-none>` is not visible because it has CSS property: `display: none`\n    at confirmPageHeadingWithoutJavaScriptEnabled (http://localhost:9003/__cypress/tests?p=cypress\\integration\\householder-planning\\appeals-service\\cookie-consent-view-preferences-without-javascript-enabled.feature:4820:54)\n    at Context.eval (http://localhost:9003/__cypress/tests?p=cypress\\integration\\householder-planning\\appeals-service\\cookie-consent-view-preferences-without-javascript-enabled.feature:3235:94)\n    at Context.resolveAndRunStepDefinition (http://localhost:9003/__cypress/tests?p=cypress\\integration\\householder-planning\\appeals-service\\cookie-consent-view-preferences-without-javascript-enabled.feature:16587:29)\n    at Context.eval (http://localhost:9003/__cypress/tests?p=cypress\\integration\\householder-planning\\appeals-service\\cookie-consent-view-preferences-without-javascript-enabled.feature:15908:35)"
+            }
+          }
+        ]
+      }
+    ]
+  }
+]

--- a/packages/e2e-tests/cypress/cucumber-json/cookies-consent-bar-with-javascript-enabled.cucumber.json
+++ b/packages/e2e-tests/cypress/cucumber-json/cookies-consent-bar-with-javascript-enabled.cucumber.json
@@ -1,0 +1,258 @@
+[
+  {
+    "description": "  As a performance analyst working on the appeals service\n  I want users to be able to say Yes to GA cookies\n  So that I will receive analytics data for the service",
+    "keyword": "Feature",
+    "name": "Cookie consent bar - with JS",
+    "line": 1,
+    "id": "cookie-consent-bar---with-js",
+    "tags": [],
+    "uri": "cookies-consent-bar-with-javascript-enabled.feature",
+    "elements": [
+      {
+        "id": "cookie-consent-bar---with-js;cookie-banner-available-until-actioned---no-decision",
+        "keyword": "Scenario",
+        "line": 8,
+        "name": "Cookie banner available until actioned - no decision",
+        "tags": [
+          {
+            "name": "@as-1230",
+            "line": 7
+          },
+          {
+            "name": "@as-1230-1a",
+            "line": 7
+          }
+        ],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 9,
+            "name": "a user has not previously submitted cookie preferences",
+            "result": {
+              "status": "passed",
+              "duration": 195000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 10,
+            "name": "the user neither accepts nor rejects not necessary cookies",
+            "result": {
+              "status": "passed",
+              "duration": 1390000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 11,
+            "name": "the cookie banner remains visible",
+            "result": {
+              "status": "passed",
+              "duration": 47000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "cookie-consent-bar---with-js;cookie-banner-available-until-actioned---accepted",
+        "keyword": "Scenario",
+        "line": 14,
+        "name": "Cookie banner available until actioned - accepted",
+        "tags": [
+          {
+            "name": "@as-1230",
+            "line": 13
+          },
+          {
+            "name": "@as-1230-1b",
+            "line": 13
+          }
+        ],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 15,
+            "name": "a user has not previously submitted cookie preferences",
+            "result": {
+              "status": "passed",
+              "duration": 117000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 16,
+            "name": "the user accepts not necessary cookies",
+            "result": {
+              "status": "passed",
+              "duration": 1474000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 17,
+            "name": "the accepted cookie banner becomes visible",
+            "result": {
+              "status": "passed",
+              "duration": 16000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "cookie-consent-bar---with-js;cookie-banner-available-until-actioned---rejected",
+        "keyword": "Scenario",
+        "line": 20,
+        "name": "Cookie banner available until actioned - rejected",
+        "tags": [
+          {
+            "name": "@as-1230",
+            "line": 19
+          },
+          {
+            "name": "@as-1230-1c",
+            "line": 19
+          }
+        ],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 21,
+            "name": "a user has not previously submitted cookie preferences",
+            "result": {
+              "status": "passed",
+              "duration": 82000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 22,
+            "name": "the user rejects not necessary cookies",
+            "result": {
+              "status": "passed",
+              "duration": 1445000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 23,
+            "name": "the rejected cookie banner becomes visible",
+            "result": {
+              "status": "passed",
+              "duration": 37000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "cookie-consent-bar---with-js;accept-not-necessary-cookies",
+        "keyword": "Scenario",
+        "line": 26,
+        "name": "Accept not necessary cookies",
+        "tags": [
+          {
+            "name": "@as-1230",
+            "line": 25
+          },
+          {
+            "name": "@as-1230-2",
+            "line": 25
+          }
+        ],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 27,
+            "name": "a user has not previously submitted cookie preferences",
+            "result": {
+              "status": "passed",
+              "duration": 222000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 28,
+            "name": "the user accepts not necessary cookies",
+            "result": {
+              "status": "passed",
+              "duration": 1479000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 29,
+            "name": "the GA cookies are enabled",
+            "result": {
+              "status": "passed",
+              "duration": 1616000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "cookie-consent-bar---with-js;reject-not-necessary-cookies",
+        "keyword": "Scenario",
+        "line": 32,
+        "name": "Reject Not necessary Cookies",
+        "tags": [
+          {
+            "name": "@as-1230",
+            "line": 31
+          },
+          {
+            "name": "@as-1230-3",
+            "line": 31
+          }
+        ],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 33,
+            "name": "a user has not previously submitted cookie preferences",
+            "result": {
+              "status": "passed",
+              "duration": 130000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 34,
+            "name": "the user rejects not necessary cookies",
+            "result": {
+              "status": "passed",
+              "duration": 1806000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 35,
+            "name": "the GA cookies remain disabled",
+            "result": {
+              "status": "passed",
+              "duration": 1618000000
+            }
+          }
+        ]
+      }
+    ]
+  }
+]

--- a/packages/e2e-tests/cypress/cucumber-json/cookies-consent-bar-without-javascript-enabled.cucumber.json
+++ b/packages/e2e-tests/cypress/cucumber-json/cookies-consent-bar-without-javascript-enabled.cucumber.json
@@ -1,0 +1,121 @@
+[
+  {
+    "description": "  As a PO on the appeals service\n  I need the cookie banner to cater for users who don’t have JS enabled\n  So that the service is compliant with the GDS standards",
+    "keyword": "Feature",
+    "name": "Cookie consent bar - no JS",
+    "line": 1,
+    "id": "cookie-consent-bar---no-js",
+    "tags": [],
+    "uri": "cookies-consent-bar-without-javascript-enabled.feature",
+    "elements": [
+      {
+        "id": "cookie-consent-bar---no-js;cookie-banner-always-displays",
+        "keyword": "Scenario",
+        "line": 8,
+        "name": "Cookie banner always displays",
+        "tags": [
+          {
+            "name": "@as-98",
+            "line": 7
+          },
+          {
+            "name": "@as-98-1",
+            "line": 7
+          }
+        ],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 9,
+            "name": "a user visits the site with JavaScript disabled",
+            "result": {
+              "status": "passed",
+              "duration": 1494000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 10,
+            "name": "the user navigates through the service",
+            "result": {
+              "status": "passed",
+              "duration": 958000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 11,
+            "name": "the cookie banner remains visible",
+            "result": {
+              "status": "passed",
+              "duration": 21000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "cookie-consent-bar---no-js;cookie-banner-links-to-cookie-settings-page",
+        "keyword": "Scenario",
+        "line": 14,
+        "name": "Cookie banner links to cookie settings page",
+        "tags": [
+          {
+            "name": "@as-98",
+            "line": 13
+          },
+          {
+            "name": "@as-98-2",
+            "line": 13
+          }
+        ],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 15,
+            "name": "a user visits the site with JavaScript disabled",
+            "result": {
+              "status": "passed",
+              "duration": 1331000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 16,
+            "name": "the user views the cookie preferences page",
+            "result": {
+              "status": "passed",
+              "duration": 902000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 17,
+            "name": "the cookies page is presented",
+            "result": {
+              "status": "passed",
+              "duration": 28000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "And ",
+            "line": 18,
+            "name": "the cookie banner does not exist",
+            "result": {
+              "status": "passed",
+              "duration": 19000000
+            }
+          }
+        ]
+      }
+    ]
+  }
+]

--- a/packages/e2e-tests/cypress/cucumber-json/cookies-disabled-by-default.cucumber.json
+++ b/packages/e2e-tests/cypress/cucumber-json/cookies-disabled-by-default.cucumber.json
@@ -1,0 +1,62 @@
+[
+  {
+    "description": "  As a PO on the appeal service\n  I want the not necessary cookies to be off by default\n  So that the service is compliant with the latest cookie legislation",
+    "keyword": "Feature",
+    "name": "Not necessary cookies to be disabled by default",
+    "line": 1,
+    "id": "not-necessary-cookies-to-be-disabled-by-default",
+    "tags": [],
+    "uri": "cookies-disabled-by-default.feature",
+    "elements": [
+      {
+        "id": "not-necessary-cookies-to-be-disabled-by-default;not-necessary-cookies-disabled-by-default",
+        "keyword": "Scenario",
+        "line": 8,
+        "name": "Not necessary cookies disabled by default",
+        "tags": [
+          {
+            "name": "@as-1193",
+            "line": 7
+          },
+          {
+            "name": "@as-1193-1",
+            "line": 7
+          }
+        ],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 9,
+            "name": "a user has not previously submitted cookie preferences",
+            "result": {
+              "status": "passed",
+              "duration": 302000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 10,
+            "name": "the user visits the service",
+            "result": {
+              "status": "passed",
+              "duration": 1617000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 11,
+            "name": "not necessary cookies are disabled",
+            "result": {
+              "status": "passed",
+              "duration": 78000000
+            }
+          }
+        ]
+      }
+    ]
+  }
+]

--- a/packages/e2e-tests/cypress/cucumber-json/eligibility-appeal-householder-planning-permission.cucumber.json
+++ b/packages/e2e-tests/cypress/cucumber-json/eligibility-appeal-householder-planning-permission.cucumber.json
@@ -1,0 +1,303 @@
+[
+  {
+    "description": " Prospective appellant states whether they are appealing against a householder planning permission decision\n So that the system can confirm whether their appeal is eligible to use the private beta service.",
+    "keyword": "Feature",
+    "name": "Eligibility - Appeal Householder Planning Permission Question",
+    "line": 1,
+    "id": "eligibility---appeal-householder-planning-permission-question",
+    "tags": [],
+    "uri": "eligibility-appeal-householder-planning-permission.feature",
+    "elements": [
+      {
+        "id": "eligibility---appeal-householder-planning-permission-question;navigation-to-the-householder-question-page",
+        "keyword": "Scenario",
+        "line": 6,
+        "name": "Navigation to the householder question page",
+        "tags": [
+          {
+            "name": "@ucd-1209",
+            "line": 5
+          },
+          {
+            "name": "@ucd-1209-ac1",
+            "line": 5
+          }
+        ],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 7,
+            "name": "access to the appeals service eligibility is available",
+            "result": {
+              "status": "passed",
+              "duration": 1903000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 8,
+            "name": "the appeal service eligibility is accessed",
+            "result": {
+              "status": "passed",
+              "duration": 1198000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 9,
+            "name": "the appeals householder planning permission question is presented",
+            "result": {
+              "status": "passed",
+              "duration": 1404000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "eligibility---appeal-householder-planning-permission-question;prospective-appellant-makes-no-selection-and-is-provided-an-error",
+        "keyword": "Scenario",
+        "line": 12,
+        "name": "Prospective appellant makes no selection and is provided an error",
+        "tags": [
+          {
+            "name": "@ucd-1209",
+            "line": 11
+          },
+          {
+            "name": "@ucd-1209-ac2",
+            "line": 11
+          }
+        ],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 13,
+            "name": "the appeals householder planning permission question is requested",
+            "result": {
+              "status": "passed",
+              "duration": 1206000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 14,
+            "name": "no confirmation is provided for householder planning permission question",
+            "result": {
+              "status": "passed",
+              "duration": 1621000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 15,
+            "name": "progress is halted with a message that a householder planning permission is required",
+            "result": {
+              "status": "passed",
+              "duration": 355000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "eligibility---appeal-householder-planning-permission-question;prospective-appellant-selects-yes-and-proceeds-through-eligibility-checker",
+        "keyword": "Scenario",
+        "line": 18,
+        "name": "Prospective appellant selects yes and proceeds through eligibility checker",
+        "tags": [
+          {
+            "name": "@ucd-1209",
+            "line": 17
+          },
+          {
+            "name": "@ucd-1209-ac3",
+            "line": 17
+          }
+        ],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 19,
+            "name": "the appeals householder planning permission question is requested",
+            "result": {
+              "status": "passed",
+              "duration": 1621000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 20,
+            "name": "confirmation is provided for householder planning permission question",
+            "result": {
+              "status": "passed",
+              "duration": 1244000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 21,
+            "name": "progress is made to the eligibility granted or refused permission status question",
+            "result": {
+              "status": "passed",
+              "duration": 20000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "eligibility---appeal-householder-planning-permission-question;prospective-appellant-selects-no-and-is-taken-to-kick-out-page",
+        "keyword": "Scenario",
+        "line": 24,
+        "name": "Prospective appellant selects no and is taken to kick-out page",
+        "tags": [
+          {
+            "name": "@ucd-1209",
+            "line": 23
+          },
+          {
+            "name": "@ucd-1209-ac4",
+            "line": 23
+          }
+        ],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 25,
+            "name": "the appeals householder planning permission question is requested",
+            "result": {
+              "status": "passed",
+              "duration": 1161000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 26,
+            "name": "confirmation is not provided for householder planning permission question",
+            "result": {
+              "status": "passed",
+              "duration": 2088000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 27,
+            "name": "the user is navigated to the 'This service is only for householder planning appeals' page",
+            "result": {
+              "status": "passed",
+              "duration": 19000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "eligibility---appeal-householder-planning-permission-question;prospective-appellant-is-on-the-kick-out-page-and-can-see-link-to-acp",
+        "keyword": "Scenario",
+        "line": 30,
+        "name": "Prospective appellant is on the kick-out page and can see link to ACP",
+        "tags": [
+          {
+            "name": "@ucd-1209",
+            "line": 29
+          },
+          {
+            "name": "@ucd-1209-ac4",
+            "line": 29
+          }
+        ],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 31,
+            "name": "the appeals householder planning permission question is requested",
+            "result": {
+              "status": "passed",
+              "duration": 4045000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 32,
+            "name": "confirmation is not provided for householder planning permission question",
+            "result": {
+              "status": "passed",
+              "duration": 2118000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 33,
+            "name": "access is available to ACP service",
+            "result": {
+              "status": "passed",
+              "duration": 45000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "eligibility---appeal-householder-planning-permission-question;householder-planning-permission-help-text",
+        "keyword": "Scenario",
+        "line": 36,
+        "name": "Householder planning permission help text",
+        "tags": [
+          {
+            "name": "@ucd-1209",
+            "line": 35
+          }
+        ],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 37,
+            "name": "the appeals householder planning permission question is requested",
+            "result": {
+              "status": "passed",
+              "duration": 1194000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 38,
+            "name": "the 'What is householder planning permission' additional information is accessed",
+            "result": {
+              "status": "passed",
+              "duration": 337000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 39,
+            "name": "the householder planning permission additional information is presented",
+            "result": {
+              "status": "passed",
+              "duration": 303000000
+            }
+          }
+        ]
+      }
+    ]
+  }
+]

--- a/packages/e2e-tests/cypress/cucumber-json/eligibility-costs.cucumber.json
+++ b/packages/e2e-tests/cypress/cucumber-json/eligibility-costs.cucumber.json
@@ -1,0 +1,213 @@
+[
+  {
+    "description": "  Note: Appeals that include claiming for Costs are not supported.",
+    "keyword": "Feature",
+    "name": "Claiming for Costs eligibility check",
+    "line": 1,
+    "id": "claiming-for-costs-eligibility-check",
+    "tags": [],
+    "uri": "eligibility-costs.feature",
+    "elements": [
+      {
+        "id": "claiming-for-costs-eligibility-check;not-claiming-for-costs-allows-progress",
+        "keyword": "Scenario",
+        "line": 4,
+        "name": "Not claiming for Costs allows progress",
+        "tags": [],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 5,
+            "name": "an answer to the Costs question is requested",
+            "result": {
+              "status": "passed",
+              "duration": 6018000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 6,
+            "name": "not claiming Costs is confirmed",
+            "result": {
+              "status": "passed",
+              "duration": 1067000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 7,
+            "name": "progress is made to Your appeal statement",
+            "result": {
+              "status": "passed",
+              "duration": 38000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "claiming-for-costs-eligibility-check;claiming-for-costs-prevents-progress",
+        "keyword": "Scenario",
+        "line": 9,
+        "name": "Claiming for Costs prevents progress",
+        "tags": [],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 10,
+            "name": "an answer to the Costs question is requested",
+            "result": {
+              "status": "passed",
+              "duration": 2647000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 11,
+            "name": "claiming Costs is confirmed",
+            "result": {
+              "status": "passed",
+              "duration": 1001000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 12,
+            "name": "progress is halted with a message that claiming for Costs is not supported",
+            "result": {
+              "status": "passed",
+              "duration": 91000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "claiming-for-costs-eligibility-check;failure-to-answer-the-costs-question-prevents-progress",
+        "keyword": "Scenario",
+        "line": 14,
+        "name": "Failure to answer the Costs question prevents progress",
+        "tags": [],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 15,
+            "name": "an answer to the Costs question is requested",
+            "result": {
+              "status": "passed",
+              "duration": 2593000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 16,
+            "name": "the Costs question is not answered",
+            "result": {
+              "status": "passed",
+              "duration": 1133000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 17,
+            "name": "progress is halted with a message that an answer to the Costs question is required",
+            "result": {
+              "status": "passed",
+              "duration": 58000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "claiming-for-costs-eligibility-check;accessing-costs-guidance",
+        "keyword": "Scenario",
+        "line": 19,
+        "name": "Accessing Costs guidance",
+        "tags": [],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 20,
+            "name": "an Appeal exists",
+            "result": {
+              "status": "passed",
+              "duration": 1148000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 21,
+            "name": "an answer to the Costs question is requested",
+            "result": {
+              "status": "passed",
+              "duration": 924000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 22,
+            "name": "access is available to guidance while an answer to the Costs question is still requested",
+            "result": {
+              "status": "passed",
+              "duration": 50000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "claiming-for-costs-eligibility-check;accessing-acp",
+        "keyword": "Scenario",
+        "line": 24,
+        "name": "Accessing ACP",
+        "tags": [],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 25,
+            "name": "an answer to the Costs question is requested",
+            "result": {
+              "status": "passed",
+              "duration": 1005000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 26,
+            "name": "claiming Costs is confirmed",
+            "result": {
+              "status": "passed",
+              "duration": 922000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 27,
+            "name": "access is available to ACP",
+            "result": {
+              "status": "passed",
+              "duration": 22000000
+            }
+          }
+        ]
+      }
+    ]
+  }
+]

--- a/packages/e2e-tests/cypress/cucumber-json/eligibility-decision-date-page-components.cucumber.json
+++ b/packages/e2e-tests/cypress/cucumber-json/eligibility-decision-date-page-components.cucumber.json
@@ -1,0 +1,133 @@
+[
+  {
+    "description": "    I need to provide the date of the decision from the local planning department,\n    so that the system can confirm whether my appeal is in time.",
+    "keyword": "Feature",
+    "name": "The Decision Date page has the right structure",
+    "line": 2,
+    "id": "the-decision-date-page-has-the-right-structure",
+    "tags": [],
+    "uri": "eligibility-decision-date-page-components.feature",
+    "elements": [
+      {
+        "id": "the-decision-date-page-has-the-right-structure;navigate-to-eligibility-decision-page-and-verify-the-content-in-the-page",
+        "keyword": "Scenario",
+        "line": 6,
+        "name": "Navigate to Eligibility Decision page and verify the content in the page",
+        "tags": [],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 7,
+            "name": "I navigate to the Eligibility checker page",
+            "result": {
+              "status": "passed",
+              "duration": 1738000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "And ",
+            "line": 8,
+            "name": "I am on the decision date page",
+            "result": {
+              "status": "passed",
+              "duration": 303000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 9,
+            "name": "I can see the logo gov uk text",
+            "result": {
+              "status": "passed",
+              "duration": 32000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "And ",
+            "line": 10,
+            "name": "I can see the header link appeal a householder planning decision",
+            "result": {
+              "status": "passed",
+              "duration": 55000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "And ",
+            "line": 11,
+            "name": "I can verify the text what is the decision date on the letter",
+            "result": {
+              "status": "passed",
+              "duration": 249000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "And ",
+            "line": 12,
+            "name": "I can see the footer",
+            "result": {
+              "status": "passed",
+              "duration": 521000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "the-decision-date-page-has-the-right-structure;user-selects-the-back-link",
+        "keyword": "Scenario",
+        "line": 15,
+        "name": "User selects the back link",
+        "tags": [],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 16,
+            "name": "I navigate to \"/eligibility/planning-department\"",
+            "result": {
+              "status": "passed",
+              "duration": 2266000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "And ",
+            "line": 17,
+            "name": "I navigate to the Eligibility checker page",
+            "result": {
+              "status": "passed",
+              "duration": 2159000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 18,
+            "name": "I select the Back link",
+            "result": {
+              "status": "passed",
+              "duration": 1335000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 19,
+            "name": "I am on \"/eligibility/planning-department\"",
+            "result": {
+              "status": "passed",
+              "duration": 20000000
+            }
+          }
+        ]
+      }
+    ]
+  }
+]

--- a/packages/e2e-tests/cypress/cucumber-json/eligibility-decision-date.cucumber.json
+++ b/packages/e2e-tests/cypress/cucumber-json/eligibility-decision-date.cucumber.json
@@ -1,0 +1,1768 @@
+[
+  {
+    "description": "  Note: A valid appeal must be submitted within 12 weeks after the original Decision Date.",
+    "keyword": "Feature",
+    "name": "Decision Date eligibility check",
+    "line": 1,
+    "id": "decision-date-eligibility-check",
+    "tags": [],
+    "uri": "eligibility-decision-date.feature",
+    "elements": [
+      {
+        "id": "decision-date-eligibility-check;eligible-decision-date-allows-progress",
+        "keyword": "Scenario",
+        "line": 4,
+        "name": "Eligible Decision Date allows progress",
+        "tags": [],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 5,
+            "name": "a Decision Date is requested",
+            "result": {
+              "status": "passed",
+              "duration": 2024000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 6,
+            "name": "an eligible Decision Date is provided",
+            "result": {
+              "status": "passed",
+              "duration": 4364000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 7,
+            "name": "progress is made to the Local Planning Department eligibility question",
+            "result": {
+              "status": "passed",
+              "duration": 1721000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "decision-date-eligibility-check;ineligible-decision-date-continues-to-decision-date-passed-page-and-allows-returning-to-the-decision-date-page",
+        "keyword": "Scenario",
+        "line": 9,
+        "name": "Ineligible Decision Date continues to Decision Date Passed page and allows returning to the Decision Date page",
+        "tags": [],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 10,
+            "name": "a Decision Date is requested",
+            "result": {
+              "status": "passed",
+              "duration": 1987000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 11,
+            "name": "an ineligible Decision Date is provided",
+            "result": {
+              "status": "passed",
+              "duration": 4016000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "And ",
+            "line": 12,
+            "name": "progress is halted with a message that the Decision Date is ineligible because it is beyond the deadline for an appeal",
+            "result": {
+              "status": "passed",
+              "duration": 16000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "And ",
+            "line": 13,
+            "name": "the re-enter the decision date link is clicked",
+            "result": {
+              "status": "passed",
+              "duration": 2255000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 14,
+            "name": "progress is made to the Decision Date question",
+            "result": {
+              "status": "passed",
+              "duration": 1750000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "decision-date-eligibility-check;ineligible-decision-date-continues-to-decision-date-passed-page-and-prevents-navigating-to-a-page-other-than-the-decision-date-page",
+        "keyword": "Scenario",
+        "line": 16,
+        "name": "Ineligible Decision Date continues to Decision Date Passed page and prevents navigating to a page other than the Decision Date page",
+        "tags": [],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 17,
+            "name": "a Decision Date is requested",
+            "result": {
+              "status": "passed",
+              "duration": 2306000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 18,
+            "name": "an ineligible Decision Date is provided",
+            "result": {
+              "status": "passed",
+              "duration": 4917000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "And ",
+            "line": 19,
+            "name": "progress is halted with a message that the Decision Date is ineligible because it is beyond the deadline for an appeal",
+            "result": {
+              "status": "passed",
+              "duration": 31000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "And ",
+            "line": 20,
+            "name": "navigate to the Householder Planning Permission question",
+            "result": {
+              "status": "passed",
+              "duration": 1336000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 21,
+            "name": "progress is halted with a message that the Decision Date is ineligible because it is beyond the deadline for an appeal",
+            "result": {
+              "status": "passed",
+              "duration": 17000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "decision-date-eligibility-check;invalid-decision-date-of-\"\"-\"\"-\"\"-is-rejected",
+        "keyword": "Scenario",
+        "line": 32,
+        "name": "Invalid Decision Date of \"\"-\"\"-\"\" is rejected",
+        "tags": [
+          {
+            "name": "@as-1666",
+            "line": 23
+          }
+        ],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 25,
+            "name": "a Decision Date is requested",
+            "result": {
+              "status": "passed",
+              "duration": 1869000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 26,
+            "name": "a Decision Date of \"\"-\"\"-\"\" is provided",
+            "result": {
+              "status": "passed",
+              "duration": 5112000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 27,
+            "name": "progress is halted with an error: \"Enter the Decision Date\"",
+            "result": {
+              "status": "passed",
+              "duration": 82000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "And ",
+            "line": 28,
+            "name": "the correct input \"day,month,year\" is highlighted",
+            "result": {
+              "status": "passed",
+              "duration": 121000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "decision-date-eligibility-check;invalid-decision-date-of-\"\"-\"\"-\"2022\"-is-rejected",
+        "keyword": "Scenario",
+        "line": 33,
+        "name": "Invalid Decision Date of \"\"-\"\"-\"2022\" is rejected",
+        "tags": [
+          {
+            "name": "@as-1666",
+            "line": 23
+          }
+        ],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 25,
+            "name": "a Decision Date is requested",
+            "result": {
+              "status": "passed",
+              "duration": 2370000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 26,
+            "name": "a Decision Date of \"\"-\"\"-\"2022\" is provided",
+            "result": {
+              "status": "passed",
+              "duration": 4806000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 27,
+            "name": "progress is halted with an error: \"The Decision Date must include a day and month\"",
+            "result": {
+              "status": "passed",
+              "duration": 59000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "And ",
+            "line": 28,
+            "name": "the correct input \"day,month\" is highlighted",
+            "result": {
+              "status": "passed",
+              "duration": 75000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "decision-date-eligibility-check;invalid-decision-date-of-\"\"-\"\"-\"2021\"-is-rejected",
+        "keyword": "Scenario",
+        "line": 34,
+        "name": "Invalid Decision Date of \"\"-\"\"-\"2021\" is rejected",
+        "tags": [
+          {
+            "name": "@as-1666",
+            "line": 23
+          }
+        ],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 25,
+            "name": "a Decision Date is requested",
+            "result": {
+              "status": "passed",
+              "duration": 1874000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 26,
+            "name": "a Decision Date of \"\"-\"\"-\"2021\" is provided",
+            "result": {
+              "status": "passed",
+              "duration": 5586000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 27,
+            "name": "progress is halted with an error: \"The Decision Date must include a day and month\"",
+            "result": {
+              "status": "passed",
+              "duration": 74000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "And ",
+            "line": 28,
+            "name": "the correct input \"day,month\" is highlighted",
+            "result": {
+              "status": "passed",
+              "duration": 61000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "decision-date-eligibility-check;invalid-decision-date-of-\"\"-\"\"-\"1000\"-is-rejected",
+        "keyword": "Scenario",
+        "line": 35,
+        "name": "Invalid Decision Date of \"\"-\"\"-\"1000\" is rejected",
+        "tags": [
+          {
+            "name": "@as-1666",
+            "line": 23
+          }
+        ],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 25,
+            "name": "a Decision Date is requested",
+            "result": {
+              "status": "passed",
+              "duration": 2302000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 26,
+            "name": "a Decision Date of \"\"-\"\"-\"1000\" is provided",
+            "result": {
+              "status": "passed",
+              "duration": 4816000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 27,
+            "name": "progress is halted with an error: \"The Decision Date must include a day and month\"",
+            "result": {
+              "status": "passed",
+              "duration": 71000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "And ",
+            "line": 28,
+            "name": "the correct input \"day,month\" is highlighted",
+            "result": {
+              "status": "passed",
+              "duration": 70000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "decision-date-eligibility-check;invalid-decision-date-of-\"\"-\"\"-\"9999\"-is-rejected",
+        "keyword": "Scenario",
+        "line": 36,
+        "name": "Invalid Decision Date of \"\"-\"\"-\"9999\" is rejected",
+        "tags": [
+          {
+            "name": "@as-1666",
+            "line": 23
+          }
+        ],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 25,
+            "name": "a Decision Date is requested",
+            "result": {
+              "status": "passed",
+              "duration": 2216000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 26,
+            "name": "a Decision Date of \"\"-\"\"-\"9999\" is provided",
+            "result": {
+              "status": "passed",
+              "duration": 5018000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 27,
+            "name": "progress is halted with an error: \"The Decision Date must include a day and month\"",
+            "result": {
+              "status": "passed",
+              "duration": 60000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "And ",
+            "line": 28,
+            "name": "the correct input \"day,month\" is highlighted",
+            "result": {
+              "status": "passed",
+              "duration": 81000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "decision-date-eligibility-check;invalid-decision-date-of-\"\"-\"09\"-\"\"-is-rejected",
+        "keyword": "Scenario",
+        "line": 37,
+        "name": "Invalid Decision Date of \"\"-\"09\"-\"\" is rejected",
+        "tags": [
+          {
+            "name": "@as-1666",
+            "line": 23
+          }
+        ],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 25,
+            "name": "a Decision Date is requested",
+            "result": {
+              "status": "passed",
+              "duration": 1993000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 26,
+            "name": "a Decision Date of \"\"-\"09\"-\"\" is provided",
+            "result": {
+              "status": "passed",
+              "duration": 5393000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 27,
+            "name": "progress is halted with an error: \"The Decision Date must include a day and year\"",
+            "result": {
+              "status": "passed",
+              "duration": 91000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "And ",
+            "line": 28,
+            "name": "the correct input \"day,year\" is highlighted",
+            "result": {
+              "status": "passed",
+              "duration": 73000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "decision-date-eligibility-check;invalid-decision-date-of-\"\"-\"12\"-\"\"-is-rejected",
+        "keyword": "Scenario",
+        "line": 38,
+        "name": "Invalid Decision Date of \"\"-\"12\"-\"\" is rejected",
+        "tags": [
+          {
+            "name": "@as-1666",
+            "line": 23
+          }
+        ],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 25,
+            "name": "a Decision Date is requested",
+            "result": {
+              "status": "passed",
+              "duration": 2404000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 26,
+            "name": "a Decision Date of \"\"-\"12\"-\"\" is provided",
+            "result": {
+              "status": "passed",
+              "duration": 4382000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 27,
+            "name": "progress is halted with an error: \"The Decision Date must include a day and year\"",
+            "result": {
+              "status": "passed",
+              "duration": 137000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "And ",
+            "line": 28,
+            "name": "the correct input \"day,year\" is highlighted",
+            "result": {
+              "status": "passed",
+              "duration": 166000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "decision-date-eligibility-check;invalid-decision-date-of-\"\"-\"14\"-\"\"-is-rejected",
+        "keyword": "Scenario",
+        "line": 39,
+        "name": "Invalid Decision Date of \"\"-\"14\"-\"\" is rejected",
+        "tags": [
+          {
+            "name": "@as-1666",
+            "line": 23
+          }
+        ],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 25,
+            "name": "a Decision Date is requested",
+            "result": {
+              "status": "passed",
+              "duration": 2225000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 26,
+            "name": "a Decision Date of \"\"-\"14\"-\"\" is provided",
+            "result": {
+              "status": "passed",
+              "duration": 5235000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 27,
+            "name": "progress is halted with an error: \"The Decision Date must include a day and year\"",
+            "result": {
+              "status": "passed",
+              "duration": 93000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "And ",
+            "line": 28,
+            "name": "the correct input \"day,year\" is highlighted",
+            "result": {
+              "status": "passed",
+              "duration": 92000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "decision-date-eligibility-check;invalid-decision-date-of-\"31\"-\"\"-\"\"-is-rejected",
+        "keyword": "Scenario",
+        "line": 40,
+        "name": "Invalid Decision Date of \"31\"-\"\"-\"\" is rejected",
+        "tags": [
+          {
+            "name": "@as-1666",
+            "line": 23
+          }
+        ],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 25,
+            "name": "a Decision Date is requested",
+            "result": {
+              "status": "passed",
+              "duration": 1966000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 26,
+            "name": "a Decision Date of \"31\"-\"\"-\"\" is provided",
+            "result": {
+              "status": "passed",
+              "duration": 5404000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 27,
+            "name": "progress is halted with an error: \"The Decision Date must include a month and year\"",
+            "result": {
+              "status": "passed",
+              "duration": 95000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "And ",
+            "line": 28,
+            "name": "the correct input \"month,year\" is highlighted",
+            "result": {
+              "status": "passed",
+              "duration": 95000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "decision-date-eligibility-check;invalid-decision-date-of-\"1\"-\"\"-\"\"-is-rejected",
+        "keyword": "Scenario",
+        "line": 41,
+        "name": "Invalid Decision Date of \"1\"-\"\"-\"\" is rejected",
+        "tags": [
+          {
+            "name": "@as-1666",
+            "line": 23
+          }
+        ],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 25,
+            "name": "a Decision Date is requested",
+            "result": {
+              "status": "passed",
+              "duration": 2206000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 26,
+            "name": "a Decision Date of \"1\"-\"\"-\"\" is provided",
+            "result": {
+              "status": "passed",
+              "duration": 5116000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 27,
+            "name": "progress is halted with an error: \"The Decision Date must include a month and year\"",
+            "result": {
+              "status": "passed",
+              "duration": 64000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "And ",
+            "line": 28,
+            "name": "the correct input \"month,year\" is highlighted",
+            "result": {
+              "status": "passed",
+              "duration": 56000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "decision-date-eligibility-check;invalid-decision-date-of-\"45\"-\"\"-\"\"-is-rejected",
+        "keyword": "Scenario",
+        "line": 42,
+        "name": "Invalid Decision Date of \"45\"-\"\"-\"\" is rejected",
+        "tags": [
+          {
+            "name": "@as-1666",
+            "line": 23
+          }
+        ],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 25,
+            "name": "a Decision Date is requested",
+            "result": {
+              "status": "passed",
+              "duration": 1578000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 26,
+            "name": "a Decision Date of \"45\"-\"\"-\"\" is provided",
+            "result": {
+              "status": "passed",
+              "duration": 5218000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 27,
+            "name": "progress is halted with an error: \"The Decision Date must include a month and year\"",
+            "result": {
+              "status": "passed",
+              "duration": 64000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "And ",
+            "line": 28,
+            "name": "the correct input \"month,year\" is highlighted",
+            "result": {
+              "status": "passed",
+              "duration": 64000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "decision-date-eligibility-check;invalid-decision-date-of-\"\"-\"12\"-\"2020\"-is-rejected",
+        "keyword": "Scenario",
+        "line": 43,
+        "name": "Invalid Decision Date of \"\"-\"12\"-\"2020\" is rejected",
+        "tags": [
+          {
+            "name": "@as-1666",
+            "line": 23
+          }
+        ],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 25,
+            "name": "a Decision Date is requested",
+            "result": {
+              "status": "passed",
+              "duration": 2307000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 26,
+            "name": "a Decision Date of \"\"-\"12\"-\"2020\" is provided",
+            "result": {
+              "status": "passed",
+              "duration": 4750000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 27,
+            "name": "progress is halted with an error: \"The Decision Date must include a day\"",
+            "result": {
+              "status": "passed",
+              "duration": 92000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "And ",
+            "line": 28,
+            "name": "the correct input \"day\" is highlighted",
+            "result": {
+              "status": "passed",
+              "duration": 42000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "decision-date-eligibility-check;invalid-decision-date-of-\"\"-\"14\"-\"2025\"-is-rejected",
+        "keyword": "Scenario",
+        "line": 44,
+        "name": "Invalid Decision Date of \"\"-\"14\"-\"2025\" is rejected",
+        "tags": [
+          {
+            "name": "@as-1666",
+            "line": 23
+          }
+        ],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 25,
+            "name": "a Decision Date is requested",
+            "result": {
+              "status": "passed",
+              "duration": 2110000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 26,
+            "name": "a Decision Date of \"\"-\"14\"-\"2025\" is provided",
+            "result": {
+              "status": "passed",
+              "duration": 4960000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 27,
+            "name": "progress is halted with an error: \"The Decision Date must include a day\"",
+            "result": {
+              "status": "passed",
+              "duration": 65000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "And ",
+            "line": 28,
+            "name": "the correct input \"day\" is highlighted",
+            "result": {
+              "status": "passed",
+              "duration": 62000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "decision-date-eligibility-check;invalid-decision-date-of-\"31\"-\"\"-\"2021\"-is-rejected",
+        "keyword": "Scenario",
+        "line": 45,
+        "name": "Invalid Decision Date of \"31\"-\"\"-\"2021\" is rejected",
+        "tags": [
+          {
+            "name": "@as-1666",
+            "line": 23
+          }
+        ],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 25,
+            "name": "a Decision Date is requested",
+            "result": {
+              "status": "passed",
+              "duration": 2340000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 26,
+            "name": "a Decision Date of \"31\"-\"\"-\"2021\" is provided",
+            "result": {
+              "status": "passed",
+              "duration": 5041000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 27,
+            "name": "progress is halted with an error: \"The Decision Date must include a month\"",
+            "result": {
+              "status": "passed",
+              "duration": 84000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "And ",
+            "line": 28,
+            "name": "the correct input \"month\" is highlighted",
+            "result": {
+              "status": "passed",
+              "duration": 55000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "decision-date-eligibility-check;invalid-decision-date-of-\"45\"-\"\"-\"3000\"-is-rejected",
+        "keyword": "Scenario",
+        "line": 46,
+        "name": "Invalid Decision Date of \"45\"-\"\"-\"3000\" is rejected",
+        "tags": [
+          {
+            "name": "@as-1666",
+            "line": 23
+          }
+        ],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 25,
+            "name": "a Decision Date is requested",
+            "result": {
+              "status": "passed",
+              "duration": 2021000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 26,
+            "name": "a Decision Date of \"45\"-\"\"-\"3000\" is provided",
+            "result": {
+              "status": "passed",
+              "duration": 4907000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 27,
+            "name": "progress is halted with an error: \"The Decision Date must include a month\"",
+            "result": {
+              "status": "passed",
+              "duration": 64000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "And ",
+            "line": 28,
+            "name": "the correct input \"month\" is highlighted",
+            "result": {
+              "status": "passed",
+              "duration": 47000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "decision-date-eligibility-check;invalid-decision-date-of-\"1\"-\"1\"-\"\"-is-rejected",
+        "keyword": "Scenario",
+        "line": 47,
+        "name": "Invalid Decision Date of \"1\"-\"1\"-\"\" is rejected",
+        "tags": [
+          {
+            "name": "@as-1666",
+            "line": 23
+          }
+        ],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 25,
+            "name": "a Decision Date is requested",
+            "result": {
+              "status": "passed",
+              "duration": 1772000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 26,
+            "name": "a Decision Date of \"1\"-\"1\"-\"\" is provided",
+            "result": {
+              "status": "passed",
+              "duration": 4430000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 27,
+            "name": "progress is halted with an error: \"The Decision Date must include a year\"",
+            "result": {
+              "status": "passed",
+              "duration": 129000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "And ",
+            "line": 28,
+            "name": "the correct input \"year\" is highlighted",
+            "result": {
+              "status": "passed",
+              "duration": 91000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "decision-date-eligibility-check;invalid-decision-date-of-\"31\"-\"12\"-\"\"-is-rejected",
+        "keyword": "Scenario",
+        "line": 48,
+        "name": "Invalid Decision Date of \"31\"-\"12\"-\"\" is rejected",
+        "tags": [
+          {
+            "name": "@as-1666",
+            "line": 23
+          }
+        ],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 25,
+            "name": "a Decision Date is requested",
+            "result": {
+              "status": "passed",
+              "duration": 2441000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 26,
+            "name": "a Decision Date of \"31\"-\"12\"-\"\" is provided",
+            "result": {
+              "status": "passed",
+              "duration": 4242000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 27,
+            "name": "progress is halted with an error: \"The Decision Date must include a year\"",
+            "result": {
+              "status": "passed",
+              "duration": 74000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "And ",
+            "line": 28,
+            "name": "the correct input \"year\" is highlighted",
+            "result": {
+              "status": "passed",
+              "duration": 44000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "decision-date-eligibility-check;invalid-decision-date-of-\"45\"-\"14\"-\"\"-is-rejected",
+        "keyword": "Scenario",
+        "line": 49,
+        "name": "Invalid Decision Date of \"45\"-\"14\"-\"\" is rejected",
+        "tags": [
+          {
+            "name": "@as-1666",
+            "line": 23
+          }
+        ],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 25,
+            "name": "a Decision Date is requested",
+            "result": {
+              "status": "passed",
+              "duration": 2105000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 26,
+            "name": "a Decision Date of \"45\"-\"14\"-\"\" is provided",
+            "result": {
+              "status": "passed",
+              "duration": 5297000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 27,
+            "name": "progress is halted with an error: \"The Decision Date must include a year\"",
+            "result": {
+              "status": "passed",
+              "duration": 91000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "And ",
+            "line": 28,
+            "name": "the correct input \"year\" is highlighted",
+            "result": {
+              "status": "passed",
+              "duration": 33000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "decision-date-eligibility-check;invalid-decision-date-of-\"40\"-\"12\"-\"2020\"-is-rejected",
+        "keyword": "Scenario",
+        "line": 50,
+        "name": "Invalid Decision Date of \"40\"-\"12\"-\"2020\" is rejected",
+        "tags": [
+          {
+            "name": "@as-1666",
+            "line": 23
+          }
+        ],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 25,
+            "name": "a Decision Date is requested",
+            "result": {
+              "status": "passed",
+              "duration": 1810000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 26,
+            "name": "a Decision Date of \"40\"-\"12\"-\"2020\" is provided",
+            "result": {
+              "status": "passed",
+              "duration": 3734000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 27,
+            "name": "progress is halted with an error: \"The Decision Date must be a real date\"",
+            "result": {
+              "status": "passed",
+              "duration": 91000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "And ",
+            "line": 28,
+            "name": "the correct input \"day\" is highlighted",
+            "result": {
+              "status": "passed",
+              "duration": 44000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "decision-date-eligibility-check;invalid-decision-date-of-\"05\"-\"14\"-\"2025\"-is-rejected",
+        "keyword": "Scenario",
+        "line": 51,
+        "name": "Invalid Decision Date of \"05\"-\"14\"-\"2025\" is rejected",
+        "tags": [
+          {
+            "name": "@as-1666",
+            "line": 23
+          }
+        ],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 25,
+            "name": "a Decision Date is requested",
+            "result": {
+              "status": "passed",
+              "duration": 2025000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 26,
+            "name": "a Decision Date of \"05\"-\"14\"-\"2025\" is provided",
+            "result": {
+              "status": "passed",
+              "duration": 4665000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 27,
+            "name": "progress is halted with an error: \"The Decision Date must be a real date\"",
+            "result": {
+              "status": "passed",
+              "duration": 165000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "And ",
+            "line": 28,
+            "name": "the correct input \"month\" is highlighted",
+            "result": {
+              "status": "passed",
+              "duration": 57000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "decision-date-eligibility-check;invalid-decision-date-of-\"1\"-\"5\"-\"2027\"-is-rejected",
+        "keyword": "Scenario",
+        "line": 52,
+        "name": "Invalid Decision Date of \"1\"-\"5\"-\"2027\" is rejected",
+        "tags": [
+          {
+            "name": "@as-1666",
+            "line": 23
+          }
+        ],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 25,
+            "name": "a Decision Date is requested",
+            "result": {
+              "status": "passed",
+              "duration": 1824000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 26,
+            "name": "a Decision Date of \"1\"-\"5\"-\"2027\" is provided",
+            "result": {
+              "status": "passed",
+              "duration": 4951000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 27,
+            "name": "progress is halted with an error: \"Decision date must be today or in the past\"",
+            "result": {
+              "status": "passed",
+              "duration": 69000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "And ",
+            "line": 28,
+            "name": "the correct input \"day,month,year\" is highlighted",
+            "result": {
+              "status": "passed",
+              "duration": 128000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "decision-date-eligibility-check;invalid-decision-date-of-\"1\"-\"1\"-\"2022\"-is-rejected",
+        "keyword": "Scenario",
+        "line": 53,
+        "name": "Invalid Decision Date of \"1\"-\"1\"-\"2022\" is rejected",
+        "tags": [
+          {
+            "name": "@as-1666",
+            "line": 23
+          }
+        ],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 25,
+            "name": "a Decision Date is requested",
+            "result": {
+              "status": "passed",
+              "duration": 1955000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 26,
+            "name": "a Decision Date of \"1\"-\"1\"-\"2022\" is provided",
+            "result": {
+              "status": "passed",
+              "duration": 5074000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 27,
+            "name": "progress is halted with an error: \"Decision date must be today or in the past\"",
+            "result": {
+              "status": "passed",
+              "duration": 70000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "And ",
+            "line": 28,
+            "name": "the correct input \"day,month,year\" is highlighted",
+            "result": {
+              "status": "passed",
+              "duration": 90000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "decision-date-eligibility-check;invalid-decision-date-of-\"32\"-\"13\"-\"2020\"-is-rejected",
+        "keyword": "Scenario",
+        "line": 54,
+        "name": "Invalid Decision Date of \"32\"-\"13\"-\"2020\" is rejected",
+        "tags": [
+          {
+            "name": "@as-1666",
+            "line": 23
+          }
+        ],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 25,
+            "name": "a Decision Date is requested",
+            "result": {
+              "status": "passed",
+              "duration": 2885000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 26,
+            "name": "a Decision Date of \"32\"-\"13\"-\"2020\" is provided",
+            "result": {
+              "status": "passed",
+              "duration": 4701000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 27,
+            "name": "progress is halted with an error: \"The Decision Date must be a real date\"",
+            "result": {
+              "status": "passed",
+              "duration": 74000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "And ",
+            "line": 28,
+            "name": "the correct input \"day,month\" is highlighted",
+            "result": {
+              "status": "passed",
+              "duration": 82000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "decision-date-eligibility-check;invalid-decision-date-of-\"1a\"-\"0b\"-\"2cde\"-is-rejected",
+        "keyword": "Scenario",
+        "line": 55,
+        "name": "Invalid Decision Date of \"1a\"-\"0b\"-\"2cde\" is rejected",
+        "tags": [
+          {
+            "name": "@as-1666",
+            "line": 23
+          }
+        ],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 25,
+            "name": "a Decision Date is requested",
+            "result": {
+              "status": "passed",
+              "duration": 2018000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 26,
+            "name": "a Decision Date of \"1a\"-\"0b\"-\"2cde\" is provided",
+            "result": {
+              "status": "passed",
+              "duration": 3905000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 27,
+            "name": "progress is halted with an error: \"The Decision Date must be a real date\"",
+            "result": {
+              "status": "passed",
+              "duration": 60000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "And ",
+            "line": 28,
+            "name": "the correct input \"day,month,year\" is highlighted",
+            "result": {
+              "status": "passed",
+              "duration": 121000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "decision-date-eligibility-check;invalid-decision-date-of-\"aa\"-\"10\"-\"2020\"-is-rejected",
+        "keyword": "Scenario",
+        "line": 56,
+        "name": "Invalid Decision Date of \"aa\"-\"10\"-\"2020\" is rejected",
+        "tags": [
+          {
+            "name": "@as-1666",
+            "line": 23
+          }
+        ],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 25,
+            "name": "a Decision Date is requested",
+            "result": {
+              "status": "passed",
+              "duration": 1844000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 26,
+            "name": "a Decision Date of \"aa\"-\"10\"-\"2020\" is provided",
+            "result": {
+              "status": "passed",
+              "duration": 5194000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 27,
+            "name": "progress is halted with an error: \"The Decision Date must be a real date\"",
+            "result": {
+              "status": "passed",
+              "duration": 66000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "And ",
+            "line": 28,
+            "name": "the correct input \"day\" is highlighted",
+            "result": {
+              "status": "passed",
+              "duration": 40000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "decision-date-eligibility-check;invalid-decision-date-of-\"aa\"-\"bb\"-\"2020\"-is-rejected",
+        "keyword": "Scenario",
+        "line": 57,
+        "name": "Invalid Decision Date of \"aa\"-\"bb\"-\"2020\" is rejected",
+        "tags": [
+          {
+            "name": "@as-1666",
+            "line": 23
+          }
+        ],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 25,
+            "name": "a Decision Date is requested",
+            "result": {
+              "status": "passed",
+              "duration": 1924000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 26,
+            "name": "a Decision Date of \"aa\"-\"bb\"-\"2020\" is provided",
+            "result": {
+              "status": "passed",
+              "duration": 4645000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 27,
+            "name": "progress is halted with an error: \"The Decision Date must be a real date\"",
+            "result": {
+              "status": "passed",
+              "duration": 48000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "And ",
+            "line": 28,
+            "name": "the correct input \"day,month\" is highlighted",
+            "result": {
+              "status": "passed",
+              "duration": 79000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "decision-date-eligibility-check;invalid-decision-date-of-\"31\"-\"zz\"-\"2020\"-is-rejected",
+        "keyword": "Scenario",
+        "line": 58,
+        "name": "Invalid Decision Date of \"31\"-\"zz\"-\"2020\" is rejected",
+        "tags": [
+          {
+            "name": "@as-1666",
+            "line": 23
+          }
+        ],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 25,
+            "name": "a Decision Date is requested",
+            "result": {
+              "status": "passed",
+              "duration": 1376000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 26,
+            "name": "a Decision Date of \"31\"-\"zz\"-\"2020\" is provided",
+            "result": {
+              "status": "passed",
+              "duration": 3466000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 27,
+            "name": "progress is halted with an error: \"The Decision Date must be a real date\"",
+            "result": {
+              "status": "passed",
+              "duration": 138000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "And ",
+            "line": 28,
+            "name": "the correct input \"month\" is highlighted",
+            "result": {
+              "status": "passed",
+              "duration": 48000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "decision-date-eligibility-check;invalid-decision-date-of-\"31\"-\"10\"-\"aaaa\"-is-rejected",
+        "keyword": "Scenario",
+        "line": 59,
+        "name": "Invalid Decision Date of \"31\"-\"10\"-\"aaaa\" is rejected",
+        "tags": [
+          {
+            "name": "@as-1666",
+            "line": 23
+          }
+        ],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 25,
+            "name": "a Decision Date is requested",
+            "result": {
+              "status": "passed",
+              "duration": 1152000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 26,
+            "name": "a Decision Date of \"31\"-\"10\"-\"aaaa\" is provided",
+            "result": {
+              "status": "passed",
+              "duration": 2624000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 27,
+            "name": "progress is halted with an error: \"The Decision Date must be a real date\"",
+            "result": {
+              "status": "passed",
+              "duration": 32000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "And ",
+            "line": 28,
+            "name": "the correct input \"year\" is highlighted",
+            "result": {
+              "status": "passed",
+              "duration": 13000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "decision-date-eligibility-check;invalid-decision-date-of-\"19\"-\"10\"-\"20\"-is-rejected",
+        "keyword": "Scenario",
+        "line": 60,
+        "name": "Invalid Decision Date of \"19\"-\"10\"-\"20\" is rejected",
+        "tags": [
+          {
+            "name": "@as-1666",
+            "line": 23
+          }
+        ],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 25,
+            "name": "a Decision Date is requested",
+            "result": {
+              "status": "passed",
+              "duration": 1063000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 26,
+            "name": "a Decision Date of \"19\"-\"10\"-\"20\" is provided",
+            "result": {
+              "status": "passed",
+              "duration": 5373000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 27,
+            "name": "progress is halted with an error: \"The Decision Date must be a real date\"",
+            "result": {
+              "status": "passed",
+              "duration": 115000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "And ",
+            "line": 28,
+            "name": "the correct input \"year\" is highlighted",
+            "result": {
+              "status": "passed",
+              "duration": 69000000
+            }
+          }
+        ]
+      }
+    ]
+  }
+]

--- a/packages/e2e-tests/cypress/cucumber-json/eligibility-enforcement-notice.cucumber.json
+++ b/packages/e2e-tests/cypress/cucumber-json/eligibility-enforcement-notice.cucumber.json
@@ -1,0 +1,177 @@
+[
+  {
+    "description": "    Our service does not cover appellants who have received an Enforcement Notice",
+    "keyword": "Feature",
+    "name": "A prospective appellant states whether or not they have received an Enforcement Notice",
+    "line": 2,
+    "id": "a-prospective-appellant-states-whether-or-not-they-have-received-an-enforcement-notice",
+    "tags": [
+      {
+        "name": "@smoketest",
+        "line": 1
+      }
+    ],
+    "uri": "eligibility-enforcement-notice.feature",
+    "elements": [
+      {
+        "id": "a-prospective-appellant-states-whether-or-not-they-have-received-an-enforcement-notice;prospective-appellant-makes-no-selection-and-is-provided-an-error",
+        "keyword": "Scenario",
+        "line": 6,
+        "name": "Prospective appellant makes no selection and is provided an error",
+        "tags": [
+          {
+            "name": "@smoketest",
+            "line": 1
+          },
+          {
+            "name": "@ucd-998",
+            "line": 5
+          },
+          {
+            "name": "@ucd-998-ac2",
+            "line": 5
+          }
+        ],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 7,
+            "name": "receipt of an Enforcement Notice is requested",
+            "result": {
+              "status": "passed",
+              "duration": 1207000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 8,
+            "name": "receipt of an Enforcement Notice is not provided",
+            "result": {
+              "status": "passed",
+              "duration": 885000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 9,
+            "name": "progress is halted with a message that the Enforcement Notice question is required",
+            "result": {
+              "status": "passed",
+              "duration": 35000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "a-prospective-appellant-states-whether-or-not-they-have-received-an-enforcement-notice;prospective-appellant-selects-no-and-proceeds-through-eligibility-checker",
+        "keyword": "Scenario",
+        "line": 12,
+        "name": "Prospective appellant selects no and proceeds through eligibility checker",
+        "tags": [
+          {
+            "name": "@smoketest",
+            "line": 1
+          },
+          {
+            "name": "@ucd-998",
+            "line": 11
+          },
+          {
+            "name": "@ucd-998-ac3",
+            "line": 11
+          }
+        ],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 13,
+            "name": "receipt of an Enforcement Notice is requested",
+            "result": {
+              "status": "passed",
+              "duration": 740000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 14,
+            "name": "the appellant has not received an Enforcement Notice",
+            "result": {
+              "status": "passed",
+              "duration": 899000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 15,
+            "name": "progress is made to the Listed Building eligibility question",
+            "result": {
+              "status": "passed",
+              "duration": 13000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "a-prospective-appellant-states-whether-or-not-they-have-received-an-enforcement-notice;prospective-appellant-selects-yes-and-is-taken-to-kick-out-page",
+        "keyword": "Scenario",
+        "line": 18,
+        "name": "Prospective appellant selects yes and is taken to kick-out page",
+        "tags": [
+          {
+            "name": "@smoketest",
+            "line": 1
+          },
+          {
+            "name": "@ucd-998",
+            "line": 17
+          },
+          {
+            "name": "@ucd-998-ac4",
+            "line": 17
+          }
+        ],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 19,
+            "name": "receipt of an Enforcement Notice is requested",
+            "result": {
+              "status": "passed",
+              "duration": 720000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 20,
+            "name": "the appellant has received an Enforcement Notice",
+            "result": {
+              "status": "passed",
+              "duration": 907000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 21,
+            "name": "progress is halted with a message that this service is only for householder planning appeals",
+            "result": {
+              "status": "passed",
+              "duration": 56000000
+            }
+          }
+        ]
+      }
+    ]
+  }
+]

--- a/packages/e2e-tests/cypress/cucumber-json/eligibility-granted-or-refused-permission.cucumber.json
+++ b/packages/e2e-tests/cypress/cucumber-json/eligibility-granted-or-refused-permission.cucumber.json
@@ -1,0 +1,173 @@
+[
+  {
+    "description": "    Prospective appellant states whether their planning permission application has been Granted, or Refused,\n    or they don't have received the decision yet",
+    "keyword": "Feature",
+    "name": "Eligibility - Appeal Householder Planning Permission Status Question",
+    "line": 1,
+    "id": "eligibility---appeal-householder-planning-permission-status-question",
+    "tags": [],
+    "uri": "eligibility-granted-or-refused-permission.feature",
+    "elements": [
+      {
+        "id": "eligibility---appeal-householder-planning-permission-status-question;prospective-appellant-selects-refused-householder-planning-permission-status-and-proceeds-through-to-decision-date-page",
+        "keyword": "Scenario",
+        "line": 5,
+        "name": "Prospective appellant selects Refused Householder Planning Permission Status and proceeds through to Decision Date page",
+        "tags": [],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 6,
+            "name": "Householder Planning Permission Status is requested",
+            "result": {
+              "status": "passed",
+              "duration": 1331000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 7,
+            "name": "Householder Planning Permission Status is set to Refused",
+            "result": {
+              "status": "passed",
+              "duration": 1913000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 8,
+            "name": "progress is made to the eligibility Decision Date question",
+            "result": {
+              "status": "passed",
+              "duration": 26000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "eligibility---appeal-householder-planning-permission-status-question;prospective-appellant-does-not-select-any-householder-planning-permission-status-and-is-provided-an-error",
+        "keyword": "Scenario",
+        "line": 10,
+        "name": "Prospective appellant does not select any Householder Planning Permission Status and is provided an error",
+        "tags": [],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 11,
+            "name": "Householder Planning Permission Status is requested",
+            "result": {
+              "status": "passed",
+              "duration": 1327000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 12,
+            "name": "No Householder Planning Permission Status is not selected",
+            "result": {
+              "status": "passed",
+              "duration": 1366000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 13,
+            "name": "Progress is halted with a message that a Householder Planning Permission Status is required",
+            "result": {
+              "status": "passed",
+              "duration": 58000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "eligibility---appeal-householder-planning-permission-status-question;prospective-appellant-selects-granted-householder-planning-permission-status-and-is-taken-to-kick-out-page",
+        "keyword": "Scenario",
+        "line": 15,
+        "name": "Prospective appellant selects Granted Householder Planning Permission Status and is taken to kick-out page",
+        "tags": [],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 16,
+            "name": "Householder Planning Permission Status is requested",
+            "result": {
+              "status": "passed",
+              "duration": 1734000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 17,
+            "name": "Householder Planning Permission Status is set to Granted",
+            "result": {
+              "status": "passed",
+              "duration": 1041000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 18,
+            "name": "User is navigated to kick-out page",
+            "result": {
+              "status": "passed",
+              "duration": 29000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "eligibility---appeal-householder-planning-permission-status-question;prospective-appellant-selects-'i-have-not-received-a-decision'-householder-planning-permission-status-and-is-taken-to-no-decision-page",
+        "keyword": "Scenario",
+        "line": 20,
+        "name": "Prospective appellant selects 'I have not received a decision' Householder Planning Permission Status and is taken to no-decision page",
+        "tags": [],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 21,
+            "name": "Householder Planning Permission Status is requested",
+            "result": {
+              "status": "passed",
+              "duration": 968000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 22,
+            "name": "Householder Planning Permission Status is set to I have not received a decision",
+            "result": {
+              "status": "passed",
+              "duration": 781000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 23,
+            "name": "User is navigated to no-decision page",
+            "result": {
+              "status": "passed",
+              "duration": 2096000000
+            }
+          }
+        ]
+      }
+    ]
+  }
+]

--- a/packages/e2e-tests/cypress/cucumber-json/eligibility-listed-building-status.cucumber.json
+++ b/packages/e2e-tests/cypress/cucumber-json/eligibility-listed-building-status.cucumber.json
@@ -1,0 +1,186 @@
+[
+  {
+    "description": "    Our service doesn't cover listed buildings.",
+    "keyword": "Feature",
+    "name": "A prospective appellant states whether or not their appeal covers a listed building",
+    "line": 2,
+    "id": "a-prospective-appellant-states-whether-or-not-their-appeal-covers-a-listed-building",
+    "tags": [
+      {
+        "name": "@smoketest",
+        "line": 1
+      }
+    ],
+    "uri": "eligibility-listed-building-status.feature",
+    "elements": [
+      {
+        "id": "a-prospective-appellant-states-whether-or-not-their-appeal-covers-a-listed-building;listed-building-statement-is-required",
+        "keyword": "Scenario",
+        "line": 6,
+        "name": "Listed Building statement is required",
+        "tags": [
+          {
+            "name": "@smoketest",
+            "line": 1
+          },
+          {
+            "name": "@as-1670",
+            "line": 5
+          }
+        ],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 7,
+            "name": "the user does not provide a Listed Building statement",
+            "result": {
+              "status": "passed",
+              "duration": 2689000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 8,
+            "name": "the user is informed that a Listed Building statement is required",
+            "result": {
+              "status": "passed",
+              "duration": 79000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "a-prospective-appellant-states-whether-or-not-their-appeal-covers-a-listed-building;user-selects-yes-option-in-the-is-your-appeal-about-a-listed-building-page",
+        "keyword": "Scenario",
+        "line": 10,
+        "name": "User selects yes option in the Is your appeal about a listed building page",
+        "tags": [
+          {
+            "name": "@smoketest",
+            "line": 1
+          }
+        ],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 11,
+            "name": "the user states that their case concerns a Listed Building",
+            "result": {
+              "status": "passed",
+              "duration": 1686000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 12,
+            "name": "the user is informed that cases concerning a Listed Building cannot be processed via this service",
+            "result": {
+              "status": "passed",
+              "duration": 25000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "And ",
+            "line": 13,
+            "name": "the user is directed to the Appeal a Planning Decision service",
+            "result": {
+              "status": "passed",
+              "duration": 16000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "a-prospective-appellant-states-whether-or-not-their-appeal-covers-a-listed-building;user-selects-no-option-in-the-is-your-appeal-about-a-listed-building-page",
+        "keyword": "Scenario",
+        "line": 15,
+        "name": "User selects no option in the Is your appeal about a listed building page",
+        "tags": [
+          {
+            "name": "@smoketest",
+            "line": 1
+          }
+        ],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 16,
+            "name": "the user states that their case does not concern a Listed Building",
+            "result": {
+              "status": "passed",
+              "duration": 1693000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 17,
+            "name": "the user can proceed to the claiming Costs eligibility check",
+            "result": {
+              "status": "passed",
+              "duration": 23000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "a-prospective-appellant-states-whether-or-not-their-appeal-covers-a-listed-building;should-retain-the-selected-answer-on-re-visiting-the-page",
+        "keyword": "Scenario",
+        "line": 20,
+        "name": "Should retain the selected answer on re-visiting the page",
+        "tags": [
+          {
+            "name": "@smoketest",
+            "line": 1
+          },
+          {
+            "name": "@as-1854",
+            "line": 19
+          }
+        ],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 21,
+            "name": "the user states that their case does not concern a Listed Building",
+            "result": {
+              "status": "passed",
+              "duration": 2293000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 22,
+            "name": "the user returns to the listed building page",
+            "result": {
+              "status": "passed",
+              "duration": 1250000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 23,
+            "name": "the user sees their previous given answer is correctly displayed",
+            "result": {
+              "status": "passed",
+              "duration": 43000000
+            }
+          }
+        ]
+      }
+    ]
+  }
+]

--- a/packages/e2e-tests/cypress/cucumber-json/eligibility-local-planning-department-no-js.cucumber.json
+++ b/packages/e2e-tests/cypress/cucumber-json/eligibility-local-planning-department-no-js.cucumber.json
@@ -1,0 +1,196 @@
+[
+  {
+    "description": "    Not every LPA is taking part in this iteration of the service.\n    ** This is expected behaviour when JavaScript is disabled in the user's browser. **",
+    "keyword": "Feature",
+    "name": "A prospective appellant selects a Local Planning Department for the case they wish to appeal",
+    "line": 2,
+    "id": "a-prospective-appellant-selects-a-local-planning-department-for-the-case-they-wish-to-appeal",
+    "tags": [
+      {
+        "name": "@smoketest",
+        "line": 1
+      }
+    ],
+    "uri": "eligibility-local-planning-department-no-js.feature",
+    "elements": [
+      {
+        "id": "a-prospective-appellant-selects-a-local-planning-department-for-the-case-they-wish-to-appeal;no-local-planning-department-selected",
+        "keyword": "Scenario",
+        "line": 6,
+        "name": "No Local Planning Department selected",
+        "tags": [
+          {
+            "name": "@smoketest",
+            "line": 1
+          }
+        ],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 7,
+            "name": "the user can select from a list of Local Planning Departments",
+            "result": {
+              "status": "passed",
+              "duration": 4329000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 8,
+            "name": "the user does not select a Local Planning Department",
+            "result": {
+              "status": "passed",
+              "duration": 2850000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 9,
+            "name": "the user is informed that a Local Planning Department in the provided list must be selected",
+            "result": {
+              "status": "passed",
+              "duration": 71000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "a-prospective-appellant-selects-a-local-planning-department-for-the-case-they-wish-to-appeal;selected-local-planning-department-not-in-the-list",
+        "keyword": "Scenario",
+        "line": 11,
+        "name": "Selected Local Planning Department not in the list",
+        "tags": [
+          {
+            "name": "@smoketest",
+            "line": 1
+          }
+        ],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 12,
+            "name": "the user can select from a list of Local Planning Departments",
+            "result": {
+              "status": "passed",
+              "duration": 1084000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 13,
+            "name": "the user selects the empty value from the list of Local Planning Departments",
+            "result": {
+              "status": "passed",
+              "duration": 3471000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 14,
+            "name": "the user is informed that a Local Planning Department in the provided list must be selected",
+            "result": {
+              "status": "passed",
+              "duration": 46000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "a-prospective-appellant-selects-a-local-planning-department-for-the-case-they-wish-to-appeal;selected-local-planning-department-is-not-participating-in-this-service",
+        "keyword": "Scenario",
+        "line": 16,
+        "name": "Selected Local Planning Department is not participating in this service",
+        "tags": [
+          {
+            "name": "@smoketest",
+            "line": 1
+          }
+        ],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 17,
+            "name": "the user can select from a list of Local Planning Departments",
+            "result": {
+              "status": "passed",
+              "duration": 782000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 18,
+            "name": "the user selects a Local Planning Department that is not participating in this service",
+            "result": {
+              "status": "failed",
+              "error_message": "CypressError: `cy.select()` can only be called on a `<select>`. Your subject is a: `<input aria-expanded=\"false\" aria-owns=\"local-planning-department__listbox\" aria-autocomplete=\"both\" aria-describedby=\"local-planning-department__assistiveHint\" autocomplete=\"off\" class=\"autocomplete__input autocomplete__input--default\" id=\"local-planning-department\" name=\"\" placeholder=\"\" type=\"text\" role=\"combobox\">`\n    at Context.select (http://localhost:9003/__cypress/runner/cypress_runner.js:135568:19)\n    at Context.<anonymous> (http://localhost:9003/__cypress/runner/cypress_runner.js:153308:21)\nFrom Your Spec Code:\n    at Context.eval (http://localhost:9003/__cypress/tests?p=cypress\\integration\\householder-planning\\appeals-service\\eligibility-local-planning-department-no-js.feature:5463:42)"
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 19,
+            "name": "the user is informed that the selected Local Planning Department is not participating in the service",
+            "result": {
+              "status": "skipped"
+            }
+          }
+        ]
+      },
+      {
+        "id": "a-prospective-appellant-selects-a-local-planning-department-for-the-case-they-wish-to-appeal;selected-local-planning-department-is-participating-in-this-service",
+        "keyword": "Scenario",
+        "line": 21,
+        "name": "Selected Local Planning Department is participating in this service",
+        "tags": [
+          {
+            "name": "@smoketest",
+            "line": 1
+          }
+        ],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 22,
+            "name": "the user can select from a list of Local Planning Departments",
+            "result": {
+              "status": "passed",
+              "duration": 2937000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 23,
+            "name": "the user selects a Local Planning Department that is participating in this service",
+            "result": {
+              "status": "failed",
+              "error_message": "CypressError: `cy.select()` can only be called on a `<select>`. Your subject is a: `<input aria-expanded=\"false\" aria-owns=\"local-planning-department__listbox\" aria-autocomplete=\"both\" aria-describedby=\"local-planning-department__assistiveHint\" autocomplete=\"off\" class=\"autocomplete__input autocomplete__input--default\" id=\"local-planning-department\" name=\"\" placeholder=\"\" type=\"text\" role=\"combobox\">`\n    at Context.select (http://localhost:9003/__cypress/runner/cypress_runner.js:135568:19)\n    at Context.<anonymous> (http://localhost:9003/__cypress/runner/cypress_runner.js:153308:21)\nFrom Your Spec Code:\n    at Context.eval (http://localhost:9003/__cypress/tests?p=cypress\\integration\\householder-planning\\appeals-service\\eligibility-local-planning-department-no-js.feature:5440:42)"
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 24,
+            "name": "the user can proceed and the appeal is updated with the selected Local Planning Department",
+            "result": {
+              "status": "skipped"
+            }
+          }
+        ]
+      }
+    ]
+  }
+]

--- a/packages/e2e-tests/cypress/cucumber-json/eligibility-local-planning-department.cucumber.json
+++ b/packages/e2e-tests/cypress/cucumber-json/eligibility-local-planning-department.cucumber.json
@@ -1,0 +1,303 @@
+[
+  {
+    "description": "    Not every LPA is taking part in this iteration of the service.",
+    "keyword": "Feature",
+    "name": "A prospective appellant supplies a Local Planning Department for the case they wish to appeal",
+    "line": 2,
+    "id": "a-prospective-appellant-supplies-a-local-planning-department-for-the-case-they-wish-to-appeal",
+    "tags": [
+      {
+        "name": "@smoketest",
+        "line": 1
+      }
+    ],
+    "uri": "eligibility-local-planning-department.feature",
+    "elements": [
+      {
+        "id": "a-prospective-appellant-supplies-a-local-planning-department-for-the-case-they-wish-to-appeal;local-planning-department-is-required",
+        "keyword": "Scenario",
+        "line": 5,
+        "name": "Local Planning Department is required",
+        "tags": [
+          {
+            "name": "@smoketest",
+            "line": 1
+          }
+        ],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 6,
+            "name": "the list of Local Planning Department is presented",
+            "result": {
+              "status": "failed",
+              "duration": 5489000000,
+              "error_message": "CypressError: `cy.visit()` failed trying to load:\n\nhttp://localhost:9003/eligibility/planning-department\n\nWe attempted to make an http request to this URL but the request failed without a response.\n\nWe received this error at the network level:\n\n  > Error: socket hang up\n\nCommon situations why this would fail:\n  - you don't have internet access\n  - you forgot to run / boot your web server\n  - your web server isn't accessible\n  - you have weird network configuration settings on your computer\n    at http://localhost:9003/__cypress/runner/cypress_runner.js:140471:23\n    at visitFailedByErr (http://localhost:9003/__cypress/runner/cypress_runner.js:139830:12)\n    at http://localhost:9003/__cypress/runner/cypress_runner.js:140470:11\nFrom previous event:\n    at go (http://localhost:9003/__cypress/runner/cypress_runner.js:140433:17)\n    at http://localhost:9003/__cypress/runner/cypress_runner.js:140499:20\nFrom previous event:\n    at visit (http://localhost:9003/__cypress/runner/cypress_runner.js:140497:38)\n    at Context.visit (http://localhost:9003/__cypress/runner/cypress_runner.js:140506:14)\nFrom Your Spec Code:\n    at Context.eval (http://localhost:9003/__cypress/tests?p=cypress\\integration\\householder-planning\\appeals-service\\eligibility-local-planning-department.feature:5527:8)\n\nFrom Node.js Internals:\n  Error: socket hang up\n      at connResetException (internal/errors.js:617:14)\n      at Socket.socketOnEnd (_http_client.js:493:23)\n      at Socket.emit (events.js:327:22)\n      at endReadableNT (_stream_readable.js:1327:12)\n      at processTicksAndRejections (internal/process/task_queues.js:80:21)\n  "
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 7,
+            "name": "the user does not provide a Local Planning Department",
+            "result": {
+              "status": "skipped"
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 8,
+            "name": "the user is informed that a Local Planning Department in the provided list is required",
+            "result": {
+              "status": "skipped"
+            }
+          }
+        ]
+      },
+      {
+        "id": "a-prospective-appellant-supplies-a-local-planning-department-for-the-case-they-wish-to-appeal;local-planning-department-not-in-the-list",
+        "keyword": "Scenario",
+        "line": 10,
+        "name": "Local Planning Department not in the list",
+        "tags": [
+          {
+            "name": "@smoketest",
+            "line": 1
+          }
+        ],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 11,
+            "name": "the list of Local Planning Department is presented",
+            "result": {
+              "status": "failed",
+              "error_message": "CypressError: `cy.visit()` failed trying to load:\n\nhttp://localhost:9003/eligibility/planning-department\n\nWe attempted to make an http request to this URL but the request failed without a response.\n\nWe received this error at the network level:\n\n  > Error: socket hang up\n\nCommon situations why this would fail:\n  - you don't have internet access\n  - you forgot to run / boot your web server\n  - your web server isn't accessible\n  - you have weird network configuration settings on your computer\n    at http://localhost:9003/__cypress/runner/cypress_runner.js:140471:23\n    at visitFailedByErr (http://localhost:9003/__cypress/runner/cypress_runner.js:139830:12)\n    at http://localhost:9003/__cypress/runner/cypress_runner.js:140470:11\nFrom previous event:\n    at go (http://localhost:9003/__cypress/runner/cypress_runner.js:140433:17)\n    at http://localhost:9003/__cypress/runner/cypress_runner.js:140499:20\nFrom previous event:\n    at visit (http://localhost:9003/__cypress/runner/cypress_runner.js:140497:38)\n    at Context.visit (http://localhost:9003/__cypress/runner/cypress_runner.js:140506:14)\nFrom Your Spec Code:\n    at Context.eval (http://localhost:9003/__cypress/tests?p=cypress\\integration\\householder-planning\\appeals-service\\eligibility-local-planning-department.feature:5527:8)\n\nFrom Node.js Internals:\n  Error: socket hang up\n      at connResetException (internal/errors.js:617:14)\n      at Socket.socketOnEnd (_http_client.js:493:23)\n      at Socket.emit (events.js:327:22)\n      at endReadableNT (_stream_readable.js:1327:12)\n      at processTicksAndRejections (internal/process/task_queues.js:80:21)\n  "
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 12,
+            "name": "the user provides a Local Planning Department not in the provided list",
+            "result": {
+              "status": "skipped"
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 13,
+            "name": "the user is informed that a Local Planning Department in the provided list is required",
+            "result": {
+              "status": "skipped"
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "And ",
+            "line": 14,
+            "name": "appeal is not updated with the unknown Local Planning Department",
+            "result": {
+              "status": "skipped"
+            }
+          }
+        ]
+      },
+      {
+        "id": "a-prospective-appellant-supplies-a-local-planning-department-for-the-case-they-wish-to-appeal;some-local-planning-departments-are-not-participating-in-this-service",
+        "keyword": "Scenario",
+        "line": 16,
+        "name": "Some Local Planning Departments are not participating in this service",
+        "tags": [
+          {
+            "name": "@smoketest",
+            "line": 1
+          }
+        ],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 17,
+            "name": "the list of Local Planning Department is presented",
+            "result": {
+              "status": "failed",
+              "error_message": "CypressError: `cy.visit()` failed trying to load:\n\nhttp://localhost:9003/eligibility/planning-department\n\nWe attempted to make an http request to this URL but the request failed without a response.\n\nWe received this error at the network level:\n\n  > Error: socket hang up\n\nCommon situations why this would fail:\n  - you don't have internet access\n  - you forgot to run / boot your web server\n  - your web server isn't accessible\n  - you have weird network configuration settings on your computer\n    at http://localhost:9003/__cypress/runner/cypress_runner.js:140471:23\n    at visitFailedByErr (http://localhost:9003/__cypress/runner/cypress_runner.js:139830:12)\n    at http://localhost:9003/__cypress/runner/cypress_runner.js:140470:11\nFrom previous event:\n    at go (http://localhost:9003/__cypress/runner/cypress_runner.js:140433:17)\n    at http://localhost:9003/__cypress/runner/cypress_runner.js:140499:20\nFrom previous event:\n    at visit (http://localhost:9003/__cypress/runner/cypress_runner.js:140497:38)\n    at Context.visit (http://localhost:9003/__cypress/runner/cypress_runner.js:140506:14)\nFrom Your Spec Code:\n    at Context.eval (http://localhost:9003/__cypress/tests?p=cypress\\integration\\householder-planning\\appeals-service\\eligibility-local-planning-department.feature:5527:8)\n\nFrom Node.js Internals:\n  Error: socket hang up\n      at connResetException (internal/errors.js:617:14)\n      at Socket.socketOnEnd (_http_client.js:493:23)\n      at Socket.emit (events.js:327:22)\n      at endReadableNT (_stream_readable.js:1327:12)\n      at processTicksAndRejections (internal/process/task_queues.js:80:21)\n  "
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 18,
+            "name": "the user provides a Local Planning Department that is not participating in this service",
+            "result": {
+              "status": "skipped"
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 19,
+            "name": "the user is informed that the selected Local Planning Department is not participating in the service",
+            "result": {
+              "status": "skipped"
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "And ",
+            "line": 20,
+            "name": "appeal is updated with the ineligible Local Planning Department",
+            "result": {
+              "status": "skipped"
+            }
+          }
+        ]
+      },
+      {
+        "id": "a-prospective-appellant-supplies-a-local-planning-department-for-the-case-they-wish-to-appeal;local-planning-department-is-successfully-provided",
+        "keyword": "Scenario",
+        "line": 22,
+        "name": "Local Planning Department is successfully provided",
+        "tags": [
+          {
+            "name": "@smoketest",
+            "line": 1
+          }
+        ],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 23,
+            "name": "the list of Local Planning Department is presented",
+            "result": {
+              "status": "failed",
+              "error_message": "CypressError: `cy.visit()` failed trying to load:\n\nhttp://localhost:9003/eligibility/planning-department\n\nWe attempted to make an http request to this URL but the request failed without a response.\n\nWe received this error at the network level:\n\n  > Error: socket hang up\n\nCommon situations why this would fail:\n  - you don't have internet access\n  - you forgot to run / boot your web server\n  - your web server isn't accessible\n  - you have weird network configuration settings on your computer\n    at http://localhost:9003/__cypress/runner/cypress_runner.js:140471:23\n    at visitFailedByErr (http://localhost:9003/__cypress/runner/cypress_runner.js:139830:12)\n    at http://localhost:9003/__cypress/runner/cypress_runner.js:140470:11\nFrom previous event:\n    at go (http://localhost:9003/__cypress/runner/cypress_runner.js:140433:17)\n    at http://localhost:9003/__cypress/runner/cypress_runner.js:140499:20\nFrom previous event:\n    at visit (http://localhost:9003/__cypress/runner/cypress_runner.js:140497:38)\n    at Context.visit (http://localhost:9003/__cypress/runner/cypress_runner.js:140506:14)\nFrom Your Spec Code:\n    at Context.eval (http://localhost:9003/__cypress/tests?p=cypress\\integration\\householder-planning\\appeals-service\\eligibility-local-planning-department.feature:5527:8)\n\nFrom Node.js Internals:\n  Error: socket hang up\n      at connResetException (internal/errors.js:617:14)\n      at Socket.socketOnEnd (_http_client.js:493:23)\n      at Socket.emit (events.js:327:22)\n      at endReadableNT (_stream_readable.js:1327:12)\n      at processTicksAndRejections (internal/process/task_queues.js:80:21)\n  "
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 24,
+            "name": "the user provides a Local Planning Department that is participating in this service",
+            "result": {
+              "status": "skipped"
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 25,
+            "name": "the user can proceed and the appeal is updated with the Local Planning Department",
+            "result": {
+              "status": "skipped"
+            }
+          }
+        ]
+      },
+      {
+        "id": "a-prospective-appellant-supplies-a-local-planning-department-for-the-case-they-wish-to-appeal;eligible-local-planning-department-(lpd)-provided---eligibility-journey-continues",
+        "keyword": "Scenario",
+        "line": 29,
+        "name": "Eligible Local Planning Department (LPD) provided - eligibility journey continues",
+        "tags": [
+          {
+            "name": "@smoketest",
+            "line": 1
+          },
+          {
+            "name": "@ucd-998",
+            "line": 27
+          },
+          {
+            "name": "@ucd-998-ac1",
+            "line": 27
+          }
+        ],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 30,
+            "name": "LPD is requested",
+            "result": {
+              "status": "failed",
+              "error_message": "CypressError: `cy.visit()` failed trying to load:\n\nhttp://localhost:9003/eligibility/planning-department\n\nWe attempted to make an http request to this URL but the request failed without a response.\n\nWe received this error at the network level:\n\n  > Error: socket hang up\n\nCommon situations why this would fail:\n  - you don't have internet access\n  - you forgot to run / boot your web server\n  - your web server isn't accessible\n  - you have weird network configuration settings on your computer\n    at http://localhost:9003/__cypress/runner/cypress_runner.js:140471:23\n    at visitFailedByErr (http://localhost:9003/__cypress/runner/cypress_runner.js:139830:12)\n    at http://localhost:9003/__cypress/runner/cypress_runner.js:140470:11\nFrom previous event:\n    at go (http://localhost:9003/__cypress/runner/cypress_runner.js:140433:17)\n    at http://localhost:9003/__cypress/runner/cypress_runner.js:140499:20\nFrom previous event:\n    at visit (http://localhost:9003/__cypress/runner/cypress_runner.js:140497:38)\n    at Context.visit (http://localhost:9003/__cypress/runner/cypress_runner.js:140506:14)\nFrom Your Spec Code:\n    at goToPlanningDepartmentPage (http://localhost:9003/__cypress/tests?p=cypress\\integration\\householder-planning\\appeals-service\\eligibility-local-planning-department.feature:5900:6)\n    at Context.eval (http://localhost:9003/__cypress/tests?p=cypress\\integration\\householder-planning\\appeals-service\\eligibility-local-planning-department.feature:2668:62)\n    at Context.resolveAndRunStepDefinition (http://localhost:9003/__cypress/tests?p=cypress\\integration\\householder-planning\\appeals-service\\eligibility-local-planning-department.feature:16647:29)\n    at Context.eval (http://localhost:9003/__cypress/tests?p=cypress\\integration\\householder-planning\\appeals-service\\eligibility-local-planning-department.feature:15968:35)\n\nFrom Node.js Internals:\n  Error: socket hang up\n      at connResetException (internal/errors.js:617:14)\n      at Socket.socketOnEnd (_http_client.js:493:23)\n      at Socket.emit (events.js:327:22)\n      at endReadableNT (_stream_readable.js:1327:12)\n      at processTicksAndRejections (internal/process/task_queues.js:80:21)\n  "
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 31,
+            "name": "an eligible LPD is provided",
+            "result": {
+              "status": "skipped"
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 32,
+            "name": "the user can proceed to the Enforcement Notice eligibility check",
+            "result": {
+              "status": "skipped"
+            }
+          }
+        ]
+      },
+      {
+        "id": "a-prospective-appellant-supplies-a-local-planning-department-for-the-case-they-wish-to-appeal;ineligible-local-planning-department-(lpd)-provided---routed-to-kick-out-page",
+        "keyword": "Scenario",
+        "line": 34,
+        "name": "Ineligible Local Planning Department (LPD) provided - routed to kick out page",
+        "tags": [
+          {
+            "name": "@smoketest",
+            "line": 1
+          }
+        ],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 35,
+            "name": "LPD is requested",
+            "result": {
+              "status": "failed",
+              "error_message": "CypressError: `cy.visit()` failed trying to load:\n\nhttp://localhost:9003/eligibility/planning-department\n\nWe attempted to make an http request to this URL but the request failed without a response.\n\nWe received this error at the network level:\n\n  > Error: socket hang up\n\nCommon situations why this would fail:\n  - you don't have internet access\n  - you forgot to run / boot your web server\n  - your web server isn't accessible\n  - you have weird network configuration settings on your computer\n    at http://localhost:9003/__cypress/runner/cypress_runner.js:140471:23\n    at visitFailedByErr (http://localhost:9003/__cypress/runner/cypress_runner.js:139830:12)\n    at http://localhost:9003/__cypress/runner/cypress_runner.js:140470:11\nFrom previous event:\n    at go (http://localhost:9003/__cypress/runner/cypress_runner.js:140433:17)\n    at http://localhost:9003/__cypress/runner/cypress_runner.js:140499:20\nFrom previous event:\n    at visit (http://localhost:9003/__cypress/runner/cypress_runner.js:140497:38)\n    at Context.visit (http://localhost:9003/__cypress/runner/cypress_runner.js:140506:14)\nFrom Your Spec Code:\n    at goToPlanningDepartmentPage (http://localhost:9003/__cypress/tests?p=cypress\\integration\\householder-planning\\appeals-service\\eligibility-local-planning-department.feature:5900:6)\n    at Context.eval (http://localhost:9003/__cypress/tests?p=cypress\\integration\\householder-planning\\appeals-service\\eligibility-local-planning-department.feature:2668:62)\n    at Context.resolveAndRunStepDefinition (http://localhost:9003/__cypress/tests?p=cypress\\integration\\householder-planning\\appeals-service\\eligibility-local-planning-department.feature:16647:29)\n    at Context.eval (http://localhost:9003/__cypress/tests?p=cypress\\integration\\householder-planning\\appeals-service\\eligibility-local-planning-department.feature:15968:35)\n\nFrom Node.js Internals:\n  Error: socket hang up\n      at connResetException (internal/errors.js:617:14)\n      at Socket.socketOnEnd (_http_client.js:493:23)\n      at Socket.emit (events.js:327:22)\n      at endReadableNT (_stream_readable.js:1327:12)\n      at processTicksAndRejections (internal/process/task_queues.js:80:21)\n  "
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 36,
+            "name": "an ineligible LPD is provided",
+            "result": {
+              "status": "skipped"
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 37,
+            "name": "progress is halted with the message “This service is not available in your area”",
+            "result": {
+              "status": "skipped"
+            }
+          }
+        ]
+      }
+    ]
+  }
+]

--- a/packages/e2e-tests/cypress/cucumber-json/google-analytics.cucumber.json
+++ b/packages/e2e-tests/cypress/cucumber-json/google-analytics.cucumber.json
@@ -1,0 +1,942 @@
+[
+  {
+    "description": "  Each of the Eligibility and Appellant Submission webpages needs to send data to Google Analytics platform",
+    "keyword": "Feature",
+    "name": "Google Analytics",
+    "line": 2,
+    "id": "google-analytics",
+    "tags": [
+      {
+        "name": "@wip",
+        "line": 1
+      }
+    ],
+    "uri": "google-analytics.feature",
+    "elements": [
+      {
+        "id": "google-analytics;required-ga-script-is-present",
+        "keyword": "Scenario",
+        "line": 11,
+        "name": "Required GA script is present",
+        "tags": [
+          {
+            "name": "@wip",
+            "line": 1
+          }
+        ],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 6,
+            "name": "an appeal is being made",
+            "result": {
+              "status": "skipped"
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 7,
+            "name": "the \"Eligibility - Decision date\" page is presented",
+            "result": {
+              "status": "skipped"
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 8,
+            "name": "the required GA script is present",
+            "result": {
+              "status": "skipped"
+            }
+          }
+        ]
+      },
+      {
+        "id": "google-analytics;required-ga-script-is-present",
+        "keyword": "Scenario",
+        "line": 12,
+        "name": "Required GA script is present",
+        "tags": [
+          {
+            "name": "@wip",
+            "line": 1
+          }
+        ],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 6,
+            "name": "an appeal is being made",
+            "result": {
+              "status": "skipped"
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 7,
+            "name": "the \"Eligibility - Decision date expired\" page is presented",
+            "result": {
+              "status": "skipped"
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 8,
+            "name": "the required GA script is present",
+            "result": {
+              "status": "skipped"
+            }
+          }
+        ]
+      },
+      {
+        "id": "google-analytics;required-ga-script-is-present",
+        "keyword": "Scenario",
+        "line": 13,
+        "name": "Required GA script is present",
+        "tags": [
+          {
+            "name": "@wip",
+            "line": 1
+          }
+        ],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 6,
+            "name": "an appeal is being made",
+            "result": {
+              "status": "skipped"
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 7,
+            "name": "the \"Eligibility - No decision date\" page is presented",
+            "result": {
+              "status": "skipped"
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 8,
+            "name": "the required GA script is present",
+            "result": {
+              "status": "skipped"
+            }
+          }
+        ]
+      },
+      {
+        "id": "google-analytics;required-ga-script-is-present",
+        "keyword": "Scenario",
+        "line": 14,
+        "name": "Required GA script is present",
+        "tags": [
+          {
+            "name": "@wip",
+            "line": 1
+          }
+        ],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 6,
+            "name": "an appeal is being made",
+            "result": {
+              "status": "skipped"
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 7,
+            "name": "the \"Eligibility - Planning department\" page is presented",
+            "result": {
+              "status": "skipped"
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 8,
+            "name": "the required GA script is present",
+            "result": {
+              "status": "skipped"
+            }
+          }
+        ]
+      },
+      {
+        "id": "google-analytics;required-ga-script-is-present",
+        "keyword": "Scenario",
+        "line": 15,
+        "name": "Required GA script is present",
+        "tags": [
+          {
+            "name": "@wip",
+            "line": 1
+          }
+        ],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 6,
+            "name": "an appeal is being made",
+            "result": {
+              "status": "skipped"
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 7,
+            "name": "the \"Eligibility - Planning department out\" page is presented",
+            "result": {
+              "status": "skipped"
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 8,
+            "name": "the required GA script is present",
+            "result": {
+              "status": "skipped"
+            }
+          }
+        ]
+      },
+      {
+        "id": "google-analytics;required-ga-script-is-present",
+        "keyword": "Scenario",
+        "line": 16,
+        "name": "Required GA script is present",
+        "tags": [
+          {
+            "name": "@wip",
+            "line": 1
+          }
+        ],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 6,
+            "name": "an appeal is being made",
+            "result": {
+              "status": "skipped"
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 7,
+            "name": "the \"Eligibility - Listed building\" page is presented",
+            "result": {
+              "status": "skipped"
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 8,
+            "name": "the required GA script is present",
+            "result": {
+              "status": "skipped"
+            }
+          }
+        ]
+      },
+      {
+        "id": "google-analytics;required-ga-script-is-present",
+        "keyword": "Scenario",
+        "line": 17,
+        "name": "Required GA script is present",
+        "tags": [
+          {
+            "name": "@wip",
+            "line": 1
+          }
+        ],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 6,
+            "name": "an appeal is being made",
+            "result": {
+              "status": "skipped"
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 7,
+            "name": "the \"Eligibility - Listed building out\" page is presented",
+            "result": {
+              "status": "skipped"
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 8,
+            "name": "the required GA script is present",
+            "result": {
+              "status": "skipped"
+            }
+          }
+        ]
+      },
+      {
+        "id": "google-analytics;required-ga-script-is-present",
+        "keyword": "Scenario",
+        "line": 18,
+        "name": "Required GA script is present",
+        "tags": [
+          {
+            "name": "@wip",
+            "line": 1
+          }
+        ],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 6,
+            "name": "an appeal is being made",
+            "result": {
+              "status": "skipped"
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 7,
+            "name": "the \"Eligibility - Appeal statement info\" page is presented",
+            "result": {
+              "status": "skipped"
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 8,
+            "name": "the required GA script is present",
+            "result": {
+              "status": "skipped"
+            }
+          }
+        ]
+      },
+      {
+        "id": "google-analytics;required-ga-script-is-present",
+        "keyword": "Scenario",
+        "line": 19,
+        "name": "Required GA script is present",
+        "tags": [
+          {
+            "name": "@wip",
+            "line": 1
+          }
+        ],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 6,
+            "name": "an appeal is being made",
+            "result": {
+              "status": "skipped"
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 7,
+            "name": "the \"Appellant submission - Appeal tasks\" page is presented",
+            "result": {
+              "status": "skipped"
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 8,
+            "name": "the required GA script is present",
+            "result": {
+              "status": "skipped"
+            }
+          }
+        ]
+      },
+      {
+        "id": "google-analytics;required-ga-script-is-present",
+        "keyword": "Scenario",
+        "line": 20,
+        "name": "Required GA script is present",
+        "tags": [
+          {
+            "name": "@wip",
+            "line": 1
+          }
+        ],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 6,
+            "name": "an appeal is being made",
+            "result": {
+              "status": "skipped"
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 7,
+            "name": "the \"Appellant submission - Your details - Who are you\" page is presented",
+            "result": {
+              "status": "skipped"
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 8,
+            "name": "the required GA script is present",
+            "result": {
+              "status": "skipped"
+            }
+          }
+        ]
+      },
+      {
+        "id": "google-analytics;required-ga-script-is-present",
+        "keyword": "Scenario",
+        "line": 21,
+        "name": "Required GA script is present",
+        "tags": [
+          {
+            "name": "@wip",
+            "line": 1
+          }
+        ],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 6,
+            "name": "an appeal is being made",
+            "result": {
+              "status": "skipped"
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 7,
+            "name": "the \"Appellant submission - Your details - Your details\" page is presented",
+            "result": {
+              "status": "skipped"
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 8,
+            "name": "the required GA script is present",
+            "result": {
+              "status": "skipped"
+            }
+          }
+        ]
+      },
+      {
+        "id": "google-analytics;required-ga-script-is-present",
+        "keyword": "Scenario",
+        "line": 22,
+        "name": "Required GA script is present",
+        "tags": [
+          {
+            "name": "@wip",
+            "line": 1
+          }
+        ],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 6,
+            "name": "an appeal is being made",
+            "result": {
+              "status": "skipped"
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 7,
+            "name": "the \"Appellant submission - Your details - Applicant name\" page is presented",
+            "result": {
+              "status": "skipped"
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 8,
+            "name": "the required GA script is present",
+            "result": {
+              "status": "skipped"
+            }
+          }
+        ]
+      },
+      {
+        "id": "google-analytics;required-ga-script-is-present",
+        "keyword": "Scenario",
+        "line": 23,
+        "name": "Required GA script is present",
+        "tags": [
+          {
+            "name": "@wip",
+            "line": 1
+          }
+        ],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 6,
+            "name": "an appeal is being made",
+            "result": {
+              "status": "skipped"
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 7,
+            "name": "the \"Appellant submission - Planning application - Application number\" page is presented",
+            "result": {
+              "status": "skipped"
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 8,
+            "name": "the required GA script is present",
+            "result": {
+              "status": "skipped"
+            }
+          }
+        ]
+      },
+      {
+        "id": "google-analytics;required-ga-script-is-present",
+        "keyword": "Scenario",
+        "line": 24,
+        "name": "Required GA script is present",
+        "tags": [
+          {
+            "name": "@wip",
+            "line": 1
+          }
+        ],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 6,
+            "name": "an appeal is being made",
+            "result": {
+              "status": "skipped"
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 7,
+            "name": "the \"Appellant submission - Planning application - Upload application\" page is presented",
+            "result": {
+              "status": "skipped"
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 8,
+            "name": "the required GA script is present",
+            "result": {
+              "status": "skipped"
+            }
+          }
+        ]
+      },
+      {
+        "id": "google-analytics;required-ga-script-is-present",
+        "keyword": "Scenario",
+        "line": 25,
+        "name": "Required GA script is present",
+        "tags": [
+          {
+            "name": "@wip",
+            "line": 1
+          }
+        ],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 6,
+            "name": "an appeal is being made",
+            "result": {
+              "status": "skipped"
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 7,
+            "name": "the \"Appellant submission - Planning application - Upload decision letter\" page is presented",
+            "result": {
+              "status": "skipped"
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 8,
+            "name": "the required GA script is present",
+            "result": {
+              "status": "skipped"
+            }
+          }
+        ]
+      },
+      {
+        "id": "google-analytics;required-ga-script-is-present",
+        "keyword": "Scenario",
+        "line": 26,
+        "name": "Required GA script is present",
+        "tags": [
+          {
+            "name": "@wip",
+            "line": 1
+          }
+        ],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 6,
+            "name": "an appeal is being made",
+            "result": {
+              "status": "skipped"
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 7,
+            "name": "the \"Appellant submission - Your appeal - Appeal statement\" page is presented",
+            "result": {
+              "status": "skipped"
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 8,
+            "name": "the required GA script is present",
+            "result": {
+              "status": "skipped"
+            }
+          }
+        ]
+      },
+      {
+        "id": "google-analytics;required-ga-script-is-present",
+        "keyword": "Scenario",
+        "line": 27,
+        "name": "Required GA script is present",
+        "tags": [
+          {
+            "name": "@wip",
+            "line": 1
+          }
+        ],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 6,
+            "name": "an appeal is being made",
+            "result": {
+              "status": "skipped"
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 7,
+            "name": "the \"Appellant submission - Appeal site - Site location\" page is presented",
+            "result": {
+              "status": "skipped"
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 8,
+            "name": "the required GA script is present",
+            "result": {
+              "status": "skipped"
+            }
+          }
+        ]
+      },
+      {
+        "id": "google-analytics;required-ga-script-is-present",
+        "keyword": "Scenario",
+        "line": 28,
+        "name": "Required GA script is present",
+        "tags": [
+          {
+            "name": "@wip",
+            "line": 1
+          }
+        ],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 6,
+            "name": "an appeal is being made",
+            "result": {
+              "status": "skipped"
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 7,
+            "name": "the \"Appellant submission - Appeal site - Site ownership\" page is presented",
+            "result": {
+              "status": "skipped"
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 8,
+            "name": "the required GA script is present",
+            "result": {
+              "status": "skipped"
+            }
+          }
+        ]
+      },
+      {
+        "id": "google-analytics;required-ga-script-is-present",
+        "keyword": "Scenario",
+        "line": 29,
+        "name": "Required GA script is present",
+        "tags": [
+          {
+            "name": "@wip",
+            "line": 1
+          }
+        ],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 6,
+            "name": "an appeal is being made",
+            "result": {
+              "status": "skipped"
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 7,
+            "name": "the \"Appellant submission - Appeal site - Site access\" page is presented",
+            "result": {
+              "status": "skipped"
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 8,
+            "name": "the required GA script is present",
+            "result": {
+              "status": "skipped"
+            }
+          }
+        ]
+      },
+      {
+        "id": "google-analytics;required-ga-script-is-present",
+        "keyword": "Scenario",
+        "line": 30,
+        "name": "Required GA script is present",
+        "tags": [
+          {
+            "name": "@wip",
+            "line": 1
+          }
+        ],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 6,
+            "name": "an appeal is being made",
+            "result": {
+              "status": "skipped"
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 7,
+            "name": "the \"Appellant submission - Appeal site - Site safety\" page is presented",
+            "result": {
+              "status": "skipped"
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 8,
+            "name": "the required GA script is present",
+            "result": {
+              "status": "skipped"
+            }
+          }
+        ]
+      },
+      {
+        "id": "google-analytics;required-ga-script-is-present",
+        "keyword": "Scenario",
+        "line": 31,
+        "name": "Required GA script is present",
+        "tags": [
+          {
+            "name": "@wip",
+            "line": 1
+          }
+        ],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 6,
+            "name": "an appeal is being made",
+            "result": {
+              "status": "skipped"
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 7,
+            "name": "the \"Appellant submission - Appeal answers\" page is presented",
+            "result": {
+              "status": "skipped"
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 8,
+            "name": "the required GA script is present",
+            "result": {
+              "status": "skipped"
+            }
+          }
+        ]
+      },
+      {
+        "id": "google-analytics;required-ga-script-is-present",
+        "keyword": "Scenario",
+        "line": 32,
+        "name": "Required GA script is present",
+        "tags": [
+          {
+            "name": "@wip",
+            "line": 1
+          }
+        ],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 6,
+            "name": "an appeal is being made",
+            "result": {
+              "status": "skipped"
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 7,
+            "name": "the \"Appeal submission\" page is presented",
+            "result": {
+              "status": "skipped"
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 8,
+            "name": "the required GA script is present",
+            "result": {
+              "status": "skipped"
+            }
+          }
+        ]
+      }
+    ]
+  }
+]

--- a/packages/e2e-tests/cypress/cucumber-json/guidance-page-after-you-appeal.cucumber.json
+++ b/packages/e2e-tests/cypress/cucumber-json/guidance-page-after-you-appeal.cucumber.json
@@ -1,0 +1,253 @@
+[
+  {
+    "description": "  As a PO on the appeal service\n  I want prospective appellants to be aware of what happens after they’ve appealed\n  So that they are aware of what will happen",
+    "keyword": "Feature",
+    "name": "Guidance Page - After you appeal",
+    "line": 1,
+    "id": "guidance-page---after-you-appeal",
+    "tags": [],
+    "uri": "guidance-page-after-you-appeal.feature",
+    "elements": [
+      {
+        "id": "guidance-page---after-you-appeal;ac1:-appellant-selects-\"before-you-appeal\"-page-from-the-content-list",
+        "keyword": "Scenario",
+        "line": 13,
+        "name": "AC1: Appellant selects \"Before you appeal\" page from the Content list",
+        "tags": [],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 7,
+            "name": "the appellant is on after you appeal page",
+            "result": {
+              "status": "passed",
+              "duration": 1700000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 8,
+            "name": "the appellant select a link from the content list: \"Before you appeal\"",
+            "result": {
+              "status": "passed",
+              "duration": 875000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 9,
+            "name": "the appellant is navigated to that page: \"/before-you-appeal\"",
+            "result": {
+              "status": "passed",
+              "duration": 26000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "guidance-page---after-you-appeal;ac1:-appellant-selects-\"when-you-can-appeal\"-page-from-the-content-list",
+        "keyword": "Scenario",
+        "line": 14,
+        "name": "AC1: Appellant selects \"When you can appeal\" page from the Content list",
+        "tags": [],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 7,
+            "name": "the appellant is on after you appeal page",
+            "result": {
+              "status": "passed",
+              "duration": 2052000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 8,
+            "name": "the appellant select a link from the content list: \"When you can appeal\"",
+            "result": {
+              "status": "passed",
+              "duration": 764000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 9,
+            "name": "the appellant is navigated to that page: \"/when-you-can-appeal\"",
+            "result": {
+              "status": "passed",
+              "duration": 31000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "guidance-page---after-you-appeal;ac1:-appellant-selects-\"the-stages-of-an-appeal\"-page-from-the-content-list",
+        "keyword": "Scenario",
+        "line": 15,
+        "name": "AC1: Appellant selects \"The stages of an appeal\" page from the Content list",
+        "tags": [],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 7,
+            "name": "the appellant is on after you appeal page",
+            "result": {
+              "status": "passed",
+              "duration": 866000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 8,
+            "name": "the appellant select a link from the content list: \"The stages of an appeal\"",
+            "result": {
+              "status": "passed",
+              "duration": 662000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 9,
+            "name": "the appellant is navigated to that page: \"/stages-of-an-appeal\"",
+            "result": {
+              "status": "passed",
+              "duration": 8000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "guidance-page---after-you-appeal;ac1:-appellant-selects-\"start-your-appeal\"-page-from-the-content-list",
+        "keyword": "Scenario",
+        "line": 16,
+        "name": "AC1: Appellant selects \"Start your appeal\" page from the Content list",
+        "tags": [],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 7,
+            "name": "the appellant is on after you appeal page",
+            "result": {
+              "status": "passed",
+              "duration": 719000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 8,
+            "name": "the appellant select a link from the content list: \"Start your appeal\"",
+            "result": {
+              "status": "passed",
+              "duration": 745000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 9,
+            "name": "the appellant is navigated to that page: \"/start-your-appeal\"",
+            "result": {
+              "status": "passed",
+              "duration": 11000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "guidance-page---after-you-appeal;ac2:-appellant-navigates-to-next-page",
+        "keyword": "Scenario",
+        "line": 18,
+        "name": "AC2: Appellant navigates to next page",
+        "tags": [],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 19,
+            "name": "the appellant is on after you appeal page",
+            "result": {
+              "status": "passed",
+              "duration": 863000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 20,
+            "name": "the appellant navigates to the next page",
+            "result": {
+              "status": "passed",
+              "duration": 779000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 21,
+            "name": "information about start your appeal is provided",
+            "result": {
+              "status": "passed",
+              "duration": 10000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "guidance-page---after-you-appeal;ac3:-appellant-navigates-to-previous-page",
+        "keyword": "Scenario",
+        "line": 23,
+        "name": "AC3: Appellant navigates to previous page",
+        "tags": [],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 24,
+            "name": "the appellant is on after you appeal page",
+            "result": {
+              "status": "passed",
+              "duration": 1044000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 25,
+            "name": "the appellant navigates to the previous page",
+            "result": {
+              "status": "passed",
+              "duration": 660000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 26,
+            "name": "information about the stages of an appeal is provided",
+            "result": {
+              "status": "passed",
+              "duration": 13000000
+            }
+          }
+        ]
+      }
+    ]
+  }
+]

--- a/packages/e2e-tests/cypress/cucumber-json/guidance-page-stages-of-an-appeal.cucumber.json
+++ b/packages/e2e-tests/cypress/cucumber-json/guidance-page-stages-of-an-appeal.cucumber.json
@@ -1,0 +1,253 @@
+[
+  {
+    "description": "  As a PO on the appeal service\n  I want prospective appellants to be aware of who the service is for\n  So that only those who need to appeal through the new appeal service do so",
+    "keyword": "Feature",
+    "name": "Guidance Page - Stages of an appeal",
+    "line": 1,
+    "id": "guidance-page---stages-of-an-appeal",
+    "tags": [],
+    "uri": "guidance-page-stages-of-an-appeal.feature",
+    "elements": [
+      {
+        "id": "guidance-page---stages-of-an-appeal;ac1:-appellant-selects-\"before-you-appeal\"-page-from-the-content-list",
+        "keyword": "Scenario",
+        "line": 13,
+        "name": "AC1: Appellant selects \"Before you appeal\" page from the Content list",
+        "tags": [],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 7,
+            "name": "the appellant is on the stages of an appeal page",
+            "result": {
+              "status": "passed",
+              "duration": 1290000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 8,
+            "name": "the appellant select a link from the content list: \"Before you appeal\"",
+            "result": {
+              "status": "passed",
+              "duration": 743000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 9,
+            "name": "the appellant is navigated to that page: \"/before-you-appeal\"",
+            "result": {
+              "status": "passed",
+              "duration": 19000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "guidance-page---stages-of-an-appeal;ac1:-appellant-selects-\"when-you-can-appeal\"-page-from-the-content-list",
+        "keyword": "Scenario",
+        "line": 14,
+        "name": "AC1: Appellant selects \"When you can appeal\" page from the Content list",
+        "tags": [],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 7,
+            "name": "the appellant is on the stages of an appeal page",
+            "result": {
+              "status": "passed",
+              "duration": 698000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 8,
+            "name": "the appellant select a link from the content list: \"When you can appeal\"",
+            "result": {
+              "status": "passed",
+              "duration": 768000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 9,
+            "name": "the appellant is navigated to that page: \"/when-you-can-appeal\"",
+            "result": {
+              "status": "passed",
+              "duration": 19000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "guidance-page---stages-of-an-appeal;ac1:-appellant-selects-\"after-you-appeal\"-page-from-the-content-list",
+        "keyword": "Scenario",
+        "line": 15,
+        "name": "AC1: Appellant selects \"After you appeal\" page from the Content list",
+        "tags": [],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 7,
+            "name": "the appellant is on the stages of an appeal page",
+            "result": {
+              "status": "passed",
+              "duration": 669000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 8,
+            "name": "the appellant select a link from the content list: \"After you appeal\"",
+            "result": {
+              "status": "passed",
+              "duration": 646000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 9,
+            "name": "the appellant is navigated to that page: \"/after-you-appeal\"",
+            "result": {
+              "status": "passed",
+              "duration": 11000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "guidance-page---stages-of-an-appeal;ac1:-appellant-selects-\"start-your-appeal\"-page-from-the-content-list",
+        "keyword": "Scenario",
+        "line": 16,
+        "name": "AC1: Appellant selects \"Start your appeal\" page from the Content list",
+        "tags": [],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 7,
+            "name": "the appellant is on the stages of an appeal page",
+            "result": {
+              "status": "passed",
+              "duration": 694000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 8,
+            "name": "the appellant select a link from the content list: \"Start your appeal\"",
+            "result": {
+              "status": "passed",
+              "duration": 765000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 9,
+            "name": "the appellant is navigated to that page: \"/start-your-appeal\"",
+            "result": {
+              "status": "passed",
+              "duration": 12000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "guidance-page---stages-of-an-appeal;ac2:-appellant-navigates-to-next-page",
+        "keyword": "Scenario",
+        "line": 18,
+        "name": "AC2: Appellant navigates to next page",
+        "tags": [],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 19,
+            "name": "the appellant is on the stages of an appeal page",
+            "result": {
+              "status": "passed",
+              "duration": 771000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 20,
+            "name": "the appellant navigates to the next page",
+            "result": {
+              "status": "passed",
+              "duration": 681000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 21,
+            "name": "information about after you appeal is provided",
+            "result": {
+              "status": "passed",
+              "duration": 9000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "guidance-page---stages-of-an-appeal;ac3:-appellant-navigates-to-previous-page",
+        "keyword": "Scenario",
+        "line": 23,
+        "name": "AC3: Appellant navigates to previous page",
+        "tags": [],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 24,
+            "name": "the appellant is on the stages of an appeal page",
+            "result": {
+              "status": "passed",
+              "duration": 671000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 25,
+            "name": "the appellant navigates to the previous page",
+            "result": {
+              "status": "passed",
+              "duration": 671000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 26,
+            "name": "information about when you can appeal is provided",
+            "result": {
+              "status": "passed",
+              "duration": 8000000
+            }
+          }
+        ]
+      }
+    ]
+  }
+]

--- a/packages/e2e-tests/cypress/cucumber-json/guidance-page-start-your-appeal.cucumber.json
+++ b/packages/e2e-tests/cypress/cucumber-json/guidance-page-start-your-appeal.cucumber.json
@@ -1,0 +1,53 @@
+[
+  {
+    "description": "  As a PO on the appeal service\n  I want prospective appellants to be aware of who the service is for\n  So that only those who need to appeal through the new appeal service do so",
+    "keyword": "Feature",
+    "name": "Guidance Page - Start your appeal",
+    "line": 1,
+    "id": "guidance-page---start-your-appeal",
+    "tags": [],
+    "uri": "guidance-page-start-your-appeal.feature",
+    "elements": [
+      {
+        "id": "guidance-page---start-your-appeal;ac1:-appellant-starts-appeal",
+        "keyword": "Scenario",
+        "line": 6,
+        "name": "AC1: Appellant starts appeal",
+        "tags": [],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 7,
+            "name": "the appellant is on the start your appeal page",
+            "result": {
+              "status": "passed",
+              "duration": 1425000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 8,
+            "name": "the appellant has selected to start the service",
+            "result": {
+              "status": "passed",
+              "duration": 1079000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 9,
+            "name": "the appellant can begin an appeal",
+            "result": {
+              "status": "passed",
+              "duration": 32000000
+            }
+          }
+        ]
+      }
+    ]
+  }
+]

--- a/packages/e2e-tests/cypress/cucumber-json/guidance-page-when-you-can-appeal.cucumber.json
+++ b/packages/e2e-tests/cypress/cucumber-json/guidance-page-when-you-can-appeal.cucumber.json
@@ -1,0 +1,253 @@
+[
+  {
+    "description": "  As a PO on the appeal service\n  I want prospective appellants to be aware of who the service is for\n  So that only those who need to appeal through the new appeal service do so",
+    "keyword": "Feature",
+    "name": "Guidance Page - When you can appeal",
+    "line": 1,
+    "id": "guidance-page---when-you-can-appeal",
+    "tags": [],
+    "uri": "guidance-page-when-you-can-appeal.feature",
+    "elements": [
+      {
+        "id": "guidance-page---when-you-can-appeal;ac1:-appellant-selects-\"before-you-appeal\"-page-from-the-content-list",
+        "keyword": "Scenario",
+        "line": 13,
+        "name": "AC1: Appellant selects \"Before you appeal\" page from the Content list",
+        "tags": [],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 7,
+            "name": "the appellant is on the when you can appeal page",
+            "result": {
+              "status": "passed",
+              "duration": 1152000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 8,
+            "name": "the appellant select a link from the content list: \"Before you appeal\"",
+            "result": {
+              "status": "passed",
+              "duration": 803000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 9,
+            "name": "the appellant is navigated to that page: \"/before-you-appeal\"",
+            "result": {
+              "status": "passed",
+              "duration": 19000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "guidance-page---when-you-can-appeal;ac1:-appellant-selects-\"the-stages-of-an-appeal\"-page-from-the-content-list",
+        "keyword": "Scenario",
+        "line": 14,
+        "name": "AC1: Appellant selects \"The stages of an appeal\" page from the Content list",
+        "tags": [],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 7,
+            "name": "the appellant is on the when you can appeal page",
+            "result": {
+              "status": "passed",
+              "duration": 1050000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 8,
+            "name": "the appellant select a link from the content list: \"The stages of an appeal\"",
+            "result": {
+              "status": "passed",
+              "duration": 691000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 9,
+            "name": "the appellant is navigated to that page: \"/stages-of-an-appeal\"",
+            "result": {
+              "status": "passed",
+              "duration": 9000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "guidance-page---when-you-can-appeal;ac1:-appellant-selects-\"after-you-appeal\"-page-from-the-content-list",
+        "keyword": "Scenario",
+        "line": 15,
+        "name": "AC1: Appellant selects \"After you appeal\" page from the Content list",
+        "tags": [],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 7,
+            "name": "the appellant is on the when you can appeal page",
+            "result": {
+              "status": "passed",
+              "duration": 674000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 8,
+            "name": "the appellant select a link from the content list: \"After you appeal\"",
+            "result": {
+              "status": "passed",
+              "duration": 691000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 9,
+            "name": "the appellant is navigated to that page: \"/after-you-appeal\"",
+            "result": {
+              "status": "passed",
+              "duration": 14000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "guidance-page---when-you-can-appeal;ac1:-appellant-selects-\"start-your-appeal\"-page-from-the-content-list",
+        "keyword": "Scenario",
+        "line": 16,
+        "name": "AC1: Appellant selects \"Start your appeal\" page from the Content list",
+        "tags": [],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 7,
+            "name": "the appellant is on the when you can appeal page",
+            "result": {
+              "status": "passed",
+              "duration": 658000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 8,
+            "name": "the appellant select a link from the content list: \"Start your appeal\"",
+            "result": {
+              "status": "passed",
+              "duration": 755000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 9,
+            "name": "the appellant is navigated to that page: \"/start-your-appeal\"",
+            "result": {
+              "status": "passed",
+              "duration": 12000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "guidance-page---when-you-can-appeal;ac2:-appellant-navigates-to-next-page",
+        "keyword": "Scenario",
+        "line": 18,
+        "name": "AC2: Appellant navigates to next page",
+        "tags": [],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 19,
+            "name": "the appellant is on the when you can appeal page",
+            "result": {
+              "status": "passed",
+              "duration": 928000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 20,
+            "name": "the appellant navigates to the next page",
+            "result": {
+              "status": "passed",
+              "duration": 1347000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 21,
+            "name": "information about the stages of an appeal is provided",
+            "result": {
+              "status": "passed",
+              "duration": 22000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "guidance-page---when-you-can-appeal;ac3:-appellant-navigates-to-previous-page",
+        "keyword": "Scenario",
+        "line": 23,
+        "name": "AC3: Appellant navigates to previous page",
+        "tags": [],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 24,
+            "name": "the appellant is on the when you can appeal page",
+            "result": {
+              "status": "passed",
+              "duration": 1139000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 25,
+            "name": "the appellant navigates to the previous page",
+            "result": {
+              "status": "passed",
+              "duration": 886000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 26,
+            "name": "information about before you appeal is provided",
+            "result": {
+              "status": "passed",
+              "duration": 28000000
+            }
+          }
+        ]
+      }
+    ]
+  }
+]

--- a/packages/e2e-tests/cypress/cucumber-json/not-found.cucumber.json
+++ b/packages/e2e-tests/cypress/cucumber-json/not-found.cucumber.json
@@ -1,0 +1,59 @@
+[
+  {
+    "description": "  As a Service owner of the appeals service\n  I need the service to adhere to the GDS design standards\n  So that the service will pass the beta assessment",
+    "keyword": "Feature",
+    "name": "Page not found",
+    "line": 1,
+    "id": "page-not-found",
+    "tags": [],
+    "uri": "not-found.feature",
+    "elements": [
+      {
+        "id": "page-not-found;the-404-page-with-gds-standards",
+        "keyword": "Scenario",
+        "line": 8,
+        "name": "The 404 page with GDS standards",
+        "tags": [
+          {
+            "name": "@as-1198",
+            "line": 7
+          }
+        ],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 9,
+            "name": "an appeal is being made",
+            "result": {
+              "status": "passed",
+              "duration": 166000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 10,
+            "name": "an unknown url is requested",
+            "result": {
+              "status": "passed",
+              "duration": 966000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 11,
+            "name": "the error page will be displayed",
+            "result": {
+              "status": "failed",
+              "duration": 24000000,
+              "error_message": "TypeError: cy.confirmNavigationPageNotFoundPage is not a function\n    at Context.eval (http://localhost:9003/__cypress/tests?p=cypress\\integration\\householder-planning\\appeals-service\\not-found.feature:2646:6)\n    at Context.resolveAndRunStepDefinition (http://localhost:9003/__cypress/tests?p=cypress\\integration\\householder-planning\\appeals-service\\not-found.feature:15953:29)\n    at Context.eval (http://localhost:9003/__cypress/tests?p=cypress\\integration\\householder-planning\\appeals-service\\not-found.feature:15274:35)\nFrom previous event:\n    at Context.thenFn (http://localhost:9003/__cypress/runner/cypress_runner.js:137744:23)\n    at Context.then (http://localhost:9003/__cypress/runner/cypress_runner.js:138183:21)\n    at Context.<anonymous> (http://localhost:9003/__cypress/runner/cypress_runner.js:153308:21)\n    at http://localhost:9003/__cypress/runner/cypress_runner.js:152716:15\nFrom previous event:\n    at runCommand (http://localhost:9003/__cypress/runner/cypress_runner.js:152695:8)\n    at next (http://localhost:9003/__cypress/runner/cypress_runner.js:152841:14)\n    at http://localhost:9003/__cypress/runner/cypress_runner.js:152869:16\nFrom previous event:\n    at next (http://localhost:9003/__cypress/runner/cypress_runner.js:152841:34)\nFrom previous event:\n    at http://localhost:9003/__cypress/runner/cypress_runner.js:152882:37\nFrom previous event:\n    at run (http://localhost:9003/__cypress/runner/cypress_runner.js:152875:21)\n    at $Cy.cy.<computed> [as then] (http://localhost:9003/__cypress/runner/cypress_runner.js:153348:11)\n    at Context.runnable.fn (http://localhost:9003/__cypress/runner/cypress_runner.js:153572:21)\n    at callFn (http://localhost:9003/__cypress/runner/cypress_runner.js:109330:21)\n    at Test.../driver/node_modules/mocha/lib/runnable.js.Runnable.run (http://localhost:9003/__cypress/runner/cypress_runner.js:109317:7)\n    at http://localhost:9003/__cypress/runner/cypress_runner.js:159577:28\nFrom previous event:\n    at Object.onRunnableRun (http://localhost:9003/__cypress/runner/cypress_runner.js:159565:17)\n    at $Cypress.action (http://localhost:9003/__cypress/runner/cypress_runner.js:149656:28)\n    at Test.Runnable.run (http://localhost:9003/__cypress/runner/cypress_runner.js:157707:13)\n    at Runner.../driver/node_modules/mocha/lib/runner.js.Runner.runTest (http://localhost:9003/__cypress/runner/cypress_runner.js:109989:10)\n    at http://localhost:9003/__cypress/runner/cypress_runner.js:110115:12\n    at next (http://localhost:9003/__cypress/runner/cypress_runner.js:109898:14)\n    at http://localhost:9003/__cypress/runner/cypress_runner.js:109908:7\n    at next (http://localhost:9003/__cypress/runner/cypress_runner.js:109810:14)\n    at Hook.<anonymous> (http://localhost:9003/__cypress/runner/cypress_runner.js:109871:7)\n    at next (http://localhost:9003/__cypress/runner/cypress_runner.js:159493:22)\n    at http://localhost:9003/__cypress/runner/cypress_runner.js:159520:11\nFrom previous event:\n    at onNext (http://localhost:9003/__cypress/runner/cypress_runner.js:159517:57)\n    at done (http://localhost:9003/__cypress/runner/cypress_runner.js:109270:5)\n    at callFn (http://localhost:9003/__cypress/runner/cypress_runner.js:109353:7)\n    at Hook.../driver/node_modules/mocha/lib/runnable.js.Runnable.run (http://localhost:9003/__cypress/runner/cypress_runner.js:109317:7)\n    at http://localhost:9003/__cypress/runner/cypress_runner.js:159577:28\nFrom previous event:\n    at Object.onRunnableRun (http://localhost:9003/__cypress/runner/cypress_runner.js:159565:17)\n    at $Cypress.action (http://localhost:9003/__cypress/runner/cypress_runner.js:149656:28)\n    at Hook.Runnable.run (http://localhost:9003/__cypress/runner/cypress_runner.js:157707:13)\n    at next (http://localhost:9003/__cypress/runner/cypress_runner.js:109832:10)\n    at http://localhost:9003/__cypress/runner/cypress_runner.js:109876:5\n    at timeslice (http://localhost:9003/__cypress/runner/cypress_runner.js:103802:27)"
+            }
+          }
+        ]
+      }
+    ]
+  }
+]

--- a/packages/e2e-tests/cypress/cucumber-json/your-planning-appeal-landing-page.cucumber.json
+++ b/packages/e2e-tests/cypress/cucumber-json/your-planning-appeal-landing-page.cucumber.json
@@ -1,0 +1,175 @@
+[
+  {
+    "keyword": "Feature",
+    "name": "A user has submitted an appeal and at a later date views the appeal status",
+    "line": 1,
+    "id": "a-user-has-submitted-an-appeal-and-at-a-later-date-views-the-appeal-status",
+    "tags": [],
+    "uri": "your-planning-appeal-landing-page.feature",
+    "elements": [
+      {
+        "id": "a-user-has-submitted-an-appeal-and-at-a-later-date-views-the-appeal-status;the-appellant-views-the-appeal",
+        "keyword": "Scenario",
+        "line": 4,
+        "name": "the appellant views the appeal",
+        "tags": [
+          {
+            "name": "@AS-1606",
+            "line": 3
+          },
+          {
+            "name": "@as-2307",
+            "line": 3
+          }
+        ],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 5,
+            "name": "an \"appellant\" has submitted an appeal",
+            "result": {
+              "status": "passed",
+              "duration": 56642000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 6,
+            "name": "your planning appeal page is viewed with a valid appealId",
+            "result": {
+              "status": "passed",
+              "duration": 857000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 7,
+            "name": "the user sees the appropriate general data for \"appellant\" along with data for step 1",
+            "result": {
+              "status": "passed",
+              "duration": 162000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "And ",
+            "line": 8,
+            "name": "the user sees the label for appellant name as \"Your name\"",
+            "result": {
+              "status": "passed",
+              "duration": 110000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "a-user-has-submitted-an-appeal-and-at-a-later-date-views-the-appeal-status;the-agent-views-the-appeal",
+        "keyword": "Scenario",
+        "line": 11,
+        "name": "the agent views the appeal",
+        "tags": [
+          {
+            "name": "@AS-1606",
+            "line": 10
+          },
+          {
+            "name": "@as-2307",
+            "line": 10
+          }
+        ],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 12,
+            "name": "an \"agent\" has submitted an appeal",
+            "result": {
+              "status": "passed",
+              "duration": 66495000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 13,
+            "name": "your planning appeal page is viewed with a valid appealId",
+            "result": {
+              "status": "passed",
+              "duration": 1308000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 14,
+            "name": "the user sees the appropriate general data for \"agent\" along with data for step 1",
+            "result": {
+              "status": "passed",
+              "duration": 184000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "And ",
+            "line": 15,
+            "name": "the user sees the label for appellant name as \"Appellant name\"",
+            "result": {
+              "status": "passed",
+              "duration": 100000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "a-user-has-submitted-an-appeal-and-at-a-later-date-views-the-appeal-status;the-appellant-or-agent-visits-a-url-with-an-invalid-appealid",
+        "keyword": "Scenario",
+        "line": 18,
+        "name": "the appellant or agent visits a url with an invalid appealId",
+        "tags": [
+          {
+            "name": "@AS-1606",
+            "line": 17
+          }
+        ],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 19,
+            "name": "an agent or appellant has submitted an appeal",
+            "result": {
+              "status": "passed",
+              "duration": 59971000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 20,
+            "name": "your planning appeal page is viewed with an incorrect appealId",
+            "result": {
+              "status": "passed",
+              "duration": 617000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 21,
+            "name": "the user sees the 404 page",
+            "result": {
+              "status": "passed",
+              "duration": 137000000
+            }
+          }
+        ]
+      }
+    ]
+  }
+]

--- a/packages/e2e-tests/cypress/integration/full-planning/appeals-service/appeal-form-task-list/appeal-form-task-list.js
+++ b/packages/e2e-tests/cypress/integration/full-planning/appeals-service/appeal-form-task-list/appeal-form-task-list.js
@@ -8,7 +8,6 @@ import {
   linkUploadDocsFromPlanningApplication,
   linkUploadDocsForYourAppeal,
   linkCheckYourAnswers,
-  var1,
   statusProvideYourContactDetails,
   statusTellAboutTheAppealSite,
   statusUploadDocsFromPlanningApplication,

--- a/packages/e2e-tests/cypress/integration/full-planning/appeals-service/check-your-answers.feature
+++ b/packages/e2e-tests/cypress/integration/full-planning/appeals-service/check-your-answers.feature
@@ -1,0 +1,24 @@
+Feature: As an Appellant/Agent
+  I want to be able to review and change my answers
+  So that my appeal is accurate
+
+  #This scenario will be updated when the forms work with real data
+  Scenario:  Appellant has provided their appeal details and is ready to check their answers before they submit their appeal
+    Given the appellant is on the 'Appeal a planning decision' page
+    When they click on 'Check your answers and submit your appeal' link
+    Then the information they have inputted will be displayed
+
+  Scenario: Agent has provided their appeal details and is ready to check their answers before they submit their appeal
+    Given the agent is on the 'Appeal a planning decision' page
+    When they click on 'Check your answers and submit your appeal' link
+    Then the information they have inputted will be displayed
+
+  Scenario Outline: Agent or Appellant select the back link
+    Given the '<user>' is on the 'Check your answers' page
+    When they select the 'Back' link
+    Then the '<user>' is on the 'Appeal a planning decision' page
+
+    Examples:
+      | user      |
+      | agent     |
+      | appellant |

--- a/packages/e2e-tests/cypress/integration/full-planning/appeals-service/check-your-answers/check-your-answers.js
+++ b/packages/e2e-tests/cypress/integration/full-planning/appeals-service/check-your-answers/check-your-answers.js
@@ -1,0 +1,41 @@
+import { Given, When, Then } from 'cypress-cucumber-preprocessor/steps';
+import { verifyPageTitle } from '../../../../../../../e2e-tests/cypress/support/common/verify-page-title';
+import {
+  CheckYourAnswersLink, getPageCaption, getPlanningAppMadeInYourName, getSectionHeading, yourContactDetails,
+} from '../../../../support/full-planning/appeals-service/page-objects/check-your-answers-po';
+import { getBackLink } from '../../../../support/common-page-objects/common-po';
+import { verifyPageHeading } from '../../../../../../../e2e-tests/cypress/support/common/verify-page-heading';
+
+const url = 'localhost:9003/full-appeal/task-list';
+const pageTitle = 'Check your answers - Appeal a householder planning decision - GOV.UK';
+const pageHeading = 'Check your answers';
+
+Given("the appellant is on the 'Appeal a planning decision' page",()=> {
+  cy.visit(url);
+})
+When("they click on 'Check your answers and submit your appeal' link",()=> {
+  CheckYourAnswersLink().click();
+})
+Then('the information they have inputted will be displayed',()=> {
+  verifyPageTitle(pageTitle);
+  verifyPageHeading(pageHeading);
+  getSectionHeading().should('exist');
+  getPageCaption().should('exist');
+  getPlanningAppMadeInYourName().should('exist');
+  getPlanningAppMadeInYourName().siblings('dd').should('contain',"No, I'm an agent acting on behalf of the applicant");
+  yourContactDetails().should('contain','Your contact details');
+})
+Given("the agent is on the 'Appeal a planning decision' page",()=> {
+  cy.visit(url);
+})
+Given("the {string} is on the 'Check your answers' page",()=> {
+  cy.visit(url);
+  CheckYourAnswersLink().click();
+  verifyPageTitle(pageTitle);
+})
+When("they select the 'Back' link",()=> {
+  getBackLink().click();
+})
+Then("the {string} is on the 'Appeal a planning decision' page",()=> {
+  cy.url().should('contain','/full-appeal/task-list');
+})

--- a/packages/e2e-tests/cypress/support/common-page-objects/common-po.js
+++ b/packages/e2e-tests/cypress/support/common-page-objects/common-po.js
@@ -5,3 +5,4 @@ export const getErrorMessageSummary =()=> cy.get('.govuk-error-summary');
 export const getAcceptAnalyticsCookies = () =>cy.get('[data-cy=cookie-banner-accept-analytics-cookies]');
 export const getCookiesBannerAcceptedHideMessage = () =>cy.get('[data-cy=cookie-banner-accepted-hide-message]');
 export const getBackLink = () => cy.get('.govuk-back-link');
+export const continueButton = () => cy.get('[data-cy=button-continue]');

--- a/packages/e2e-tests/cypress/support/full-planning/appeals-service/page-objects/check-your-answers-po.js
+++ b/packages/e2e-tests/cypress/support/full-planning/appeals-service/page-objects/check-your-answers-po.js
@@ -1,0 +1,9 @@
+export const getPageCaption = () => cy.get('[data-cy="caption"]');
+export const getPageHeading = () =>  cy.get('[data-cy="page-title"]');
+export const getSectionHeading = () =>  cy.get('[data-cy="your-contact-details"]');
+export const getPlanningAppMadeInYourName = () =>  cy.findAllByText('Was the planning application made in your name?');
+export const CheckYourAnswersLink = () =>  cy.get('[data-cy="submitYourAppealSection"]');
+export const yourContactDetails = () => cy.get('.govuk-summary-list__key');
+
+
+

--- a/packages/e2e-tests/cypress/support/householder-planning/appeals-service/back-link/back-link-commands.js
+++ b/packages/e2e-tests/cypress/support/householder-planning/appeals-service/back-link/back-link-commands.js
@@ -1,0 +1,73 @@
+Cypress.Commands.add(
+  'alterDetailsAboutVisitingTheAppealSite',
+  require('./alterDetailsAboutVisitingTheAppealSite'),
+);
+
+Cypress.Commands.add('clickBackLink', require('./clickBackLink'));
+
+Cypress.Commands.add('clickBackLinkAndValidateUrl', require('./clickBackLinkAndValidateUrl'));
+
+Cypress.Commands.add('hasErrorOnCurrentPage', require('./hasErrorOnCurrentPage'));
+
+Cypress.Commands.add('hasErrorOnPreviousPage', require('./hasErrorOnPreviousPage'));
+
+Cypress.Commands.add(
+  'navigateForwardsWithinAppealSteps',
+  require('./navigateForwardsWithinAppealSteps'),
+);
+
+Cypress.Commands.add(
+  'navigateForwardsWithinEligibilitySteps',
+  require('./navigateForwardsWithinEligibilitySteps'),
+);
+
+Cypress.Commands.add(
+  'provideDetailsAboutTheOriginalPlanningApplication',
+  require('./provideDetailsAboutTheOriginalPlanningApplication'),
+);
+
+Cypress.Commands.add('validateBackLinkIsNotAvailable', require('./validateBackLinkIsNotAvailable'));
+
+Cypress.Commands.add(
+  'validateBackStepsFromOriginalPlanningApplicationToTaskList',
+  require('./validateBackStepsFromOriginalPlanningApplicationToTaskList'),
+);
+
+Cypress.Commands.add(
+  'validateBackStepsFromVisitingAppealSiteToCheckYourAnswers',
+  require('./validateBackStepsFromVisitingAppealSiteToCheckYourAnswers'),
+);
+
+Cypress.Commands.add(
+  'validateBackStepsWithinAppealJourney',
+  require('./validateBackStepsWithinAppealJourney'),
+);
+
+Cypress.Commands.add(
+  'validateBackStepsWithinEligibilityJourney',
+  require('./validateBackStepsWithinEligibilityJourney'),
+);
+
+Cypress.Commands.add('validateBreadcrumbsAreVisible', require('./validateBreadcrumbsAreVisible'));
+
+Cypress.Commands.add(
+  'validatePreviousPageDisplayedWithoutCurrentPageRefreshed',
+  require('./validatePreviousPageDisplayedWithoutCurrentPageRefreshed'),
+);
+
+Cypress.Commands.add(
+  'validateThePreviousPageDisplaysWithoutError',
+  require('./validateThePreviousPageDisplaysWithoutError'),
+);
+
+Cypress.Commands.add(
+  'validateUserIsOnServiceStartPage',
+  require('./validateUserIsOnServiceStartPage'),
+);
+
+Cypress.Commands.add(
+  'visitServiceByDirectlyBrowsingToUnexpectedFirstPage',
+  require('./visitServiceByDirectlyBrowsingToUnexpectedFirstPage'),
+);
+
+Cypress.Commands.add('visitServiceStartPage', require('./visitServiceStartPage'));

--- a/packages/forms-web-app/__tests__/unit/controllers/full-planning/full-appeal/task-list.test.js
+++ b/packages/forms-web-app/__tests__/unit/controllers/full-planning/full-appeal/task-list.test.js
@@ -56,9 +56,9 @@ describe('controllers/full-planning/full-appeal/task-list', () => {
           {
             href: '/full-appeal/check-answers',
             text: 'Check your answers and submit your appeal',
-            status: 'CANNOT START YET',
+            status: 'NOT STARTED',
             attributes: {
-              'submitYourAppealSection-status': 'CANNOT START YET',
+              'submitYourAppealSection-status': 'NOT STARTED',
               name: 'submitYourAppealSection',
             },
           },


### PR DESCRIPTION
## Ticket Number
<!-- Add the number from the Jira board -->
https://pins-ds.atlassian.net/browse/AS-3614

## Description of change
Add e2e tests for check your answers page for sub task-AS-4224

## Checklist
<!-- Put an `x` in all the boxes that apply: -->
- [ ] Requires infrastructure changes
- [ ] If adding or remove environment variables (e.g. in `docker-compose.yaml`) then I have updated the appropriate Helm chart
- [ ] I have updated the documentation accordingly
- [X ] My commit history in this PR is linear
- [ ] New features have tests
- [ ] Breaking change (team conversation required)

## Important

Please do not merge from `master` (please only [rebase](https://github.com/foundry4/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
