### PR TITLE
fix(as-4197): check design and access statement appeal data exists be…

### DIFF
--- a/packages/forms-web-app/__tests__/unit/controllers/full-appeal/submit-appeal/design-access-statement.test.js
+++ b/packages/forms-web-app/__tests__/unit/controllers/full-appeal/submit-appeal/design-access-statement.test.js
@@ -137,5 +137,39 @@ describe('controllers/full-appeal/submit-appeal/design-access-statement', () => 
       expect(res.redirect).toHaveBeenCalledWith(`/${DECISION_LETTER}`);
       expect(req.session.appeal).toEqual(submittedAppeal);
     });
+
+    it('should redirect to the correct page if valid if appeal.requiredDocumentsSection.designAccessStatement does not exist', async () => {
+      delete appeal.requiredDocumentsSection.designAccessStatement;
+
+      const submittedAppeal = {
+        ...appeal,
+        state: 'SUBMITTED',
+      };
+
+      createDocument.mockReturnValue(file);
+      getTaskStatus.mockReturnValue(TASK_STATUS.NOT_STARTED);
+      createOrUpdateAppeal.mockReturnValue(submittedAppeal);
+
+      req = {
+        ...req,
+        body: {},
+        files: {
+          'file-upload': file,
+        },
+      };
+
+      await postDesignAccessStatement(req, res);
+
+      expect(createDocument).toHaveBeenCalledWith(
+        appeal,
+        file,
+        null,
+        documentTypes.designAccessStatement.name
+      );
+      expect(getTaskStatus).toHaveBeenCalledWith(appeal, sectionName, taskName);
+      expect(createOrUpdateAppeal).toHaveBeenCalledWith(appeal);
+      expect(res.redirect).toHaveBeenCalledWith(`/${DECISION_LETTER}`);
+      expect(req.session.appeal).toEqual(submittedAppeal);
+    });
   });
 });

--- a/packages/forms-web-app/src/controllers/full-appeal/submit-appeal/design-access-statement.js
+++ b/packages/forms-web-app/src/controllers/full-appeal/submit-appeal/design-access-statement.js
@@ -40,6 +40,10 @@ const postDesignAccessStatement = async (req, res) => {
   try {
     const document = await createDocument(appeal, files['file-upload'], null, taskName);
 
+    if (!appeal[sectionName][taskName]) {
+      appeal[sectionName][taskName] = {};
+    }
+
     appeal[sectionName][taskName].uploadedFile = {
       id: document.id,
       name: files['file-upload'].name,


### PR DESCRIPTION
## Ticket Number
https://pins-ds.atlassian.net/browse/AS-4197

## Description of change
Check design and access statement appeal data exists before setting it.

Originally had this issue locally and fixed it and I can only replicate by removing that fix but it's not working in Dev for some reason so this will fix it in Dev and if we work out why it's not working in Dev then we an remove it.

## Checklist
<!-- Put an `x` in all the boxes that apply: -->
- [ ] Requires infrastructure changes
- [ ] If adding or remove environment variables (e.g. in `docker-compose.yaml`) then I have updated the appropriate Helm chart
- [ ] I have updated the documentation accordingly
- [ ] My commit history in this PR is linear
- [ ] New features have tests
- [ ] Breaking change (team conversation required)

## Important

Please do not merge from `master` (please only [rebase](https://github.com/foundry4/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
