### PR TITLE
feat(as-4306): add full appeal visible from road page

### DIFF
--- a/packages/appeals-service-api/__tests__/integration/appeals.test.js
+++ b/packages/appeals-service-api/__tests__/integration/appeals.test.js
@@ -25,6 +25,8 @@ async function createAppeal() {
   delete appeal.sectionStates.appealSiteSection.isAgriculturalHolding;
   delete appeal.sectionStates.appealSiteSection.isAgriculturalHoldingTenant;
   delete appeal.sectionStates.appealSiteSection.areOtherTenants;
+  delete appeal.sectionStates.appealSiteSection.isVisibleFromRoad;
+  delete appeal.sectionStates.appealSiteSection.visibleFromRoadDetails;
 
   await mongodb.get().collection('appeals').insertOne({ _id: appeal.id, uuid: appeal.id, appeal });
   return appeal;

--- a/packages/appeals-service-api/__tests__/unit/controllers/appeals.test.js
+++ b/packages/appeals-service-api/__tests__/unit/controllers/appeals.test.js
@@ -26,6 +26,8 @@ async function addInDatabase() {
   delete appeal.sectionStates.appealSiteSection.isAgriculturalHolding;
   delete appeal.sectionStates.appealSiteSection.isAgriculturalHoldingTenant;
   delete appeal.sectionStates.appealSiteSection.areOtherTenants;
+  delete appeal.sectionStates.appealSiteSection.isVisibleFromRoad;
+  delete appeal.sectionStates.appealSiteSection.visibleFromRoadDetails;
 
   await mongodb.get().collection('appeals').insertOne({ _id: appeal.id, uuid: appeal.id, appeal });
   return appeal;

--- a/packages/appeals-service-api/src/models/appeal.js
+++ b/packages/appeals-service-api/src/models/appeal.js
@@ -82,6 +82,8 @@ exports.appealDocument = {
     isAgriculturalHolding: null,
     isAgriculturalHoldingTenant: null,
     areOtherTenants: null,
+    isVisibleFromRoad: null,
+    visibleFromRoadDetails: null,
   },
   appealSubmission: {
     appealPDFStatement: {
@@ -142,6 +144,8 @@ exports.appealDocument = {
       isAgriculturalHolding: 'NOT STARTED',
       isAgriculturalHoldingTenant: 'NOT STARTED',
       areOtherTenants: 'NOT STARTED',
+      isVisibleFromRoad: 'NOT STARTED',
+      visibleFromRoadDetails: 'NOT STARTED',
     },
     contactDetailsSection: 'NOT STARTED',
     aboutAppealSiteSection: 'NOT STARTED',

--- a/packages/business-rules/src/lib/pins-yup.js
+++ b/packages/business-rules/src/lib/pins-yup.js
@@ -3,5 +3,6 @@ const { appeal } = require('../validators');
 
 yup.addMethod(yup.date, 'isInThePast', appeal.decisionDate.isInThePast);
 yup.addMethod(yup.date, 'isWithinDeadlinePeriod', appeal.decisionDate.isWithinDeadlinePeriod);
+yup.addMethod(yup.mixed, 'conditionalText', appeal.conditionalText);
 
 module.exports = yup;

--- a/packages/business-rules/src/lib/pins-yup.test.js
+++ b/packages/business-rules/src/lib/pins-yup.test.js
@@ -8,4 +8,8 @@ describe('pins-yup', () => {
   it('should have a pinsYup.date().isWithinDeadlinePeriod method defined', () => {
     expect(typeof pinsYup.date().isWithinDeadlinePeriod).toEqual('function');
   });
+
+  it('should have a pinsYup.mixed().conditionalText method defined', () => {
+    expect(typeof pinsYup.mixed().conditionalText).toEqual('function');
+  });
 });

--- a/packages/business-rules/src/schemas/full-appeal/insert.js
+++ b/packages/business-rules/src/schemas/full-appeal/insert.js
@@ -127,6 +127,16 @@ const insert = pinsYup
         isAgriculturalHolding: pinsYup.bool().nullable(),
         isAgriculturalHoldingTenant: pinsYup.bool().nullable(),
         areOtherTenants: pinsYup.bool().nullable(),
+        isVisibleFromRoad: pinsYup.bool().nullable(),
+        visibleFromRoadDetails: pinsYup.lazy((visibleFromRoadDetails) => {
+          return pinsYup.mixed().conditionalText({
+            fieldValue: visibleFromRoadDetails,
+            fieldName: 'visibleFromRoadDetails',
+            targetFieldName: 'isVisibleFromRoad',
+            emptyError: 'Tell us how visibility is restricted',
+            tooLongError: 'How visibility is restricted must be $maxLength characters or less',
+          });
+        }),
       })
       .noUnknown(true),
     planningApplicationDocumentsSection: pinsYup

--- a/packages/business-rules/src/schemas/full-appeal/insert.test.js
+++ b/packages/business-rules/src/schemas/full-appeal/insert.test.js
@@ -843,6 +843,58 @@ describe('schemas/full-appeal/insert', () => {
       });
     });
 
+    describe('appealSiteSection.isVisibleFromRoad', () => {
+      it('should throw an error when not given a boolean', async () => {
+        appeal.appealSiteSection.isVisibleFromRoad = 'false ';
+
+        await expect(() => insert.validate(appeal, config)).rejects.toThrow(
+          'appealSiteSection.isVisibleFromRoad must be a `boolean` type, but the final value was: `"false "` (cast from the value `false`).',
+        );
+      });
+
+      it('should not throw an error when given a null value', async () => {
+        appeal.appealSiteSection.isVisibleFromRoad = null;
+
+        const result = await insert.validate(appeal, config);
+        expect(result).toEqual(appeal);
+      });
+
+      it('should not throw an error when not given a value', async () => {
+        delete appeal.appealSiteSection.isVisibleFromRoad;
+
+        const result = await insert.validate(appeal, config);
+        expect(result).toEqual(appeal);
+      });
+    });
+
+    describe('appealSiteSection.visibleFromRoadDetails', () => {
+      it('should throw an error when not given a value and appealSiteSection.isVisibleFromRoad is false', async () => {
+        appeal.appealSiteSection.isVisibleFromRoad = false;
+        appeal.appealSiteSection.visibleFromRoadDetails = null;
+
+        await expect(() => insert.validate(appeal, config)).rejects.toThrow(
+          'Tell us how visibility is restricted',
+        );
+      });
+
+      it('should throw an error when given a value longer than 255 chars and appealSiteSection.isVisibleFromRoad is false', async () => {
+        appeal.appealSiteSection.isVisibleFromRoad = false;
+        appeal.appealSiteSection.visibleFromRoadDetails = 'a'.repeat(256);
+
+        await expect(() => insert.validate(appeal, config)).rejects.toThrow(
+          'How visibility is restricted must be 255 characters or less',
+        );
+      });
+
+      it('should not throw an error when given a null value and appealSiteSection.isVisibleFromRoad is true', async () => {
+        appeal.appealSiteSection.isVisibleFromRoad = true;
+        appeal.appealSiteSection.visibleFromRoadDetails = null;
+
+        const result = await insert.validate(appeal, config);
+        expect(result).toEqual(appeal);
+      });
+    });
+
     describe('aboutYouSection', () => {
       it('should remove unknown fields', async () => {
         appeal2.aboutYouSection.unknownField = 'unknown field';

--- a/packages/business-rules/src/schemas/full-appeal/update.js
+++ b/packages/business-rules/src/schemas/full-appeal/update.js
@@ -102,6 +102,16 @@ const update = pinsYup
         isAgriculturalHolding: pinsYup.bool().required(),
         isAgriculturalHoldingTenant: pinsYup.bool().required(),
         areOtherTenants: pinsYup.bool().required(),
+        isVisibleFromRoad: pinsYup.bool().required(),
+        visibleFromRoadDetails: pinsYup.lazy((visibleFromRoadDetails) => {
+          return pinsYup.mixed().conditionalText({
+            fieldValue: visibleFromRoadDetails,
+            fieldName: 'visibleFromRoadDetails',
+            targetFieldName: 'isVisibleFromRoad',
+            emptyError: 'Tell us how visibility is restricted',
+            tooLongError: 'How visibility is restricted must be $maxLength characters or less',
+          });
+        }),
       })
       .noUnknown(true),
     planningApplicationDocumentsSection: pinsYup

--- a/packages/business-rules/src/schemas/full-appeal/update.test.js
+++ b/packages/business-rules/src/schemas/full-appeal/update.test.js
@@ -819,6 +819,52 @@ describe('schemas/full-appeal/update', () => {
           );
         });
       });
+
+      describe('appealSiteSection.isVisibleFromRoad', () => {
+        it('should throw an error when not given a boolean', async () => {
+          appeal.appealSiteSection.isVisibleFromRoad = 'false ';
+
+          await expect(() => update.validate(appeal, config)).rejects.toThrow(
+            'appealSiteSection.isVisibleFromRoad must be a `boolean` type, but the final value was: `"false "` (cast from the value `false`).',
+          );
+        });
+
+        it('should throw an error when not given a value', async () => {
+          delete appeal.appealSiteSection.isVisibleFromRoad;
+
+          await expect(() => update.validate(appeal, config)).rejects.toThrow(
+            'appealSiteSection.isVisibleFromRoad is a required field',
+          );
+        });
+      });
+
+      describe('appealSiteSection.visibleFromRoadDetails', () => {
+        it('should throw an error when not given a value and appealSiteSection.isVisibleFromRoad is false', async () => {
+          appeal.appealSiteSection.isVisibleFromRoad = false;
+          appeal.appealSiteSection.visibleFromRoadDetails = null;
+
+          await expect(() => update.validate(appeal, config)).rejects.toThrow(
+            'Tell us how visibility is restricted',
+          );
+        });
+
+        it('should throw an error when given a value longer than 255 chars and appealSiteSection.isVisibleFromRoad is false', async () => {
+          appeal.appealSiteSection.isVisibleFromRoad = false;
+          appeal.appealSiteSection.visibleFromRoadDetails = 'a'.repeat(256);
+
+          await expect(() => update.validate(appeal, config)).rejects.toThrow(
+            'How visibility is restricted must be 255 characters or less',
+          );
+        });
+
+        it('should not throw an error when given a null value and appealSiteSection.isVisibleFromRoad is true', async () => {
+          appeal.appealSiteSection.isVisibleFromRoad = true;
+          appeal.appealSiteSection.visibleFromRoadDetails = null;
+
+          const result = await update.validate(appeal, config);
+          expect(result).toEqual(appeal);
+        });
+      });
     });
 
     describe('aboutYouSection', () => {

--- a/packages/business-rules/src/validators/appeal/index.js
+++ b/packages/business-rules/src/validators/appeal/index.js
@@ -1,5 +1,7 @@
 const decisionDate = require('./decision-date');
+const conditionalText = require('../common/conditional-text');
 
 module.exports = {
   decisionDate,
+  conditionalText,
 };

--- a/packages/business-rules/src/validators/appeal/index.test.js
+++ b/packages/business-rules/src/validators/appeal/index.test.js
@@ -1,10 +1,12 @@
 const index = require('./index');
 const decisionDate = require('./decision-date');
+const conditionalText = require('../common/conditional-text');
 
 describe('validators/appeal/index', () => {
   it('should export the expected shape', () => {
     expect(index).toEqual({
       decisionDate,
+      conditionalText,
     });
   });
 });

--- a/packages/business-rules/src/validators/common/conditional-text.js
+++ b/packages/business-rules/src/validators/common/conditional-text.js
@@ -1,0 +1,26 @@
+const createYupError = require('../../utils/create-yup-error');
+
+function conditionalTextField({
+  fieldValue,
+  fieldName,
+  targetFieldName,
+  emptyError,
+  tooLongError,
+  targetFieldValue = false,
+  maxLength = 255,
+}) {
+  return this.test(fieldName, null, function test() {
+    if (this.options.parent[targetFieldName] === targetFieldValue) {
+      if (!fieldValue) {
+        return createYupError.call(this, emptyError);
+      }
+
+      if (fieldValue.length > maxLength) {
+        return createYupError.call(this, tooLongError.replace('$maxLength', maxLength));
+      }
+    }
+    return true;
+  });
+}
+
+module.exports = conditionalTextField;

--- a/packages/business-rules/src/validators/index.js
+++ b/packages/business-rules/src/validators/index.js
@@ -1,4 +1,5 @@
 const { isInThePast, isWithinDeadlinePeriod } = require('./appeal/decision-date');
+const conditionalText = require('./common/conditional-text');
 
 module.exports = {
   appeal: {
@@ -6,5 +7,6 @@ module.exports = {
       isInThePast,
       isWithinDeadlinePeriod,
     },
+    conditionalText,
   },
 };

--- a/packages/business-rules/src/validators/index.test.js
+++ b/packages/business-rules/src/validators/index.test.js
@@ -1,5 +1,6 @@
 const index = require('./index');
 const { isInThePast, isWithinDeadlinePeriod } = require('./appeal/decision-date');
+const conditionalText = require('./common/conditional-text');
 
 describe('validators/index', () => {
   it(`should export the expected data shape`, () => {
@@ -9,6 +10,7 @@ describe('validators/index', () => {
           isInThePast,
           isWithinDeadlinePeriod,
         },
+        conditionalText,
       },
     });
   });

--- a/packages/business-rules/test/data/full-appeal.js
+++ b/packages/business-rules/test/data/full-appeal.js
@@ -49,6 +49,8 @@ const appeal = {
     isAgriculturalHolding: true,
     isAgriculturalHoldingTenant: true,
     areOtherTenants: true,
+    isVisibleFromRoad: false,
+    visibleFromRoadDetails: 'Access via the road at the side of the property',
   },
   planningApplicationDocumentsSection: {
     applicationNumber: 'ABCDE12345',

--- a/packages/forms-web-app/__tests__/unit/controllers/full-appeal/submit-appeal/visible-from-road.test.js
+++ b/packages/forms-web-app/__tests__/unit/controllers/full-appeal/submit-appeal/visible-from-road.test.js
@@ -1,0 +1,292 @@
+const {
+  getVisibleFromRoad,
+  postVisibleFromRoad,
+} = require('../../../../../src/controllers/full-appeal/submit-appeal/visible-from-road');
+const { createOrUpdateAppeal } = require('../../../../../src/lib/appeals-api-wrapper');
+const { getTaskStatus } = require('../../../../../src/services/task.service');
+const { APPEAL_DOCUMENT } = require('../../../../../src/lib/empty-appeal');
+const { mockReq, mockRes } = require('../../../mocks');
+const {
+  VIEW: {
+    FULL_APPEAL: { HEALTH_SAFETY_ISSUES, VISIBLE_FROM_ROAD },
+  },
+} = require('../../../../../src/lib/full-appeal/views');
+
+jest.mock('../../../../../src/lib/appeals-api-wrapper');
+jest.mock('../../../../../src/services/task.service');
+
+describe('controllers/full-appeal/submit-appeal/visible-from-road', () => {
+  let req;
+  let res;
+  let appeal;
+
+  const sectionName = 'appealSiteSection';
+  const taskName = 'isVisibleFromRoad';
+  const appealId = 'da368e66-de7b-44c4-a403-36e5bf5b000b';
+  const errors = { 'visible-from-road': 'Select an option' };
+  const errorSummary = [{ text: 'There was an error', href: '#' }];
+
+  beforeEach(() => {
+    appeal = {
+      ...APPEAL_DOCUMENT.empty,
+      id: appealId,
+      appealSiteSection: {
+        isVisibleFromRoad: true,
+        visibleFromRoadDetails: null,
+      },
+    };
+    req = {
+      ...mockReq(),
+      body: {},
+      session: {
+        appeal,
+      },
+    };
+    res = mockRes();
+
+    jest.resetAllMocks();
+  });
+
+  describe('getVisibleFromRoad', () => {
+    it('should call the correct template', () => {
+      getVisibleFromRoad(req, res);
+
+      expect(res.render).toHaveBeenCalledTimes(1);
+      expect(res.render).toHaveBeenCalledWith(VISIBLE_FROM_ROAD, {
+        isVisibleFromRoad: true,
+        visibleFromRoadDetails: null,
+      });
+    });
+
+    it('should call the correct template when appeal.appealSiteSection is not defined', () => {
+      delete appeal.appealSiteSection;
+
+      getVisibleFromRoad(req, res);
+
+      expect(res.render).toHaveBeenCalledTimes(1);
+      expect(res.render).toHaveBeenCalledWith(VISIBLE_FROM_ROAD, {
+        isVisibleFromRoad: undefined,
+        visibleFromRoadDetails: undefined,
+      });
+    });
+  });
+
+  describe('postVisibleFromRoad', () => {
+    it('should re-render the template with errors if submission validation fails', async () => {
+      req = {
+        ...req,
+        body: {
+          'visible-from-road': false,
+          'visible-from-road-details': null,
+          errors,
+          errorSummary,
+        },
+      };
+
+      await postVisibleFromRoad(req, res);
+
+      expect(res.redirect).not.toHaveBeenCalled();
+      expect(res.render).toHaveBeenCalledTimes(1);
+      expect(res.render).toHaveBeenCalledWith(VISIBLE_FROM_ROAD, {
+        isVisibleFromRoad: false,
+        visibleFromRoadDetails: null,
+        errors,
+        errorSummary,
+      });
+    });
+
+    it('should re-render the template with errors if an error is thrown', async () => {
+      const error = new Error('Internal Server Error');
+
+      req = {
+        ...req,
+        body: {
+          'visible-from-road': 'yes',
+          'visible-from-road-details': null,
+        },
+      };
+
+      createOrUpdateAppeal.mockImplementation(() => {
+        throw error;
+      });
+
+      await postVisibleFromRoad(req, res);
+
+      expect(res.redirect).not.toHaveBeenCalled();
+      expect(res.render).toHaveBeenCalledTimes(1);
+      expect(res.render).toHaveBeenCalledWith(VISIBLE_FROM_ROAD, {
+        isVisibleFromRoad: true,
+        visibleFromRoadDetails: null,
+        errors: {},
+        errorSummary: [{ text: error.toString(), href: '#' }],
+      });
+    });
+
+    it('should redirect to the correct page if `yes` has been selected', async () => {
+      const submittedAppeal = {
+        ...appeal,
+        state: 'SUBMITTED',
+      };
+
+      createOrUpdateAppeal.mockReturnValue(submittedAppeal);
+
+      req = {
+        ...req,
+        body: {
+          'visible-from-road': 'yes',
+          'visible-from-road-details': null,
+        },
+      };
+
+      await postVisibleFromRoad(req, res);
+
+      expect(getTaskStatus).toHaveBeenCalledWith(appeal, sectionName, taskName);
+      expect(createOrUpdateAppeal).toHaveBeenCalledWith(appeal);
+      expect(res.redirect).toHaveBeenCalledWith(`/${HEALTH_SAFETY_ISSUES}`);
+      expect(req.session.appeal).toEqual(submittedAppeal);
+    });
+
+    it('should redirect to the correct page if `no` has been selected', async () => {
+      appeal.appealSiteSection = {
+        isVisibleFromRoad: true,
+        visibleFromRoadDetails: null,
+      };
+
+      const submittedAppeal = {
+        ...appeal,
+        state: 'SUBMITTED',
+      };
+
+      createOrUpdateAppeal.mockReturnValue(submittedAppeal);
+
+      req = {
+        ...req,
+        body: {
+          'visible-from-road': 'no',
+          'visible-from-road-details': 'Access via the road at the side of the property',
+        },
+      };
+
+      await postVisibleFromRoad(req, res);
+
+      expect(getTaskStatus).toHaveBeenCalledWith(appeal, sectionName, taskName);
+      expect(createOrUpdateAppeal).toHaveBeenCalledWith(appeal);
+      expect(res.redirect).toHaveBeenCalledWith(`/${HEALTH_SAFETY_ISSUES}`);
+      expect(req.session.appeal).toEqual(submittedAppeal);
+    });
+
+    it('should redirect to the correct page if `yes` has been selected and appeal.appealSiteSection is not defined', async () => {
+      const submittedAppeal = {
+        ...appeal,
+        state: 'SUBMITTED',
+      };
+
+      delete appeal.appealSiteSection;
+
+      createOrUpdateAppeal.mockReturnValue(submittedAppeal);
+
+      req = {
+        ...req,
+        body: {
+          'visible-from-road': 'yes',
+          'visible-from-road-details': null,
+        },
+      };
+
+      await postVisibleFromRoad(req, res);
+
+      expect(getTaskStatus).toHaveBeenCalledWith(appeal, sectionName, taskName);
+      expect(createOrUpdateAppeal).toHaveBeenCalledWith(appeal);
+      expect(res.redirect).toHaveBeenCalledWith(`/${HEALTH_SAFETY_ISSUES}`);
+      expect(req.session.appeal).toEqual(submittedAppeal);
+    });
+
+    it('should redirect to the correct page if `no` has been selected and appeal.appealSiteSection is not defined', async () => {
+      appeal.appealSiteSection = {
+        isVisibleFromRoad: true,
+        visibleFromRoadDetails: null,
+      };
+
+      const submittedAppeal = {
+        ...appeal,
+        state: 'SUBMITTED',
+      };
+
+      delete appeal.appealSiteSection;
+
+      createOrUpdateAppeal.mockReturnValue(submittedAppeal);
+
+      req = {
+        ...req,
+        body: {
+          'visible-from-road': 'no',
+          'visible-from-road-details': 'Access via the road at the side of the property',
+        },
+      };
+
+      await postVisibleFromRoad(req, res);
+
+      expect(getTaskStatus).toHaveBeenCalledWith(appeal, sectionName, taskName);
+      expect(createOrUpdateAppeal).toHaveBeenCalledWith(appeal);
+      expect(res.redirect).toHaveBeenCalledWith(`/${HEALTH_SAFETY_ISSUES}`);
+      expect(req.session.appeal).toEqual(submittedAppeal);
+    });
+
+    it('should redirect to the correct page if `yes` has been selected and appeal.sectionStates.appealSiteSection is not defined', async () => {
+      const submittedAppeal = {
+        ...appeal,
+        state: 'SUBMITTED',
+      };
+
+      delete appeal.sectionStates.appealSiteSection;
+
+      createOrUpdateAppeal.mockReturnValue(submittedAppeal);
+
+      req = {
+        ...req,
+        body: {
+          'visible-from-road': 'yes',
+          'visible-from-road-details': null,
+        },
+      };
+
+      await postVisibleFromRoad(req, res);
+
+      expect(getTaskStatus).toHaveBeenCalledWith(appeal, sectionName, taskName);
+      expect(createOrUpdateAppeal).toHaveBeenCalledWith(appeal);
+      expect(res.redirect).toHaveBeenCalledWith(`/${HEALTH_SAFETY_ISSUES}`);
+      expect(req.session.appeal).toEqual(submittedAppeal);
+    });
+
+    it('should redirect to the correct page if `no` has been selected and appeal.sectionStates.appealSiteSection is not defined', async () => {
+      appeal.appealSiteSection = {
+        isVisibleFromRoad: true,
+        visibleFromRoadDetails: null,
+      };
+
+      const submittedAppeal = {
+        ...appeal,
+        state: 'SUBMITTED',
+      };
+
+      delete appeal.sectionStates.appealSiteSection;
+
+      createOrUpdateAppeal.mockReturnValue(submittedAppeal);
+
+      req = {
+        ...req,
+        body: {
+          'visible-from-road': 'no',
+          'visible-from-road-details': 'Access via the road at the side of the property',
+        },
+      };
+
+      await postVisibleFromRoad(req, res);
+
+      expect(getTaskStatus).toHaveBeenCalledWith(appeal, sectionName, taskName);
+      expect(createOrUpdateAppeal).toHaveBeenCalledWith(appeal);
+      expect(res.redirect).toHaveBeenCalledWith(`/${HEALTH_SAFETY_ISSUES}`);
+      expect(req.session.appeal).toEqual(submittedAppeal);
+    });
+  });
+});

--- a/packages/forms-web-app/__tests__/unit/lib/full-appeal/views.test.js
+++ b/packages/forms-web-app/__tests__/unit/lib/full-appeal/views.test.js
@@ -31,6 +31,7 @@ describe('/lib/full-appeal/views', () => {
         DECLARATION: 'full-appeal/submit-appeal/declaration',
         APPEAL_SUBMITTED: 'full-appeal/submit-appeal/appeal-submitted',
         DECLARATION_INFORMATION: 'full-appeal/submit-appeal/declaration-information',
+        HEALTH_SAFETY_ISSUES: 'full-appeal/submit-appeal/health-safety-issues',
       },
     });
   });

--- a/packages/forms-web-app/__tests__/unit/routes/full-appeal/submit-appeal/index.test.js
+++ b/packages/forms-web-app/__tests__/unit/routes/full-appeal/submit-appeal/index.test.js
@@ -20,6 +20,7 @@ const otherTenantsRouter = require('../../../../../src/routes/full-appeal/submit
 const declarationRouter = require('../../../../../src/routes/full-appeal/submit-appeal/declaration');
 const declarationInformationRouter = require('../../../../../src/routes/full-appeal/submit-appeal/declaration-information');
 const appealSubmittedRouter = require('../../../../../src/routes/full-appeal/submit-appeal/appeal-submitted');
+const visibleFromRoadRouter = require('../../../../../src/routes/full-appeal/submit-appeal/visible-from-road');
 
 describe('routes/full-appeal/submit-appeal/index', () => {
   beforeEach(() => {
@@ -28,7 +29,7 @@ describe('routes/full-appeal/submit-appeal/index', () => {
   });
 
   it('should define the expected routes', () => {
-    expect(use.mock.calls.length).toBe(21);
+    expect(use.mock.calls.length).toBe(22);
     expect(use).toHaveBeenCalledWith(taskListRouter);
     expect(use).toHaveBeenCalledWith(checkAnswersRouter);
     expect(use).toHaveBeenCalledWith(contactDetailsRouter);
@@ -50,5 +51,6 @@ describe('routes/full-appeal/submit-appeal/index', () => {
     expect(use).toHaveBeenCalledWith(declarationRouter);
     expect(use).toHaveBeenCalledWith(declarationInformationRouter);
     expect(use).toHaveBeenCalledWith(appealSubmittedRouter);
+    expect(use).toHaveBeenCalledWith(visibleFromRoadRouter);
   });
 });

--- a/packages/forms-web-app/__tests__/unit/routes/full-appeal/submit-appeal/visible-from-road.test.js
+++ b/packages/forms-web-app/__tests__/unit/routes/full-appeal/submit-appeal/visible-from-road.test.js
@@ -1,0 +1,49 @@
+const { get, post } = require('../../router-mock');
+const {
+  getVisibleFromRoad,
+  postVisibleFromRoad,
+} = require('../../../../../src/controllers/full-appeal/submit-appeal/visible-from-road');
+const fetchExistingAppealMiddleware = require('../../../../../src/middleware/fetch-existing-appeal');
+const {
+  validationErrorHandler,
+} = require('../../../../../src/validators/validation-error-handler');
+const { rules: optionsValidationRules } = require('../../../../../src/validators/common/options');
+const {
+  rules: conditionalTextValidationRules,
+} = require('../../../../../src/validators/common/conditional-text');
+
+jest.mock('../../../../../src/middleware/fetch-existing-appeal');
+jest.mock('../../../../../src/validators/common/options');
+jest.mock('../../../../../src/validators/common/conditional-text');
+
+describe('routes/full-appeal/submit-appeal/visible-from-road', () => {
+  beforeEach(() => {
+    // eslint-disable-next-line global-require
+    require('../../../../../src/routes/full-appeal/submit-appeal/visible-from-road');
+  });
+
+  it('should define the expected routes', () => {
+    expect(get).toHaveBeenCalledWith(
+      '/submit-appeal/visible-from-road',
+      [fetchExistingAppealMiddleware],
+      getVisibleFromRoad
+    );
+    expect(post).toHaveBeenCalledWith(
+      '/submit-appeal/visible-from-road',
+      optionsValidationRules(),
+      conditionalTextValidationRules(),
+      validationErrorHandler,
+      postVisibleFromRoad
+    );
+    expect(optionsValidationRules).toHaveBeenCalledWith({
+      fieldName: 'visible-from-road',
+      emptyError: 'Select yes if the site is visible from a public road',
+    });
+    expect(conditionalTextValidationRules).toHaveBeenCalledWith({
+      fieldName: 'visible-from-road-details',
+      targetFieldName: 'visible-from-road',
+      emptyError: 'Tell us how visibility is restricted',
+      tooLongError: 'How visibility is restricted must be $maxLength characters or less',
+    });
+  });
+});

--- a/packages/forms-web-app/__tests__/unit/validators/common/conditional-text.test.js
+++ b/packages/forms-web-app/__tests__/unit/validators/common/conditional-text.test.js
@@ -1,0 +1,175 @@
+const { validationResult } = require('express-validator');
+const { rules } = require('../../../../src/validators/common/conditional-text');
+const { testExpressValidatorMiddleware } = require('../validation-middleware-helper');
+
+describe('validators/common/conditional-text', () => {
+  const res = jest.fn();
+  const fieldName = 'visible-from-road-details';
+  const targetFieldName = 'visible-from-road';
+  const emptyError = 'Tell us how visibility is restricted';
+  const tooLongError = 'How visibility is restricted must be $maxLength characters or less';
+
+  it('should not return an error if the condition does not match', async () => {
+    const req = {
+      body: {
+        'visible-from-road': 'yes',
+        'visible-from-road-details': '',
+      },
+    };
+
+    await testExpressValidatorMiddleware(
+      req,
+      res,
+      rules({
+        fieldName,
+        targetFieldName,
+        emptyError,
+        tooLongError,
+      })
+    );
+
+    const result = validationResult(req);
+
+    expect(result.errors).toHaveLength(0);
+  });
+
+  it('should not return an error if the condition matches with the default conditional value and a valid value is given', async () => {
+    const req = {
+      body: {
+        'visible-from-road': 'no',
+        'visible-from-road-details': 'a'.repeat(100),
+      },
+    };
+
+    await testExpressValidatorMiddleware(
+      req,
+      res,
+      rules({
+        fieldName,
+        targetFieldName,
+        emptyError,
+        tooLongError,
+      })
+    );
+
+    const result = validationResult(req);
+
+    expect(result.errors).toHaveLength(0);
+  });
+
+  it('should not return an error if the condition matches with a custom conditional value and a valid value is given', async () => {
+    const req = {
+      body: {
+        'visible-from-road': 'yes',
+        'visible-from-road-details': 'a'.repeat(100),
+      },
+    };
+
+    await testExpressValidatorMiddleware(
+      req,
+      res,
+      rules({
+        fieldName,
+        targetFieldName,
+        targetFieldValue: 'yes',
+        emptyError,
+        tooLongError,
+      })
+    );
+
+    const result = validationResult(req);
+
+    expect(result.errors).toHaveLength(0);
+  });
+
+  it('should return an error if the condition matches and no value is given', async () => {
+    const req = {
+      body: {
+        'visible-from-road': 'no',
+        'visible-from-road-details': '',
+      },
+    };
+
+    await testExpressValidatorMiddleware(
+      req,
+      res,
+      rules({
+        fieldName,
+        targetFieldName,
+        emptyError,
+        tooLongError,
+      })
+    );
+
+    const result = validationResult(req);
+
+    expect(result.errors).toHaveLength(1);
+    expect(result.errors[0].location).toEqual('body');
+    expect(result.errors[0].msg).toEqual(emptyError);
+    expect(result.errors[0].param).toEqual(fieldName);
+    expect(result.errors[0].value).toEqual('');
+  });
+
+  it('should return an error if the condition matches with the default max length and a value longer than the max length is given', async () => {
+    const fieldValue = 'a'.repeat(256);
+    const req = {
+      body: {
+        'visible-from-road': 'no',
+        'visible-from-road-details': fieldValue,
+      },
+    };
+
+    await testExpressValidatorMiddleware(
+      req,
+      res,
+      rules({
+        fieldName,
+        targetFieldName,
+        emptyError,
+        tooLongError,
+      })
+    );
+
+    const result = validationResult(req);
+
+    expect(result.errors).toHaveLength(1);
+    expect(result.errors[0].location).toEqual('body');
+    expect(result.errors[0].msg).toEqual(
+      'How visibility is restricted must be 255 characters or less'
+    );
+    expect(result.errors[0].param).toEqual(fieldName);
+    expect(result.errors[0].value).toEqual(fieldValue);
+  });
+
+  it('should return an error if the condition matches with a custom max length and a value longer than the max length is given', async () => {
+    const fieldValue = 'a'.repeat(101);
+    const req = {
+      body: {
+        'visible-from-road': 'no',
+        'visible-from-road-details': fieldValue,
+      },
+    };
+
+    await testExpressValidatorMiddleware(
+      req,
+      res,
+      rules({
+        fieldName,
+        targetFieldName,
+        emptyError,
+        tooLongError,
+        maxLength: 100,
+      })
+    );
+
+    const result = validationResult(req);
+
+    expect(result.errors).toHaveLength(1);
+    expect(result.errors[0].location).toEqual('body');
+    expect(result.errors[0].msg).toEqual(
+      'How visibility is restricted must be 100 characters or less'
+    );
+    expect(result.errors[0].param).toEqual(fieldName);
+    expect(result.errors[0].value).toEqual(fieldValue);
+  });
+});

--- a/packages/forms-web-app/src/controllers/full-appeal/submit-appeal/visible-from-road.js
+++ b/packages/forms-web-app/src/controllers/full-appeal/submit-appeal/visible-from-road.js
@@ -1,0 +1,77 @@
+const logger = require('../../../lib/logger');
+const { createOrUpdateAppeal } = require('../../../lib/appeals-api-wrapper');
+const {
+  VIEW: {
+    FULL_APPEAL: { HEALTH_SAFETY_ISSUES, VISIBLE_FROM_ROAD },
+  },
+} = require('../../../lib/full-appeal/views');
+const { getTaskStatus } = require('../../../services/task.service');
+
+const sectionName = 'appealSiteSection';
+const isVisibleFromRoadTask = 'isVisibleFromRoad';
+const visibleFromRoadDetailsTask = 'visibleFromRoadDetails';
+
+const getVisibleFromRoad = (req, res) => {
+  const {
+    appeal: { [sectionName]: { isVisibleFromRoad, visibleFromRoadDetails } = {} },
+  } = req.session;
+  res.render(VISIBLE_FROM_ROAD, {
+    isVisibleFromRoad,
+    visibleFromRoadDetails,
+  });
+};
+
+const postVisibleFromRoad = async (req, res) => {
+  const {
+    body,
+    body: { errors = {}, errorSummary = [] },
+    session: { appeal },
+  } = req;
+
+  const isVisibleFromRoad = body['visible-from-road'] && body['visible-from-road'] === 'yes';
+  const visibleFromRoadDetails = body['visible-from-road-details'];
+
+  if (Object.keys(errors).length > 0) {
+    return res.render(VISIBLE_FROM_ROAD, {
+      isVisibleFromRoad,
+      visibleFromRoadDetails,
+      errors,
+      errorSummary,
+    });
+  }
+
+  try {
+    appeal[sectionName] = appeal[sectionName] || {};
+    appeal[sectionName][isVisibleFromRoadTask] = isVisibleFromRoad;
+    appeal[sectionName][visibleFromRoadDetailsTask] = visibleFromRoadDetails;
+    appeal.sectionStates[sectionName] = appeal.sectionStates[sectionName] || {};
+    appeal.sectionStates[sectionName].isVisibleFromRoad = getTaskStatus(
+      appeal,
+      sectionName,
+      isVisibleFromRoadTask
+    );
+    appeal.sectionStates[sectionName].visibleFromRoadDetails = getTaskStatus(
+      appeal,
+      sectionName,
+      visibleFromRoadDetailsTask
+    );
+
+    req.session.appeal = await createOrUpdateAppeal(appeal);
+  } catch (err) {
+    logger.error(err);
+
+    return res.render(VISIBLE_FROM_ROAD, {
+      isVisibleFromRoad,
+      visibleFromRoadDetails,
+      errors,
+      errorSummary: [{ text: err.toString(), href: '#' }],
+    });
+  }
+
+  return res.redirect(`/${HEALTH_SAFETY_ISSUES}`);
+};
+
+module.exports = {
+  getVisibleFromRoad,
+  postVisibleFromRoad,
+};

--- a/packages/forms-web-app/src/lib/full-appeal/views.js
+++ b/packages/forms-web-app/src/lib/full-appeal/views.js
@@ -27,6 +27,7 @@ const VIEW = {
     DECLARATION: 'full-appeal/submit-appeal/declaration',
     APPEAL_SUBMITTED: 'full-appeal/submit-appeal/appeal-submitted',
     DECLARATION_INFORMATION: 'full-appeal/submit-appeal/declaration-information',
+    HEALTH_SAFETY_ISSUES: 'full-appeal/submit-appeal/health-safety-issues',
   },
 };
 

--- a/packages/forms-web-app/src/routes/full-appeal/submit-appeal/index.js
+++ b/packages/forms-web-app/src/routes/full-appeal/submit-appeal/index.js
@@ -20,6 +20,7 @@ const otherTenantsRouter = require('./other-tenants');
 const declarationRouter = require('./declaration');
 const appealSubmittedRouter = require('./appeal-submitted');
 const declarationInformationRouter = require('./declaration-information');
+const visibleFromRoadRouter = require('./visible-from-road');
 
 const router = express.Router();
 
@@ -44,5 +45,6 @@ router.use(otherTenantsRouter);
 router.use(declarationRouter);
 router.use(appealSubmittedRouter);
 router.use(declarationInformationRouter);
+router.use(visibleFromRoadRouter);
 
 module.exports = router;

--- a/packages/forms-web-app/src/routes/full-appeal/submit-appeal/visible-from-road.js
+++ b/packages/forms-web-app/src/routes/full-appeal/submit-appeal/visible-from-road.js
@@ -1,0 +1,32 @@
+const express = require('express');
+const {
+  getVisibleFromRoad,
+  postVisibleFromRoad,
+} = require('../../../controllers/full-appeal/submit-appeal/visible-from-road');
+const fetchExistingAppealMiddleware = require('../../../middleware/fetch-existing-appeal');
+const { validationErrorHandler } = require('../../../validators/validation-error-handler');
+const { rules: optionsValidationRules } = require('../../../validators/common/options');
+const {
+  rules: conditionalTextValidationRules,
+} = require('../../../validators/common/conditional-text');
+
+const router = express.Router();
+
+router.get('/submit-appeal/visible-from-road', [fetchExistingAppealMiddleware], getVisibleFromRoad);
+router.post(
+  '/submit-appeal/visible-from-road',
+  optionsValidationRules({
+    fieldName: 'visible-from-road',
+    emptyError: 'Select yes if the site is visible from a public road',
+  }),
+  conditionalTextValidationRules({
+    fieldName: 'visible-from-road-details',
+    targetFieldName: 'visible-from-road',
+    emptyError: 'Tell us how visibility is restricted',
+    tooLongError: 'How visibility is restricted must be $maxLength characters or less',
+  }),
+  validationErrorHandler,
+  postVisibleFromRoad
+);
+
+module.exports = router;

--- a/packages/forms-web-app/src/services/task.service.js
+++ b/packages/forms-web-app/src/services/task.service.js
@@ -183,6 +183,10 @@ const FULL_APPEAL_SECTIONS = {
       href: `/${FULL_APPEAL.OTHER_TENANTS}`,
       rule: notStartedRule,
     },
+    visibleFromRoad: {
+      href: `/${FULL_APPEAL.VISIBLE_FROM_ROAD}`,
+      rule: notStartedRule,
+    },
   },
   yourAppealSection: {
     appealStatement: {

--- a/packages/forms-web-app/src/validators/common/conditional-text.js
+++ b/packages/forms-web-app/src/validators/common/conditional-text.js
@@ -1,0 +1,22 @@
+const { body } = require('express-validator');
+
+const rules = ({
+  fieldName,
+  targetFieldName,
+  emptyError,
+  tooLongError,
+  targetFieldValue = 'no',
+  maxLength = 255,
+}) => [
+  body(fieldName)
+    .if(body(targetFieldName).matches(targetFieldValue))
+    .notEmpty()
+    .withMessage(emptyError)
+    .bail()
+    .isLength({ min: 1, max: maxLength })
+    .withMessage(tooLongError.replace('$maxLength', maxLength)),
+];
+
+module.exports = {
+  rules,
+};

--- a/packages/forms-web-app/src/views/full-appeal/submit-appeal/visible-from-road.njk
+++ b/packages/forms-web-app/src/views/full-appeal/submit-appeal/visible-from-road.njk
@@ -1,0 +1,87 @@
+{% extends "layouts/main.njk" %}
+
+{% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
+{% from "govuk/components/radios/macro.njk" import govukRadios %}
+{% from "govuk/components/textarea/macro.njk" import govukTextarea %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
+
+{% set title = "Is the site visible from a public road? - Appeal a planning decision - GOV.UK" %}
+{% block pageTitle %}{{ "Error: " + title if errors else title }}{% endblock %}
+
+{% set visibleFromRoadDetailsHtml %}
+  {{ govukTextarea({
+    name: "visible-from-road-details",
+    id: "visible-from-road-details",
+    label: {
+      text: "How is visibility restricted?"
+    },
+    value: visibleFromRoadDetails,
+    errorMessage: errors['visible-from-road-details'] and {
+      text: errors['visible-from-road-details'].msg
+    }
+  }) }}
+{% endset %}
+
+{% block backButton %}
+  {{ govukBackLink({
+    text: 'Back',
+    href: '/full-appeal/submit-appeal/agricultural-holding',
+    attributes: {
+      'data-cy': 'back'
+    }
+  }) }}
+{% endblock %}
+
+{% block content %}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      {% if errorSummary %}
+        {{ govukErrorSummary({
+          titleText: "There is a problem",
+          errorList: errorSummary,
+          attributes: {"data-cy": "error-wrapper"}
+        }) }}
+      {% endif %}
+      <form action="" method="post" novalidate>
+        <span class="govuk-caption-l">Tell us about the appeal site</span>
+        {{ govukRadios({
+          classes: "govuk-radios",
+          idPrefix: "visible-from-road",
+          name: "visible-from-road",
+          errorMessage: errors['visible-from-road'] and {
+            text: errors['visible-from-road'].msg
+          },
+          fieldset: {
+            legend: {
+              text: "Is the site visible from a public road?",
+              isPageHeading: true,
+              classes: "govuk-fieldset__legend--l"
+            }
+          },
+          items: [
+            {
+              value: "yes",
+              text: "Yes",
+              attributes: { "data-cy": "answer-yes" },
+              checked: isVisibleFromRoad == true
+            },
+            {
+              value: "no",
+              text: "No",
+              attributes: { "data-cy": "answer-no" },
+              checked: isVisibleFromRoad == false,
+              conditional: {
+                html: visibleFromRoadDetailsHtml
+              }
+            }
+          ]
+        }) }}
+        {{ govukButton({
+          text: "Continue",
+          type: "submit",
+          attributes: { "data-cy":"button-save-and-continue"}
+        }) }}
+      </form>
+    </div>
+  </div>
+{% endblock %}


### PR DESCRIPTION
## Ticket Number
https://pins-ds.atlassian.net/browse/AS-4306

## Description of change
Add Full Appeal Visible From Road page.

Also added a common Conditional Text validator for both the UI and JSON Schema that can be used to validate that any text field is required and has a max length based on the selection of another field.

![Screenshot 2022-01-28 at 09-05-54 Is the site visible from a public road - Appeal a planning decision - GOV UK](https://user-images.githubusercontent.com/6839214/151518416-ca656be3-74cb-403c-908b-c98dcfb913e3.png)

## Checklist
<!-- Put an `x` in all the boxes that apply: -->
- [ ] Requires infrastructure changes
- [ ] If adding or remove environment variables (e.g. in `docker-compose.yaml`) then I have updated the appropriate Helm chart
- [ ] I have updated the documentation accordingly
- [ ] My commit history in this PR is linear
- [ ] New features have tests
- [ ] Breaking change (team conversation required)

## Important

Please do not merge from `master` (please only [rebase](https://github.com/foundry4/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
