### PR TITLE
feat(as-4231): add full appeal agricultural holding page

### DIFF
--- a/packages/appeals-service-api/__tests__/integration/appeals.test.js
+++ b/packages/appeals-service-api/__tests__/integration/appeals.test.js
@@ -21,6 +21,8 @@ async function createAppeal() {
   delete appeal.eligibility.applicationCategories;
   delete appeal.sectionStates.appealSiteSection.ownsSomeOfTheLand;
   delete appeal.sectionStates.appealSiteSection.ownsAllTheLand;
+  delete appeal.sectionStates.appealSiteSection.knowsTheOwners;
+  delete appeal.sectionStates.appealSiteSection.isAgriculturalHolding;
 
   await mongodb.get().collection('appeals').insertOne({ _id: appeal.id, uuid: appeal.id, appeal });
   return appeal;

--- a/packages/appeals-service-api/__tests__/unit/controllers/appeals.test.js
+++ b/packages/appeals-service-api/__tests__/unit/controllers/appeals.test.js
@@ -22,6 +22,8 @@ async function addInDatabase() {
   delete appeal.eligibility.applicationCategories;
   delete appeal.sectionStates.appealSiteSection.ownsSomeOfTheLand;
   delete appeal.sectionStates.appealSiteSection.ownsAllTheLand;
+  delete appeal.sectionStates.appealSiteSection.knowsTheOwners;
+  delete appeal.sectionStates.appealSiteSection.isAgriculturalHolding;
 
   await mongodb.get().collection('appeals').insertOne({ _id: appeal.id, uuid: appeal.id, appeal });
   return appeal;

--- a/packages/appeals-service-api/src/models/appeal.js
+++ b/packages/appeals-service-api/src/models/appeal.js
@@ -79,6 +79,7 @@ exports.appealDocument = {
     ownsSomeOfTheLand: null,
     ownsAllTheLand: null,
     knowsTheOwners: null,
+    isAgriculturalHolding: null,
   },
   appealSubmission: {
     appealPDFStatement: {
@@ -135,6 +136,8 @@ exports.appealDocument = {
       healthAndSafety: 'NOT STARTED',
       ownsSomeOfTheLand: 'NOT STARTED',
       ownsAllTheLand: 'NOT STARTED',
+      knowsTheOwners: 'NOT STARTED',
+      isAgriculturalHolding: 'NOT STARTED',
     },
     contactDetailsSection: 'NOT STARTED',
     aboutAppealSiteSection: 'NOT STARTED',

--- a/packages/business-rules/src/schemas/full-appeal/insert.js
+++ b/packages/business-rules/src/schemas/full-appeal/insert.js
@@ -124,6 +124,7 @@ const insert = pinsYup
           }
           return pinsYup.string().nullable();
         }),
+        isAgriculturalHolding: pinsYup.bool().nullable(),
       })
       .noUnknown(true),
     planningApplicationDocumentsSection: pinsYup

--- a/packages/business-rules/src/schemas/full-appeal/insert.test.js
+++ b/packages/business-rules/src/schemas/full-appeal/insert.test.js
@@ -771,6 +771,30 @@ describe('schemas/full-appeal/insert', () => {
       });
     });
 
+    describe('appealSiteSection.isAgriculturalHolding', () => {
+      it('should throw an error when not given a boolean', async () => {
+        appeal.appealSiteSection.isAgriculturalHolding = 'true ';
+
+        await expect(() => insert.validate(appeal, config)).rejects.toThrow(
+          'appealSiteSection.isAgriculturalHolding must be a `boolean` type, but the final value was: `"true "` (cast from the value `true`).',
+        );
+      });
+
+      it('should not throw an error when given a null value', async () => {
+        appeal.appealSiteSection.isAgriculturalHolding = null;
+
+        const result = await insert.validate(appeal, config);
+        expect(result).toEqual(appeal);
+      });
+
+      it('should not throw an error when not given a value', async () => {
+        delete appeal.appealSiteSection.isAgriculturalHolding;
+
+        const result = await insert.validate(appeal, config);
+        expect(result).toEqual(appeal);
+      });
+    });
+
     describe('aboutYouSection', () => {
       it('should remove unknown fields', async () => {
         appeal2.aboutYouSection.unknownField = 'unknown field';

--- a/packages/business-rules/src/schemas/full-appeal/update.js
+++ b/packages/business-rules/src/schemas/full-appeal/update.js
@@ -99,6 +99,7 @@ const update = pinsYup
         ownsSomeOfTheLand: pinsYup.bool().required(),
         ownsAllTheLand: pinsYup.bool().required(),
         knowsTheOwners: pinsYup.string().oneOf(Object.values(KNOW_THE_OWNERS)).required(),
+        isAgriculturalHolding: pinsYup.bool().required(),
       })
       .noUnknown(true),
     planningApplicationDocumentsSection: pinsYup

--- a/packages/business-rules/src/schemas/full-appeal/update.test.js
+++ b/packages/business-rules/src/schemas/full-appeal/update.test.js
@@ -765,6 +765,24 @@ describe('schemas/full-appeal/update', () => {
           );
         });
       });
+
+      describe('appealSiteSection.isAgriculturalHolding', () => {
+        it('should throw an error when not given a boolean', async () => {
+          appeal.appealSiteSection.isAgriculturalHolding = 'true ';
+
+          await expect(() => update.validate(appeal, config)).rejects.toThrow(
+            'appealSiteSection.isAgriculturalHolding must be a `boolean` type, but the final value was: `"true "` (cast from the value `true`).',
+          );
+        });
+
+        it('should throw an error when not given a value', async () => {
+          delete appeal.appealSiteSection.isAgriculturalHolding;
+
+          await expect(() => update.validate(appeal, config)).rejects.toThrow(
+            'appealSiteSection.isAgriculturalHolding is a required field',
+          );
+        });
+      });
     });
 
     describe('aboutYouSection', () => {

--- a/packages/business-rules/test/data/full-appeal.js
+++ b/packages/business-rules/test/data/full-appeal.js
@@ -46,6 +46,7 @@ const appeal = {
     ownsSomeOfTheLand: false,
     ownsAllTheLand: true,
     knowsTheOwners: 'yes',
+    isAgriculturalHolding: true,
   },
   planningApplicationDocumentsSection: {
     applicationNumber: 'ABCDE12345',

--- a/packages/forms-web-app/__tests__/unit/controllers/full-appeal/submit-appeal/agricultural-holding.test.js
+++ b/packages/forms-web-app/__tests__/unit/controllers/full-appeal/submit-appeal/agricultural-holding.test.js
@@ -1,0 +1,256 @@
+const {
+  getAgriculturalHolding,
+  postAgriculturalHolding,
+} = require('../../../../../src/controllers/full-appeal/submit-appeal/agricultural-holding');
+const { createOrUpdateAppeal } = require('../../../../../src/lib/appeals-api-wrapper');
+const { getTaskStatus } = require('../../../../../src/services/task.service');
+const { APPEAL_DOCUMENT } = require('../../../../../src/lib/empty-appeal');
+const { mockReq, mockRes } = require('../../../mocks');
+const {
+  VIEW: {
+    FULL_APPEAL: { AGRICULTURAL_HOLDING, ARE_YOU_A_TENANT, VISIBLE_FROM_ROAD },
+  },
+} = require('../../../../../src/lib/full-appeal/views');
+
+jest.mock('../../../../../src/lib/appeals-api-wrapper');
+jest.mock('../../../../../src/services/task.service');
+
+describe('controllers/full-appeal/submit-appeal/agricultural-holding', () => {
+  let req;
+  let res;
+  let appeal;
+
+  const sectionName = 'appealSiteSection';
+  const taskName = 'isAgriculturalHolding';
+  const appealId = 'da368e66-de7b-44c4-a403-36e5bf5b000b';
+  const errors = { 'agricultural-holding': 'Select an option' };
+  const errorSummary = [{ text: 'There was an error', href: '#' }];
+
+  beforeEach(() => {
+    appeal = {
+      ...APPEAL_DOCUMENT.empty,
+      id: appealId,
+      appealSiteSection: {
+        isAgriculturalHolding: false,
+      },
+    };
+    req = {
+      ...mockReq(),
+      body: {},
+      session: {
+        appeal,
+      },
+    };
+    res = mockRes();
+
+    jest.resetAllMocks();
+  });
+
+  describe('getAgriculturalHolding', () => {
+    it('should call the correct template', () => {
+      getAgriculturalHolding(req, res);
+
+      expect(res.render).toHaveBeenCalledTimes(1);
+      expect(res.render).toHaveBeenCalledWith(AGRICULTURAL_HOLDING, {
+        isAgriculturalHolding: false,
+      });
+    });
+
+    it('should call the correct template when appeal.appealSiteSection is not defined', () => {
+      delete appeal.appealSiteSection;
+
+      getAgriculturalHolding(req, res);
+
+      expect(res.render).toHaveBeenCalledTimes(1);
+      expect(res.render).toHaveBeenCalledWith(AGRICULTURAL_HOLDING, {
+        isAgriculturalHolding: undefined,
+      });
+    });
+  });
+
+  describe('postAgriculturalHolding', () => {
+    it('should re-render the template with errors if submission validation fails', async () => {
+      req = {
+        ...req,
+        body: {
+          'agricultural-holding': undefined,
+          errors,
+          errorSummary,
+        },
+      };
+
+      await postAgriculturalHolding(req, res);
+
+      expect(res.redirect).not.toHaveBeenCalled();
+      expect(res.render).toHaveBeenCalledTimes(1);
+      expect(res.render).toHaveBeenCalledWith(AGRICULTURAL_HOLDING, {
+        errors,
+        errorSummary,
+      });
+    });
+
+    it('should re-render the template with errors if an error is thrown', async () => {
+      const error = new Error('Internal Server Error');
+
+      createOrUpdateAppeal.mockImplementation(() => {
+        throw error;
+      });
+
+      await postAgriculturalHolding(req, res);
+
+      expect(res.redirect).not.toHaveBeenCalled();
+      expect(res.render).toHaveBeenCalledTimes(1);
+      expect(res.render).toHaveBeenCalledWith(AGRICULTURAL_HOLDING, {
+        isAgriculturalHolding: false,
+        errors: {},
+        errorSummary: [{ text: error.toString(), href: '#' }],
+      });
+    });
+
+    it('should redirect to the correct page if `yes` has been selected', async () => {
+      const submittedAppeal = {
+        ...appeal,
+        state: 'SUBMITTED',
+      };
+
+      createOrUpdateAppeal.mockReturnValue(submittedAppeal);
+
+      req = {
+        ...req,
+        body: {
+          'agricultural-holding': 'yes',
+        },
+      };
+
+      await postAgriculturalHolding(req, res);
+
+      expect(getTaskStatus).toHaveBeenCalledWith(appeal, sectionName, taskName);
+      expect(createOrUpdateAppeal).toHaveBeenCalledWith(appeal);
+      expect(res.redirect).toHaveBeenCalledWith(`/${ARE_YOU_A_TENANT}`);
+      expect(req.session.appeal).toEqual(submittedAppeal);
+    });
+
+    it('should redirect to the correct page if `no` has been selected', async () => {
+      const submittedAppeal = {
+        ...appeal,
+        state: 'SUBMITTED',
+      };
+
+      createOrUpdateAppeal.mockReturnValue(submittedAppeal);
+
+      req = {
+        ...req,
+        body: {
+          'agricultural-holding': 'no',
+        },
+      };
+
+      await postAgriculturalHolding(req, res);
+
+      expect(getTaskStatus).toHaveBeenCalledWith(appeal, sectionName, taskName);
+      expect(createOrUpdateAppeal).toHaveBeenCalledWith(appeal);
+      expect(res.redirect).toHaveBeenCalledWith(`/${VISIBLE_FROM_ROAD}`);
+      expect(req.session.appeal).toEqual(submittedAppeal);
+    });
+
+    it('should redirect to the correct page if `yes` has been selected and appeal.appealSiteSection is not defined', async () => {
+      const submittedAppeal = {
+        ...appeal,
+        state: 'SUBMITTED',
+      };
+
+      delete appeal.appealSiteSection;
+
+      createOrUpdateAppeal.mockReturnValue(submittedAppeal);
+
+      req = {
+        ...req,
+        body: {
+          'agricultural-holding': 'yes',
+        },
+      };
+
+      await postAgriculturalHolding(req, res);
+
+      expect(getTaskStatus).toHaveBeenCalledWith(appeal, sectionName, taskName);
+      expect(createOrUpdateAppeal).toHaveBeenCalledWith(appeal);
+      expect(res.redirect).toHaveBeenCalledWith(`/${ARE_YOU_A_TENANT}`);
+      expect(req.session.appeal).toEqual(submittedAppeal);
+    });
+
+    it('should redirect to the correct page if `no` has been selected and appeal.appealSiteSection is not defined', async () => {
+      const submittedAppeal = {
+        ...appeal,
+        state: 'SUBMITTED',
+      };
+
+      delete appeal.appealSiteSection;
+
+      createOrUpdateAppeal.mockReturnValue(submittedAppeal);
+
+      req = {
+        ...req,
+        body: {
+          'agricultural-holding': 'no',
+        },
+      };
+
+      await postAgriculturalHolding(req, res);
+
+      expect(getTaskStatus).toHaveBeenCalledWith(appeal, sectionName, taskName);
+      expect(createOrUpdateAppeal).toHaveBeenCalledWith(appeal);
+      expect(res.redirect).toHaveBeenCalledWith(`/${VISIBLE_FROM_ROAD}`);
+      expect(req.session.appeal).toEqual(submittedAppeal);
+    });
+
+    it('should redirect to the correct page if `yes` has been selected and appeal.sectionStates.appealSiteSection is not defined', async () => {
+      const submittedAppeal = {
+        ...appeal,
+        state: 'SUBMITTED',
+      };
+
+      delete appeal.sectionStates.appealSiteSection;
+
+      createOrUpdateAppeal.mockReturnValue(submittedAppeal);
+
+      req = {
+        ...req,
+        body: {
+          'agricultural-holding': 'yes',
+        },
+      };
+
+      await postAgriculturalHolding(req, res);
+
+      expect(getTaskStatus).toHaveBeenCalledWith(appeal, sectionName, taskName);
+      expect(createOrUpdateAppeal).toHaveBeenCalledWith(appeal);
+      expect(res.redirect).toHaveBeenCalledWith(`/${ARE_YOU_A_TENANT}`);
+      expect(req.session.appeal).toEqual(submittedAppeal);
+    });
+
+    it('should redirect to the correct page if `no` has been selected and appeal.sectionStates.appealSiteSection is not defined', async () => {
+      const submittedAppeal = {
+        ...appeal,
+        state: 'SUBMITTED',
+      };
+
+      delete appeal.sectionStates.appealSiteSection;
+
+      createOrUpdateAppeal.mockReturnValue(submittedAppeal);
+
+      req = {
+        ...req,
+        body: {
+          'agricultural-holding': 'no',
+        },
+      };
+
+      await postAgriculturalHolding(req, res);
+
+      expect(getTaskStatus).toHaveBeenCalledWith(appeal, sectionName, taskName);
+      expect(createOrUpdateAppeal).toHaveBeenCalledWith(appeal);
+      expect(res.redirect).toHaveBeenCalledWith(`/${VISIBLE_FROM_ROAD}`);
+      expect(req.session.appeal).toEqual(submittedAppeal);
+    });
+  });
+});

--- a/packages/forms-web-app/__tests__/unit/lib/full-appeal/views.test.js
+++ b/packages/forms-web-app/__tests__/unit/lib/full-appeal/views.test.js
@@ -24,6 +24,8 @@ describe('/lib/full-appeal/views', () => {
         AGRICULTURAL_HOLDING: 'full-appeal/submit-appeal/agricultural-holding',
         TELLING_THE_LANDOWNERS: 'full-appeal/submit-appeal/telling-the-landowners',
         IDENTIFYING_THE_OWNERS: 'full-appeal/submit-appeal/identifying-the-owners',
+        ARE_YOU_A_TENANT: 'full-appeal/submit-appeal/are-you-a-tenant',
+        VISIBLE_FROM_ROAD: 'full-appeal/submit-appeal/visible-from-road',
       },
     });
   });

--- a/packages/forms-web-app/__tests__/unit/routes/full-appeal/submit-appeal/agricultural-holding.test.js
+++ b/packages/forms-web-app/__tests__/unit/routes/full-appeal/submit-appeal/agricultural-holding.test.js
@@ -1,0 +1,38 @@
+const { get, post } = require('../../router-mock');
+const {
+  getAgriculturalHolding,
+  postAgriculturalHolding,
+} = require('../../../../../src/controllers/full-appeal/submit-appeal/agricultural-holding');
+const fetchExistingAppealMiddleware = require('../../../../../src/middleware/fetch-existing-appeal');
+const {
+  validationErrorHandler,
+} = require('../../../../../src/validators/validation-error-handler');
+const { rules: optionsValidationRules } = require('../../../../../src/validators/common/options');
+
+jest.mock('../../../../../src/middleware/fetch-existing-appeal');
+jest.mock('../../../../../src/validators/common/options');
+
+describe('routes/full-appeal/submit-appeal/agricultural-holding', () => {
+  beforeEach(() => {
+    // eslint-disable-next-line global-require
+    require('../../../../../src/routes/full-appeal/submit-appeal/agricultural-holding');
+  });
+
+  it('should define the expected routes', () => {
+    expect(get).toHaveBeenCalledWith(
+      '/submit-appeal/agricultural-holding',
+      [fetchExistingAppealMiddleware],
+      getAgriculturalHolding
+    );
+    expect(post).toHaveBeenCalledWith(
+      '/submit-appeal/agricultural-holding',
+      optionsValidationRules(),
+      validationErrorHandler,
+      postAgriculturalHolding
+    );
+    expect(optionsValidationRules).toHaveBeenCalledWith({
+      fieldName: 'agricultural-holding',
+      emptyError: 'Select yes if the appeal site is part of an agricultural holding',
+    });
+  });
+});

--- a/packages/forms-web-app/__tests__/unit/routes/full-appeal/submit-appeal/index.test.js
+++ b/packages/forms-web-app/__tests__/unit/routes/full-appeal/submit-appeal/index.test.js
@@ -14,6 +14,7 @@ const originalApplicantRouter = require('../../../../../src/routes/full-appeal/s
 const ownSomeOfTheLandRouter = require('../../../../../src/routes/full-appeal/submit-appeal/own-some-of-the-land');
 const ownAllTheLandRouter = require('../../../../../src/routes/full-appeal/submit-appeal/own-all-the-land');
 const knowTheOwnersRouter = require('../../../../../src/routes/full-appeal/submit-appeal/know-the-owners');
+const agriculturalHoldingRouter = require('../../../../../src/routes/full-appeal/submit-appeal/agricultural-holding');
 
 describe('routes/full-appeal/submit-appeal/index', () => {
   beforeEach(() => {
@@ -22,7 +23,7 @@ describe('routes/full-appeal/submit-appeal/index', () => {
   });
 
   it('should define the expected routes', () => {
-    expect(use.mock.calls.length).toBe(15);
+    expect(use.mock.calls.length).toBe(16);
     expect(use).toHaveBeenCalledWith(taskListRouter);
     expect(use).toHaveBeenCalledWith(checkAnswersRouter);
     expect(use).toHaveBeenCalledWith(contactDetailsRouter);
@@ -38,5 +39,6 @@ describe('routes/full-appeal/submit-appeal/index', () => {
     expect(use).toHaveBeenCalledWith(ownSomeOfTheLandRouter);
     expect(use).toHaveBeenCalledWith(ownAllTheLandRouter);
     expect(use).toHaveBeenCalledWith(knowTheOwnersRouter);
+    expect(use).toHaveBeenCalledWith(agriculturalHoldingRouter);
   });
 });

--- a/packages/forms-web-app/src/controllers/full-appeal/submit-appeal/agricultural-holding.js
+++ b/packages/forms-web-app/src/controllers/full-appeal/submit-appeal/agricultural-holding.js
@@ -1,0 +1,62 @@
+const logger = require('../../../lib/logger');
+const { createOrUpdateAppeal } = require('../../../lib/appeals-api-wrapper');
+const {
+  VIEW: {
+    FULL_APPEAL: { AGRICULTURAL_HOLDING, ARE_YOU_A_TENANT, VISIBLE_FROM_ROAD },
+  },
+} = require('../../../lib/full-appeal/views');
+const { getTaskStatus } = require('../../../services/task.service');
+
+const sectionName = 'appealSiteSection';
+const taskName = 'isAgriculturalHolding';
+
+const getAgriculturalHolding = (req, res) => {
+  const {
+    appeal: { [sectionName]: { [taskName]: isAgriculturalHolding } = {} },
+  } = req.session;
+  res.render(AGRICULTURAL_HOLDING, {
+    isAgriculturalHolding,
+  });
+};
+
+const postAgriculturalHolding = async (req, res) => {
+  const {
+    body,
+    body: { errors = {}, errorSummary = [] },
+    session: { appeal },
+  } = req;
+
+  if (Object.keys(errors).length > 0) {
+    return res.render(AGRICULTURAL_HOLDING, {
+      errors,
+      errorSummary,
+    });
+  }
+
+  const isAgriculturalHolding = body['agricultural-holding'] === 'yes';
+
+  try {
+    appeal[sectionName] = appeal[sectionName] || {};
+    appeal[sectionName][taskName] = isAgriculturalHolding;
+    appeal.sectionStates[sectionName] = appeal.sectionStates[sectionName] || {};
+    appeal.sectionStates[sectionName][taskName] = getTaskStatus(appeal, sectionName, taskName);
+    req.session.appeal = await createOrUpdateAppeal(appeal);
+  } catch (err) {
+    logger.error(err);
+
+    return res.render(AGRICULTURAL_HOLDING, {
+      isAgriculturalHolding,
+      errors,
+      errorSummary: [{ text: err.toString(), href: '#' }],
+    });
+  }
+
+  return isAgriculturalHolding
+    ? res.redirect(`/${ARE_YOU_A_TENANT}`)
+    : res.redirect(`/${VISIBLE_FROM_ROAD}`);
+};
+
+module.exports = {
+  getAgriculturalHolding,
+  postAgriculturalHolding,
+};

--- a/packages/forms-web-app/src/lib/full-appeal/views.js
+++ b/packages/forms-web-app/src/lib/full-appeal/views.js
@@ -20,6 +20,8 @@ const VIEW = {
     AGRICULTURAL_HOLDING: 'full-appeal/submit-appeal/agricultural-holding',
     TELLING_THE_LANDOWNERS: 'full-appeal/submit-appeal/telling-the-landowners',
     IDENTIFYING_THE_OWNERS: 'full-appeal/submit-appeal/identifying-the-owners',
+    ARE_YOU_A_TENANT: 'full-appeal/submit-appeal/are-you-a-tenant',
+    VISIBLE_FROM_ROAD: 'full-appeal/submit-appeal/visible-from-road',
   },
 };
 

--- a/packages/forms-web-app/src/routes/full-appeal/submit-appeal/agricultural-holding.js
+++ b/packages/forms-web-app/src/routes/full-appeal/submit-appeal/agricultural-holding.js
@@ -1,0 +1,27 @@
+const express = require('express');
+const {
+  getAgriculturalHolding,
+  postAgriculturalHolding,
+} = require('../../../controllers/full-appeal/submit-appeal/agricultural-holding');
+const fetchExistingAppealMiddleware = require('../../../middleware/fetch-existing-appeal');
+const { validationErrorHandler } = require('../../../validators/validation-error-handler');
+const { rules: optionsValidationRules } = require('../../../validators/common/options');
+
+const router = express.Router();
+
+router.get(
+  '/submit-appeal/agricultural-holding',
+  [fetchExistingAppealMiddleware],
+  getAgriculturalHolding
+);
+router.post(
+  '/submit-appeal/agricultural-holding',
+  optionsValidationRules({
+    fieldName: 'agricultural-holding',
+    emptyError: 'Select yes if the appeal site is part of an agricultural holding',
+  }),
+  validationErrorHandler,
+  postAgriculturalHolding
+);
+
+module.exports = router;

--- a/packages/forms-web-app/src/routes/full-appeal/submit-appeal/index.js
+++ b/packages/forms-web-app/src/routes/full-appeal/submit-appeal/index.js
@@ -14,6 +14,7 @@ const originalApplicantRouter = require('./original-applicant');
 const ownSomeOfTheLandRouter = require('./own-some-of-the-land');
 const ownAllTheLandRouter = require('./own-all-the-land');
 const knowTheOwnersRouter = require('./know-the-owners');
+const agriculturalHoldingRouter = require('./agricultural-holding');
 
 const router = express.Router();
 
@@ -32,5 +33,6 @@ router.use(originalApplicantRouter);
 router.use(ownSomeOfTheLandRouter);
 router.use(ownAllTheLandRouter);
 router.use(knowTheOwnersRouter);
+router.use(agriculturalHoldingRouter);
 
 module.exports = router;

--- a/packages/forms-web-app/src/services/task.service.js
+++ b/packages/forms-web-app/src/services/task.service.js
@@ -167,6 +167,14 @@ const FULL_APPEAL_SECTIONS = {
       href: `/${FULL_APPEAL.OWN_SOME_OF_THE_LAND}`,
       rule: notStartedRule,
     },
+    knowTheOwners: {
+      href: `/${FULL_APPEAL.KNOW_THE_OWNERS}`,
+      rule: notStartedRule,
+    },
+    agriculturalHolding: {
+      href: `/${FULL_APPEAL.AGRICULTURAL_HOLDING}`,
+      rule: notStartedRule,
+    },
   },
   yourAppealSection: {
     appealStatement: {

--- a/packages/forms-web-app/src/views/full-appeal/submit-appeal/agricultural-holding.njk
+++ b/packages/forms-web-app/src/views/full-appeal/submit-appeal/agricultural-holding.njk
@@ -1,0 +1,72 @@
+{% extends "layouts/main.njk" %}
+
+{% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
+{% from "govuk/components/radios/macro.njk" import govukRadios %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
+
+{% set title = "Is the appeal site part of an agricultural holding? - Appeal a planning decision - GOV.UK" %}
+{% block pageTitle %}{{ "Error: " + title if errors else title }}{% endblock %}
+
+{% block backButton %}
+  {{ govukBackLink({
+    text: 'Back',
+    href: '/full-appeal/submit-appeal/own-all-the-land',
+    attributes: {
+      'data-cy': 'back'
+    }
+  }) }}
+{% endblock %}
+
+{% block content %}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      {% if errorSummary %}
+        {{ govukErrorSummary({
+          titleText: "There is a problem",
+          errorList: errorSummary,
+          attributes: {"data-cy": "error-wrapper"}
+        }) }}
+      {% endif %}
+      <form action="" method="post" novalidate>
+        <span class="govuk-caption-l">Tell us about the appeal site</span>
+        {{ govukRadios({
+          classes: "govuk-radios",
+          idPrefix: "agricultural-holding",
+          name: "agricultural-holding",
+          errorMessage: errors['agricultural-holding'] and {
+            text: errors['agricultural-holding'].msg
+          },
+          hint: {
+            text: 'An agricultural holding is land that has an agricultural tenant.'
+          },
+          fieldset: {
+            legend: {
+              text: "Is the appeal site part of an agricultural holding?",
+              isPageHeading: true,
+              classes: "govuk-fieldset__legend--l"
+            }
+          },
+          items: [
+            {
+              value: "yes",
+              text: "Yes",
+              attributes: { "data-cy": "answer-yes" },
+              checked: isAgriculturalHolding == true
+            },
+            {
+              value: "no",
+              text: "No",
+              attributes: { "data-cy": "answer-no" },
+              checked: isAgriculturalHolding == false
+            }
+          ]
+        }) }}
+        {{ govukButton({
+          text: "Continue",
+          type: "submit",
+          attributes: { "data-cy":"button-save-and-continue"}
+        }) }}
+      </form>
+    </div>
+  </div>
+{% endblock %}


### PR DESCRIPTION
## Ticket Number
https://pins-ds.atlassian.net/browse/AS-4231

## Description of change
Add Full Appeal Agricultural Holding page

![Screenshot 2022-01-26 at 09-56-16 Is the appeal site part of an agricultural holding - Appeal a planning decision - GOV UK](https://user-images.githubusercontent.com/6839214/151142018-6a307317-d92f-4273-bbda-7033d942ed6d.png)

## Checklist
<!-- Put an `x` in all the boxes that apply: -->
- [ ] Requires infrastructure changes
- [ ] If adding or remove environment variables (e.g. in `docker-compose.yaml`) then I have updated the appropriate Helm chart
- [ ] I have updated the documentation accordingly
- [ ] My commit history in this PR is linear
- [ ] New features have tests
- [ ] Breaking change (team conversation required)

## Important

Please do not merge from `master` (please only [rebase](https://github.com/foundry4/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
