### PR TITLE
feat(as-4230): add full appeal own some of the land page

### DIFF
--- a/packages/appeals-service-api/__tests__/integration/appeals.test.js
+++ b/packages/appeals-service-api/__tests__/integration/appeals.test.js
@@ -19,6 +19,7 @@ async function createAppeal() {
   appeal.createdAt = now;
   appeal.updatedAt = now;
   delete appeal.eligibility.applicationCategories;
+  delete appeal.sectionStates.appealSiteSection.ownsSomeOfTheLand;
 
   await mongodb.get().collection('appeals').insertOne({ _id: appeal.id, uuid: appeal.id, appeal });
   return appeal;

--- a/packages/appeals-service-api/__tests__/unit/controllers/appeals.test.js
+++ b/packages/appeals-service-api/__tests__/unit/controllers/appeals.test.js
@@ -20,6 +20,7 @@ async function addInDatabase() {
   appeal.createdAt = now;
   appeal.updatedAt = now;
   delete appeal.eligibility.applicationCategories;
+  delete appeal.sectionStates.appealSiteSection.ownsSomeOfTheLand;
 
   await mongodb.get().collection('appeals').insertOne({ _id: appeal.id, uuid: appeal.id, appeal });
   return appeal;

--- a/packages/appeals-service-api/src/models/appeal.js
+++ b/packages/appeals-service-api/src/models/appeal.js
@@ -76,6 +76,7 @@ exports.appealDocument = {
       hasIssues: null,
       healthAndSafetyIssues: '',
     },
+    ownsSomeOfTheLand: null,
   },
   appealSubmission: {
     appealPDFStatement: {
@@ -130,6 +131,7 @@ exports.appealDocument = {
       siteAccess: 'NOT STARTED',
       siteOwnership: 'NOT STARTED',
       healthAndSafety: 'NOT STARTED',
+      ownsSomeOfTheLand: 'NOT STARTED',
     },
     contactDetailsSection: 'NOT STARTED',
     aboutAppealSiteSection: 'NOT STARTED',

--- a/packages/business-rules/src/schemas/full-appeal/insert.js
+++ b/packages/business-rules/src/schemas/full-appeal/insert.js
@@ -102,18 +102,22 @@ const insert = pinsYup
         email: pinsYup.string().email().max(255).nullable(),
       })
       .noUnknown(true),
-    appealSiteSection: pinsYup.object().shape({
-      siteAddress: pinsYup
-        .object()
-        .shape({
-          addressLine1: pinsYup.string().max(60).nullable(),
-          addressLine2: pinsYup.string().max(60).nullable(),
-          town: pinsYup.string().max(60).nullable(),
-          county: pinsYup.string().max(60).nullable(),
-          postcode: pinsYup.string().max(8).nullable(),
-        })
-        .noUnknown(true),
-    }),
+    appealSiteSection: pinsYup
+      .object()
+      .shape({
+        siteAddress: pinsYup
+          .object()
+          .shape({
+            addressLine1: pinsYup.string().max(60).nullable(),
+            addressLine2: pinsYup.string().max(60).nullable(),
+            town: pinsYup.string().max(60).nullable(),
+            county: pinsYup.string().max(60).nullable(),
+            postcode: pinsYup.string().max(8).nullable(),
+          })
+          .noUnknown(true),
+        ownsSomeOfTheLand: pinsYup.bool().nullable(),
+      })
+      .noUnknown(true),
     planningApplicationDocumentsSection: pinsYup
       .object()
       .shape({

--- a/packages/business-rules/src/schemas/full-appeal/insert.test.js
+++ b/packages/business-rules/src/schemas/full-appeal/insert.test.js
@@ -576,6 +576,21 @@ describe('schemas/full-appeal/insert', () => {
     });
 
     describe('appealSiteSection', () => {
+      it('should remove unknown fields', async () => {
+        appeal2.appealSiteSection.unknownField = 'unknown field';
+
+        const result = await insert.validate(appeal2, config);
+        expect(result).toEqual(appeal);
+      });
+
+      it('should throw an error when given a null value', async () => {
+        appeal.appealSiteSection = null;
+
+        await expect(() => insert.validate(appeal, config)).rejects.toThrow(
+          'appealSiteSection must be a `object` type, but the final value was: `null`',
+        );
+      });
+
       describe('appealSiteSection.siteAddress', () => {
         describe('appealSiteSection.siteAddress', () => {
           it('should remove unknown fields', async () => {
@@ -677,6 +692,30 @@ describe('schemas/full-appeal/insert', () => {
             const result = await insert.validate(appeal, config);
             expect(result).toEqual(appeal);
           });
+        });
+      });
+
+      describe('appealSiteSection.ownsSomeOfTheLand', () => {
+        it('should throw an error when not given a boolean', async () => {
+          appeal.appealSiteSection.ownsSomeOfTheLand = 'false ';
+
+          await expect(() => insert.validate(appeal, config)).rejects.toThrow(
+            'appealSiteSection.ownsSomeOfTheLand must be a `boolean` type, but the final value was: `"false "` (cast from the value `false`).',
+          );
+        });
+
+        it('should not throw an error when given a null value', async () => {
+          appeal.appealSiteSection.ownsSomeOfTheLand = null;
+
+          const result = await insert.validate(appeal, config);
+          expect(result).toEqual(appeal);
+        });
+
+        it('should not throw an error when not given a value', async () => {
+          delete appeal.appealSiteSection.ownsSomeOfTheLand;
+
+          const result = await insert.validate(appeal, config);
+          expect(result).toEqual(appeal);
         });
       });
     });

--- a/packages/business-rules/src/schemas/full-appeal/update.js
+++ b/packages/business-rules/src/schemas/full-appeal/update.js
@@ -82,18 +82,22 @@ const update = pinsYup
         email: pinsYup.string().email().max(255).required(),
       })
       .noUnknown(true),
-    appealSiteSection: pinsYup.object().shape({
-      siteAddress: pinsYup
-        .object()
-        .shape({
-          addressLine1: pinsYup.string().max(60).required(),
-          addressLine2: pinsYup.string().max(60).nullable(),
-          town: pinsYup.string().max(60).nullable(),
-          county: pinsYup.string().max(60).nullable(),
-          postcode: pinsYup.string().max(8).required(),
-        })
-        .noUnknown(true),
-    }),
+    appealSiteSection: pinsYup
+      .object()
+      .shape({
+        siteAddress: pinsYup
+          .object()
+          .shape({
+            addressLine1: pinsYup.string().max(60).required(),
+            addressLine2: pinsYup.string().max(60).nullable(),
+            town: pinsYup.string().max(60).nullable(),
+            county: pinsYup.string().max(60).nullable(),
+            postcode: pinsYup.string().max(8).required(),
+          })
+          .noUnknown(true),
+        ownsSomeOfTheLand: pinsYup.bool().required(),
+      })
+      .noUnknown(true),
     planningApplicationDocumentsSection: pinsYup
       .object()
       .shape({

--- a/packages/business-rules/src/schemas/full-appeal/update.test.js
+++ b/packages/business-rules/src/schemas/full-appeal/update.test.js
@@ -564,6 +564,21 @@ describe('schemas/full-appeal/update', () => {
     });
 
     describe('appealSiteSection', () => {
+      it('should remove unknown fields', async () => {
+        appeal2.appealSiteSection.unknownField = 'unknown field';
+
+        const result = await update.validate(appeal2, config);
+        expect(result).toEqual(appeal);
+      });
+
+      it('should throw an error when given a null value', async () => {
+        appeal.appealSiteSection = null;
+
+        await expect(() => update.validate(appeal, config)).rejects.toThrow(
+          'appealSiteSection must be a `object` type, but the final value was: `null`',
+        );
+      });
+
       describe('appealSiteSection.siteAddress', () => {
         describe('appealSiteSection.siteAddress', () => {
           it('should remove unknown fields', async () => {
@@ -691,6 +706,24 @@ describe('schemas/full-appeal/update', () => {
               'appealSiteSection.siteAddress.postcode is a required field',
             );
           });
+        });
+      });
+
+      describe('appealSiteSection.ownsSomeOfTheLand', () => {
+        it('should throw an error when not given a boolean', async () => {
+          appeal.appealSiteSection.ownsSomeOfTheLand = 'false ';
+
+          await expect(() => update.validate(appeal, config)).rejects.toThrow(
+            'appealSiteSection.ownsSomeOfTheLand must be a `boolean` type, but the final value was: `"false "` (cast from the value `false`).',
+          );
+        });
+
+        it('should throw an error when not given a value', async () => {
+          delete appeal.appealSiteSection.ownsSomeOfTheLand;
+
+          await expect(() => update.validate(appeal, config)).rejects.toThrow(
+            'appealSiteSection.ownsSomeOfTheLand is a required field',
+          );
         });
       });
     });

--- a/packages/business-rules/test/data/full-appeal.js
+++ b/packages/business-rules/test/data/full-appeal.js
@@ -43,6 +43,7 @@ const appeal = {
       county: 'Site County',
       postcode: 'SW1 1AA',
     },
+    ownsSomeOfTheLand: false,
   },
   planningApplicationDocumentsSection: {
     applicationNumber: 'ABCDE12345',

--- a/packages/forms-web-app/__tests__/unit/controllers/full-appeal/submit-appeal/own-some-of-the-land.test.js
+++ b/packages/forms-web-app/__tests__/unit/controllers/full-appeal/submit-appeal/own-some-of-the-land.test.js
@@ -1,0 +1,256 @@
+const {
+  getOwnSomeOfTheLand,
+  postOwnSomeOfTheLand,
+} = require('../../../../../src/controllers/full-appeal/submit-appeal/own-some-of-the-land');
+const { createOrUpdateAppeal } = require('../../../../../src/lib/appeals-api-wrapper');
+const { getTaskStatus } = require('../../../../../src/services/task.service');
+const { APPEAL_DOCUMENT } = require('../../../../../src/lib/empty-appeal');
+const { mockReq, mockRes } = require('../../../mocks');
+const {
+  VIEW: {
+    FULL_APPEAL: { OWN_SOME_OF_THE_LAND, KNOW_THE_OWNERS },
+  },
+} = require('../../../../../src/lib/full-appeal/views');
+
+jest.mock('../../../../../src/lib/appeals-api-wrapper');
+jest.mock('../../../../../src/services/task.service');
+
+describe('controllers/full-appeal/submit-appeal/own-some-of-the-land', () => {
+  let req;
+  let res;
+  let appeal;
+
+  const sectionName = 'appealSiteSection';
+  const taskName = 'ownsSomeOfTheLand';
+  const appealId = 'da368e66-de7b-44c4-a403-36e5bf5b000b';
+  const errors = { 'own-some-of-the-land': 'Select an option' };
+  const errorSummary = [{ text: 'There was an error', href: '#' }];
+
+  beforeEach(() => {
+    appeal = {
+      ...APPEAL_DOCUMENT.empty,
+      id: appealId,
+      appealSiteSection: {
+        ownsSomeOfTheLand: false,
+      },
+    };
+    req = {
+      ...mockReq(),
+      body: {},
+      session: {
+        appeal,
+      },
+    };
+    res = mockRes();
+
+    jest.resetAllMocks();
+  });
+
+  describe('getOwnSomeOfTheLand', () => {
+    it('should call the correct template', () => {
+      getOwnSomeOfTheLand(req, res);
+
+      expect(res.render).toHaveBeenCalledTimes(1);
+      expect(res.render).toHaveBeenCalledWith(OWN_SOME_OF_THE_LAND, {
+        ownsSomeOfTheLand: false,
+      });
+    });
+
+    it('should call the correct template when appeal.appealSiteSection is not defined', () => {
+      delete appeal.appealSiteSection;
+
+      getOwnSomeOfTheLand(req, res);
+
+      expect(res.render).toHaveBeenCalledTimes(1);
+      expect(res.render).toHaveBeenCalledWith(OWN_SOME_OF_THE_LAND, {
+        ownsSomeOfTheLand: undefined,
+      });
+    });
+  });
+
+  describe('postOwnSomeOfTheLand', () => {
+    it('should re-render the template with errors if submission validation fails', async () => {
+      req = {
+        ...req,
+        body: {
+          'own-some-of-the-land': undefined,
+          errors,
+          errorSummary,
+        },
+      };
+
+      await postOwnSomeOfTheLand(req, res);
+
+      expect(res.redirect).not.toHaveBeenCalled();
+      expect(res.render).toHaveBeenCalledTimes(1);
+      expect(res.render).toHaveBeenCalledWith(OWN_SOME_OF_THE_LAND, {
+        errors,
+        errorSummary,
+      });
+    });
+
+    it('should re-render the template with errors if an error is thrown', async () => {
+      const error = new Error('Internal Server Error');
+
+      createOrUpdateAppeal.mockImplementation(() => {
+        throw error;
+      });
+
+      await postOwnSomeOfTheLand(req, res);
+
+      expect(res.redirect).not.toHaveBeenCalled();
+      expect(res.render).toHaveBeenCalledTimes(1);
+      expect(res.render).toHaveBeenCalledWith(OWN_SOME_OF_THE_LAND, {
+        ownsSomeOfTheLand: false,
+        errors: {},
+        errorSummary: [{ text: error.toString(), href: '#' }],
+      });
+    });
+
+    it('should redirect to the correct page if `yes` has been selected', async () => {
+      const submittedAppeal = {
+        ...appeal,
+        state: 'SUBMITTED',
+      };
+
+      createOrUpdateAppeal.mockReturnValue(submittedAppeal);
+
+      req = {
+        ...req,
+        body: {
+          'own-some-of-the-land': 'yes',
+        },
+      };
+
+      await postOwnSomeOfTheLand(req, res);
+
+      expect(getTaskStatus).toHaveBeenCalledWith(appeal, sectionName, taskName);
+      expect(createOrUpdateAppeal).toHaveBeenCalledWith(appeal);
+      expect(res.redirect).toHaveBeenCalledWith(`/${KNOW_THE_OWNERS}`);
+      expect(req.session.appeal).toEqual(submittedAppeal);
+    });
+
+    it('should redirect to the correct page if `no` has been selected', async () => {
+      const submittedAppeal = {
+        ...appeal,
+        state: 'SUBMITTED',
+      };
+
+      createOrUpdateAppeal.mockReturnValue(submittedAppeal);
+
+      req = {
+        ...req,
+        body: {
+          'own-some-of-the-land': 'no',
+        },
+      };
+
+      await postOwnSomeOfTheLand(req, res);
+
+      expect(getTaskStatus).toHaveBeenCalledWith(appeal, sectionName, taskName);
+      expect(createOrUpdateAppeal).toHaveBeenCalledWith(appeal);
+      expect(res.redirect).toHaveBeenCalledWith(`/${KNOW_THE_OWNERS}`);
+      expect(req.session.appeal).toEqual(submittedAppeal);
+    });
+
+    it('should redirect to the correct page if `yes` has been selected and appeal.appealSiteSection is not defined', async () => {
+      const submittedAppeal = {
+        ...appeal,
+        state: 'SUBMITTED',
+      };
+
+      delete appeal.appealSiteSection;
+
+      createOrUpdateAppeal.mockReturnValue(submittedAppeal);
+
+      req = {
+        ...req,
+        body: {
+          'own-some-of-the-land': 'yes',
+        },
+      };
+
+      await postOwnSomeOfTheLand(req, res);
+
+      expect(getTaskStatus).toHaveBeenCalledWith(appeal, sectionName, taskName);
+      expect(createOrUpdateAppeal).toHaveBeenCalledWith(appeal);
+      expect(res.redirect).toHaveBeenCalledWith(`/${KNOW_THE_OWNERS}`);
+      expect(req.session.appeal).toEqual(submittedAppeal);
+    });
+
+    it('should redirect to the correct page if `no` has been selected and appeal.appealSiteSection is not defined', async () => {
+      const submittedAppeal = {
+        ...appeal,
+        state: 'SUBMITTED',
+      };
+
+      delete appeal.appealSiteSection;
+
+      createOrUpdateAppeal.mockReturnValue(submittedAppeal);
+
+      req = {
+        ...req,
+        body: {
+          'own-some-of-the-land': 'no',
+        },
+      };
+
+      await postOwnSomeOfTheLand(req, res);
+
+      expect(getTaskStatus).toHaveBeenCalledWith(appeal, sectionName, taskName);
+      expect(createOrUpdateAppeal).toHaveBeenCalledWith(appeal);
+      expect(res.redirect).toHaveBeenCalledWith(`/${KNOW_THE_OWNERS}`);
+      expect(req.session.appeal).toEqual(submittedAppeal);
+    });
+
+    it('should redirect to the correct page if `yes` has been selected and appeal.sectionStates.appealSiteSection is not defined', async () => {
+      const submittedAppeal = {
+        ...appeal,
+        state: 'SUBMITTED',
+      };
+
+      delete appeal.sectionStates.appealSiteSection;
+
+      createOrUpdateAppeal.mockReturnValue(submittedAppeal);
+
+      req = {
+        ...req,
+        body: {
+          'own-some-of-the-land': 'yes',
+        },
+      };
+
+      await postOwnSomeOfTheLand(req, res);
+
+      expect(getTaskStatus).toHaveBeenCalledWith(appeal, sectionName, taskName);
+      expect(createOrUpdateAppeal).toHaveBeenCalledWith(appeal);
+      expect(res.redirect).toHaveBeenCalledWith(`/${KNOW_THE_OWNERS}`);
+      expect(req.session.appeal).toEqual(submittedAppeal);
+    });
+
+    it('should redirect to the correct page if `no` has been selected and appeal.sectionStates.appealSiteSection is not defined', async () => {
+      const submittedAppeal = {
+        ...appeal,
+        state: 'SUBMITTED',
+      };
+
+      delete appeal.sectionStates.appealSiteSection;
+
+      createOrUpdateAppeal.mockReturnValue(submittedAppeal);
+
+      req = {
+        ...req,
+        body: {
+          'own-some-of-the-land': 'no',
+        },
+      };
+
+      await postOwnSomeOfTheLand(req, res);
+
+      expect(getTaskStatus).toHaveBeenCalledWith(appeal, sectionName, taskName);
+      expect(createOrUpdateAppeal).toHaveBeenCalledWith(appeal);
+      expect(res.redirect).toHaveBeenCalledWith(`/${KNOW_THE_OWNERS}`);
+      expect(req.session.appeal).toEqual(submittedAppeal);
+    });
+  });
+});

--- a/packages/forms-web-app/__tests__/unit/lib/full-appeal/views.test.js
+++ b/packages/forms-web-app/__tests__/unit/lib/full-appeal/views.test.js
@@ -19,6 +19,8 @@ describe('/lib/full-appeal/views', () => {
         APPEAL_STATEMENT: 'full-appeal/submit-appeal/appeal-statement',
         PLANS_DRAWINGS: 'full-appeal/plans-drawings',
         ORIGINAL_APPLICANT: 'full-appeal/submit-appeal/original-applicant',
+        OWN_SOME_OF_THE_LAND: 'full-appeal/submit-appeal/own-some-of-the-land',
+        KNOW_THE_OWNERS: 'full-appeal/submit-appeal/know-the-owners',
       },
     });
   });

--- a/packages/forms-web-app/__tests__/unit/routes/full-appeal/submit-appeal/index.test.js
+++ b/packages/forms-web-app/__tests__/unit/routes/full-appeal/submit-appeal/index.test.js
@@ -11,6 +11,7 @@ const applicantNameRouter = require('../../../../../src/routes/full-appeal/submi
 const decisionLetterRouter = require('../../../../../src/routes/full-appeal/submit-appeal/decision-letter');
 const appealStatementRouter = require('../../../../../src/routes/full-appeal/submit-appeal/appeal-statement');
 const originalApplicantRouter = require('../../../../../src/routes/full-appeal/submit-appeal/original-applicant');
+const ownSomeOfTheLandRouter = require('../../../../../src/routes/full-appeal/submit-appeal/own-some-of-the-land');
 
 describe('routes/full-appeal/submit-appeal/index', () => {
   beforeEach(() => {
@@ -19,7 +20,7 @@ describe('routes/full-appeal/submit-appeal/index', () => {
   });
 
   it('should define the expected routes', () => {
-    expect(use.mock.calls.length).toBe(12);
+    expect(use.mock.calls.length).toBe(13);
     expect(use).toHaveBeenCalledWith(taskListRouter);
     expect(use).toHaveBeenCalledWith(checkAnswersRouter);
     expect(use).toHaveBeenCalledWith(contactDetailsRouter);
@@ -32,5 +33,6 @@ describe('routes/full-appeal/submit-appeal/index', () => {
     expect(use).toHaveBeenCalledWith(decisionLetterRouter);
     expect(use).toHaveBeenCalledWith(appealStatementRouter);
     expect(use).toHaveBeenCalledWith(originalApplicantRouter);
+    expect(use).toHaveBeenCalledWith(ownSomeOfTheLandRouter);
   });
 });

--- a/packages/forms-web-app/__tests__/unit/routes/full-appeal/submit-appeal/own-some-of-the-land.test.js
+++ b/packages/forms-web-app/__tests__/unit/routes/full-appeal/submit-appeal/own-some-of-the-land.test.js
@@ -1,0 +1,38 @@
+const { get, post } = require('../../router-mock');
+const {
+  getOwnSomeOfTheLand,
+  postOwnSomeOfTheLand,
+} = require('../../../../../src/controllers/full-appeal/submit-appeal/own-some-of-the-land');
+const fetchExistingAppealMiddleware = require('../../../../../src/middleware/fetch-existing-appeal');
+const {
+  validationErrorHandler,
+} = require('../../../../../src/validators/validation-error-handler');
+const { rules: yesNoValidationRules } = require('../../../../../src/validators/common/yes-no');
+
+jest.mock('../../../../../src/middleware/fetch-existing-appeal');
+jest.mock('../../../../../src/validators/common/yes-no');
+
+describe('routes/full-appeal/submit-appeal/own-some-of-the-land', () => {
+  beforeEach(() => {
+    // eslint-disable-next-line global-require
+    require('../../../../../src/routes/full-appeal/submit-appeal/own-some-of-the-land');
+  });
+
+  it('should define the expected routes', () => {
+    expect(get).toHaveBeenCalledWith(
+      '/submit-appeal/own-some-of-the-land',
+      [fetchExistingAppealMiddleware],
+      getOwnSomeOfTheLand
+    );
+    expect(post).toHaveBeenCalledWith(
+      '/submit-appeal/own-some-of-the-land',
+      yesNoValidationRules(),
+      validationErrorHandler,
+      postOwnSomeOfTheLand
+    );
+    expect(yesNoValidationRules).toHaveBeenCalledWith(
+      'own-some-of-the-land',
+      'Select yes if you own some of the land involved in the appeal'
+    );
+  });
+});

--- a/packages/forms-web-app/src/controllers/full-appeal/submit-appeal/own-some-of-the-land.js
+++ b/packages/forms-web-app/src/controllers/full-appeal/submit-appeal/own-some-of-the-land.js
@@ -1,0 +1,60 @@
+const logger = require('../../../lib/logger');
+const { createOrUpdateAppeal } = require('../../../lib/appeals-api-wrapper');
+const {
+  VIEW: {
+    FULL_APPEAL: { OWN_SOME_OF_THE_LAND, KNOW_THE_OWNERS },
+  },
+} = require('../../../lib/full-appeal/views');
+const { getTaskStatus } = require('../../../services/task.service');
+
+const sectionName = 'appealSiteSection';
+const taskName = 'ownsSomeOfTheLand';
+
+const getOwnSomeOfTheLand = (req, res) => {
+  const {
+    appeal: { [sectionName]: { [taskName]: ownsSomeOfTheLand } = {} },
+  } = req.session;
+  res.render(OWN_SOME_OF_THE_LAND, {
+    ownsSomeOfTheLand,
+  });
+};
+
+const postOwnSomeOfTheLand = async (req, res) => {
+  const {
+    body,
+    body: { errors = {}, errorSummary = [] },
+    session: { appeal },
+  } = req;
+
+  if (Object.keys(errors).length > 0) {
+    return res.render(OWN_SOME_OF_THE_LAND, {
+      errors,
+      errorSummary,
+    });
+  }
+
+  const ownsSomeOfTheLand = body['own-some-of-the-land'] === 'yes';
+
+  try {
+    appeal[sectionName] = appeal[sectionName] || {};
+    appeal[sectionName][taskName] = ownsSomeOfTheLand;
+    appeal.sectionStates[sectionName] = appeal.sectionStates[sectionName] || {};
+    appeal.sectionStates[sectionName][taskName] = getTaskStatus(appeal, sectionName, taskName);
+    req.session.appeal = await createOrUpdateAppeal(appeal);
+  } catch (err) {
+    logger.error(err);
+
+    return res.render(OWN_SOME_OF_THE_LAND, {
+      ownsSomeOfTheLand,
+      errors,
+      errorSummary: [{ text: err.toString(), href: '#' }],
+    });
+  }
+
+  return res.redirect(`/${KNOW_THE_OWNERS}`);
+};
+
+module.exports = {
+  getOwnSomeOfTheLand,
+  postOwnSomeOfTheLand,
+};

--- a/packages/forms-web-app/src/lib/full-appeal/views.js
+++ b/packages/forms-web-app/src/lib/full-appeal/views.js
@@ -15,6 +15,8 @@ const VIEW = {
     APPEAL_STATEMENT: 'full-appeal/submit-appeal/appeal-statement',
     PLANS_DRAWINGS: 'full-appeal/plans-drawings',
     ORIGINAL_APPLICANT: 'full-appeal/submit-appeal/original-applicant',
+    OWN_SOME_OF_THE_LAND: 'full-appeal/submit-appeal/own-some-of-the-land',
+    KNOW_THE_OWNERS: 'full-appeal/submit-appeal/know-the-owners',
   },
 };
 

--- a/packages/forms-web-app/src/routes/full-appeal/submit-appeal/index.js
+++ b/packages/forms-web-app/src/routes/full-appeal/submit-appeal/index.js
@@ -11,6 +11,7 @@ const applicantNameRouter = require('./applicant-name');
 const decisionLetterRouter = require('./decision-letter');
 const appealStatementRouter = require('./appeal-statement');
 const originalApplicantRouter = require('./original-applicant');
+const ownSomeOfTheLandRouter = require('./own-some-of-the-land');
 
 const router = express.Router();
 
@@ -26,5 +27,6 @@ router.use(applicantNameRouter);
 router.use(decisionLetterRouter);
 router.use(appealStatementRouter);
 router.use(originalApplicantRouter);
+router.use(ownSomeOfTheLandRouter);
 
 module.exports = router;

--- a/packages/forms-web-app/src/routes/full-appeal/submit-appeal/own-some-of-the-land.js
+++ b/packages/forms-web-app/src/routes/full-appeal/submit-appeal/own-some-of-the-land.js
@@ -1,0 +1,27 @@
+const express = require('express');
+const {
+  getOwnSomeOfTheLand,
+  postOwnSomeOfTheLand,
+} = require('../../../controllers/full-appeal/submit-appeal/own-some-of-the-land');
+const fetchExistingAppealMiddleware = require('../../../middleware/fetch-existing-appeal');
+const { validationErrorHandler } = require('../../../validators/validation-error-handler');
+const { rules: yesNoValidationRules } = require('../../../validators/common/yes-no');
+
+const router = express.Router();
+
+router.get(
+  '/submit-appeal/own-some-of-the-land',
+  [fetchExistingAppealMiddleware],
+  getOwnSomeOfTheLand
+);
+router.post(
+  '/submit-appeal/own-some-of-the-land',
+  yesNoValidationRules(
+    'own-some-of-the-land',
+    'Select yes if you own some of the land involved in the appeal'
+  ),
+  validationErrorHandler,
+  postOwnSomeOfTheLand
+);
+
+module.exports = router;

--- a/packages/forms-web-app/src/views/full-appeal/submit-appeal/own-some-of-the-land.njk
+++ b/packages/forms-web-app/src/views/full-appeal/submit-appeal/own-some-of-the-land.njk
@@ -1,0 +1,70 @@
+{% extends "layouts/main.njk" %}
+
+{% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
+{% from "govuk/components/radios/macro.njk" import govukRadios %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
+
+{% set title = "Do you own some of the land involved in the appeal? - Appeal a planning decision - GOV.UK" %}
+{% block pageTitle %}{{ "Error: " + title if errors else title }}{% endblock %}
+
+{% block backButton %}
+  {{ govukBackLink({
+    text: 'Back',
+    href: '/full-appeal/submit-appeal/own-all-the-land',
+    attributes: {
+      'data-cy': 'back'
+    }
+  }) }}
+{% endblock %}
+
+{% block content %}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      {% if errorSummary %}
+        {{ govukErrorSummary({
+          titleText: "There is a problem",
+          errorList: errorSummary,
+          attributes: {"data-cy": "error-wrapper"}
+        }) }}
+      {% endif %}
+      <form action="" method="post" novalidate>
+        <span class="govuk-caption-l">Tell us about the appeal site</span>
+        {{ govukRadios({
+          classes: "govuk-radios",
+          idPrefix: "own-some-of-the-land",
+          name: "own-some-of-the-land",
+          errorMessage: errors['own-some-of-the-land'] and {
+            text: errors['own-some-of-the-land'].msg
+          },
+          fieldset: {
+            legend: {
+              text: "Do you own some of the land involved in the appeal?",
+              isPageHeading: true,
+              classes: "govuk-fieldset__legend--l"
+            }
+          },
+          items: [
+            {
+              value: "yes",
+              text: "Yes",
+              attributes: { "data-cy": "answer-yes" },
+              checked: ownsSomeOfTheLand == true
+            },
+            {
+              value: "no",
+              text: "No",
+              attributes: { "data-cy": "answer-no" },
+              checked: ownsSomeOfTheLand == false
+            }
+          ]
+        }) }}
+        {{ govukButton({
+          text: "Continue",
+          type: "submit",
+          attributes: { "data-cy":"button-save-and-continue"}
+        }) }}
+      </form>
+    </div>
+  </div>
+
+{% endblock %}


### PR DESCRIPTION
## Ticket Number
https://pins-ds.atlassian.net/browse/AS-4230

## Description of change
Adds the Full Appeal page for 'Do you own some of the land involved in the appeal? '

## Checklist
<!-- Put an `x` in all the boxes that apply: -->
- [ ] Requires infrastructure changes
- [ ] If adding or remove environment variables (e.g. in `docker-compose.yaml`) then I have updated the appropriate Helm chart
- [ ] I have updated the documentation accordingly
- [ ] My commit history in this PR is linear
- [ ] New features have tests
- [ ] Breaking change (team conversation required)

## Important

Please do not merge from `master` (please only [rebase](https://github.com/foundry4/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
