### PR TITLE
Feature/as 4375 file upload back links and validation

### DIFF
--- a/packages/appeals-service-api/src/models/appeal.js
+++ b/packages/appeals-service-api/src/models/appeal.js
@@ -91,6 +91,7 @@ exports.appealDocument = {
     companyName: null,
   },
   planningApplicationDocumentsSection: {
+    applicationNumber: null,
     isDesignAccessStatementSubmitted: null,
     originalApplication: {
       uploadedFile: {

--- a/packages/appeals-service-api/src/models/appeal.js
+++ b/packages/appeals-service-api/src/models/appeal.js
@@ -92,6 +92,24 @@ exports.appealDocument = {
   },
   planningApplicationDocumentsSection: {
     isDesignAccessStatementSubmitted: null,
+    originalApplication: {
+      uploadedFile: {
+        name: '',
+        id: null,
+      },
+    },
+    decisionLetter: {
+      uploadedFile: {
+        name: '',
+        id: null,
+      },
+    },
+    designAccessStatement: {
+      uploadedFile: {
+        name: '',
+        id: null,
+      },
+    },
   },
   sectionStates: {
     aboutYouSection: {
@@ -116,6 +134,9 @@ exports.appealDocument = {
     aboutAppealSiteSection: 'NOT STARTED',
     planningApplicationDocumentsSection: {
       isDesignAccessStatementSubmitted: 'NOT STARTED',
+      originalApplication: 'NOT STARTED',
+      decisionLetter: 'NOT STARTED',
+      designAccessStatement: 'NOT STARTED',
     },
   },
 };

--- a/packages/business-rules/src/schemas/full-appeal/insert.js
+++ b/packages/business-rules/src/schemas/full-appeal/insert.js
@@ -117,6 +117,7 @@ const insert = pinsYup
     planningApplicationDocumentsSection: pinsYup
       .object()
       .shape({
+        applicationNumber: pinsYup.string().max(30).nullable(),
         isDesignAccessStatementSubmitted: pinsYup.bool().nullable(),
         originalApplication: pinsYup
           .object()

--- a/packages/business-rules/src/schemas/full-appeal/insert.js
+++ b/packages/business-rules/src/schemas/full-appeal/insert.js
@@ -84,9 +84,40 @@ const insert = pinsYup
           .noUnknown(true),
       })
       .noUnknown(true),
-    requiredDocumentsSection: pinsYup
+    contactDetailsSection: pinsYup
       .object()
       .shape({
+        name: pinsYup.lazy((name) => {
+          if (name) {
+            return pinsYup
+              .string()
+              .min(2)
+              .max(80)
+              .matches(/^[a-z\-' ]+$/i)
+              .required();
+          }
+          return pinsYup.string().nullable();
+        }),
+        companyName: pinsYup.string().max(50).nullable(),
+        email: pinsYup.string().email().max(255).nullable(),
+      })
+      .noUnknown(true),
+    appealSiteSection: pinsYup.object().shape({
+      siteAddress: pinsYup
+        .object()
+        .shape({
+          addressLine1: pinsYup.string().max(60).nullable(),
+          addressLine2: pinsYup.string().max(60).nullable(),
+          town: pinsYup.string().max(60).nullable(),
+          county: pinsYup.string().max(60).nullable(),
+          postcode: pinsYup.string().max(8).nullable(),
+        })
+        .noUnknown(true),
+    }),
+    planningApplicationDocumentsSection: pinsYup
+      .object()
+      .shape({
+        isDesignAccessStatementSubmitted: pinsYup.bool().nullable(),
         originalApplication: pinsYup
           .object()
           .shape({
@@ -126,42 +157,6 @@ const insert = pinsYup
               .noUnknown(true),
           })
           .noUnknown(true),
-      })
-      .noUnknown(true),
-    contactDetailsSection: pinsYup
-      .object()
-      .shape({
-        name: pinsYup.lazy((name) => {
-          if (name) {
-            return pinsYup
-              .string()
-              .min(2)
-              .max(80)
-              .matches(/^[a-z\-' ]+$/i)
-              .required();
-          }
-          return pinsYup.string().nullable();
-        }),
-        companyName: pinsYup.string().max(50).nullable(),
-        email: pinsYup.string().email().max(255).nullable(),
-      })
-      .noUnknown(true),
-    appealSiteSection: pinsYup.object().shape({
-      siteAddress: pinsYup
-        .object()
-        .shape({
-          addressLine1: pinsYup.string().max(60).nullable(),
-          addressLine2: pinsYup.string().max(60).nullable(),
-          town: pinsYup.string().max(60).nullable(),
-          county: pinsYup.string().max(60).nullable(),
-          postcode: pinsYup.string().max(8).nullable(),
-        })
-        .noUnknown(true),
-    }),
-    planningApplicationDocumentsSection: pinsYup
-      .object()
-      .shape({
-        isDesignAccessStatementSubmitted: pinsYup.bool().nullable(),
       })
       .noUnknown(true),
     sectionStates: pinsYup.object().shape({}),

--- a/packages/business-rules/src/schemas/full-appeal/insert.test.js
+++ b/packages/business-rules/src/schemas/full-appeal/insert.test.js
@@ -787,6 +787,23 @@ describe('schemas/full-appeal/insert', () => {
         );
       });
 
+      describe('planningApplicationDocumentsSection.applicationNumber', () => {
+        it('should throw an error when given a value with more than 30 characters', async () => {
+          appeal.planningApplicationDocumentsSection.applicationNumber = 'a'.repeat(31);
+
+          await expect(() => insert.validate(appeal, config)).rejects.toThrow(
+            'planningApplicationDocumentsSection.applicationNumber must be at most 30 characters',
+          );
+        });
+
+        it('should not throw an error when not given a value', async () => {
+          delete appeal.planningApplicationDocumentsSection.applicationNumber;
+
+          const result = await insert.validate(appeal, config);
+          expect(result).toEqual(appeal);
+        });
+      });
+
       describe('planningApplicationDocumentsSection.isDesignAccessStatementSubmitted', () => {
         it('should throw an error when not given a boolean value', async () => {
           appeal.planningApplicationDocumentsSection = {

--- a/packages/business-rules/src/schemas/full-appeal/insert.test.js
+++ b/packages/business-rules/src/schemas/full-appeal/insert.test.js
@@ -475,399 +475,6 @@ describe('schemas/full-appeal/insert', () => {
       });
     });
 
-    describe('requiredDocumentsSection', () => {
-      it('should remove unknown fields', async () => {
-        appeal2.requiredDocumentsSection.unknownField = 'unknown field';
-
-        const result = await insert.validate(appeal2, config);
-        expect(result).toEqual(appeal);
-      });
-
-      it('should throw an error when given a null value', async () => {
-        appeal.requiredDocumentsSection = null;
-
-        await expect(() => insert.validate(appeal, config)).rejects.toThrow(
-          'requiredDocumentsSection must be a `object` type, but the final value was: `null`',
-        );
-      });
-    });
-
-    describe('requiredDocumentsSection.originalApplication', () => {
-      it('should remove unknown fields', async () => {
-        appeal2.requiredDocumentsSection.originalApplication.unknownField = 'unknown field';
-
-        const result = await insert.validate(appeal2, config);
-        expect(result).toEqual(appeal);
-      });
-
-      it('should throw an error when given a null value', async () => {
-        appeal.requiredDocumentsSection.originalApplication = null;
-
-        await expect(() => insert.validate(appeal, config)).rejects.toThrow(
-          'requiredDocumentsSection.originalApplication must be a `object` type, but the final value was: `null`',
-        );
-      });
-    });
-
-    describe('requiredDocumentsSection.originalApplication.uploadedFile', () => {
-      it('should remove unknown fields', async () => {
-        appeal2.requiredDocumentsSection.originalApplication.uploadedFile.unknownField =
-          'unknown field';
-
-        const result = await insert.validate(appeal2, config);
-        expect(result).toEqual(appeal);
-      });
-
-      it('should throw an error when given a null value', async () => {
-        appeal.requiredDocumentsSection.originalApplication.uploadedFile = null;
-
-        await expect(() => insert.validate(appeal, config)).rejects.toThrow(
-          'requiredDocumentsSection.originalApplication.uploadedFile must be a `object` type, but the final value was: `null`',
-        );
-      });
-    });
-
-    describe('requiredDocumentsSection.originalApplication.uploadedFile.name', () => {
-      it('should throw an error when given a value with more than 255 characters', async () => {
-        appeal.requiredDocumentsSection.originalApplication.uploadedFile.name = 'a'.repeat(256);
-
-        await expect(() => insert.validate(appeal, config)).rejects.toThrow(
-          'requiredDocumentsSection.originalApplication.uploadedFile.name must be at most 255 characters',
-        );
-      });
-
-      it('should strip leading/trailing spaces', async () => {
-        appeal2.requiredDocumentsSection.originalApplication.uploadedFile.name = '  test-pdf.pdf  ';
-        appeal.requiredDocumentsSection.originalApplication.uploadedFile.name = 'test-pdf.pdf';
-
-        const result = await insert.validate(appeal2, config);
-        expect(result).toEqual(appeal);
-      });
-
-      it('should not throw an error when not given a value', async () => {
-        delete appeal2.requiredDocumentsSection.originalApplication.uploadedFile.name;
-        appeal.requiredDocumentsSection.originalApplication.uploadedFile.name = '';
-
-        const result = await insert.validate(appeal, config);
-        expect(result).toEqual(appeal);
-      });
-    });
-
-    describe('requiredDocumentsSection.originalApplication.uploadedFile.originalFileName', () => {
-      it('should throw an error when given a value with more than 255 characters', async () => {
-        appeal.requiredDocumentsSection.originalApplication.uploadedFile.originalFileName =
-          'a'.repeat(256);
-
-        await expect(() => insert.validate(appeal, config)).rejects.toThrow(
-          'requiredDocumentsSection.originalApplication.uploadedFile.originalFileName must be at most 255 characters',
-        );
-      });
-
-      it('should strip leading/trailing spaces', async () => {
-        appeal2.requiredDocumentsSection.originalApplication.uploadedFile.originalFileName =
-          '  test-pdf.pdf  ';
-        appeal.requiredDocumentsSection.originalApplication.uploadedFile.originalFileName =
-          'test-pdf.pdf';
-
-        const result = await insert.validate(appeal2, config);
-        expect(result).toEqual(appeal);
-      });
-
-      it('should not throw an error when not given a value', async () => {
-        delete appeal2.requiredDocumentsSection.originalApplication.uploadedFile.originalFileName;
-        appeal.requiredDocumentsSection.originalApplication.uploadedFile.originalFileName = '';
-
-        const result = await insert.validate(appeal, config);
-        expect(result).toEqual(appeal);
-      });
-    });
-
-    describe('requiredDocumentsSection.originalApplication.uploadedFile.id', () => {
-      it('should strip leading/trailing spaces', async () => {
-        appeal2.requiredDocumentsSection.originalApplication.uploadedFile.id =
-          '  271c9b5b-af90-4b45-b0e7-0a7882da1e03  ';
-        appeal.requiredDocumentsSection.originalApplication.uploadedFile.id =
-          '271c9b5b-af90-4b45-b0e7-0a7882da1e03';
-
-        const result = await insert.validate(appeal2, config);
-        expect(result).toEqual(appeal);
-      });
-
-      it('should throw an error when not given a UUID', async () => {
-        appeal.requiredDocumentsSection.originalApplication.uploadedFile.id = 'abc123';
-
-        await expect(() => insert.validate(appeal, config)).rejects.toThrow(
-          'requiredDocumentsSection.originalApplication.uploadedFile.id must be a valid UUID',
-        );
-      });
-
-      it('should not throw an error when given a null value', async () => {
-        appeal.requiredDocumentsSection.originalApplication.uploadedFile.id = null;
-
-        const result = await insert.validate(appeal, config);
-        expect(result).toEqual(appeal);
-      });
-
-      it('should not throw an error when not given a value', async () => {
-        delete appeal2.requiredDocumentsSection.originalApplication.uploadedFile.id;
-        appeal.requiredDocumentsSection.originalApplication.uploadedFile.id = null;
-
-        const result = await insert.validate(appeal2, config);
-        expect(result).toEqual(appeal);
-      });
-    });
-
-    describe('requiredDocumentsSection.designAccessStatement', () => {
-      it('should remove unknown fields', async () => {
-        appeal2.requiredDocumentsSection.designAccessStatement.unknownField = 'unknown field';
-
-        const result = await insert.validate(appeal2, config);
-        expect(result).toEqual(appeal);
-      });
-
-      it('should throw an error when given a null value', async () => {
-        appeal.requiredDocumentsSection.designAccessStatement = null;
-
-        await expect(() => insert.validate(appeal, config)).rejects.toThrow(
-          'requiredDocumentsSection.designAccessStatement must be a `object` type, but the final value was: `null`',
-        );
-      });
-    });
-
-    describe('requiredDocumentsSection.designAccessStatement.uploadedFile', () => {
-      it('should remove unknown fields', async () => {
-        appeal2.requiredDocumentsSection.designAccessStatement.uploadedFile.unknownField =
-          'unknown field';
-
-        const result = await insert.validate(appeal2, config);
-        expect(result).toEqual(appeal);
-      });
-
-      it('should throw an error when given a null value', async () => {
-        appeal.requiredDocumentsSection.designAccessStatement.uploadedFile = null;
-
-        await expect(() => insert.validate(appeal, config)).rejects.toThrow(
-          'requiredDocumentsSection.designAccessStatement.uploadedFile must be a `object` type, but the final value was: `null`',
-        );
-      });
-    });
-
-    describe('requiredDocumentsSection.designAccessStatement.uploadedFile.name', () => {
-      it('should throw an error when given a value with more than 255 characters', async () => {
-        appeal.requiredDocumentsSection.designAccessStatement.uploadedFile.name = 'a'.repeat(256);
-
-        await expect(() => insert.validate(appeal, config)).rejects.toThrow(
-          'requiredDocumentsSection.designAccessStatement.uploadedFile.name must be at most 255 characters',
-        );
-      });
-
-      it('should strip leading/trailing spaces', async () => {
-        appeal2.requiredDocumentsSection.designAccessStatement.uploadedFile.name =
-          '  test-pdf.pdf  ';
-        appeal.requiredDocumentsSection.designAccessStatement.uploadedFile.name = 'test-pdf.pdf';
-
-        const result = await insert.validate(appeal2, config);
-        expect(result).toEqual(appeal);
-      });
-
-      it('should not throw an error when not given a value', async () => {
-        delete appeal2.requiredDocumentsSection.designAccessStatement.uploadedFile.name;
-        appeal.requiredDocumentsSection.designAccessStatement.uploadedFile.name = '';
-
-        const result = await insert.validate(appeal, config);
-        expect(result).toEqual(appeal);
-      });
-    });
-
-    describe('requiredDocumentsSection.designAccessStatement.uploadedFile.originalFileName', () => {
-      it('should throw an error when given a value with more than 255 characters', async () => {
-        appeal.requiredDocumentsSection.designAccessStatement.uploadedFile.originalFileName =
-          'a'.repeat(256);
-
-        await expect(() => insert.validate(appeal, config)).rejects.toThrow(
-          'requiredDocumentsSection.designAccessStatement.uploadedFile.originalFileName must be at most 255 characters',
-        );
-      });
-
-      it('should strip leading/trailing spaces', async () => {
-        appeal2.requiredDocumentsSection.designAccessStatement.uploadedFile.originalFileName =
-          '  test-pdf.pdf  ';
-        appeal.requiredDocumentsSection.designAccessStatement.uploadedFile.originalFileName =
-          'test-pdf.pdf';
-
-        const result = await insert.validate(appeal2, config);
-        expect(result).toEqual(appeal);
-      });
-
-      it('should not throw an error when not given a value', async () => {
-        delete appeal2.requiredDocumentsSection.designAccessStatement.uploadedFile.originalFileName;
-        appeal.requiredDocumentsSection.designAccessStatement.uploadedFile.originalFileName = '';
-
-        const result = await insert.validate(appeal, config);
-        expect(result).toEqual(appeal);
-      });
-    });
-
-    describe('requiredDocumentsSection.designAccessStatement.uploadedFile.id', () => {
-      it('should strip leading/trailing spaces', async () => {
-        appeal2.requiredDocumentsSection.designAccessStatement.uploadedFile.id =
-          '  271c9b5b-af90-4b45-b0e7-0a7882da1e03  ';
-        appeal.requiredDocumentsSection.designAccessStatement.uploadedFile.id =
-          '271c9b5b-af90-4b45-b0e7-0a7882da1e03';
-
-        const result = await insert.validate(appeal2, config);
-        expect(result).toEqual(appeal);
-      });
-
-      it('should throw an error when not given a UUID', async () => {
-        appeal.requiredDocumentsSection.designAccessStatement.uploadedFile.id = 'abc123';
-
-        await expect(() => insert.validate(appeal, config)).rejects.toThrow(
-          'requiredDocumentsSection.designAccessStatement.uploadedFile.id must be a valid UUID',
-        );
-      });
-
-      it('should not throw an error when given a null value', async () => {
-        appeal.requiredDocumentsSection.designAccessStatement.uploadedFile.id = null;
-
-        const result = await insert.validate(appeal, config);
-        expect(result).toEqual(appeal);
-      });
-
-      it('should not throw an error when not given a value', async () => {
-        delete appeal2.requiredDocumentsSection.designAccessStatement.uploadedFile.id;
-        appeal.requiredDocumentsSection.designAccessStatement.uploadedFile.id = null;
-
-        const result = await insert.validate(appeal2, config);
-        expect(result).toEqual(appeal);
-      });
-    });
-
-    describe('requiredDocumentsSection.decisionLetter', () => {
-      it('should remove unknown fields', async () => {
-        appeal2.requiredDocumentsSection.decisionLetter.unknownField = 'unknown field';
-
-        const result = await insert.validate(appeal2, config);
-        expect(result).toEqual(appeal);
-      });
-
-      it('should throw an error when given a null value', async () => {
-        appeal.requiredDocumentsSection.decisionLetter = null;
-
-        await expect(() => insert.validate(appeal, config)).rejects.toThrow(
-          'requiredDocumentsSection.decisionLetter must be a `object` type, but the final value was: `null`',
-        );
-      });
-    });
-
-    describe('requiredDocumentsSection.decisionLetter.uploadedFile', () => {
-      it('should remove unknown fields', async () => {
-        appeal2.requiredDocumentsSection.decisionLetter.uploadedFile.unknownField = 'unknown field';
-
-        const result = await insert.validate(appeal2, config);
-        expect(result).toEqual(appeal);
-      });
-
-      it('should throw an error when given a null value', async () => {
-        appeal.requiredDocumentsSection.decisionLetter.uploadedFile = null;
-
-        await expect(() => insert.validate(appeal, config)).rejects.toThrow(
-          'requiredDocumentsSection.decisionLetter.uploadedFile must be a `object` type, but the final value was: `null`',
-        );
-      });
-    });
-
-    describe('requiredDocumentsSection.decisionLetter.uploadedFile.name', () => {
-      it('should throw an error when given a value with more than 255 characters', async () => {
-        appeal.requiredDocumentsSection.decisionLetter.uploadedFile.name = 'a'.repeat(256);
-
-        await expect(() => insert.validate(appeal, config)).rejects.toThrow(
-          'requiredDocumentsSection.decisionLetter.uploadedFile.name must be at most 255 characters',
-        );
-      });
-
-      it('should strip leading/trailing spaces', async () => {
-        appeal2.requiredDocumentsSection.decisionLetter.uploadedFile.name = '  test-pdf.pdf  ';
-        appeal.requiredDocumentsSection.decisionLetter.uploadedFile.name = 'test-pdf.pdf';
-
-        const result = await insert.validate(appeal2, config);
-        expect(result).toEqual(appeal);
-      });
-
-      it('should not throw an error when not given a value', async () => {
-        delete appeal2.requiredDocumentsSection.decisionLetter.uploadedFile.name;
-        appeal.requiredDocumentsSection.decisionLetter.uploadedFile.name = '';
-
-        const result = await insert.validate(appeal, config);
-        expect(result).toEqual(appeal);
-      });
-    });
-
-    describe('requiredDocumentsSection.decisionLetter.uploadedFile.originalFileName', () => {
-      it('should throw an error when given a value with more than 255 characters', async () => {
-        appeal.requiredDocumentsSection.decisionLetter.uploadedFile.originalFileName = 'a'.repeat(
-          256,
-        );
-
-        await expect(() => insert.validate(appeal, config)).rejects.toThrow(
-          'requiredDocumentsSection.decisionLetter.uploadedFile.originalFileName must be at most 255 characters',
-        );
-      });
-
-      it('should strip leading/trailing spaces', async () => {
-        appeal2.requiredDocumentsSection.decisionLetter.uploadedFile.originalFileName =
-          '  test-pdf.pdf  ';
-        appeal.requiredDocumentsSection.decisionLetter.uploadedFile.originalFileName =
-          'test-pdf.pdf';
-
-        const result = await insert.validate(appeal2, config);
-        expect(result).toEqual(appeal);
-      });
-
-      it('should not throw an error when not given a value', async () => {
-        delete appeal2.requiredDocumentsSection.decisionLetter.uploadedFile.originalFileName;
-        appeal.requiredDocumentsSection.decisionLetter.uploadedFile.originalFileName = '';
-
-        const result = await insert.validate(appeal, config);
-        expect(result).toEqual(appeal);
-      });
-    });
-
-    describe('requiredDocumentsSection.decisionLetter.uploadedFile.id', () => {
-      it('should strip leading/trailing spaces', async () => {
-        appeal2.requiredDocumentsSection.decisionLetter.uploadedFile.id =
-          '  271c9b5b-af90-4b45-b0e7-0a7882da1e03  ';
-        appeal.requiredDocumentsSection.decisionLetter.uploadedFile.id =
-          '271c9b5b-af90-4b45-b0e7-0a7882da1e03';
-
-        const result = await insert.validate(appeal2, config);
-        expect(result).toEqual(appeal);
-      });
-
-      it('should throw an error when not given a UUID', async () => {
-        appeal.requiredDocumentsSection.decisionLetter.uploadedFile.id = 'abc123';
-
-        await expect(() => insert.validate(appeal, config)).rejects.toThrow(
-          'requiredDocumentsSection.decisionLetter.uploadedFile.id must be a valid UUID',
-        );
-      });
-
-      it('should not throw an error when given a null value', async () => {
-        appeal.requiredDocumentsSection.decisionLetter.uploadedFile.id = null;
-
-        const result = await insert.validate(appeal, config);
-        expect(result).toEqual(appeal);
-      });
-
-      it('should not throw an error when not given a value', async () => {
-        delete appeal2.requiredDocumentsSection.decisionLetter.uploadedFile.id;
-        appeal.requiredDocumentsSection.decisionLetter.uploadedFile.id = null;
-
-        const result = await insert.validate(appeal2, config);
-        expect(result).toEqual(appeal);
-      });
-    });
-
     describe('contactDetailsSection', () => {
       it('should remove unknown fields', async () => {
         appeal2.contactDetailsSection.unknownField = 'unknown field';
@@ -1195,6 +802,418 @@ describe('schemas/full-appeal/insert', () => {
           delete appeal.planningApplicationDocumentsSection.isDesignAccessStatementSubmitted;
 
           const result = await insert.validate(appeal, config);
+          expect(result).toEqual(appeal);
+        });
+      });
+
+      describe('planningApplicationDocumentsSection', () => {
+        it('should remove unknown fields', async () => {
+          appeal2.planningApplicationDocumentsSection.unknownField = 'unknown field';
+
+          const result = await insert.validate(appeal2, config);
+          expect(result).toEqual(appeal);
+        });
+
+        it('should throw an error when given a null value', async () => {
+          appeal.planningApplicationDocumentsSection = null;
+
+          await expect(() => insert.validate(appeal, config)).rejects.toThrow(
+            'planningApplicationDocumentsSection must be a `object` type, but the final value was: `null`',
+          );
+        });
+      });
+
+      describe('planningApplicationDocumentsSection.originalApplication', () => {
+        it('should remove unknown fields', async () => {
+          appeal2.planningApplicationDocumentsSection.originalApplication.unknownField =
+            'unknown field';
+
+          const result = await insert.validate(appeal2, config);
+          expect(result).toEqual(appeal);
+        });
+
+        it('should throw an error when given a null value', async () => {
+          appeal.planningApplicationDocumentsSection.originalApplication = null;
+
+          await expect(() => insert.validate(appeal, config)).rejects.toThrow(
+            'planningApplicationDocumentsSection.originalApplication must be a `object` type, but the final value was: `null`',
+          );
+        });
+      });
+
+      describe('planningApplicationDocumentsSection.originalApplication.uploadedFile', () => {
+        it('should remove unknown fields', async () => {
+          appeal2.planningApplicationDocumentsSection.originalApplication.uploadedFile.unknownField =
+            'unknown field';
+
+          const result = await insert.validate(appeal2, config);
+          expect(result).toEqual(appeal);
+        });
+
+        it('should throw an error when given a null value', async () => {
+          appeal.planningApplicationDocumentsSection.originalApplication.uploadedFile = null;
+
+          await expect(() => insert.validate(appeal, config)).rejects.toThrow(
+            'planningApplicationDocumentsSection.originalApplication.uploadedFile must be a `object` type, but the final value was: `null`',
+          );
+        });
+      });
+
+      describe('planningApplicationDocumentsSection.originalApplication.uploadedFile.name', () => {
+        it('should throw an error when given a value with more than 255 characters', async () => {
+          appeal.planningApplicationDocumentsSection.originalApplication.uploadedFile.name =
+            'a'.repeat(256);
+
+          await expect(() => insert.validate(appeal, config)).rejects.toThrow(
+            'planningApplicationDocumentsSection.originalApplication.uploadedFile.name must be at most 255 characters',
+          );
+        });
+
+        it('should strip leading/trailing spaces', async () => {
+          appeal2.planningApplicationDocumentsSection.originalApplication.uploadedFile.name =
+            '  test-pdf.pdf  ';
+          appeal.planningApplicationDocumentsSection.originalApplication.uploadedFile.name =
+            'test-pdf.pdf';
+
+          const result = await insert.validate(appeal2, config);
+          expect(result).toEqual(appeal);
+        });
+
+        it('should not throw an error when not given a value', async () => {
+          delete appeal2.planningApplicationDocumentsSection.originalApplication.uploadedFile.name;
+          appeal.planningApplicationDocumentsSection.originalApplication.uploadedFile.name = '';
+
+          const result = await insert.validate(appeal, config);
+          expect(result).toEqual(appeal);
+        });
+      });
+
+      describe('planningApplicationDocumentsSection.originalApplication.uploadedFile.originalFileName', () => {
+        it('should throw an error when given a value with more than 255 characters', async () => {
+          appeal.planningApplicationDocumentsSection.originalApplication.uploadedFile.originalFileName =
+            'a'.repeat(256);
+
+          await expect(() => insert.validate(appeal, config)).rejects.toThrow(
+            'planningApplicationDocumentsSection.originalApplication.uploadedFile.originalFileName must be at most 255 characters',
+          );
+        });
+
+        it('should strip leading/trailing spaces', async () => {
+          appeal2.planningApplicationDocumentsSection.originalApplication.uploadedFile.originalFileName =
+            '  test-pdf.pdf  ';
+          appeal.planningApplicationDocumentsSection.originalApplication.uploadedFile.originalFileName =
+            'test-pdf.pdf';
+
+          const result = await insert.validate(appeal2, config);
+          expect(result).toEqual(appeal);
+        });
+
+        it('should not throw an error when not given a value', async () => {
+          delete appeal2.planningApplicationDocumentsSection.originalApplication.uploadedFile
+            .originalFileName;
+          appeal.planningApplicationDocumentsSection.originalApplication.uploadedFile.originalFileName =
+            '';
+
+          const result = await insert.validate(appeal, config);
+          expect(result).toEqual(appeal);
+        });
+      });
+
+      describe('planningApplicationDocumentsSection.originalApplication.uploadedFile.id', () => {
+        it('should strip leading/trailing spaces', async () => {
+          appeal2.planningApplicationDocumentsSection.originalApplication.uploadedFile.id =
+            '  271c9b5b-af90-4b45-b0e7-0a7882da1e03  ';
+          appeal.planningApplicationDocumentsSection.originalApplication.uploadedFile.id =
+            '271c9b5b-af90-4b45-b0e7-0a7882da1e03';
+
+          const result = await insert.validate(appeal2, config);
+          expect(result).toEqual(appeal);
+        });
+
+        it('should throw an error when not given a UUID', async () => {
+          appeal.planningApplicationDocumentsSection.originalApplication.uploadedFile.id = 'abc123';
+
+          await expect(() => insert.validate(appeal, config)).rejects.toThrow(
+            'planningApplicationDocumentsSection.originalApplication.uploadedFile.id must be a valid UUID',
+          );
+        });
+
+        it('should not throw an error when given a null value', async () => {
+          appeal.planningApplicationDocumentsSection.originalApplication.uploadedFile.id = null;
+
+          const result = await insert.validate(appeal, config);
+          expect(result).toEqual(appeal);
+        });
+
+        it('should not throw an error when not given a value', async () => {
+          delete appeal2.planningApplicationDocumentsSection.originalApplication.uploadedFile.id;
+          appeal.planningApplicationDocumentsSection.originalApplication.uploadedFile.id = null;
+
+          const result = await insert.validate(appeal2, config);
+          expect(result).toEqual(appeal);
+        });
+      });
+
+      describe('planningApplicationDocumentsSection.designAccessStatement', () => {
+        it('should remove unknown fields', async () => {
+          appeal2.planningApplicationDocumentsSection.designAccessStatement.unknownField =
+            'unknown field';
+
+          const result = await insert.validate(appeal2, config);
+          expect(result).toEqual(appeal);
+        });
+
+        it('should throw an error when given a null value', async () => {
+          appeal.planningApplicationDocumentsSection.designAccessStatement = null;
+
+          await expect(() => insert.validate(appeal, config)).rejects.toThrow(
+            'planningApplicationDocumentsSection.designAccessStatement must be a `object` type, but the final value was: `null`',
+          );
+        });
+      });
+
+      describe('planningApplicationDocumentsSection.designAccessStatement.uploadedFile', () => {
+        it('should remove unknown fields', async () => {
+          appeal2.planningApplicationDocumentsSection.designAccessStatement.uploadedFile.unknownField =
+            'unknown field';
+
+          const result = await insert.validate(appeal2, config);
+          expect(result).toEqual(appeal);
+        });
+
+        it('should throw an error when given a null value', async () => {
+          appeal.planningApplicationDocumentsSection.designAccessStatement.uploadedFile = null;
+
+          await expect(() => insert.validate(appeal, config)).rejects.toThrow(
+            'planningApplicationDocumentsSection.designAccessStatement.uploadedFile must be a `object` type, but the final value was: `null`',
+          );
+        });
+      });
+
+      describe('planningApplicationDocumentsSection.designAccessStatement.uploadedFile.name', () => {
+        it('should throw an error when given a value with more than 255 characters', async () => {
+          appeal.planningApplicationDocumentsSection.designAccessStatement.uploadedFile.name =
+            'a'.repeat(256);
+
+          await expect(() => insert.validate(appeal, config)).rejects.toThrow(
+            'planningApplicationDocumentsSection.designAccessStatement.uploadedFile.name must be at most 255 characters',
+          );
+        });
+
+        it('should strip leading/trailing spaces', async () => {
+          appeal2.planningApplicationDocumentsSection.designAccessStatement.uploadedFile.name =
+            '  test-pdf.pdf  ';
+          appeal.planningApplicationDocumentsSection.designAccessStatement.uploadedFile.name =
+            'test-pdf.pdf';
+
+          const result = await insert.validate(appeal2, config);
+          expect(result).toEqual(appeal);
+        });
+
+        it('should not throw an error when not given a value', async () => {
+          delete appeal2.planningApplicationDocumentsSection.designAccessStatement.uploadedFile
+            .name;
+          appeal.planningApplicationDocumentsSection.designAccessStatement.uploadedFile.name = '';
+
+          const result = await insert.validate(appeal, config);
+          expect(result).toEqual(appeal);
+        });
+      });
+
+      describe('planningApplicationDocumentsSection.designAccessStatement.uploadedFile.originalFileName', () => {
+        it('should throw an error when given a value with more than 255 characters', async () => {
+          appeal.planningApplicationDocumentsSection.designAccessStatement.uploadedFile.originalFileName =
+            'a'.repeat(256);
+
+          await expect(() => insert.validate(appeal, config)).rejects.toThrow(
+            'planningApplicationDocumentsSection.designAccessStatement.uploadedFile.originalFileName must be at most 255 characters',
+          );
+        });
+
+        it('should strip leading/trailing spaces', async () => {
+          appeal2.planningApplicationDocumentsSection.designAccessStatement.uploadedFile.originalFileName =
+            '  test-pdf.pdf  ';
+          appeal.planningApplicationDocumentsSection.designAccessStatement.uploadedFile.originalFileName =
+            'test-pdf.pdf';
+
+          const result = await insert.validate(appeal2, config);
+          expect(result).toEqual(appeal);
+        });
+
+        it('should not throw an error when not given a value', async () => {
+          delete appeal2.planningApplicationDocumentsSection.designAccessStatement.uploadedFile
+            .originalFileName;
+          appeal.planningApplicationDocumentsSection.designAccessStatement.uploadedFile.originalFileName =
+            '';
+
+          const result = await insert.validate(appeal, config);
+          expect(result).toEqual(appeal);
+        });
+      });
+
+      describe('planningApplicationDocumentsSection.designAccessStatement.uploadedFile.id', () => {
+        it('should strip leading/trailing spaces', async () => {
+          appeal2.planningApplicationDocumentsSection.designAccessStatement.uploadedFile.id =
+            '  271c9b5b-af90-4b45-b0e7-0a7882da1e03  ';
+          appeal.planningApplicationDocumentsSection.designAccessStatement.uploadedFile.id =
+            '271c9b5b-af90-4b45-b0e7-0a7882da1e03';
+
+          const result = await insert.validate(appeal2, config);
+          expect(result).toEqual(appeal);
+        });
+
+        it('should throw an error when not given a UUID', async () => {
+          appeal.planningApplicationDocumentsSection.designAccessStatement.uploadedFile.id =
+            'abc123';
+
+          await expect(() => insert.validate(appeal, config)).rejects.toThrow(
+            'planningApplicationDocumentsSection.designAccessStatement.uploadedFile.id must be a valid UUID',
+          );
+        });
+
+        it('should not throw an error when given a null value', async () => {
+          appeal.planningApplicationDocumentsSection.designAccessStatement.uploadedFile.id = null;
+
+          const result = await insert.validate(appeal, config);
+          expect(result).toEqual(appeal);
+        });
+
+        it('should not throw an error when not given a value', async () => {
+          delete appeal2.planningApplicationDocumentsSection.designAccessStatement.uploadedFile.id;
+          appeal.planningApplicationDocumentsSection.designAccessStatement.uploadedFile.id = null;
+
+          const result = await insert.validate(appeal2, config);
+          expect(result).toEqual(appeal);
+        });
+      });
+
+      describe('planningApplicationDocumentsSection.decisionLetter', () => {
+        it('should remove unknown fields', async () => {
+          appeal2.planningApplicationDocumentsSection.decisionLetter.unknownField = 'unknown field';
+
+          const result = await insert.validate(appeal2, config);
+          expect(result).toEqual(appeal);
+        });
+
+        it('should throw an error when given a null value', async () => {
+          appeal.planningApplicationDocumentsSection.decisionLetter = null;
+
+          await expect(() => insert.validate(appeal, config)).rejects.toThrow(
+            'planningApplicationDocumentsSection.decisionLetter must be a `object` type, but the final value was: `null`',
+          );
+        });
+      });
+
+      describe('planningApplicationDocumentsSection.decisionLetter.uploadedFile', () => {
+        it('should remove unknown fields', async () => {
+          appeal2.planningApplicationDocumentsSection.decisionLetter.uploadedFile.unknownField =
+            'unknown field';
+
+          const result = await insert.validate(appeal2, config);
+          expect(result).toEqual(appeal);
+        });
+
+        it('should throw an error when given a null value', async () => {
+          appeal.planningApplicationDocumentsSection.decisionLetter.uploadedFile = null;
+
+          await expect(() => insert.validate(appeal, config)).rejects.toThrow(
+            'planningApplicationDocumentsSection.decisionLetter.uploadedFile must be a `object` type, but the final value was: `null`',
+          );
+        });
+      });
+
+      describe('planningApplicationDocumentsSection.decisionLetter.uploadedFile.name', () => {
+        it('should throw an error when given a value with more than 255 characters', async () => {
+          appeal.planningApplicationDocumentsSection.decisionLetter.uploadedFile.name = 'a'.repeat(
+            256,
+          );
+
+          await expect(() => insert.validate(appeal, config)).rejects.toThrow(
+            'planningApplicationDocumentsSection.decisionLetter.uploadedFile.name must be at most 255 characters',
+          );
+        });
+
+        it('should strip leading/trailing spaces', async () => {
+          appeal2.planningApplicationDocumentsSection.decisionLetter.uploadedFile.name =
+            '  test-pdf.pdf  ';
+          appeal.planningApplicationDocumentsSection.decisionLetter.uploadedFile.name =
+            'test-pdf.pdf';
+
+          const result = await insert.validate(appeal2, config);
+          expect(result).toEqual(appeal);
+        });
+
+        it('should not throw an error when not given a value', async () => {
+          delete appeal2.planningApplicationDocumentsSection.decisionLetter.uploadedFile.name;
+          appeal.planningApplicationDocumentsSection.decisionLetter.uploadedFile.name = '';
+
+          const result = await insert.validate(appeal, config);
+          expect(result).toEqual(appeal);
+        });
+      });
+
+      describe('planningApplicationDocumentsSection.decisionLetter.uploadedFile.originalFileName', () => {
+        it('should throw an error when given a value with more than 255 characters', async () => {
+          appeal.planningApplicationDocumentsSection.decisionLetter.uploadedFile.originalFileName =
+            'a'.repeat(256);
+
+          await expect(() => insert.validate(appeal, config)).rejects.toThrow(
+            'planningApplicationDocumentsSection.decisionLetter.uploadedFile.originalFileName must be at most 255 characters',
+          );
+        });
+
+        it('should strip leading/trailing spaces', async () => {
+          appeal2.planningApplicationDocumentsSection.decisionLetter.uploadedFile.originalFileName =
+            '  test-pdf.pdf  ';
+          appeal.planningApplicationDocumentsSection.decisionLetter.uploadedFile.originalFileName =
+            'test-pdf.pdf';
+
+          const result = await insert.validate(appeal2, config);
+          expect(result).toEqual(appeal);
+        });
+
+        it('should not throw an error when not given a value', async () => {
+          delete appeal2.planningApplicationDocumentsSection.decisionLetter.uploadedFile
+            .originalFileName;
+          appeal.planningApplicationDocumentsSection.decisionLetter.uploadedFile.originalFileName =
+            '';
+
+          const result = await insert.validate(appeal, config);
+          expect(result).toEqual(appeal);
+        });
+      });
+
+      describe('planningApplicationDocumentsSection.decisionLetter.uploadedFile.id', () => {
+        it('should strip leading/trailing spaces', async () => {
+          appeal2.planningApplicationDocumentsSection.decisionLetter.uploadedFile.id =
+            '  271c9b5b-af90-4b45-b0e7-0a7882da1e03  ';
+          appeal.planningApplicationDocumentsSection.decisionLetter.uploadedFile.id =
+            '271c9b5b-af90-4b45-b0e7-0a7882da1e03';
+
+          const result = await insert.validate(appeal2, config);
+          expect(result).toEqual(appeal);
+        });
+
+        it('should throw an error when not given a UUID', async () => {
+          appeal.planningApplicationDocumentsSection.decisionLetter.uploadedFile.id = 'abc123';
+
+          await expect(() => insert.validate(appeal, config)).rejects.toThrow(
+            'planningApplicationDocumentsSection.decisionLetter.uploadedFile.id must be a valid UUID',
+          );
+        });
+
+        it('should not throw an error when given a null value', async () => {
+          appeal.planningApplicationDocumentsSection.decisionLetter.uploadedFile.id = null;
+
+          const result = await insert.validate(appeal, config);
+          expect(result).toEqual(appeal);
+        });
+
+        it('should not throw an error when not given a value', async () => {
+          delete appeal2.planningApplicationDocumentsSection.decisionLetter.uploadedFile.id;
+          appeal.planningApplicationDocumentsSection.decisionLetter.uploadedFile.id = null;
+
+          const result = await insert.validate(appeal2, config);
           expect(result).toEqual(appeal);
         });
       });

--- a/packages/business-rules/src/schemas/full-appeal/update.js
+++ b/packages/business-rules/src/schemas/full-appeal/update.js
@@ -69,9 +69,35 @@ const update = pinsYup
           .noUnknown(true),
       })
       .noUnknown(true),
-    requiredDocumentsSection: pinsYup
+    contactDetailsSection: pinsYup
       .object()
       .shape({
+        name: pinsYup
+          .string()
+          .min(2)
+          .max(80)
+          .matches(/^[a-z\-' ]+$/i)
+          .required(),
+        companyName: pinsYup.string().max(50).nullable(),
+        email: pinsYup.string().email().max(255).required(),
+      })
+      .noUnknown(true),
+    appealSiteSection: pinsYup.object().shape({
+      siteAddress: pinsYup
+        .object()
+        .shape({
+          addressLine1: pinsYup.string().max(60).required(),
+          addressLine2: pinsYup.string().max(60).nullable(),
+          town: pinsYup.string().max(60).nullable(),
+          county: pinsYup.string().max(60).nullable(),
+          postcode: pinsYup.string().max(8).required(),
+        })
+        .noUnknown(true),
+    }),
+    planningApplicationDocumentsSection: pinsYup
+      .object()
+      .shape({
+        isDesignAccessStatementSubmitted: pinsYup.bool().required(),
         originalApplication: pinsYup
           .object()
           .shape({
@@ -111,37 +137,6 @@ const update = pinsYup
               .noUnknown(true),
           })
           .noUnknown(true),
-      })
-      .noUnknown(true),
-    contactDetailsSection: pinsYup
-      .object()
-      .shape({
-        name: pinsYup
-          .string()
-          .min(2)
-          .max(80)
-          .matches(/^[a-z\-' ]+$/i)
-          .required(),
-        companyName: pinsYup.string().max(50).nullable(),
-        email: pinsYup.string().email().max(255).required(),
-      })
-      .noUnknown(true),
-    appealSiteSection: pinsYup.object().shape({
-      siteAddress: pinsYup
-        .object()
-        .shape({
-          addressLine1: pinsYup.string().max(60).required(),
-          addressLine2: pinsYup.string().max(60).nullable(),
-          town: pinsYup.string().max(60).nullable(),
-          county: pinsYup.string().max(60).nullable(),
-          postcode: pinsYup.string().max(8).required(),
-        })
-        .noUnknown(true),
-    }),
-    planningApplicationDocumentsSection: pinsYup
-      .object()
-      .shape({
-        isDesignAccessStatementSubmitted: pinsYup.bool().required(),
       })
       .noUnknown(true),
     sectionStates: pinsYup.object().shape({}),

--- a/packages/business-rules/src/schemas/full-appeal/update.js
+++ b/packages/business-rules/src/schemas/full-appeal/update.js
@@ -97,6 +97,7 @@ const update = pinsYup
     planningApplicationDocumentsSection: pinsYup
       .object()
       .shape({
+        applicationNumber: pinsYup.string().max(30).required(),
         isDesignAccessStatementSubmitted: pinsYup.bool().required(),
         originalApplication: pinsYup
           .object()

--- a/packages/business-rules/src/schemas/full-appeal/update.test.js
+++ b/packages/business-rules/src/schemas/full-appeal/update.test.js
@@ -810,6 +810,32 @@ describe('schemas/full-appeal/update', () => {
         );
       });
 
+      describe('planningApplicationDocumentsSection.applicationNumber', () => {
+        it('should throw an error when given a value with more than 30 characters', async () => {
+          appeal.planningApplicationDocumentsSection.applicationNumber = 'a'.repeat(31);
+
+          await expect(() => update.validate(appeal, config)).rejects.toThrow(
+            'planningApplicationDocumentsSection.applicationNumber must be at most 30 characters',
+          );
+        });
+
+        it('should throw an error when given a null value', async () => {
+          appeal.planningApplicationDocumentsSection.applicationNumber = null;
+
+          await expect(() => update.validate(appeal, config)).rejects.toThrow(
+            'planningApplicationDocumentsSection.applicationNumber must be a `string` type, but the final value was: `null`',
+          );
+        });
+
+        it('should throw an error when not given a value', async () => {
+          delete appeal.planningApplicationDocumentsSection.applicationNumber;
+
+          await expect(() => update.validate(appeal, config)).rejects.toThrow(
+            'planningApplicationDocumentsSection.applicationNumber is a required field',
+          );
+        });
+      });
+
       describe('planningApplicationDocumentsSection.isDesignAccessStatementSubmitted', () => {
         it('should throw an error when not given a boolean value', async () => {
           appeal.planningApplicationDocumentsSection = {

--- a/packages/business-rules/src/schemas/full-appeal/update.test.js
+++ b/packages/business-rules/src/schemas/full-appeal/update.test.js
@@ -311,141 +311,6 @@ describe('schemas/full-appeal/update', () => {
       });
     });
 
-    describe('requiredDocumentsSection', () => {
-      it('should remove unknown fields', async () => {
-        appeal2.requiredDocumentsSection.unknownField = 'unknown field';
-
-        const result = await update.validate(appeal2, config);
-        expect(result).toEqual(appeal);
-      });
-
-      it('should throw an error when given a null value', async () => {
-        appeal.requiredDocumentsSection = null;
-
-        await expect(() => update.validate(appeal, config)).rejects.toThrow(
-          'requiredDocumentsSection must be a `object` type, but the final value was: `null`',
-        );
-      });
-    });
-
-    describe('requiredDocumentsSection.originalApplication', () => {
-      it('should remove unknown fields', async () => {
-        appeal2.requiredDocumentsSection.originalApplication.unknownField = 'unknown field';
-
-        const result = await update.validate(appeal2, config);
-        expect(result).toEqual(appeal);
-      });
-
-      it('should throw an error when given a null value', async () => {
-        appeal.requiredDocumentsSection.originalApplication = null;
-
-        await expect(() => update.validate(appeal, config)).rejects.toThrow(
-          'requiredDocumentsSection.originalApplication must be a `object` type, but the final value was: `null`',
-        );
-      });
-    });
-
-    describe('requiredDocumentsSection.originalApplication.uploadedFile', () => {
-      it('should remove unknown fields', async () => {
-        appeal2.requiredDocumentsSection.originalApplication.uploadedFile.unknownField =
-          'unknown field';
-
-        const result = await update.validate(appeal2, config);
-        expect(result).toEqual(appeal);
-      });
-
-      it('should throw an error when given a null value', async () => {
-        appeal.requiredDocumentsSection.originalApplication.uploadedFile = null;
-
-        await expect(() => update.validate(appeal, config)).rejects.toThrow(
-          'requiredDocumentsSection.originalApplication.uploadedFile must be a `object` type, but the final value was: `null`',
-        );
-      });
-    });
-
-    describe('requiredDocumentsSection.originalApplication.uploadedFile.name', () => {
-      it('should throw an error when given a value with more than 255 characters', async () => {
-        appeal.requiredDocumentsSection.originalApplication.uploadedFile.name = 'a'.repeat(256);
-
-        await expect(() => update.validate(appeal, config)).rejects.toThrow(
-          'requiredDocumentsSection.originalApplication.uploadedFile.name must be at most 255 characters',
-        );
-      });
-
-      it('should strip leading/trailing spaces', async () => {
-        appeal2.requiredDocumentsSection.originalApplication.uploadedFile.name = '  test-pdf.pdf  ';
-        appeal.requiredDocumentsSection.originalApplication.uploadedFile.name = 'test-pdf.pdf';
-
-        const result = await update.validate(appeal2, config);
-        expect(result).toEqual(appeal);
-      });
-
-      it('should throw an error when not given a value', async () => {
-        delete appeal.requiredDocumentsSection.originalApplication.uploadedFile.name;
-
-        await expect(() => update.validate(appeal, config)).rejects.toThrow(
-          'requiredDocumentsSection.originalApplication.uploadedFile.name is a required field',
-        );
-      });
-    });
-
-    describe('requiredDocumentsSection.originalApplication.uploadedFile.originalFileName', () => {
-      it('should throw an error when given a value with more than 255 characters', async () => {
-        appeal.requiredDocumentsSection.originalApplication.uploadedFile.originalFileName =
-          'a'.repeat(256);
-
-        await expect(() => update.validate(appeal, config)).rejects.toThrow(
-          'requiredDocumentsSection.originalApplication.uploadedFile.originalFileName must be at most 255 characters',
-        );
-      });
-
-      it('should strip leading/trailing spaces', async () => {
-        appeal2.requiredDocumentsSection.originalApplication.uploadedFile.originalFileName =
-          '  test-pdf.pdf  ';
-        appeal.requiredDocumentsSection.originalApplication.uploadedFile.originalFileName =
-          'test-pdf.pdf';
-
-        const result = await update.validate(appeal2, config);
-        expect(result).toEqual(appeal);
-      });
-
-      it('should throw an error when not given a value', async () => {
-        delete appeal.requiredDocumentsSection.originalApplication.uploadedFile.originalFileName;
-
-        await expect(() => update.validate(appeal, config)).rejects.toThrow(
-          'requiredDocumentsSection.originalApplication.uploadedFile.originalFileName is a required field',
-        );
-      });
-    });
-
-    describe('requiredDocumentsSection.originalApplication.uploadedFile.id', () => {
-      it('should strip leading/trailing spaces', async () => {
-        appeal2.requiredDocumentsSection.originalApplication.uploadedFile.id =
-          '  271c9b5b-af90-4b45-b0e7-0a7882da1e03  ';
-        appeal.requiredDocumentsSection.originalApplication.uploadedFile.id =
-          '271c9b5b-af90-4b45-b0e7-0a7882da1e03';
-
-        const result = await update.validate(appeal2, config);
-        expect(result).toEqual(appeal);
-      });
-
-      it('should throw an error when not given a UUID', async () => {
-        appeal.requiredDocumentsSection.originalApplication.uploadedFile.id = 'abc123';
-
-        await expect(() => update.validate(appeal, config)).rejects.toThrow(
-          'requiredDocumentsSection.originalApplication.uploadedFile.id must be a valid UUID',
-        );
-      });
-
-      it('should throw an error when not given a value', async () => {
-        delete appeal.requiredDocumentsSection.originalApplication.uploadedFile.id;
-
-        await expect(() => update.validate(appeal, config)).rejects.toThrow(
-          'requiredDocumentsSection.originalApplication.uploadedFile.id is a required field',
-        );
-      });
-    });
-
     describe('yourAppealSection', () => {
       it('should remove unknown fields', async () => {
         appeal2.yourAppealSection.unknownField = 'unknown field';
@@ -592,243 +457,6 @@ describe('schemas/full-appeal/update', () => {
 
         await expect(() => update.validate(appeal, config)).rejects.toThrow(
           'yourAppealSection.appealStatement.hasSensitiveInformation is a required field',
-        );
-      });
-    });
-
-    describe('requiredDocumentsSection.designAccessStatement', () => {
-      it('should remove unknown fields', async () => {
-        appeal2.requiredDocumentsSection.designAccessStatement.unknownField = 'unknown field';
-
-        const result = await update.validate(appeal2, config);
-        expect(result).toEqual(appeal);
-      });
-
-      it('should throw an error when given a null value', async () => {
-        appeal.requiredDocumentsSection.designAccessStatement = null;
-
-        await expect(() => update.validate(appeal, config)).rejects.toThrow(
-          'requiredDocumentsSection.designAccessStatement must be a `object` type, but the final value was: `null`',
-        );
-      });
-    });
-
-    describe('requiredDocumentsSection.designAccessStatement.uploadedFile', () => {
-      it('should remove unknown fields', async () => {
-        appeal2.requiredDocumentsSection.designAccessStatement.uploadedFile.unknownField =
-          'unknown field';
-
-        const result = await update.validate(appeal2, config);
-        expect(result).toEqual(appeal);
-      });
-
-      it('should throw an error when given a null value', async () => {
-        appeal.requiredDocumentsSection.designAccessStatement.uploadedFile = null;
-
-        await expect(() => update.validate(appeal, config)).rejects.toThrow(
-          'requiredDocumentsSection.designAccessStatement.uploadedFile must be a `object` type, but the final value was: `null`',
-        );
-      });
-    });
-
-    describe('requiredDocumentsSection.designAccessStatement.uploadedFile.name', () => {
-      it('should throw an error when given a value with more than 255 characters', async () => {
-        appeal.requiredDocumentsSection.designAccessStatement.uploadedFile.name = 'a'.repeat(256);
-
-        await expect(() => update.validate(appeal, config)).rejects.toThrow(
-          'requiredDocumentsSection.designAccessStatement.uploadedFile.name must be at most 255 characters',
-        );
-      });
-
-      it('should strip leading/trailing spaces', async () => {
-        appeal2.requiredDocumentsSection.designAccessStatement.uploadedFile.name =
-          '  test-pdf.pdf  ';
-        appeal.requiredDocumentsSection.designAccessStatement.uploadedFile.name = 'test-pdf.pdf';
-
-        const result = await update.validate(appeal2, config);
-        expect(result).toEqual(appeal);
-      });
-
-      it('should throw an error when not given a value', async () => {
-        delete appeal.requiredDocumentsSection.designAccessStatement.uploadedFile.name;
-
-        await expect(() => update.validate(appeal, config)).rejects.toThrow(
-          'requiredDocumentsSection.designAccessStatement.uploadedFile.name is a required field',
-        );
-      });
-    });
-
-    describe('requiredDocumentsSection.designAccessStatement.uploadedFile.originalFileName', () => {
-      it('should throw an error when given a value with more than 255 characters', async () => {
-        appeal.requiredDocumentsSection.designAccessStatement.uploadedFile.originalFileName =
-          'a'.repeat(256);
-
-        await expect(() => update.validate(appeal, config)).rejects.toThrow(
-          'requiredDocumentsSection.designAccessStatement.uploadedFile.originalFileName must be at most 255 characters',
-        );
-      });
-
-      it('should strip leading/trailing spaces', async () => {
-        appeal2.requiredDocumentsSection.designAccessStatement.uploadedFile.originalFileName =
-          '  test-pdf.pdf  ';
-        appeal.requiredDocumentsSection.designAccessStatement.uploadedFile.originalFileName =
-          'test-pdf.pdf';
-
-        const result = await update.validate(appeal2, config);
-        expect(result).toEqual(appeal);
-      });
-
-      it('should throw an error when not given a value', async () => {
-        delete appeal.requiredDocumentsSection.designAccessStatement.uploadedFile.originalFileName;
-
-        await expect(() => update.validate(appeal, config)).rejects.toThrow(
-          'requiredDocumentsSection.designAccessStatement.uploadedFile.originalFileName is a required field',
-        );
-      });
-    });
-
-    describe('requiredDocumentsSection.designAccessStatement.uploadedFile.id', () => {
-      it('should strip leading/trailing spaces', async () => {
-        appeal2.requiredDocumentsSection.designAccessStatement.uploadedFile.id =
-          '  271c9b5b-af90-4b45-b0e7-0a7882da1e03  ';
-        appeal.requiredDocumentsSection.designAccessStatement.uploadedFile.id =
-          '271c9b5b-af90-4b45-b0e7-0a7882da1e03';
-
-        const result = await update.validate(appeal2, config);
-        expect(result).toEqual(appeal);
-      });
-
-      it('should throw an error when not given a UUID', async () => {
-        appeal.requiredDocumentsSection.designAccessStatement.uploadedFile.id = 'abc123';
-
-        await expect(() => update.validate(appeal, config)).rejects.toThrow(
-          'requiredDocumentsSection.designAccessStatement.uploadedFile.id must be a valid UUID',
-        );
-      });
-
-      it('should throw an error when not given a value', async () => {
-        delete appeal.requiredDocumentsSection.designAccessStatement.uploadedFile.id;
-
-        await expect(() => update.validate(appeal, config)).rejects.toThrow(
-          'requiredDocumentsSection.designAccessStatement.uploadedFile.id is a required field',
-        );
-      });
-    });
-
-    describe('requiredDocumentsSection.decisionLetter', () => {
-      it('should remove unknown fields', async () => {
-        appeal2.requiredDocumentsSection.decisionLetter.unknownField = 'unknown field';
-
-        const result = await update.validate(appeal2, config);
-        expect(result).toEqual(appeal);
-      });
-
-      it('should throw an error when given a null value', async () => {
-        appeal.requiredDocumentsSection.decisionLetter = null;
-
-        await expect(() => update.validate(appeal, config)).rejects.toThrow(
-          'requiredDocumentsSection.decisionLetter must be a `object` type, but the final value was: `null`',
-        );
-      });
-    });
-
-    describe('requiredDocumentsSection.decisionLetter.uploadedFile', () => {
-      it('should remove unknown fields', async () => {
-        appeal2.requiredDocumentsSection.decisionLetter.uploadedFile.unknownField = 'unknown field';
-
-        const result = await update.validate(appeal2, config);
-        expect(result).toEqual(appeal);
-      });
-
-      it('should throw an error when given a null value', async () => {
-        appeal.requiredDocumentsSection.decisionLetter.uploadedFile = null;
-
-        await expect(() => update.validate(appeal, config)).rejects.toThrow(
-          'requiredDocumentsSection.decisionLetter.uploadedFile must be a `object` type, but the final value was: `null`',
-        );
-      });
-    });
-
-    describe('requiredDocumentsSection.decisionLetter.uploadedFile.name', () => {
-      it('should throw an error when given a value with more than 255 characters', async () => {
-        appeal.requiredDocumentsSection.decisionLetter.uploadedFile.name = 'a'.repeat(256);
-
-        await expect(() => update.validate(appeal, config)).rejects.toThrow(
-          'requiredDocumentsSection.decisionLetter.uploadedFile.name must be at most 255 characters',
-        );
-      });
-
-      it('should strip leading/trailing spaces', async () => {
-        appeal2.requiredDocumentsSection.decisionLetter.uploadedFile.name = '  test-pdf.pdf  ';
-        appeal.requiredDocumentsSection.decisionLetter.uploadedFile.name = 'test-pdf.pdf';
-
-        const result = await update.validate(appeal2, config);
-        expect(result).toEqual(appeal);
-      });
-
-      it('should throw an error when not given a value', async () => {
-        delete appeal.requiredDocumentsSection.decisionLetter.uploadedFile.name;
-
-        await expect(() => update.validate(appeal, config)).rejects.toThrow(
-          'requiredDocumentsSection.decisionLetter.uploadedFile.name is a required field',
-        );
-      });
-    });
-
-    describe('requiredDocumentsSection.decisionLetter.uploadedFile.originalFileName', () => {
-      it('should throw an error when given a value with more than 255 characters', async () => {
-        appeal.requiredDocumentsSection.decisionLetter.uploadedFile.originalFileName = 'a'.repeat(
-          256,
-        );
-
-        await expect(() => update.validate(appeal, config)).rejects.toThrow(
-          'requiredDocumentsSection.decisionLetter.uploadedFile.originalFileName must be at most 255 characters',
-        );
-      });
-
-      it('should strip leading/trailing spaces', async () => {
-        appeal2.requiredDocumentsSection.decisionLetter.uploadedFile.originalFileName =
-          '  test-pdf.pdf  ';
-        appeal.requiredDocumentsSection.decisionLetter.uploadedFile.originalFileName =
-          'test-pdf.pdf';
-
-        const result = await update.validate(appeal2, config);
-        expect(result).toEqual(appeal);
-      });
-
-      it('should throw an error when not given a value', async () => {
-        delete appeal.requiredDocumentsSection.decisionLetter.uploadedFile.originalFileName;
-
-        await expect(() => update.validate(appeal, config)).rejects.toThrow(
-          'requiredDocumentsSection.decisionLetter.uploadedFile.originalFileName is a required field',
-        );
-      });
-    });
-
-    describe('requiredDocumentsSection.decisionLetter.uploadedFile.id', () => {
-      it('should strip leading/trailing spaces', async () => {
-        appeal2.requiredDocumentsSection.decisionLetter.uploadedFile.id =
-          '  271c9b5b-af90-4b45-b0e7-0a7882da1e03  ';
-        appeal.requiredDocumentsSection.decisionLetter.uploadedFile.id =
-          '271c9b5b-af90-4b45-b0e7-0a7882da1e03';
-
-        const result = await update.validate(appeal2, config);
-        expect(result).toEqual(appeal);
-      });
-
-      it('should throw an error when not given a UUID', async () => {
-        appeal.requiredDocumentsSection.decisionLetter.uploadedFile.id = 'abc123';
-
-        await expect(() => update.validate(appeal, config)).rejects.toThrow(
-          'requiredDocumentsSection.decisionLetter.uploadedFile.id must be a valid UUID',
-        );
-      });
-
-      it('should throw an error when not given a value', async () => {
-        delete appeal.requiredDocumentsSection.decisionLetter.uploadedFile.id;
-
-        await expect(() => update.validate(appeal, config)).rejects.toThrow(
-          'requiredDocumentsSection.decisionLetter.uploadedFile.id is a required field',
         );
       });
     });
@@ -1206,6 +834,376 @@ describe('schemas/full-appeal/update', () => {
 
           await expect(() => update.validate(appeal, config)).rejects.toThrow(
             'planningApplicationDocumentsSection.isDesignAccessStatementSubmitted is a required field',
+          );
+        });
+      });
+
+      describe('planningApplicationDocumentsSection.originalApplication', () => {
+        it('should remove unknown fields', async () => {
+          appeal2.planningApplicationDocumentsSection.originalApplication.unknownField =
+            'unknown field';
+
+          const result = await update.validate(appeal2, config);
+          expect(result).toEqual(appeal);
+        });
+
+        it('should throw an error when given a null value', async () => {
+          appeal.planningApplicationDocumentsSection.originalApplication = null;
+
+          await expect(() => update.validate(appeal, config)).rejects.toThrow(
+            'planningApplicationDocumentsSection.originalApplication must be a `object` type, but the final value was: `null`',
+          );
+        });
+      });
+
+      describe('planningApplicationDocumentsSection.originalApplication.uploadedFile', () => {
+        it('should remove unknown fields', async () => {
+          appeal2.planningApplicationDocumentsSection.originalApplication.uploadedFile.unknownField =
+            'unknown field';
+
+          const result = await update.validate(appeal2, config);
+          expect(result).toEqual(appeal);
+        });
+
+        it('should throw an error when given a null value', async () => {
+          appeal.planningApplicationDocumentsSection.originalApplication.uploadedFile = null;
+
+          await expect(() => update.validate(appeal, config)).rejects.toThrow(
+            'planningApplicationDocumentsSection.originalApplication.uploadedFile must be a `object` type, but the final value was: `null`',
+          );
+        });
+      });
+
+      describe('planningApplicationDocumentsSection.originalApplication.uploadedFile.name', () => {
+        it('should throw an error when given a value with more than 255 characters', async () => {
+          appeal.planningApplicationDocumentsSection.originalApplication.uploadedFile.name =
+            'a'.repeat(256);
+
+          await expect(() => update.validate(appeal, config)).rejects.toThrow(
+            'planningApplicationDocumentsSection.originalApplication.uploadedFile.name must be at most 255 characters',
+          );
+        });
+
+        it('should strip leading/trailing spaces', async () => {
+          appeal2.planningApplicationDocumentsSection.originalApplication.uploadedFile.name =
+            '  test-pdf.pdf  ';
+          appeal.planningApplicationDocumentsSection.originalApplication.uploadedFile.name =
+            'test-pdf.pdf';
+
+          const result = await update.validate(appeal2, config);
+          expect(result).toEqual(appeal);
+        });
+
+        it('should throw an error when not given a value', async () => {
+          delete appeal.planningApplicationDocumentsSection.originalApplication.uploadedFile.name;
+
+          await expect(() => update.validate(appeal, config)).rejects.toThrow(
+            'planningApplicationDocumentsSection.originalApplication.uploadedFile.name is a required field',
+          );
+        });
+      });
+
+      describe('planningApplicationDocumentsSection.originalApplication.uploadedFile.originalFileName', () => {
+        it('should throw an error when given a value with more than 255 characters', async () => {
+          appeal.planningApplicationDocumentsSection.originalApplication.uploadedFile.originalFileName =
+            'a'.repeat(256);
+
+          await expect(() => update.validate(appeal, config)).rejects.toThrow(
+            'planningApplicationDocumentsSection.originalApplication.uploadedFile.originalFileName must be at most 255 characters',
+          );
+        });
+
+        it('should strip leading/trailing spaces', async () => {
+          appeal2.planningApplicationDocumentsSection.originalApplication.uploadedFile.originalFileName =
+            '  test-pdf.pdf  ';
+          appeal.planningApplicationDocumentsSection.originalApplication.uploadedFile.originalFileName =
+            'test-pdf.pdf';
+
+          const result = await update.validate(appeal2, config);
+          expect(result).toEqual(appeal);
+        });
+
+        it('should throw an error when not given a value', async () => {
+          delete appeal.planningApplicationDocumentsSection.originalApplication.uploadedFile
+            .originalFileName;
+
+          await expect(() => update.validate(appeal, config)).rejects.toThrow(
+            'planningApplicationDocumentsSection.originalApplication.uploadedFile.originalFileName is a required field',
+          );
+        });
+      });
+
+      describe('planningApplicationDocumentsSection.originalApplication.uploadedFile.id', () => {
+        it('should strip leading/trailing spaces', async () => {
+          appeal2.planningApplicationDocumentsSection.originalApplication.uploadedFile.id =
+            '  271c9b5b-af90-4b45-b0e7-0a7882da1e03  ';
+          appeal.planningApplicationDocumentsSection.originalApplication.uploadedFile.id =
+            '271c9b5b-af90-4b45-b0e7-0a7882da1e03';
+
+          const result = await update.validate(appeal2, config);
+          expect(result).toEqual(appeal);
+        });
+
+        it('should throw an error when not given a UUID', async () => {
+          appeal.planningApplicationDocumentsSection.originalApplication.uploadedFile.id = 'abc123';
+
+          await expect(() => update.validate(appeal, config)).rejects.toThrow(
+            'planningApplicationDocumentsSection.originalApplication.uploadedFile.id must be a valid UUID',
+          );
+        });
+
+        it('should throw an error when not given a value', async () => {
+          delete appeal.planningApplicationDocumentsSection.originalApplication.uploadedFile.id;
+
+          await expect(() => update.validate(appeal, config)).rejects.toThrow(
+            'planningApplicationDocumentsSection.originalApplication.uploadedFile.id is a required field',
+          );
+        });
+      });
+
+      describe('planningApplicationDocumentsSection.designAccessStatement', () => {
+        it('should remove unknown fields', async () => {
+          appeal2.planningApplicationDocumentsSection.designAccessStatement.unknownField =
+            'unknown field';
+
+          const result = await update.validate(appeal2, config);
+          expect(result).toEqual(appeal);
+        });
+
+        it('should throw an error when given a null value', async () => {
+          appeal.planningApplicationDocumentsSection.designAccessStatement = null;
+
+          await expect(() => update.validate(appeal, config)).rejects.toThrow(
+            'planningApplicationDocumentsSection.designAccessStatement must be a `object` type, but the final value was: `null`',
+          );
+        });
+      });
+
+      describe('planningApplicationDocumentsSection.designAccessStatement.uploadedFile', () => {
+        it('should remove unknown fields', async () => {
+          appeal2.planningApplicationDocumentsSection.designAccessStatement.uploadedFile.unknownField =
+            'unknown field';
+
+          const result = await update.validate(appeal2, config);
+          expect(result).toEqual(appeal);
+        });
+
+        it('should throw an error when given a null value', async () => {
+          appeal.planningApplicationDocumentsSection.designAccessStatement.uploadedFile = null;
+
+          await expect(() => update.validate(appeal, config)).rejects.toThrow(
+            'planningApplicationDocumentsSection.designAccessStatement.uploadedFile must be a `object` type, but the final value was: `null`',
+          );
+        });
+      });
+
+      describe('planningApplicationDocumentsSection.designAccessStatement.uploadedFile.name', () => {
+        it('should throw an error when given a value with more than 255 characters', async () => {
+          appeal.planningApplicationDocumentsSection.designAccessStatement.uploadedFile.name =
+            'a'.repeat(256);
+
+          await expect(() => update.validate(appeal, config)).rejects.toThrow(
+            'planningApplicationDocumentsSection.designAccessStatement.uploadedFile.name must be at most 255 characters',
+          );
+        });
+
+        it('should strip leading/trailing spaces', async () => {
+          appeal2.planningApplicationDocumentsSection.designAccessStatement.uploadedFile.name =
+            '  test-pdf.pdf  ';
+          appeal.planningApplicationDocumentsSection.designAccessStatement.uploadedFile.name =
+            'test-pdf.pdf';
+
+          const result = await update.validate(appeal2, config);
+          expect(result).toEqual(appeal);
+        });
+
+        it('should throw an error when not given a value', async () => {
+          delete appeal.planningApplicationDocumentsSection.designAccessStatement.uploadedFile.name;
+
+          await expect(() => update.validate(appeal, config)).rejects.toThrow(
+            'planningApplicationDocumentsSection.designAccessStatement.uploadedFile.name is a required field',
+          );
+        });
+      });
+
+      describe('planningApplicationDocumentsSection.designAccessStatement.uploadedFile.originalFileName', () => {
+        it('should throw an error when given a value with more than 255 characters', async () => {
+          appeal.planningApplicationDocumentsSection.designAccessStatement.uploadedFile.originalFileName =
+            'a'.repeat(256);
+
+          await expect(() => update.validate(appeal, config)).rejects.toThrow(
+            'planningApplicationDocumentsSection.designAccessStatement.uploadedFile.originalFileName must be at most 255 characters',
+          );
+        });
+
+        it('should strip leading/trailing spaces', async () => {
+          appeal2.planningApplicationDocumentsSection.designAccessStatement.uploadedFile.originalFileName =
+            '  test-pdf.pdf  ';
+          appeal.planningApplicationDocumentsSection.designAccessStatement.uploadedFile.originalFileName =
+            'test-pdf.pdf';
+
+          const result = await update.validate(appeal2, config);
+          expect(result).toEqual(appeal);
+        });
+
+        it('should throw an error when not given a value', async () => {
+          delete appeal.planningApplicationDocumentsSection.designAccessStatement.uploadedFile
+            .originalFileName;
+
+          await expect(() => update.validate(appeal, config)).rejects.toThrow(
+            'planningApplicationDocumentsSection.designAccessStatement.uploadedFile.originalFileName is a required field',
+          );
+        });
+      });
+
+      describe('planningApplicationDocumentsSection.designAccessStatement.uploadedFile.id', () => {
+        it('should strip leading/trailing spaces', async () => {
+          appeal2.planningApplicationDocumentsSection.designAccessStatement.uploadedFile.id =
+            '  271c9b5b-af90-4b45-b0e7-0a7882da1e03  ';
+          appeal.planningApplicationDocumentsSection.designAccessStatement.uploadedFile.id =
+            '271c9b5b-af90-4b45-b0e7-0a7882da1e03';
+
+          const result = await update.validate(appeal2, config);
+          expect(result).toEqual(appeal);
+        });
+
+        it('should throw an error when not given a UUID', async () => {
+          appeal.planningApplicationDocumentsSection.designAccessStatement.uploadedFile.id =
+            'abc123';
+
+          await expect(() => update.validate(appeal, config)).rejects.toThrow(
+            'planningApplicationDocumentsSection.designAccessStatement.uploadedFile.id must be a valid UUID',
+          );
+        });
+
+        it('should throw an error when not given a value', async () => {
+          delete appeal.planningApplicationDocumentsSection.designAccessStatement.uploadedFile.id;
+
+          await expect(() => update.validate(appeal, config)).rejects.toThrow(
+            'planningApplicationDocumentsSection.designAccessStatement.uploadedFile.id is a required field',
+          );
+        });
+      });
+
+      describe('planningApplicationDocumentsSection.decisionLetter', () => {
+        it('should remove unknown fields', async () => {
+          appeal2.planningApplicationDocumentsSection.decisionLetter.unknownField = 'unknown field';
+
+          const result = await update.validate(appeal2, config);
+          expect(result).toEqual(appeal);
+        });
+
+        it('should throw an error when given a null value', async () => {
+          appeal.planningApplicationDocumentsSection.decisionLetter = null;
+
+          await expect(() => update.validate(appeal, config)).rejects.toThrow(
+            'planningApplicationDocumentsSection.decisionLetter must be a `object` type, but the final value was: `null`',
+          );
+        });
+      });
+
+      describe('planningApplicationDocumentsSection.decisionLetter.uploadedFile', () => {
+        it('should remove unknown fields', async () => {
+          appeal2.planningApplicationDocumentsSection.decisionLetter.uploadedFile.unknownField =
+            'unknown field';
+
+          const result = await update.validate(appeal2, config);
+          expect(result).toEqual(appeal);
+        });
+
+        it('should throw an error when given a null value', async () => {
+          appeal.planningApplicationDocumentsSection.decisionLetter.uploadedFile = null;
+
+          await expect(() => update.validate(appeal, config)).rejects.toThrow(
+            'planningApplicationDocumentsSection.decisionLetter.uploadedFile must be a `object` type, but the final value was: `null`',
+          );
+        });
+      });
+
+      describe('planningApplicationDocumentsSection.decisionLetter.uploadedFile.name', () => {
+        it('should throw an error when given a value with more than 255 characters', async () => {
+          appeal.planningApplicationDocumentsSection.decisionLetter.uploadedFile.name = 'a'.repeat(
+            256,
+          );
+
+          await expect(() => update.validate(appeal, config)).rejects.toThrow(
+            'planningApplicationDocumentsSection.decisionLetter.uploadedFile.name must be at most 255 characters',
+          );
+        });
+
+        it('should strip leading/trailing spaces', async () => {
+          appeal2.planningApplicationDocumentsSection.decisionLetter.uploadedFile.name =
+            '  test-pdf.pdf  ';
+          appeal.planningApplicationDocumentsSection.decisionLetter.uploadedFile.name =
+            'test-pdf.pdf';
+
+          const result = await update.validate(appeal2, config);
+          expect(result).toEqual(appeal);
+        });
+
+        it('should throw an error when not given a value', async () => {
+          delete appeal.planningApplicationDocumentsSection.decisionLetter.uploadedFile.name;
+
+          await expect(() => update.validate(appeal, config)).rejects.toThrow(
+            'planningApplicationDocumentsSection.decisionLetter.uploadedFile.name is a required field',
+          );
+        });
+      });
+
+      describe('planningApplicationDocumentsSection.decisionLetter.uploadedFile.originalFileName', () => {
+        it('should throw an error when given a value with more than 255 characters', async () => {
+          appeal.planningApplicationDocumentsSection.decisionLetter.uploadedFile.originalFileName =
+            'a'.repeat(256);
+
+          await expect(() => update.validate(appeal, config)).rejects.toThrow(
+            'planningApplicationDocumentsSection.decisionLetter.uploadedFile.originalFileName must be at most 255 characters',
+          );
+        });
+
+        it('should strip leading/trailing spaces', async () => {
+          appeal2.planningApplicationDocumentsSection.decisionLetter.uploadedFile.originalFileName =
+            '  test-pdf.pdf  ';
+          appeal.planningApplicationDocumentsSection.decisionLetter.uploadedFile.originalFileName =
+            'test-pdf.pdf';
+
+          const result = await update.validate(appeal2, config);
+          expect(result).toEqual(appeal);
+        });
+
+        it('should throw an error when not given a value', async () => {
+          delete appeal.planningApplicationDocumentsSection.decisionLetter.uploadedFile
+            .originalFileName;
+
+          await expect(() => update.validate(appeal, config)).rejects.toThrow(
+            'planningApplicationDocumentsSection.decisionLetter.uploadedFile.originalFileName is a required field',
+          );
+        });
+      });
+
+      describe('c.decisionLetter.uploadedFile.id', () => {
+        it('should strip leading/trailing spaces', async () => {
+          appeal2.planningApplicationDocumentsSection.decisionLetter.uploadedFile.id =
+            '  271c9b5b-af90-4b45-b0e7-0a7882da1e03  ';
+          appeal.planningApplicationDocumentsSection.decisionLetter.uploadedFile.id =
+            '271c9b5b-af90-4b45-b0e7-0a7882da1e03';
+
+          const result = await update.validate(appeal2, config);
+          expect(result).toEqual(appeal);
+        });
+
+        it('should throw an error when not given a UUID', async () => {
+          appeal.planningApplicationDocumentsSection.decisionLetter.uploadedFile.id = 'abc123';
+
+          await expect(() => update.validate(appeal, config)).rejects.toThrow(
+            'planningApplicationDocumentsSection.decisionLetter.uploadedFile.id must be a valid UUID',
+          );
+        });
+
+        it('should throw an error when not given a value', async () => {
+          delete appeal.planningApplicationDocumentsSection.decisionLetter.uploadedFile.id;
+
+          await expect(() => update.validate(appeal, config)).rejects.toThrow(
+            'planningApplicationDocumentsSection.decisionLetter.uploadedFile.id is a required field',
           );
         });
       });

--- a/packages/business-rules/test/data/full-appeal.js
+++ b/packages/business-rules/test/data/full-appeal.js
@@ -45,6 +45,7 @@ const appeal = {
     },
   },
   planningApplicationDocumentsSection: {
+    applicationNumber: 'ABCDE12345',
     isDesignAccessStatementSubmitted: true,
     originalApplication: {
       uploadedFile: {

--- a/packages/business-rules/test/data/full-appeal.js
+++ b/packages/business-rules/test/data/full-appeal.js
@@ -30,7 +30,22 @@ const appeal = {
       hasSensitiveInformation: false,
     },
   },
-  requiredDocumentsSection: {
+  contactDetailsSection: {
+    name: 'a name',
+    email: 'anemail@gmail.com',
+    companyName: 'Test Company',
+  },
+  appealSiteSection: {
+    siteAddress: {
+      addressLine1: 'Site Address 1',
+      addressLine2: 'Site Address 2',
+      town: 'Site Town',
+      county: 'Site County',
+      postcode: 'SW1 1AA',
+    },
+  },
+  planningApplicationDocumentsSection: {
+    isDesignAccessStatementSubmitted: true,
     originalApplication: {
       uploadedFile: {
         name: 'originalApplication.pdf',
@@ -52,23 +67,6 @@ const appeal = {
         id: '89b73320-8165-43f9-83e8-43bc0d927140',
       },
     },
-  },
-  contactDetailsSection: {
-    name: 'a name',
-    email: 'anemail@gmail.com',
-    companyName: 'Test Company',
-  },
-  appealSiteSection: {
-    siteAddress: {
-      addressLine1: 'Site Address 1',
-      addressLine2: 'Site Address 2',
-      town: 'Site Town',
-      county: 'Site County',
-      postcode: 'SW1 1AA',
-    },
-  },
-  planningApplicationDocumentsSection: {
-    isDesignAccessStatementSubmitted: true,
   },
 };
 

--- a/packages/e2e-tests/cypress/integration/full-appeal/appeals-service/design-access-statement.feature
+++ b/packages/e2e-tests/cypress/integration/full-appeal/appeals-service/design-access-statement.feature
@@ -44,10 +44,10 @@ Feature: As an appellant/agent
     Then an error message 'Select your design and access statement' is displayed
 
 
-#  Scenario: 6. Navigate from 'Design and access statement' page back to Task List
-#    Given an appellant is on the 'Design and access statement' page
-#    When they click on the 'Back' link
-#    Then they are presented with the 'Did you submit a design and access statement with your application?' page
-##And the last task they are working on will show 'In progress'
+ Scenario: 6. Navigate from 'Design and access statement' page back to Task List
+   Given an appellant is on the 'Design and access statement' page
+   When they click on the 'Back' link
+   Then they are presented with the 'Did you submit a design and access statement with your application?' page
+#And the last task they are working on will show 'In progress'
 
 

--- a/packages/e2e-tests/cypress/integration/full-appeal/appeals-service/upload-decision-letter.feature
+++ b/packages/e2e-tests/cypress/integration/full-appeal/appeals-service/upload-decision-letter.feature
@@ -11,18 +11,18 @@ Feature: As an appellant/agent
     Given an appellant is on the 'Decision Letter' page
     When they upload a file '<filename>' and click on Continue button
     Then 'Task list' page is displayed
-    When an appellant is on the 'Decision Letter' page
-    Then the uploaded file '<filename>' is displayed
-    Examples:
-      | filename               |
-      | upload-file-valid.doc  |
-      | upload-file-valid.docx |
-      | upload-file-valid.jpeg |
-      | upload-file-valid.jpg  |
-      | upload-file-valid.png  |
-      | upload-file-valid.tif  |
-      | upload-file-valid.tiff |
-      | upload-file-valid.pdf  |
+    # When an appellant is on the 'Decision Letter' page
+    # Then the uploaded file '<filename>' is displayed
+    # Examples:
+    #   | filename               |
+    #   | upload-file-valid.doc  |
+    #   | upload-file-valid.docx |
+    #   | upload-file-valid.jpeg |
+    #   | upload-file-valid.jpg  |
+    #   | upload-file-valid.png  |
+    #   | upload-file-valid.tif  |
+    #   | upload-file-valid.tiff |
+    #   | upload-file-valid.pdf  |
 
   Scenario: 3. Appellant/agent uploads valid file using Drag and Drop
     Given an appellant is on the 'Decision Letter' page
@@ -47,5 +47,5 @@ Feature: As an appellant/agent
   Scenario: 6. Navigate from 'Decision Letter' page back to Task List
     Given an appellant is on the 'Decision Letter' page
     When they click on the 'Back' link
-    Then they are presented with the 'Appeal a planning decision' task list page
+    Then they are presented with the 'Design and access statement' page
     #And the last task they are working on will show ‘In progress’

--- a/packages/e2e-tests/cypress/integration/full-appeal/appeals-service/upload-decision-letter/upload-decision-letter.js
+++ b/packages/e2e-tests/cypress/integration/full-appeal/appeals-service/upload-decision-letter/upload-decision-letter.js
@@ -75,8 +75,8 @@ Then( "an error message {string} is displayed", (errorMessage) => {
 Given("an appellant has not uploaded any document",()=> {
   goToAppealsPage(url);
 });
-Then("they are presented with the 'Appeal a planning decision' task list page", () => {
-  cy.url().should('contain',taskListUrl)
+Then("they are presented with the 'Design and access statement' page", () => {
+  cy.url().should('contain', designAccessStatementUrl);
 });
 When("they click on the 'Back' link",()=> {
   getBackLink().click();

--- a/packages/e2e-tests/cypress/integration/full-appeal/appeals-service/upload-planning-application-form.feature
+++ b/packages/e2e-tests/cypress/integration/full-appeal/appeals-service/upload-planning-application-form.feature
@@ -11,19 +11,19 @@ Feature: As an appellant/agent
     Given an appellant is on the 'Planning Application form' page
     When they upload a file '<filename>' and click on Continue button
     Then 'What is your planning application number' page is displayed
-    When they click on the 'Back' link
-    Then 'Planning Application form' page is displayed
-    And the uploaded file '<filename>' is displayed
-    Examples:
-      | filename               |
-      | upload-file-valid.doc  |
-      | upload-file-valid.docx |
-      | upload-file-valid.jpeg |
-      | upload-file-valid.jpg  |
-      | upload-file-valid.png  |
-      | upload-file-valid.tif  |
-      | upload-file-valid.tiff |
-      | upload-file-valid.pdf  |
+    # When they click on the 'Back' link
+    # Then 'Planning Application form' page is displayed
+    # And the uploaded file '<filename>' is displayed
+    # Examples:
+    #   | filename               |
+    #   | upload-file-valid.doc  |
+    #   | upload-file-valid.docx |
+    #   | upload-file-valid.jpeg |
+    #   | upload-file-valid.jpg  |
+    #   | upload-file-valid.png  |
+    #   | upload-file-valid.tif  |
+    #   | upload-file-valid.tiff |
+    #   | upload-file-valid.pdf  |
 
   Scenario: 3. Appellant/agent uploads valid file using Drag and Drop
     Given an appellant is on the 'Planning Application form' page

--- a/packages/forms-web-app/__tests__/unit/controllers/full-appeal/submit-appeal/application-form.test.js
+++ b/packages/forms-web-app/__tests__/unit/controllers/full-appeal/submit-appeal/application-form.test.js
@@ -9,7 +9,11 @@ const { createDocument } = require('../../../../../src/lib/documents-api-wrapper
 const { getTaskStatus } = require('../../../../../src/services/task.service');
 const TASK_STATUS = require('../../../../../src/services/task-status/task-statuses');
 const { mockReq, mockRes } = require('../../../mocks');
-const { VIEW } = require('../../../../../src/lib/full-appeal/views');
+const {
+  VIEW: {
+    FULL_APPEAL: { APPLICATION_FORM, APPLICATION_NUMBER },
+  },
+} = require('../../../../../src/lib/full-appeal/views');
 const file = require('../../../../fixtures/file-upload');
 
 jest.mock('../../../../../src/lib/appeals-api-wrapper');
@@ -21,8 +25,8 @@ describe('controllers/full-appeal/submit-appeal/application-form', () => {
   let res;
   let appeal;
 
-  const sectionName = 'requiredDocumentsSection';
-  const taskName = 'originalApplication';
+  const sectionName = 'planningApplicationDocumentsSection';
+  const taskName = documentTypes.originalApplication.name;
   const appealId = 'da368e66-de7b-44c4-a403-36e5bf5b000b';
   const errors = { 'file-upload': 'Select a file upload' };
   const errorSummary = [{ text: 'There was an error', href: '#' }];
@@ -43,6 +47,8 @@ describe('controllers/full-appeal/submit-appeal/application-form', () => {
       session: {
         appeal,
       },
+      sectionName,
+      taskName,
     };
     res = mockRes();
 
@@ -52,7 +58,7 @@ describe('controllers/full-appeal/submit-appeal/application-form', () => {
   describe('getApplicationForm', () => {
     it('should call the correct template', () => {
       getApplicationForm(req, res);
-      expect(res.render).toHaveBeenCalledWith(VIEW.FULL_APPEAL.APPLICATION_FORM, {
+      expect(res.render).toHaveBeenCalledWith(APPLICATION_FORM, {
         appealId,
         uploadedFile: file,
       });
@@ -75,30 +81,30 @@ describe('controllers/full-appeal/submit-appeal/application-form', () => {
       await postApplicationForm(req, res);
 
       expect(res.redirect).not.toHaveBeenCalled();
-      expect(res.render).toHaveBeenCalledWith(VIEW.FULL_APPEAL.APPLICATION_FORM, {
+      expect(res.render).toHaveBeenCalledWith(APPLICATION_FORM, {
         appealId,
         uploadedFile: file,
-        errors,
         errorSummary,
+        errors,
       });
     });
 
     it('should re-render the template with errors if an error is thrown', async () => {
       const error = new Error('Internal Server Error');
 
-      createDocument.mockImplementation(() => Promise.reject(error));
+      createOrUpdateAppeal.mockImplementation(() => Promise.reject(error));
 
       await postApplicationForm(req, res);
 
       expect(res.redirect).not.toHaveBeenCalled();
-      expect(res.render).toHaveBeenCalledWith(VIEW.FULL_APPEAL.APPLICATION_FORM, {
+      expect(res.render).toHaveBeenCalledWith(APPLICATION_FORM, {
         appealId,
         uploadedFile: file,
         errorSummary: [{ text: error.toString(), href: '#' }],
       });
     });
 
-    it('should redirect to the correct page if valid', async () => {
+    it('should redirect to the correct page if valid and a file is being uploaded', async () => {
       const submittedAppeal = {
         ...appeal,
         state: 'SUBMITTED',
@@ -118,15 +124,57 @@ describe('controllers/full-appeal/submit-appeal/application-form', () => {
 
       await postApplicationForm(req, res);
 
-      expect(createDocument).toHaveBeenCalledWith(
-        appeal,
-        file,
-        null,
-        documentTypes.originalApplication.name
-      );
+      expect(createDocument).toHaveBeenCalledWith(appeal, file, null, taskName);
       expect(getTaskStatus).toHaveBeenCalledWith(appeal, sectionName, taskName);
       expect(createOrUpdateAppeal).toHaveBeenCalledWith(appeal);
-      expect(res.redirect).toHaveBeenCalledWith(`/${VIEW.FULL_APPEAL.APPLICATION_NUMBER}`);
+      expect(res.redirect).toHaveBeenCalledWith(`/${APPLICATION_NUMBER}`);
+      expect(req.session.appeal).toEqual(submittedAppeal);
+    });
+
+    it('should redirect to the correct page if valid and a file is not being uploaded', async () => {
+      const submittedAppeal = {
+        ...appeal,
+        state: 'SUBMITTED',
+      };
+
+      getTaskStatus.mockReturnValue(TASK_STATUS.NOT_STARTED);
+      createOrUpdateAppeal.mockReturnValue(submittedAppeal);
+
+      await postApplicationForm(req, res);
+
+      expect(createDocument).not.toHaveBeenCalled();
+      expect(getTaskStatus).toHaveBeenCalledWith(appeal, sectionName, taskName);
+      expect(createOrUpdateAppeal).toHaveBeenCalledWith(appeal);
+      expect(res.redirect).toHaveBeenCalledWith(`/${APPLICATION_NUMBER}`);
+      expect(req.session.appeal).toEqual(submittedAppeal);
+    });
+
+    it('should redirect to the correct page if valid if appeal.planningApplicationDocumentsSection.originalApplication does not exist', async () => {
+      delete appeal.planningApplicationDocumentsSection.originalApplication;
+
+      const submittedAppeal = {
+        ...appeal,
+        state: 'SUBMITTED',
+      };
+
+      createDocument.mockReturnValue(file);
+      getTaskStatus.mockReturnValue(TASK_STATUS.NOT_STARTED);
+      createOrUpdateAppeal.mockReturnValue(submittedAppeal);
+
+      req = {
+        ...req,
+        body: {},
+        files: {
+          'file-upload': file,
+        },
+      };
+
+      await postApplicationForm(req, res);
+
+      expect(createDocument).toHaveBeenCalledWith(appeal, file, null, taskName);
+      expect(getTaskStatus).toHaveBeenCalledWith(appeal, sectionName, taskName);
+      expect(createOrUpdateAppeal).toHaveBeenCalledWith(appeal);
+      expect(res.redirect).toHaveBeenCalledWith(`/${APPLICATION_NUMBER}`);
       expect(req.session.appeal).toEqual(submittedAppeal);
     });
   });

--- a/packages/forms-web-app/__tests__/unit/controllers/full-appeal/submit-appeal/application-number.test.js
+++ b/packages/forms-web-app/__tests__/unit/controllers/full-appeal/submit-appeal/application-number.test.js
@@ -14,8 +14,9 @@ jest.mock('../../../../../src/lib/appeals-api-wrapper');
 jest.mock('../../../../../src/services/task.service');
 jest.mock('../../../../../src/lib/logger');
 
-const sectionName = 'requiredDocumentsSection';
+const sectionName = 'planningApplicationDocumentsSection';
 const taskName = 'applicationNumber';
+const applicationNumber = 'ABCDE12345';
 
 describe('controllers/full-appeal/submit-appeal/application-number', () => {
   let req;
@@ -28,6 +29,8 @@ describe('controllers/full-appeal/submit-appeal/application-number', () => {
 
     ({ empty: appeal } = APPEAL_DOCUMENT);
 
+    appeal.planningApplicationDocumentsSection.applicationNumber = applicationNumber;
+
     jest.resetAllMocks();
   });
 
@@ -35,7 +38,7 @@ describe('controllers/full-appeal/submit-appeal/application-number', () => {
     it('should call the correct template', () => {
       applicationNumberController.getApplicationNumber(req, res);
       expect(res.render).toHaveBeenCalledWith(APPLICATION_NUMBER, {
-        appeal: req.session.appeal,
+        applicationNumber,
       });
     });
   });
@@ -55,13 +58,7 @@ describe('controllers/full-appeal/submit-appeal/application-number', () => {
 
       expect(res.redirect).not.toHaveBeenCalled();
       expect(res.render).toHaveBeenCalledWith(APPLICATION_NUMBER, {
-        appeal: {
-          ...req.session.appeal,
-          [sectionName]: {
-            ...req.session.appeal[sectionName],
-            [taskName]: undefined,
-          },
-        },
+        applicationNumber,
         errorSummary: [{ text: 'There were errors here', href: '#' }],
         errors: { a: 'b' },
       });
@@ -84,7 +81,7 @@ describe('controllers/full-appeal/submit-appeal/application-number', () => {
       expect(res.redirect).not.toHaveBeenCalled();
 
       expect(res.render).toHaveBeenCalledWith(APPLICATION_NUMBER, {
-        appeal: req.session.appeal,
+        applicationNumber,
         errors: {},
         errorSummary: [{ text: error.toString(), href: '#' }],
       });

--- a/packages/forms-web-app/__tests__/unit/controllers/full-appeal/submit-appeal/decision-letter.test.js
+++ b/packages/forms-web-app/__tests__/unit/controllers/full-appeal/submit-appeal/decision-letter.test.js
@@ -30,12 +30,14 @@ describe('controllers/full-appeal/submit-appeal/decision-letter', () => {
   const appealId = 'da368e66-de7b-44c4-a403-36e5bf5b000b';
   const errors = { 'file-upload': 'Select a file upload' };
   const errorSummary = [{ text: 'There was an error', href: '#' }];
+  const isDesignAccessStatementSubmitted = true;
 
   beforeEach(() => {
     appeal = {
       ...APPEAL_DOCUMENT.empty,
       id: appealId,
       [sectionName]: {
+        isDesignAccessStatementSubmitted,
         [taskName]: {
           uploadedFile: file,
         },
@@ -63,6 +65,7 @@ describe('controllers/full-appeal/submit-appeal/decision-letter', () => {
       expect(res.render).toHaveBeenCalledWith(DECISION_LETTER, {
         appealId,
         uploadedFile: file,
+        isDesignAccessStatementSubmitted,
       });
     });
   });
@@ -87,6 +90,7 @@ describe('controllers/full-appeal/submit-appeal/decision-letter', () => {
       expect(res.render).toHaveBeenCalledWith(DECISION_LETTER, {
         appealId,
         uploadedFile: file,
+        isDesignAccessStatementSubmitted,
         errors,
         errorSummary,
       });
@@ -104,6 +108,7 @@ describe('controllers/full-appeal/submit-appeal/decision-letter', () => {
       expect(res.render).toHaveBeenCalledWith(DECISION_LETTER, {
         appealId,
         uploadedFile: file,
+        isDesignAccessStatementSubmitted,
         errorSummary: [{ text: error.toString(), href: '#' }],
       });
     });

--- a/packages/forms-web-app/__tests__/unit/controllers/full-appeal/submit-appeal/design-access-statement-submitted.test.js
+++ b/packages/forms-web-app/__tests__/unit/controllers/full-appeal/submit-appeal/design-access-statement-submitted.test.js
@@ -203,5 +203,55 @@ describe('controllers/full-appeal/submit-appeal/design-access-statement-submitte
       expect(res.redirect).toHaveBeenCalledWith(`/${DECISION_LETTER}`);
       expect(req.session.appeal).toEqual(submittedAppeal);
     });
+
+    it('should redirect to the correct page if `yes` has been selected and appeal.sectionStates.planningApplicationDocumentsSection is not defined', async () => {
+      const submittedAppeal = {
+        ...appeal,
+        state: 'SUBMITTED',
+      };
+
+      delete appeal.sectionStates.planningApplicationDocumentsSection;
+
+      createOrUpdateAppeal.mockReturnValue(submittedAppeal);
+
+      req = {
+        ...req,
+        body: {
+          'design-access-statement-submitted': 'yes',
+        },
+      };
+
+      await postDesignAccessStatementSubmitted(req, res);
+
+      expect(getTaskStatus).toHaveBeenCalledWith(appeal, sectionName, taskName);
+      expect(createOrUpdateAppeal).toHaveBeenCalledWith(appeal);
+      expect(res.redirect).toHaveBeenCalledWith(`/${DESIGN_ACCESS_STATEMENT}`);
+      expect(req.session.appeal).toEqual(submittedAppeal);
+    });
+
+    it('should redirect to the correct page if `no` has been selected and appeal.sectionStates.planningApplicationDocumentsSection is not defined', async () => {
+      const submittedAppeal = {
+        ...appeal,
+        state: 'SUBMITTED',
+      };
+
+      delete appeal.sectionStates.planningApplicationDocumentsSection;
+
+      createOrUpdateAppeal.mockReturnValue(submittedAppeal);
+
+      req = {
+        ...req,
+        body: {
+          'design-access-statement-submitted': 'no',
+        },
+      };
+
+      await postDesignAccessStatementSubmitted(req, res);
+
+      expect(getTaskStatus).toHaveBeenCalledWith(appeal, sectionName, taskName);
+      expect(createOrUpdateAppeal).toHaveBeenCalledWith(appeal);
+      expect(res.redirect).toHaveBeenCalledWith(`/${DECISION_LETTER}`);
+      expect(req.session.appeal).toEqual(submittedAppeal);
+    });
   });
 });

--- a/packages/forms-web-app/__tests__/unit/controllers/full-appeal/submit-appeal/design-access-statement.test.js
+++ b/packages/forms-web-app/__tests__/unit/controllers/full-appeal/submit-appeal/design-access-statement.test.js
@@ -25,7 +25,7 @@ describe('controllers/full-appeal/submit-appeal/design-access-statement', () => 
   let res;
   let appeal;
 
-  const sectionName = 'requiredDocumentsSection';
+  const sectionName = 'planningApplicationDocumentsSection';
   const taskName = documentTypes.designAccessStatement.name;
   const appealId = 'da368e66-de7b-44c4-a403-36e5bf5b000b';
   const errors = { 'file-upload': 'Select a file upload' };
@@ -47,6 +47,8 @@ describe('controllers/full-appeal/submit-appeal/design-access-statement', () => 
       session: {
         appeal,
       },
+      sectionName,
+      taskName,
     };
     res = mockRes();
 
@@ -85,15 +87,15 @@ describe('controllers/full-appeal/submit-appeal/design-access-statement', () => 
       expect(res.render).toHaveBeenCalledWith(DESIGN_ACCESS_STATEMENT, {
         appealId,
         uploadedFile: file,
-        errors,
         errorSummary,
+        errors,
       });
     });
 
     it('should re-render the template with errors if an error is thrown', async () => {
       const error = new Error('Internal Server Error');
 
-      createDocument.mockImplementation(() => Promise.reject(error));
+      createOrUpdateAppeal.mockImplementation(() => Promise.reject(error));
 
       await postDesignAccessStatement(req, res);
 
@@ -106,7 +108,7 @@ describe('controllers/full-appeal/submit-appeal/design-access-statement', () => 
       });
     });
 
-    it('should redirect to the correct page if valid', async () => {
+    it('should redirect to the correct page if valid and a file is being uploaded', async () => {
       const submittedAppeal = {
         ...appeal,
         state: 'SUBMITTED',
@@ -126,20 +128,34 @@ describe('controllers/full-appeal/submit-appeal/design-access-statement', () => 
 
       await postDesignAccessStatement(req, res);
 
-      expect(createDocument).toHaveBeenCalledWith(
-        appeal,
-        file,
-        null,
-        documentTypes.designAccessStatement.name
-      );
+      expect(createDocument).toHaveBeenCalledWith(appeal, file, null, taskName);
       expect(getTaskStatus).toHaveBeenCalledWith(appeal, sectionName, taskName);
       expect(createOrUpdateAppeal).toHaveBeenCalledWith(appeal);
       expect(res.redirect).toHaveBeenCalledWith(`/${DECISION_LETTER}`);
       expect(req.session.appeal).toEqual(submittedAppeal);
     });
 
-    it('should redirect to the correct page if valid if appeal.requiredDocumentsSection.designAccessStatement does not exist', async () => {
-      delete appeal.requiredDocumentsSection.designAccessStatement;
+    it('should redirect to the correct page if valid and a file is not being uploaded', async () => {
+      const submittedAppeal = {
+        ...appeal,
+        state: 'SUBMITTED',
+      };
+
+      createDocument.mockReturnValue(file);
+      getTaskStatus.mockReturnValue(TASK_STATUS.NOT_STARTED);
+      createOrUpdateAppeal.mockReturnValue(submittedAppeal);
+
+      await postDesignAccessStatement(req, res);
+
+      expect(createDocument).not.toHaveBeenCalled();
+      expect(getTaskStatus).toHaveBeenCalledWith(appeal, sectionName, taskName);
+      expect(createOrUpdateAppeal).toHaveBeenCalledWith(appeal);
+      expect(res.redirect).toHaveBeenCalledWith(`/${DECISION_LETTER}`);
+      expect(req.session.appeal).toEqual(submittedAppeal);
+    });
+
+    it('should redirect to the correct page if valid if appeal.planningApplicationDocumentsSection.designAccessStatement does not exist', async () => {
+      delete appeal.planningApplicationDocumentsSection.designAccessStatement;
 
       const submittedAppeal = {
         ...appeal,
@@ -160,12 +176,7 @@ describe('controllers/full-appeal/submit-appeal/design-access-statement', () => 
 
       await postDesignAccessStatement(req, res);
 
-      expect(createDocument).toHaveBeenCalledWith(
-        appeal,
-        file,
-        null,
-        documentTypes.designAccessStatement.name
-      );
+      expect(createDocument).toHaveBeenCalledWith(appeal, file, null, taskName);
       expect(getTaskStatus).toHaveBeenCalledWith(appeal, sectionName, taskName);
       expect(createOrUpdateAppeal).toHaveBeenCalledWith(appeal);
       expect(res.redirect).toHaveBeenCalledWith(`/${DECISION_LETTER}`);

--- a/packages/forms-web-app/__tests__/unit/middleware/set-section-and-task-names.test.js
+++ b/packages/forms-web-app/__tests__/unit/middleware/set-section-and-task-names.test.js
@@ -1,0 +1,19 @@
+const setSectionAndTaskNames = require('../../../src/middleware/set-section-and-task-names');
+
+describe('middleware/set-section-and-task-names', () => {
+  const req = {};
+  const res = jest.fn();
+  const next = jest.fn();
+  const sectionName = 'requiredDocumentsSection';
+  const taskName = 'originalApplication';
+
+  it('should set req.sectionName and req.taskName with the given values', () => {
+    const middlewareFn = setSectionAndTaskNames(sectionName, taskName);
+    middlewareFn(req, res, next);
+
+    expect(req).toEqual({
+      sectionName,
+      taskName,
+    });
+  });
+});

--- a/packages/forms-web-app/__tests__/unit/routes/full-appeal/submit-appeal/appeal-statement.test.js
+++ b/packages/forms-web-app/__tests__/unit/routes/full-appeal/submit-appeal/appeal-statement.test.js
@@ -1,3 +1,4 @@
+const { documentTypes } = require('@pins/common');
 const { get, post } = require('../../router-mock');
 const {
   getAppealStatement,
@@ -10,9 +11,11 @@ const {
 const {
   rules: appealStatementValidationRules,
 } = require('../../../../../src/validators/common/appeal-statement');
+const setSectionAndTaskNames = require('../../../../../src/middleware/set-section-and-task-names');
 
 jest.mock('../../../../../src/middleware/fetch-existing-appeal');
 jest.mock('../../../../../src/validators/common/appeal-statement');
+jest.mock('../../../../../src/middleware/set-section-and-task-names');
 
 describe('routes/full-appeal/submit-appeal/appeal-statement', () => {
   beforeEach(() => {
@@ -24,14 +27,20 @@ describe('routes/full-appeal/submit-appeal/appeal-statement', () => {
     expect(get).toHaveBeenCalledWith(
       '/submit-appeal/appeal-statement',
       [fetchExistingAppealMiddleware],
+      setSectionAndTaskNames(),
       getAppealStatement
     );
     expect(post).toHaveBeenCalledWith(
       '/submit-appeal/appeal-statement',
+      setSectionAndTaskNames(),
       appealStatementValidationRules(),
       validationErrorHandler,
       postAppealStatement
     );
     expect(appealStatementValidationRules).toHaveBeenCalledWith('Select your appeal statement');
+    expect(setSectionAndTaskNames).toHaveBeenCalledWith(
+      'yourAppealSection',
+      documentTypes.appealStatement.name
+    );
   });
 });

--- a/packages/forms-web-app/__tests__/unit/routes/full-appeal/submit-appeal/application-form.test.js
+++ b/packages/forms-web-app/__tests__/unit/routes/full-appeal/submit-appeal/application-form.test.js
@@ -1,3 +1,4 @@
+const { documentTypes } = require('@pins/common');
 const { get, post } = require('../../router-mock');
 const {
   getApplicationForm,
@@ -10,9 +11,11 @@ const {
 const {
   rules: fileUploadValidationRules,
 } = require('../../../../../src/validators/common/file-upload');
+const setSectionAndTaskNames = require('../../../../../src/middleware/set-section-and-task-names');
 
 jest.mock('../../../../../src/middleware/fetch-existing-appeal');
 jest.mock('../../../../../src/validators/common/file-upload');
+jest.mock('../../../../../src/middleware/set-section-and-task-names');
 
 describe('routes/full-appeal/submit-appeal/application-form', () => {
   beforeEach(() => {
@@ -24,14 +27,20 @@ describe('routes/full-appeal/submit-appeal/application-form', () => {
     expect(get).toHaveBeenCalledWith(
       '/submit-appeal/application-form',
       [fetchExistingAppealMiddleware],
+      setSectionAndTaskNames(),
       getApplicationForm
     );
     expect(post).toHaveBeenCalledWith(
       '/submit-appeal/application-form',
+      setSectionAndTaskNames(),
       fileUploadValidationRules(),
       validationErrorHandler,
       postApplicationForm
     );
     expect(fileUploadValidationRules).toHaveBeenCalledWith('Select your planning application form');
+    expect(setSectionAndTaskNames).toHaveBeenCalledWith(
+      'planningApplicationDocumentsSection',
+      documentTypes.originalApplication.name
+    );
   });
 });

--- a/packages/forms-web-app/__tests__/unit/routes/full-appeal/submit-appeal/decision-letter.test.js
+++ b/packages/forms-web-app/__tests__/unit/routes/full-appeal/submit-appeal/decision-letter.test.js
@@ -1,3 +1,4 @@
+const { documentTypes } = require('@pins/common');
 const { get, post } = require('../../router-mock');
 const {
   getDecisionLetter,
@@ -10,9 +11,11 @@ const {
 const {
   rules: fileUploadValidationRules,
 } = require('../../../../../src/validators/common/file-upload');
+const setSectionAndTaskNames = require('../../../../../src/middleware/set-section-and-task-names');
 
 jest.mock('../../../../../src/middleware/fetch-existing-appeal');
 jest.mock('../../../../../src/validators/common/file-upload');
+jest.mock('../../../../../src/middleware/set-section-and-task-names');
 
 describe('routes/full-appeal/submit-appeal/decision-letter', () => {
   beforeEach(() => {
@@ -24,14 +27,20 @@ describe('routes/full-appeal/submit-appeal/decision-letter', () => {
     expect(get).toHaveBeenCalledWith(
       '/submit-appeal/decision-letter',
       [fetchExistingAppealMiddleware],
+      setSectionAndTaskNames(),
       getDecisionLetter
     );
     expect(post).toHaveBeenCalledWith(
       '/submit-appeal/decision-letter',
+      setSectionAndTaskNames(),
       fileUploadValidationRules(),
       validationErrorHandler,
       postDecisionLetter
     );
     expect(fileUploadValidationRules).toHaveBeenCalledWith('Select your decision letter');
+    expect(setSectionAndTaskNames).toHaveBeenCalledWith(
+      'planningApplicationDocumentsSection',
+      documentTypes.decisionLetter.name
+    );
   });
 });

--- a/packages/forms-web-app/__tests__/unit/routes/full-appeal/submit-appeal/design-access-statement.test.js
+++ b/packages/forms-web-app/__tests__/unit/routes/full-appeal/submit-appeal/design-access-statement.test.js
@@ -1,3 +1,4 @@
+const { documentTypes } = require('@pins/common');
 const { get, post } = require('../../router-mock');
 const {
   getDesignAccessStatement,
@@ -10,9 +11,11 @@ const {
 const {
   rules: fileUploadValidationRules,
 } = require('../../../../../src/validators/common/file-upload');
+const setSectionAndTaskNames = require('../../../../../src/middleware/set-section-and-task-names');
 
 jest.mock('../../../../../src/middleware/fetch-existing-appeal');
 jest.mock('../../../../../src/validators/common/file-upload');
+jest.mock('../../../../../src/middleware/set-section-and-task-names');
 
 describe('routes/full-appeal/submit-appeal/design-access-statement', () => {
   beforeEach(() => {
@@ -24,16 +27,22 @@ describe('routes/full-appeal/submit-appeal/design-access-statement', () => {
     expect(get).toHaveBeenCalledWith(
       '/submit-appeal/design-access-statement',
       [fetchExistingAppealMiddleware],
+      setSectionAndTaskNames(),
       getDesignAccessStatement
     );
     expect(post).toHaveBeenCalledWith(
       '/submit-appeal/design-access-statement',
+      setSectionAndTaskNames(),
       fileUploadValidationRules(),
       validationErrorHandler,
       postDesignAccessStatement
     );
     expect(fileUploadValidationRules).toHaveBeenCalledWith(
       'Select your design and access statement'
+    );
+    expect(setSectionAndTaskNames).toHaveBeenCalledWith(
+      'planningApplicationDocumentsSection',
+      documentTypes.designAccessStatement.name
     );
   });
 });

--- a/packages/forms-web-app/src/controllers/full-appeal/submit-appeal/appeal-site-address.js
+++ b/packages/forms-web-app/src/controllers/full-appeal/submit-appeal/appeal-site-address.js
@@ -15,14 +15,12 @@ const sectionName = 'appealSiteSection';
 const taskName = 'siteAddress';
 
 exports.getAppealSiteAddress = (req, res) => {
-  req.session.appeal.appealType = '1005';
   res.render(currentPage, {
     appeal: req.session.appeal,
   });
 };
 
 exports.postAppealSiteAddress = async (req, res) => {
-  req.session.appeal.appealType = '1005';
   const { body } = req;
   const { errors = {}, errorSummary = [] } = body;
 

--- a/packages/forms-web-app/src/controllers/full-appeal/submit-appeal/applicant-name.js
+++ b/packages/forms-web-app/src/controllers/full-appeal/submit-appeal/applicant-name.js
@@ -12,14 +12,12 @@ const sectionName = 'aboutYouSection';
 const taskName = 'yourDetails';
 
 exports.getApplicantName = (req, res) => {
-  req.session.appeal.appealType = '1005';
   res.render(currentPage, {
     appeal: req.session.appeal,
   });
 };
 
 exports.postApplicantName = async (req, res) => {
-  req.session.appeal.appealType = '1005';
   const { body } = req;
   const { errors = {}, errorSummary = [] } = body;
 

--- a/packages/forms-web-app/src/controllers/full-appeal/submit-appeal/application-number.js
+++ b/packages/forms-web-app/src/controllers/full-appeal/submit-appeal/application-number.js
@@ -1,22 +1,19 @@
 const {
   VIEW: {
-    FULL_APPEAL: { APPLICATION_NUMBER },
+    FULL_APPEAL: { APPLICATION_NUMBER, DESIGN_ACCESS_STATEMENT_SUBMITTED },
   },
 } = require('../../../lib/full-appeal/views');
 const { createOrUpdateAppeal } = require('../../../lib/appeals-api-wrapper');
 const logger = require('../../../lib/logger');
-const {
-  getNextTask,
-  getTaskStatus,
-  FULL_APPEAL_SECTIONS,
-} = require('../../../services/task.service');
+const { getTaskStatus } = require('../../../services/task.service');
 
-const sectionName = 'requiredDocumentsSection';
+const sectionName = 'planningApplicationDocumentsSection';
 const taskName = 'applicationNumber';
 
 exports.getApplicationNumber = (req, res) => {
+  const { applicationNumber } = req.session.appeal.planningApplicationDocumentsSection;
   res.render(APPLICATION_NUMBER, {
-    appeal: req.session.appeal,
+    applicationNumber,
   });
 };
 
@@ -24,14 +21,19 @@ exports.postApplicationNumber = async (req, res) => {
   const { body } = req;
   const { errors = {}, errorSummary = [] } = body;
 
-  const { appeal } = req.session;
+  const {
+    appeal,
+    appeal: {
+      planningApplicationDocumentsSection: { applicationNumber },
+    },
+  } = req.session;
   const task = appeal[sectionName];
 
   task.applicationNumber = body['application-number'];
 
   if (Object.keys(errors).length > 0) {
     res.render(APPLICATION_NUMBER, {
-      appeal,
+      applicationNumber,
       errors,
       errorSummary,
     });
@@ -44,12 +46,12 @@ exports.postApplicationNumber = async (req, res) => {
   } catch (e) {
     logger.error(e);
     res.render(APPLICATION_NUMBER, {
-      appeal,
+      applicationNumber,
       errors,
       errorSummary: [{ text: e.toString(), href: '#' }],
     });
     return;
   }
 
-  res.redirect(getNextTask(appeal, { sectionName, taskName }, FULL_APPEAL_SECTIONS).href);
+  res.redirect(`/${DESIGN_ACCESS_STATEMENT_SUBMITTED}`);
 };

--- a/packages/forms-web-app/src/controllers/full-appeal/submit-appeal/decision-letter.js
+++ b/packages/forms-web-app/src/controllers/full-appeal/submit-appeal/decision-letter.js
@@ -1,4 +1,3 @@
-const { documentTypes } = require('@pins/common');
 const {
   VIEW: {
     FULL_APPEAL: { DECISION_LETTER, TASK_LIST },
@@ -9,53 +8,69 @@ const { createDocument } = require('../../../lib/documents-api-wrapper');
 const { createOrUpdateAppeal } = require('../../../lib/appeals-api-wrapper');
 const { getTaskStatus } = require('../../../services/task.service');
 
-const sectionName = 'requiredDocumentsSection';
-const taskName = documentTypes.decisionLetter.name;
-const viewData = (appeal, errorSummary, errors) => {
-  return {
-    appealId: appeal.id,
-    uploadedFile: appeal[sectionName][taskName] && appeal[sectionName][taskName].uploadedFile,
-    errorSummary,
-    errors,
-  };
-};
-
 const getDecisionLetter = (req, res) => {
-  const { appeal } = req.session;
-  res.render(DECISION_LETTER, viewData(appeal));
+  const {
+    session: {
+      appeal,
+      appeal: { id: appealId },
+    },
+    sectionName,
+    taskName,
+  } = req;
+  res.render(DECISION_LETTER, {
+    appealId,
+    uploadedFile: appeal[sectionName][taskName]?.uploadedFile,
+  });
 };
 
 const postDecisionLetter = async (req, res) => {
   const {
     body: { errors = {}, errorSummary = [] },
-    files = {},
-    session: { appeal },
+    files,
+    session: {
+      appeal,
+      appeal: { id: appealId },
+    },
+    sectionName,
+    taskName,
   } = req;
 
   if (Object.keys(errors).length > 0) {
-    return res.render(DECISION_LETTER, viewData(appeal, errorSummary, errors));
+    return res.render(DECISION_LETTER, {
+      appealId,
+      uploadedFile: appeal[sectionName][taskName]?.uploadedFile,
+      errorSummary,
+      errors,
+    });
   }
 
   try {
-    const document = await createDocument(appeal, files['file-upload'], null, taskName);
+    if (files) {
+      const document = await createDocument(appeal, files['file-upload'], null, taskName);
 
-    if (!appeal[sectionName][taskName]) {
-      appeal[sectionName][taskName] = {};
+      if (!appeal[sectionName][taskName]) {
+        appeal[sectionName][taskName] = {};
+      }
+
+      appeal[sectionName][taskName].uploadedFile = {
+        id: document.id,
+        name: files['file-upload'].name,
+        fileName: files['file-upload'].name,
+        originalFileName: files['file-upload'].name,
+        location: document.location,
+        size: document.size,
+      };
     }
 
-    appeal[sectionName][taskName].uploadedFile = {
-      id: document.id,
-      name: files['file-upload'].name,
-      fileName: files['file-upload'].name,
-      originalFileName: files['file-upload'].name,
-      location: document.location,
-      size: document.size,
-    };
     appeal.sectionStates[sectionName][taskName] = getTaskStatus(appeal, sectionName, taskName);
     req.session.appeal = await createOrUpdateAppeal(appeal);
   } catch (err) {
     logger.error(err);
-    return res.render(DECISION_LETTER, viewData(appeal, [{ text: err.toString(), href: '#' }]));
+    return res.render(DECISION_LETTER, {
+      appealId,
+      uploadedFile: appeal[sectionName][taskName]?.uploadedFile,
+      errorSummary: [{ text: err.toString(), href: '#' }],
+    });
   }
 
   return res.redirect(`/${TASK_LIST}`);

--- a/packages/forms-web-app/src/controllers/full-appeal/submit-appeal/decision-letter.js
+++ b/packages/forms-web-app/src/controllers/full-appeal/submit-appeal/decision-letter.js
@@ -12,7 +12,10 @@ const getDecisionLetter = (req, res) => {
   const {
     session: {
       appeal,
-      appeal: { id: appealId },
+      appeal: {
+        id: appealId,
+        planningApplicationDocumentsSection: { isDesignAccessStatementSubmitted },
+      },
     },
     sectionName,
     taskName,
@@ -20,6 +23,7 @@ const getDecisionLetter = (req, res) => {
   res.render(DECISION_LETTER, {
     appealId,
     uploadedFile: appeal[sectionName][taskName]?.uploadedFile,
+    isDesignAccessStatementSubmitted,
   });
 };
 
@@ -29,7 +33,10 @@ const postDecisionLetter = async (req, res) => {
     files,
     session: {
       appeal,
-      appeal: { id: appealId },
+      appeal: {
+        id: appealId,
+        planningApplicationDocumentsSection: { isDesignAccessStatementSubmitted },
+      },
     },
     sectionName,
     taskName,
@@ -39,6 +46,7 @@ const postDecisionLetter = async (req, res) => {
     return res.render(DECISION_LETTER, {
       appealId,
       uploadedFile: appeal[sectionName][taskName]?.uploadedFile,
+      isDesignAccessStatementSubmitted,
       errorSummary,
       errors,
     });
@@ -69,6 +77,7 @@ const postDecisionLetter = async (req, res) => {
     return res.render(DECISION_LETTER, {
       appealId,
       uploadedFile: appeal[sectionName][taskName]?.uploadedFile,
+      isDesignAccessStatementSubmitted,
       errorSummary: [{ text: err.toString(), href: '#' }],
     });
   }

--- a/packages/forms-web-app/src/controllers/full-appeal/submit-appeal/design-access-statement.js
+++ b/packages/forms-web-app/src/controllers/full-appeal/submit-appeal/design-access-statement.js
@@ -1,4 +1,3 @@
-const { documentTypes } = require('@pins/common');
 const {
   VIEW: {
     FULL_APPEAL: { DESIGN_ACCESS_STATEMENT, DECISION_LETTER },
@@ -9,57 +8,70 @@ const { createDocument } = require('../../../lib/documents-api-wrapper');
 const { createOrUpdateAppeal } = require('../../../lib/appeals-api-wrapper');
 const { getTaskStatus } = require('../../../services/task.service');
 
-const sectionName = 'requiredDocumentsSection';
-const taskName = documentTypes.designAccessStatement.name;
-const viewData = (appeal, errorSummary, errors) => {
-  return {
-    appealId: appeal.id,
-    uploadedFile: appeal[sectionName][taskName] && appeal[sectionName][taskName].uploadedFile,
-    errorSummary,
-    errors,
-  };
-};
-
 const getDesignAccessStatement = (req, res) => {
-  const { appeal } = req.session;
-  logger.debug({ taskName, appeal }, 'taskname');
-  res.render(DESIGN_ACCESS_STATEMENT, viewData(appeal));
+  const {
+    session: {
+      appeal,
+      appeal: { id: appealId },
+    },
+    sectionName,
+    taskName,
+  } = req;
+
+  res.render(DESIGN_ACCESS_STATEMENT, {
+    appealId,
+    uploadedFile: appeal[sectionName][taskName]?.uploadedFile,
+  });
 };
 
 const postDesignAccessStatement = async (req, res) => {
   const {
     body: { errors = {}, errorSummary = [] },
-    files = {},
-    session: { appeal },
+    files,
+    session: {
+      appeal,
+      appeal: { id: appealId },
+    },
+    sectionName,
+    taskName,
   } = req;
 
   if (Object.keys(errors).length > 0) {
-    return res.render(DESIGN_ACCESS_STATEMENT, viewData(appeal, errorSummary, errors));
+    return res.render(DESIGN_ACCESS_STATEMENT, {
+      appealId,
+      uploadedFile: appeal[sectionName][taskName]?.uploadedFile,
+      errorSummary,
+      errors,
+    });
   }
 
   try {
-    const document = await createDocument(appeal, files['file-upload'], null, taskName);
+    if (files) {
+      const document = await createDocument(appeal, files['file-upload'], null, taskName);
 
-    if (!appeal[sectionName][taskName]) {
-      appeal[sectionName][taskName] = {};
+      if (!appeal[sectionName][taskName]) {
+        appeal[sectionName][taskName] = {};
+      }
+
+      appeal[sectionName][taskName].uploadedFile = {
+        id: document.id,
+        name: files['file-upload'].name,
+        fileName: files['file-upload'].name,
+        originalFileName: files['file-upload'].name,
+        location: document.location,
+        size: document.size,
+      };
     }
 
-    appeal[sectionName][taskName].uploadedFile = {
-      id: document.id,
-      name: files['file-upload'].name,
-      fileName: files['file-upload'].name,
-      originalFileName: files['file-upload'].name,
-      location: document.location,
-      size: document.size,
-    };
     appeal.sectionStates[sectionName][taskName] = getTaskStatus(appeal, sectionName, taskName);
     req.session.appeal = await createOrUpdateAppeal(appeal);
   } catch (err) {
     logger.error(err);
-    return res.render(
-      DESIGN_ACCESS_STATEMENT,
-      viewData(appeal, [{ text: err.toString(), href: '#' }])
-    );
+    return res.render(DESIGN_ACCESS_STATEMENT, {
+      appealId,
+      uploadedFile: appeal[sectionName][taskName]?.uploadedFile,
+      errorSummary: [{ text: err.toString(), href: '#' }],
+    });
   }
 
   return res.redirect(`/${DECISION_LETTER}`);

--- a/packages/forms-web-app/src/controllers/full-appeal/submit-appeal/original-applicant.js
+++ b/packages/forms-web-app/src/controllers/full-appeal/submit-appeal/original-applicant.js
@@ -29,7 +29,6 @@ const FORM_FIELD = {
 exports.FORM_FIELD = FORM_FIELD;
 
 exports.getOriginalApplicant = (req, res) => {
-  req.session.appeal.appealType = '1005';
   res.render(currentPage, {
     FORM_FIELD,
     appeal: req.session.appeal,
@@ -37,7 +36,6 @@ exports.getOriginalApplicant = (req, res) => {
 };
 
 exports.postOriginalApplicant = async (req, res) => {
-  req.session.appeal.appealType = '1005';
   const { body } = req;
 
   const { errors = {}, errorSummary = [] } = body;

--- a/packages/forms-web-app/src/lib/empty-appeal.js
+++ b/packages/forms-web-app/src/lib/empty-appeal.js
@@ -32,12 +32,6 @@ module.exports.APPEAL_DOCUMENT = {
           id: null,
         },
       },
-      designAccessStatement: {
-        uploadedFile: {
-          name: '',
-          id: null,
-        },
-      },
     },
     yourAppealSection: {
       appealStatement: {
@@ -85,6 +79,26 @@ module.exports.APPEAL_DOCUMENT = {
       email: null,
       companyName: null,
     },
+    planningApplicationDocumentsSection: {
+      originalApplication: {
+        uploadedFile: {
+          name: '',
+          id: null,
+        },
+      },
+      decisionLetter: {
+        uploadedFile: {
+          name: '',
+          id: null,
+        },
+      },
+      designAccessStatement: {
+        uploadedFile: {
+          name: '',
+          id: null,
+        },
+      },
+    },
     sectionStates: {
       aboutYouSection: {
         yourDetails: 'NOT STARTED',
@@ -105,6 +119,11 @@ module.exports.APPEAL_DOCUMENT = {
         healthAndSafety: 'NOT STARTED',
       },
       contactDetailsSection: 'NOT STARTED',
+      planningApplicationDocumentsSection: {
+        originalApplication: 'NOT STARTED',
+        decisionLetter: 'NOT STARTED',
+        designAccessStatement: 'NOT STARTED',
+      },
     },
   },
 };

--- a/packages/forms-web-app/src/lib/empty-appeal.js
+++ b/packages/forms-web-app/src/lib/empty-appeal.js
@@ -80,6 +80,8 @@ module.exports.APPEAL_DOCUMENT = {
       companyName: null,
     },
     planningApplicationDocumentsSection: {
+      applicationNumber: null,
+      isDesignAccessStatementSubmitted: null,
       originalApplication: {
         uploadedFile: {
           name: '',

--- a/packages/forms-web-app/src/middleware/set-section-and-task-names.js
+++ b/packages/forms-web-app/src/middleware/set-section-and-task-names.js
@@ -1,0 +1,9 @@
+const setSectionAndTaskNames = (sectionName, taskName) => {
+  return (req, res, next) => {
+    req.sectionName = sectionName;
+    req.taskName = taskName;
+    next();
+  };
+};
+
+module.exports = setSectionAndTaskNames;

--- a/packages/forms-web-app/src/routes/full-appeal/submit-appeal/appeal-statement.js
+++ b/packages/forms-web-app/src/routes/full-appeal/submit-appeal/appeal-statement.js
@@ -1,4 +1,5 @@
 const express = require('express');
+const { documentTypes } = require('@pins/common');
 const {
   getAppealStatement,
   postAppealStatement,
@@ -8,12 +9,21 @@ const { validationErrorHandler } = require('../../../validators/validation-error
 const {
   rules: appealStatementValidationRules,
 } = require('../../../validators/common/appeal-statement');
+const setSectionAndTaskNames = require('../../../middleware/set-section-and-task-names');
 
 const router = express.Router();
+const sectionName = 'yourAppealSection';
+const taskName = documentTypes.appealStatement.name;
 
-router.get('/submit-appeal/appeal-statement', [fetchExistingAppealMiddleware], getAppealStatement);
+router.get(
+  '/submit-appeal/appeal-statement',
+  [fetchExistingAppealMiddleware],
+  setSectionAndTaskNames(sectionName, taskName),
+  getAppealStatement
+);
 router.post(
   '/submit-appeal/appeal-statement',
+  setSectionAndTaskNames(sectionName, taskName),
   appealStatementValidationRules('Select your appeal statement'),
   validationErrorHandler,
   postAppealStatement

--- a/packages/forms-web-app/src/routes/full-appeal/submit-appeal/application-form.js
+++ b/packages/forms-web-app/src/routes/full-appeal/submit-appeal/application-form.js
@@ -1,4 +1,5 @@
 const express = require('express');
+const { documentTypes } = require('@pins/common');
 const {
   getApplicationForm,
   postApplicationForm,
@@ -6,12 +7,21 @@ const {
 const fetchExistingAppealMiddleware = require('../../../middleware/fetch-existing-appeal');
 const { validationErrorHandler } = require('../../../validators/validation-error-handler');
 const { rules: fileUploadValidationRules } = require('../../../validators/common/file-upload');
+const setSectionAndTaskNames = require('../../../middleware/set-section-and-task-names');
 
 const router = express.Router();
+const sectionName = 'planningApplicationDocumentsSection';
+const taskName = documentTypes.originalApplication.name;
 
-router.get('/submit-appeal/application-form', [fetchExistingAppealMiddleware], getApplicationForm);
+router.get(
+  '/submit-appeal/application-form',
+  [fetchExistingAppealMiddleware],
+  setSectionAndTaskNames(sectionName, taskName),
+  getApplicationForm
+);
 router.post(
   '/submit-appeal/application-form',
+  setSectionAndTaskNames(sectionName, taskName),
   fileUploadValidationRules('Select your planning application form'),
   validationErrorHandler,
   postApplicationForm

--- a/packages/forms-web-app/src/routes/full-appeal/submit-appeal/decision-letter.js
+++ b/packages/forms-web-app/src/routes/full-appeal/submit-appeal/decision-letter.js
@@ -1,3 +1,4 @@
+const { documentTypes } = require('@pins/common');
 const express = require('express');
 const {
   getDecisionLetter,
@@ -6,12 +7,21 @@ const {
 const fetchExistingAppealMiddleware = require('../../../middleware/fetch-existing-appeal');
 const { validationErrorHandler } = require('../../../validators/validation-error-handler');
 const { rules: fileUploadValidationRules } = require('../../../validators/common/file-upload');
+const setSectionAndTaskNames = require('../../../middleware/set-section-and-task-names');
 
 const router = express.Router();
+const sectionName = 'planningApplicationDocumentsSection';
+const taskName = documentTypes.decisionLetter.name;
 
-router.get('/submit-appeal/decision-letter', [fetchExistingAppealMiddleware], getDecisionLetter);
+router.get(
+  '/submit-appeal/decision-letter',
+  [fetchExistingAppealMiddleware],
+  setSectionAndTaskNames(sectionName, taskName),
+  getDecisionLetter
+);
 router.post(
   '/submit-appeal/decision-letter',
+  setSectionAndTaskNames(sectionName, taskName),
   fileUploadValidationRules('Select your decision letter'),
   validationErrorHandler,
   postDecisionLetter

--- a/packages/forms-web-app/src/routes/full-appeal/submit-appeal/design-access-statement.js
+++ b/packages/forms-web-app/src/routes/full-appeal/submit-appeal/design-access-statement.js
@@ -1,4 +1,5 @@
 const express = require('express');
+const { documentTypes } = require('@pins/common');
 const {
   getDesignAccessStatement,
   postDesignAccessStatement,
@@ -6,16 +7,21 @@ const {
 const fetchExistingAppealMiddleware = require('../../../middleware/fetch-existing-appeal');
 const { validationErrorHandler } = require('../../../validators/validation-error-handler');
 const { rules: fileUploadValidationRules } = require('../../../validators/common/file-upload');
+const setSectionAndTaskNames = require('../../../middleware/set-section-and-task-names');
 
 const router = express.Router();
+const sectionName = 'planningApplicationDocumentsSection';
+const taskName = documentTypes.designAccessStatement.name;
 
 router.get(
   '/submit-appeal/design-access-statement',
   [fetchExistingAppealMiddleware],
+  setSectionAndTaskNames(sectionName, taskName),
   getDesignAccessStatement
 );
 router.post(
   '/submit-appeal/design-access-statement',
+  setSectionAndTaskNames(sectionName, taskName),
   fileUploadValidationRules('Select your design and access statement'),
   validationErrorHandler,
   postDesignAccessStatement

--- a/packages/forms-web-app/src/validators/common/file-upload.js
+++ b/packages/forms-web-app/src/validators/common/file-upload.js
@@ -1,9 +1,7 @@
 const { checkSchema } = require('express-validator');
 const fileUploadSchema = require('./schemas/file-upload');
 
-const rules = (noFilesError) => {
-  return [checkSchema(fileUploadSchema(noFilesError))];
-};
+const rules = (noFilesError) => [checkSchema(fileUploadSchema(noFilesError))];
 
 module.exports = {
   rules,

--- a/packages/forms-web-app/src/validators/common/schemas/file-upload.js
+++ b/packages/forms-web-app/src/validators/common/schemas/file-upload.js
@@ -12,9 +12,18 @@ const schema = (noFilesError) => ({
   'file-upload': {
     custom: {
       options: async (value, { req, path }) => {
-        const { files } = req;
+        const {
+          files,
+          session: { appeal },
+          sectionName,
+          taskName,
+        } = req;
 
-        if (files === null || (files && !files[path])) {
+        if (!files) {
+          if (appeal[sectionName] && appeal[sectionName][taskName]?.uploadedFile.id) {
+            return true;
+          }
+
           throw new Error(noFilesError || 'Select a file to upload');
         }
 

--- a/packages/forms-web-app/src/views/full-appeal/submit-appeal/application-number.njk
+++ b/packages/forms-web-app/src/views/full-appeal/submit-appeal/application-number.njk
@@ -42,7 +42,7 @@
           hint: {
             text: "You can find this on the decision letter from your local planning department"
           },
-          value: appeal.requiredDocumentsSection.applicationNumber,
+          value: applicationNumber,
           errorMessage: errors['application-number'] and {
             text: errors['application-number'].msg
           }

--- a/packages/forms-web-app/src/views/full-appeal/submit-appeal/decision-letter.njk
+++ b/packages/forms-web-app/src/views/full-appeal/submit-appeal/decision-letter.njk
@@ -6,13 +6,15 @@
 {% from "govuk/components/button/macro.njk" import govukButton %}
 
 {% set labelText = "Drag and drop or choose a file" %}
+{% set backLink = '/full-appeal/submit-appeal/' %}
+{% set backLink = backLink + 'design-access-statement' if isDesignAccessStatementSubmitted else backLink + 'design-access-statement-submitted' %}
 {% set title = "Decision letter - Appeal a planning decision - GOV.UK" %}
 {% block pageTitle %}{{ "Error: " + title if errors else title }}{% endblock %}
 
 {% block backButton %}
   {{ govukBackLink({
     text: 'Back',
-    href: '/full-appeal/submit-appeal/task-list',
+    href: backLink,
     attributes: {
       'data-cy': 'back'
     }

--- a/packages/forms-web-app/src/views/full-appeal/submit-appeal/design-access-statement.njk
+++ b/packages/forms-web-app/src/views/full-appeal/submit-appeal/design-access-statement.njk
@@ -12,7 +12,7 @@
 {% block backButton %}
   {{ govukBackLink({
     text: 'Back',
-    href: '/full-appeal/submit-appeal/task-list',
+    href: '/full-appeal/submit-appeal/design-access-statement-submitted',
     attributes: {
       'data-cy': 'back'
     }


### PR DESCRIPTION
## Ticket Number
https://pins-ds.atlassian.net/browse/AS-4375

## Description of change
Changes to the Full Appeal Application Documents journey, which fixes

- Update file upload pages to prevent validation for pages that have already had a file uploaded.
- Update the payload structure so these pages are in the correct section
- Update back links so they link to the correct page, including conditional back link setting on the Decision Letter page
- Update E2E tests for the back link changes

PR has quite a lot of files but is split into smaller logical commits

## Checklist
<!-- Put an `x` in all the boxes that apply: -->
- [ ] Requires infrastructure changes
- [ ] If adding or remove environment variables (e.g. in `docker-compose.yaml`) then I have updated the appropriate Helm chart
- [ ] I have updated the documentation accordingly
- [ ] My commit history in this PR is linear
- [ ] New features have tests
- [ ] Breaking change (team conversation required)

## Important

Please do not merge from `master` (please only [rebase](https://github.com/foundry4/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
