### PR TITLE
fix(as-4301): add text and error message to application form page

### DIFF
--- a/packages/forms-web-app/__tests__/unit/routes/full-appeal/submit-appeal/application-form.test.js
+++ b/packages/forms-web-app/__tests__/unit/routes/full-appeal/submit-appeal/application-form.test.js
@@ -26,5 +26,6 @@ describe('routes/full-appeal/submit-appeal/index', () => {
       validationErrorHandler,
       postApplicationForm
     );
+    expect(fileUploadValidationRules).toHaveBeenCalledWith('Select your planning application form');
   });
 });

--- a/packages/forms-web-app/__tests__/unit/validators/common/file-upload.test.js
+++ b/packages/forms-web-app/__tests__/unit/validators/common/file-upload.test.js
@@ -3,13 +3,24 @@ const { rules } = require('../../../../src/validators/common/file-upload');
 const fileUploadSchema = require('../../../../src/validators/common/schemas/file-upload');
 
 jest.mock('express-validator');
+jest.mock('../../../../src/validators/common/schemas/file-upload');
 
 describe('validators/common/file-upload', () => {
   describe('rules', () => {
-    it('should call checkSchema with the correct schema', () => {
+    it('should call checkSchema with the correct schema when noFilesError is not given', () => {
       rules();
 
-      expect(checkSchema).toHaveBeenCalledWith(fileUploadSchema);
+      expect(checkSchema).toHaveBeenCalledWith(fileUploadSchema());
+      expect(fileUploadSchema).toHaveBeenCalledWith();
+    });
+
+    it('should call checkSchema with the correct schema when noFilesError is given', () => {
+      const noFilesError = 'Select your planning application form';
+
+      rules(noFilesError);
+
+      expect(checkSchema).toHaveBeenCalledWith(fileUploadSchema(noFilesError));
+      expect(fileUploadSchema).toHaveBeenCalledWith(noFilesError);
     });
   });
 });

--- a/packages/forms-web-app/__tests__/unit/validators/common/schemas/file-upload.test.js
+++ b/packages/forms-web-app/__tests__/unit/validators/common/schemas/file-upload.test.js
@@ -22,26 +22,43 @@ describe('validators/common/schemas/file-upload', () => {
   });
 
   it('has a defined custom schema object', () => {
-    expect(fileUploadSchema['file-upload'].custom.options).toBeDefined();
+    expect(fileUploadSchema()['file-upload'].custom.options).toBeDefined();
   });
 
   describe(`schema['file-upload'].custom.options`, () => {
+    const noFilesError = 'Select your planning application form';
+    const noFilesErrorDefault = 'Select a file to upload';
+
     let schema;
 
     beforeEach(() => {
-      schema = fileUploadSchema['file-upload'].custom.options;
+      schema = fileUploadSchema()['file-upload'].custom.options;
     });
 
-    it('should throw an error if req.files is null', () => {
+    it('should throw the correct error if req.files is null and noFilesError is not given', () => {
       req.files = null;
 
-      expect(() => schema(null, { req })).rejects.toThrow('Select a file to upload');
+      expect(() => schema(null, { req })).rejects.toThrow(noFilesErrorDefault);
     });
 
-    it('should throw an error if a file has not been uploaded', () => {
+    it('should throw the correct error if req.files is null and noFilesError is given', () => {
+      req.files = null;
+      schema = fileUploadSchema(noFilesError)['file-upload'].custom.options;
+
+      expect(() => schema(null, { req })).rejects.toThrow(noFilesError);
+    });
+
+    it('should throw the correct error if a file has not been uploaded and noFilesError is not given', () => {
       req.files = {};
 
-      expect(() => schema(null, { req })).rejects.toThrow('Select a file to upload');
+      expect(() => schema(null, { req })).rejects.toThrow(noFilesErrorDefault);
+    });
+
+    it('should throw the correct error if a file has not been uploaded and noFilesError is given', () => {
+      req.files = {};
+      schema = fileUploadSchema(noFilesError)['file-upload'].custom.options;
+
+      expect(() => schema(null, { req })).rejects.toThrow(noFilesError);
     });
 
     it('should call the validMimeType validator when given a single file', () => {

--- a/packages/forms-web-app/src/routes/full-appeal/submit-appeal/application-form.js
+++ b/packages/forms-web-app/src/routes/full-appeal/submit-appeal/application-form.js
@@ -11,7 +11,7 @@ const router = express.Router();
 router.get('/submit-appeal/application-form', getApplicationForm);
 router.post(
   '/submit-appeal/application-form',
-  fileUploadValidationRules(),
+  fileUploadValidationRules('Select your planning application form'),
   validationErrorHandler,
   postApplicationForm
 );

--- a/packages/forms-web-app/src/validators/common/file-upload.js
+++ b/packages/forms-web-app/src/validators/common/file-upload.js
@@ -1,8 +1,8 @@
 const { checkSchema } = require('express-validator');
 const fileUploadSchema = require('./schemas/file-upload');
 
-const rules = () => {
-  return [checkSchema(fileUploadSchema)];
+const rules = (noFilesError) => {
+  return [checkSchema(fileUploadSchema(noFilesError))];
 };
 
 module.exports = {

--- a/packages/forms-web-app/src/validators/common/schemas/file-upload.js
+++ b/packages/forms-web-app/src/validators/common/schemas/file-upload.js
@@ -8,14 +8,14 @@ const {
 const validateFileSize = require('../../custom/file-size');
 const mimeTypes = require('../../../lib/mime-types');
 
-module.exports = {
+const schema = (noFilesError) => ({
   'file-upload': {
     custom: {
       options: async (value, { req, path }) => {
         const { files } = req;
 
         if (files === null || (files && !files[path])) {
-          throw new Error('Select a file to upload');
+          throw new Error(noFilesError || 'Select a file to upload');
         }
 
         const uploadedFiles = !Array.isArray(files[path]) ? [files[path]] : files[path];
@@ -50,4 +50,6 @@ module.exports = {
       },
     },
   },
-};
+});
+
+module.exports = schema;

--- a/packages/forms-web-app/src/views/full-appeal/submit-appeal/application-form.njk
+++ b/packages/forms-web-app/src/views/full-appeal/submit-appeal/application-form.njk
@@ -23,7 +23,9 @@
       <h1 data-cy="heading" class="govuk-heading-xl">
         Planning application form
       </h1>
-
+      <p class="govuk-body">
+        If you do not have your planning application form, you can find it by searching for your planning application on your local planning department's website.
+      </p>
       <form action="" method="post" novalidate enctype="multipart/form-data">
         {{ govukFileUpload({
           id: "file-upload",


### PR DESCRIPTION
## Ticket Number
https://pins-ds.atlassian.net/browse/AS-4301

## Description of change
Update the full appeals application form page

- Add `If you do not have your planning application form, you can find it by searching for your planning application on your local planning department's website.` text under the page title
- Update the 'no files uploaded' error message  from `Select a file to upload` to `Select your planning application form`. Since this is a common validation component, the component has been changed so that the custom error message can be passed in when called in the route. The old message will be used as a default if no error message is passed in.

## Checklist
<!-- Put an `x` in all the boxes that apply: -->
- [ ] Requires infrastructure changes
- [ ] If adding or remove environment variables (e.g. in `docker-compose.yaml`) then I have updated the appropriate Helm chart
- [ ] I have updated the documentation accordingly
- [ ] My commit history in this PR is linear
- [ ] New features have tests
- [ ] Breaking change (team conversation required)

## Important

Please do not merge from `master` (please only [rebase](https://github.com/foundry4/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
