### PR TITLE
feat: add e2e tests for decision letter file upload

### DIFF
--- a/packages/e2e-tests/cypress/integration/full-appeal/appeals-service/upload-decision-letter.feature
+++ b/packages/e2e-tests/cypress/integration/full-appeal/appeals-service/upload-decision-letter.feature
@@ -1,0 +1,51 @@
+Feature: As an appellant/agent
+  I want to add a copy of the LPA Decision Letter
+  So that the planning Inspectorate can have the necessary evidence to support my appeal
+
+  Scenario: 1. Navigate from 'Design and Access Statement page' to 'Decision Letter' page
+    Given an appellant is on the 'Design and access statement' page
+    When they have uploaded a file and select 'continue'
+    Then the 'Decision Letter' page is displayed
+
+  Scenario Outline: 2. Appellant/agent uploads valid file using File Upload
+    Given an appellant is on the 'Decision Letter' page
+    When they upload a file '<filename>' and click on Continue button
+    Then 'Task list' page is displayed
+    When an appellant is on the 'Decision Letter' page
+    Then the uploaded file '<filename>' is displayed
+    Examples:
+      | filename               |
+      | upload-file-valid.doc  |
+      | upload-file-valid.docx |
+      | upload-file-valid.jpeg |
+      | upload-file-valid.jpg  |
+      | upload-file-valid.png  |
+      | upload-file-valid.tif  |
+      | upload-file-valid.tiff |
+      | upload-file-valid.pdf  |
+
+  Scenario: 3. Appellant/agent uploads valid file using Drag and Drop
+    Given an appellant is on the 'Decision Letter' page
+    When they drag and drop a file and click on Continue button
+    Then 'Task list' page is displayed
+
+  Scenario Outline: 4. Appellant uploads a large file and an invalid file
+    Given an appellant has uploaded a file '<filename>'
+    When they select the 'Continue' button
+    Then an error message '<error message>' is displayed
+    Examples:
+      | filename                                | error message                                                                     |
+      | upload_file_large.tiff                  | upload_file_large.tiff must be smaller than 15MB                                  |
+      | appeal-statement-invalid-wrong-type.mp3 | appeal-statement-invalid-wrong-type.mp3 must be a DOC, DOCX, PDF, TIF, JPG or PNG |
+      | appeal-statement-invalid-wrong-type.csv | appeal-statement-invalid-wrong-type.csv must be a DOC, DOCX, PDF, TIF, JPG or PNG |
+
+  Scenario: 5. Appellant does not upload any document
+    Given an appellant has not uploaded any document
+    When they select the 'Continue' button
+    Then an error message 'Select your decision letter' is displayed
+
+  Scenario: 6. Navigate from 'Decision Letter' page back to Task List
+    Given an appellant is on the 'Decision Letter' page
+    When they click on the 'Back' link
+    Then they are presented with the 'Appeal a planning decision' task list page
+    #And the last task they are working on will show ‘In progress’

--- a/packages/e2e-tests/cypress/integration/full-appeal/appeals-service/upload-decision-letter/upload-decision-letter.js
+++ b/packages/e2e-tests/cypress/integration/full-appeal/appeals-service/upload-decision-letter/upload-decision-letter.js
@@ -1,0 +1,87 @@
+import { Given, When, Then } from 'cypress-cucumber-preprocessor/steps';
+import { goToAppealsPage } from '../../../../support/common/go-to-page/goToAppealsPage';
+import {
+  getBackLink,
+  getErrorMessageSummary,
+  getFileUploadButton,
+} from '../../../../support/common-page-objects/common-po';
+import { getSaveAndContinueButton } from '../../../../support/householder-planning/lpa-questionnaire/PageObjects/common-page-objects';
+import { verifyPageHeading } from '../../../../support/common/verify-page-heading';
+import { verifyPageTitle } from '../../../../support/common/verify-page-title';
+import { verifySectionName } from '../../../../support/common/verifySectionName';
+import {
+  errorFileUploadField,
+  filesCanUploadHintText,
+  sectionText, uploadedFileLabel, uploadedFileName,
+} from '../../../../support/full-appeal/appeals-service/page-objects/file-upload-po';
+import { pageCaption } from '../../../../support/full-appeal/appeals-service/page-objects/planning-application-number-po';
+import { verifyErrorMessage } from '../../../../support/common/verify-error-message';
+
+const url = 'full-appeal/submit-appeal/decision-letter';
+const taskListUrl = 'full-appeal/submit-appeal/task-list';
+const planningAppNumberUrl ='full-appeal/submit-appeal/application-number';
+const designAccessStatementUrl = 'full-appeal/submit-appeal/design-access-statement';
+const decisionLetterUrl = 'full-appeal/submit-appeal/decision-letter'
+const textPageCaption = 'Upload documents from your planning application';
+const pageTitle = "Decision letter - Appeal a planning decision - GOV.UK";
+const pageHeading = 'Decision letter';
+const decisionLetterSectionText = 'This is the letter from the local planning department telling you about the decision on your planning application.';
+
+
+Given("an appellant is on the 'Design and access statement' page",()=> {
+  goToAppealsPage(designAccessStatementUrl);
+});
+When("they have uploaded a file and select 'continue'",()=> {
+  getFileUploadButton().attachFile('upload-file-valid.jpeg');
+  getSaveAndContinueButton().click();
+});
+Then("the 'Decision Letter' page is displayed",()=> {
+  cy.url().should('contain', decisionLetterUrl);
+  verifyPageHeading(pageHeading);
+  verifyPageTitle(pageTitle);
+  //verifySectionName()
+  sectionText().should('contain', decisionLetterSectionText);
+});
+When("they select the 'Continue' button",()=> {
+  getSaveAndContinueButton().click();
+});
+Given( "an appellant is on the 'Decision Letter' page", () => {
+  goToAppealsPage(url);
+} );
+When( "they upload a file {string} and click on Continue button", (filename) => {
+  getFileUploadButton().attachFile(filename);
+  getSaveAndContinueButton().click();
+} );
+Then( "'Task list' page is displayed", () => {
+  cy.url().should('contain', taskListUrl);
+} );
+When("they click on the 'Back' link",()=> {
+  getBackLink().click();
+});
+Then("'Decision Letter' page is displayed",()=> {
+  cy.url().should('contain', url);
+})
+Then("the uploaded file {string} is displayed", (filename) => {
+  uploadedFileLabel().should('exist');
+  uploadedFileName().should('contain', filename);
+})
+Given("an appellant has uploaded a file {string}", (filename) => {
+  goToAppealsPage(url);
+  getFileUploadButton().attachFile(filename);
+})
+Then( "an error message {string} is displayed", (errorMessage) => {
+  verifyErrorMessage(errorMessage,errorFileUploadField,getErrorMessageSummary);
+});
+Given("an appellant has not uploaded any document",()=> {
+  goToAppealsPage(url);
+});
+Then("they are presented with the 'Appeal a planning decision' task list page", () => {
+  cy.url().should('contain',taskListUrl)
+});
+When("they click on the 'Back' link",()=> {
+  getBackLink().click();
+});
+When( "they drag and drop a file and click on Continue button", () => {
+  getFileUploadButton().attachFile('appeal-statement-valid.jpeg', { subjectType: 'drag-n-drop' });
+  getSaveAndContinueButton().click();
+});


### PR DESCRIPTION
## Ticket Number
<!-- Add the number from the Jira board -->
https://pins-ds.atlassian.net/browse/AS-4205

## Description of change
Add e2e tests for Decision Letter file upload page

## Checklist
<!-- Put an `x` in all the boxes that apply: -->
- [ ] Requires infrastructure changes
- [ ] If adding or remove environment variables (e.g. in `docker-compose.yaml`) then I have updated the appropriate Helm chart
- [ ] I have updated the documentation accordingly
- [X ] My commit history in this PR is linear
- [ ] New features have tests
- [ ] Breaking change (team conversation required)

## Important

Please do not merge from `master` (please only [rebase](https://github.com/foundry4/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
