### PR TITLE
Feature/as 4235 who owns land

### DIFF
--- a/packages/forms-web-app/__tests__/unit/controllers/full-appeal/submit-appeal/know-the-owners.test.js
+++ b/packages/forms-web-app/__tests__/unit/controllers/full-appeal/submit-appeal/know-the-owners.test.js
@@ -31,6 +31,7 @@ describe('controllers/full-appeal/submit-appeal/know-the-owners', () => {
       ...APPEAL_DOCUMENT.empty,
       id: appealId,
       appealSiteSection: {
+        ownsSomeOfTheLand: true,
         knowsTheOwners: 'yes',
       },
     };
@@ -52,6 +53,7 @@ describe('controllers/full-appeal/submit-appeal/know-the-owners', () => {
 
       expect(res.render).toHaveBeenCalledTimes(1);
       expect(res.render).toHaveBeenCalledWith(KNOW_THE_OWNERS, {
+        ownsSomeOfTheLand: true,
         knowsTheOwners: 'yes',
       });
     });
@@ -63,6 +65,7 @@ describe('controllers/full-appeal/submit-appeal/know-the-owners', () => {
 
       expect(res.render).toHaveBeenCalledTimes(1);
       expect(res.render).toHaveBeenCalledWith(KNOW_THE_OWNERS, {
+        ownsSomeOfTheLand: undefined,
         knowsTheOwners: undefined,
       });
     });
@@ -84,6 +87,7 @@ describe('controllers/full-appeal/submit-appeal/know-the-owners', () => {
       expect(res.redirect).not.toHaveBeenCalled();
       expect(res.render).toHaveBeenCalledTimes(1);
       expect(res.render).toHaveBeenCalledWith(KNOW_THE_OWNERS, {
+        ownsSomeOfTheLand: true,
         errors,
         errorSummary,
       });
@@ -108,6 +112,7 @@ describe('controllers/full-appeal/submit-appeal/know-the-owners', () => {
       expect(res.redirect).not.toHaveBeenCalled();
       expect(res.render).toHaveBeenCalledTimes(1);
       expect(res.render).toHaveBeenCalledWith(KNOW_THE_OWNERS, {
+        ownsSomeOfTheLand: true,
         knowsTheOwners: 'yes',
         errors: {},
         errorSummary: [{ text: error.toString(), href: '#' }],

--- a/packages/forms-web-app/__tests__/unit/lib/full-appeal/error-message/know-the-owners.test.js
+++ b/packages/forms-web-app/__tests__/unit/lib/full-appeal/error-message/know-the-owners.test.js
@@ -1,0 +1,45 @@
+const errorMessage = require('../../../../../src/lib/full-appeal/error-message/know-the-owners');
+
+describe('lib/full-appeal/error-message/know-the-owners', () => {
+  let req;
+
+  beforeEach(() => {
+    req = {
+      session: {
+        appeal: {},
+      },
+    };
+  });
+
+  it('should return the correct error message when ownsSomeOfTheLand is true', () => {
+    req.session.appeal = {
+      appealSiteSection: {
+        ownsSomeOfTheLand: true,
+      },
+    };
+
+    const result = errorMessage(req);
+
+    expect(result).toEqual(
+      'Select if you know who owns the rest of the land involved in the appeal'
+    );
+  });
+
+  it('should return the correct error message when ownsSomeOfTheLand is false', () => {
+    req.session.appeal = {
+      appealSiteSection: {
+        ownsSomeOfTheLand: false,
+      },
+    };
+
+    const result = errorMessage(req);
+
+    expect(result).toEqual('Select if you know who owns the land involved in the appeal');
+  });
+
+  it('should return the correct error message when ownsSomeOfTheLand is not set', () => {
+    const result = errorMessage(req);
+
+    expect(result).toEqual('Select if you know who owns the land involved in the appeal');
+  });
+});

--- a/packages/forms-web-app/__tests__/unit/routes/full-appeal/submit-appeal/design-access-statement-submitted.test.js
+++ b/packages/forms-web-app/__tests__/unit/routes/full-appeal/submit-appeal/design-access-statement-submitted.test.js
@@ -30,9 +30,9 @@ describe('routes/full-appeal/submit-appeal/design-access-statement-submitted', (
       validationErrorHandler,
       postDesignAccessStatementSubmitted
     );
-    expect(optionsValidationRules).toHaveBeenCalledWith(
-      'design-access-statement-submitted',
-      'Select yes if you submitted a design and access statement with your application'
-    );
+    expect(optionsValidationRules).toHaveBeenCalledWith({
+      fieldName: 'design-access-statement-submitted',
+      emptyError: 'Select yes if you submitted a design and access statement with your application',
+    });
   });
 });

--- a/packages/forms-web-app/__tests__/unit/routes/full-appeal/submit-appeal/know-the-owners.test.js
+++ b/packages/forms-web-app/__tests__/unit/routes/full-appeal/submit-appeal/know-the-owners.test.js
@@ -11,9 +11,11 @@ const {
   validationErrorHandler,
 } = require('../../../../../src/validators/validation-error-handler');
 const { rules: optionsValidationRules } = require('../../../../../src/validators/common/options');
+const errorMessage = require('../../../../../src/lib/full-appeal/error-message/know-the-owners');
 
 jest.mock('../../../../../src/middleware/fetch-existing-appeal');
 jest.mock('../../../../../src/validators/common/options');
+jest.mock('../../../../../src/lib/full-appeal/error-message/know-the-owners');
 
 describe('routes/full-appeal/submit-appeal/know-the-owners', () => {
   beforeEach(() => {
@@ -33,10 +35,10 @@ describe('routes/full-appeal/submit-appeal/know-the-owners', () => {
       validationErrorHandler,
       postKnowTheOwners
     );
-    expect(optionsValidationRules).toHaveBeenCalledWith(
-      'know-the-owners',
-      'Select if you know who owns the rest of the land involved in the appeal',
-      Object.values(KNOW_THE_OWNERS)
-    );
+    expect(optionsValidationRules).toHaveBeenCalledWith({
+      fieldName: 'know-the-owners',
+      validOptions: Object.values(KNOW_THE_OWNERS),
+      emptyError: errorMessage,
+    });
   });
 });

--- a/packages/forms-web-app/__tests__/unit/routes/full-appeal/submit-appeal/own-all-the-land.test.js
+++ b/packages/forms-web-app/__tests__/unit/routes/full-appeal/submit-appeal/own-all-the-land.test.js
@@ -30,9 +30,9 @@ describe('routes/full-appeal/submit-appeal/own-all-the-land', () => {
       validationErrorHandler,
       postOwnAllTheLand
     );
-    expect(optionsValidationRules).toHaveBeenCalledWith(
-      'own-all-the-land',
-      'Select yes if you own all the land involved in the appeal'
-    );
+    expect(optionsValidationRules).toHaveBeenCalledWith({
+      fieldName: 'own-all-the-land',
+      emptyError: 'Select yes if you own all the land involved in the appeal',
+    });
   });
 });

--- a/packages/forms-web-app/__tests__/unit/routes/full-appeal/submit-appeal/own-some-of-the-land.test.js
+++ b/packages/forms-web-app/__tests__/unit/routes/full-appeal/submit-appeal/own-some-of-the-land.test.js
@@ -30,9 +30,9 @@ describe('routes/full-appeal/submit-appeal/own-some-of-the-land', () => {
       validationErrorHandler,
       postOwnSomeOfTheLand
     );
-    expect(optionsValidationRules).toHaveBeenCalledWith(
-      'own-some-of-the-land',
-      'Select yes if you own some of the land involved in the appeal'
-    );
+    expect(optionsValidationRules).toHaveBeenCalledWith({
+      fieldName: 'own-some-of-the-land',
+      emptyError: 'Select yes if you own some of the land involved in the appeal',
+    });
   });
 });

--- a/packages/forms-web-app/src/controllers/full-appeal/submit-appeal/know-the-owners.js
+++ b/packages/forms-web-app/src/controllers/full-appeal/submit-appeal/know-the-owners.js
@@ -17,9 +17,10 @@ const taskName = 'knowsTheOwners';
 
 const getKnowTheOwners = (req, res) => {
   const {
-    appeal: { [sectionName]: { [taskName]: knowsTheOwners } = {} },
+    appeal: { [sectionName]: { ownsSomeOfTheLand, [taskName]: knowsTheOwners } = {} },
   } = req.session;
   res.render(KNOW_THE_OWNERS, {
+    ownsSomeOfTheLand,
     knowsTheOwners,
   });
 };
@@ -28,11 +29,15 @@ const postKnowTheOwners = async (req, res) => {
   const {
     body,
     body: { errors = {}, errorSummary = [] },
-    session: { appeal },
+    session: {
+      appeal,
+      appeal: { [sectionName]: { ownsSomeOfTheLand } = {} },
+    },
   } = req;
 
   if (Object.keys(errors).length > 0) {
     return res.render(KNOW_THE_OWNERS, {
+      ownsSomeOfTheLand,
       errors,
       errorSummary,
     });
@@ -50,6 +55,7 @@ const postKnowTheOwners = async (req, res) => {
     logger.error(err);
 
     return res.render(KNOW_THE_OWNERS, {
+      ownsSomeOfTheLand,
       knowsTheOwners,
       errors,
       errorSummary: [{ text: err.toString(), href: '#' }],

--- a/packages/forms-web-app/src/lib/full-appeal/error-message/know-the-owners.js
+++ b/packages/forms-web-app/src/lib/full-appeal/error-message/know-the-owners.js
@@ -1,0 +1,9 @@
+const errorMessage = (req) => {
+  const { appealSiteSection: { ownsSomeOfTheLand } = {} } = req.session.appeal;
+  if (ownsSomeOfTheLand) {
+    return 'Select if you know who owns the rest of the land involved in the appeal';
+  }
+  return 'Select if you know who owns the land involved in the appeal';
+};
+
+module.exports = errorMessage;

--- a/packages/forms-web-app/src/routes/full-appeal/submit-appeal/design-access-statement-submitted.js
+++ b/packages/forms-web-app/src/routes/full-appeal/submit-appeal/design-access-statement-submitted.js
@@ -16,10 +16,10 @@ router.get(
 );
 router.post(
   '/submit-appeal/design-access-statement-submitted',
-  optionsValidationRules(
-    'design-access-statement-submitted',
-    'Select yes if you submitted a design and access statement with your application'
-  ),
+  optionsValidationRules({
+    fieldName: 'design-access-statement-submitted',
+    emptyError: 'Select yes if you submitted a design and access statement with your application',
+  }),
   validationErrorHandler,
   postDesignAccessStatementSubmitted
 );

--- a/packages/forms-web-app/src/routes/full-appeal/submit-appeal/know-the-owners.js
+++ b/packages/forms-web-app/src/routes/full-appeal/submit-appeal/know-the-owners.js
@@ -9,17 +9,18 @@ const {
 const fetchExistingAppealMiddleware = require('../../../middleware/fetch-existing-appeal');
 const { validationErrorHandler } = require('../../../validators/validation-error-handler');
 const { rules: optionsValidationRules } = require('../../../validators/common/options');
+const errorMessage = require('../../../lib/full-appeal/error-message/know-the-owners');
 
 const router = express.Router();
 
 router.get('/submit-appeal/know-the-owners', [fetchExistingAppealMiddleware], getKnowTheOwners);
 router.post(
   '/submit-appeal/know-the-owners',
-  optionsValidationRules(
-    'know-the-owners',
-    'Select if you know who owns the rest of the land involved in the appeal',
-    Object.values(KNOW_THE_OWNERS)
-  ),
+  optionsValidationRules({
+    fieldName: 'know-the-owners',
+    validOptions: Object.values(KNOW_THE_OWNERS),
+    emptyError: errorMessage,
+  }),
   validationErrorHandler,
   postKnowTheOwners
 );

--- a/packages/forms-web-app/src/routes/full-appeal/submit-appeal/own-all-the-land.js
+++ b/packages/forms-web-app/src/routes/full-appeal/submit-appeal/own-all-the-land.js
@@ -12,10 +12,10 @@ const router = express.Router();
 router.get('/submit-appeal/own-all-the-land', [fetchExistingAppealMiddleware], getOwnAllTheLand);
 router.post(
   '/submit-appeal/own-all-the-land',
-  optionsValidationRules(
-    'own-all-the-land',
-    'Select yes if you own all the land involved in the appeal'
-  ),
+  optionsValidationRules({
+    fieldName: 'own-all-the-land',
+    emptyError: 'Select yes if you own all the land involved in the appeal',
+  }),
   validationErrorHandler,
   postOwnAllTheLand
 );

--- a/packages/forms-web-app/src/routes/full-appeal/submit-appeal/own-some-of-the-land.js
+++ b/packages/forms-web-app/src/routes/full-appeal/submit-appeal/own-some-of-the-land.js
@@ -16,10 +16,10 @@ router.get(
 );
 router.post(
   '/submit-appeal/own-some-of-the-land',
-  optionsValidationRules(
-    'own-some-of-the-land',
-    'Select yes if you own some of the land involved in the appeal'
-  ),
+  optionsValidationRules({
+    fieldName: 'own-some-of-the-land',
+    emptyError: 'Select yes if you own some of the land involved in the appeal',
+  }),
   validationErrorHandler,
   postOwnSomeOfTheLand
 );

--- a/packages/forms-web-app/src/validators/common/options.js
+++ b/packages/forms-web-app/src/validators/common/options.js
@@ -1,12 +1,15 @@
 const { body } = require('express-validator');
 
-const rules = (fieldName, notEmptyError = 'Select an option', validOptions = ['yes', 'no']) => [
-  body(fieldName)
-    .notEmpty()
-    .withMessage(notEmptyError)
-    .bail()
-    .isIn(validOptions)
-    .withMessage(notEmptyError),
+const rules = ({ fieldName, emptyError = null, validOptions = ['yes', 'no'] }) => [
+  body(fieldName).custom((value, { req }) => {
+    const error = typeof emptyError === 'function' ? emptyError(req) : emptyError;
+
+    if (value && validOptions.includes(value)) {
+      return true;
+    }
+
+    throw new Error(error || 'Select an option');
+  }),
 ];
 
 module.exports = {

--- a/packages/forms-web-app/src/views/full-appeal/submit-appeal/know-the-owners.njk
+++ b/packages/forms-web-app/src/views/full-appeal/submit-appeal/know-the-owners.njk
@@ -4,7 +4,12 @@
 {% from "govuk/components/radios/macro.njk" import govukRadios %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
 
-{% set title = "Do you know who owns the rest of the land involved in the appeal? - Appeal a planning decision - GOV.UK" %}
+{% set heading = "Do you know who owns the land involved in the appeal?" %}
+{% if ownsSomeOfTheLand %}
+  {% set heading = "Do you know who owns the rest of the land involved in the appeal?" %}
+{% endif %}
+
+{% set title = heading + " - Appeal a planning decision - GOV.UK" %}
 {% block pageTitle %}{{ "Error: " + title if errors else title }}{% endblock %}
 
 {% block backButton %}
@@ -38,7 +43,7 @@
           },
           fieldset: {
             legend: {
-              text: "Do you know who owns the rest of the land involved in the appeal?",
+              text: heading,
               isPageHeading: true,
               classes: "govuk-fieldset__legend--l"
             }


### PR DESCRIPTION
## Ticket Number
https://pins-ds.atlassian.net/browse/AS-4235

## Description of change
This change makes the title and error message of the 'Do you know who owns the land involved in the appeal?' page conditional based on the value selected in the 'Do you own some of the land involved in the appeal?' page

**If yes is selected then the title and error message are**

![Screenshot 2022-01-25 at 14-39-35 Error Do you know who owns the rest of the land involved in the appeal - Appeal a plannin](https://user-images.githubusercontent.com/6839214/150997810-6def65ac-ad17-4141-9fc0-38a06b51816f.png)

**If no is selected then the title and error message are**

![Screenshot 2022-01-25 at 14-39-57 Error Do you know who owns the land involved in the appeal - Appeal a planning decision -](https://user-images.githubusercontent.com/6839214/150997866-3a2046d7-aef0-42ea-8cc7-c94a11601329.png)

Also refactored the options validator so a error message function can be given which enables a conditional error message based on the value of another field to be set in the router

## Checklist
<!-- Put an `x` in all the boxes that apply: -->
- [ ] Requires infrastructure changes
- [ ] If adding or remove environment variables (e.g. in `docker-compose.yaml`) then I have updated the appropriate Helm chart
- [ ] I have updated the documentation accordingly
- [ ] My commit history in this PR is linear
- [ ] New features have tests
- [ ] Breaking change (team conversation required)

## Important

Please do not merge from `master` (please only [rebase](https://github.com/foundry4/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
