### PR TITLE
fix(full appeal): appeal.planningApplicationDocumentsSection.applicationNumber is used for lpa email

### DIFF
--- a/packages/appeals-service-api/__tests__/unit/lib/full-appeal/notify.test.js
+++ b/packages/appeals-service-api/__tests__/unit/lib/full-appeal/notify.test.js
@@ -81,6 +81,9 @@ describe('lib/full-appeal/notify', () => {
               postcode: 'rt12 9ya',
             },
           },
+          planningApplicationDocumentsSection: {
+            applicationNumber: '12345',
+          },
           eligibility: {
             applicationDecision: 'refused',
           },
@@ -139,7 +142,7 @@ describe('lib/full-appeal/notify', () => {
         expect(mockSetDestinationEmailAddress).toHaveBeenCalledWith('some@example.com');
         expect(mockSetTemplateVariablesFromObject).toHaveBeenCalledWith({
           'loca planning department': 'a happy value',
-          'planning application number': '123/abc/xyz',
+          'planning application number': '12345',
           'site address': '999 some street\na town\nrt12 9ya',
           refused: 'yes',
           granted: 'no',

--- a/packages/appeals-service-api/src/lib/full-appeal/notify.js
+++ b/packages/appeals-service-api/src/lib/full-appeal/notify.js
@@ -68,7 +68,7 @@ async function sendAppealSubmissionReceivedNotificationEmailToLpa(appeal) {
       .setTemplateVariablesFromObject({
         'loca planning department': lpa.name, // todo: template i kontrol et
         'submission date': format(appeal.submissionDate, 'dd MMMM yyyy'),
-        'planning application number': appeal.requiredDocumentsSection.applicationNumber,
+        'planning application number': appeal.planningApplicationDocumentsSection.applicationNumber,
         'site address': getAddressMultiLine(appeal.appealSiteSection.siteAddress),
         refused:
           applicationDecision === FULL_APPEAL.PLANNING_APPLICATION_STATUS.REFUSED ? 'yes' : 'no',


### PR DESCRIPTION
## Ticket Number
https://pins-ds.atlassian.net/browse/AS-4476

## Description of change
appeal.planningApplicationDocumentsSection.applicationNumber is used for lpa email

## Checklist
<!-- Put an `x` in all the boxes that apply: -->
- [ ] Requires infrastructure changes
- [ ] If adding or remove environment variables (e.g. in `docker-compose.yaml`) then I have updated the appropriate Helm chart
- [ ] I have updated the documentation accordingly
- [ ] My commit history in this PR is linear
- [ ] New features have tests
- [ ] Breaking change (team conversation required)

## Important

Please do not merge from `master` (please only [rebase](https://github.com/foundry4/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
