### PR TITLE
feat(business-rules): stop defaulting the appeal type to householder to help be backwards compatible

### DIFF
--- a/packages/appeals-service-api/src/validators/appeals/appeals.validator.js
+++ b/packages/appeals-service-api/src/validators/appeals/appeals.validator.js
@@ -1,5 +1,4 @@
 const {
-  constants: { APPEAL_ID },
   schemas: { validate },
 } = require('@pins/business-rules');
 const { isAppealSubmitted } = require('../../services/appeal.service');
@@ -8,10 +7,6 @@ const ApiError = require('../../error/apiError');
 
 const appealUpdateValidationRules = async (req, res, next) => {
   try {
-    if (!req.body.appealType) {
-      req.body.appealType = APPEAL_ID.HOUSEHOLDER;
-    }
-
     req.body = await validate.update(req.body);
     logger.debug('Valid input format');
 
@@ -30,10 +25,6 @@ const appealUpdateValidationRules = async (req, res, next) => {
 
 const appealInsertValidationRules = async (req, res, next) => {
   try {
-    if (!req.body.appealType) {
-      req.body.appealType = APPEAL_ID.HOUSEHOLDER;
-    }
-
     req.body = await validate.insert(req.body);
     logger.debug('Valid input format');
 

--- a/packages/business-rules/src/schemas/householder-appeal/update.js
+++ b/packages/business-rules/src/schemas/householder-appeal/update.js
@@ -22,7 +22,12 @@ const update = pinsYup
     }),
     submissionDate: pinsYup.date().transform(parseDateString).nullable(),
     state: pinsYup.string().oneOf(Object.values(APPEAL_STATE)).required(),
-    appealType: pinsYup.string().oneOf(Object.values(APPEAL_ID)).required(),
+    appealType: pinsYup.lazy((appealType) => {
+      if (appealType) {
+        return pinsYup.string().oneOf(Object.values(APPEAL_ID));
+      }
+      return pinsYup.string().nullable();
+    }),
     eligibility: pinsYup
       .object()
       .shape({

--- a/packages/business-rules/src/schemas/householder-appeal/update.test.js
+++ b/packages/business-rules/src/schemas/householder-appeal/update.test.js
@@ -210,12 +210,11 @@ describe('schemas/householder-appeal/update', () => {
         );
       });
 
-      it('should throw an error when not given a value', async () => {
+      it('should not throw an error when not given a value', async () => {
         delete appeal.appealType;
 
-        await expect(() => update.validate(appeal, config)).rejects.toThrow(
-          'appealType is a required field',
-        );
+        const result = await update.validate(appeal, config);
+        expect(result).toEqual(appeal);
       });
     });
 

--- a/packages/business-rules/src/schemas/validate.js
+++ b/packages/business-rules/src/schemas/validate.js
@@ -7,17 +7,15 @@ const BusinessRulesError = require('../lib/business-rules-error');
 const validate = (action, data, config = { abortEarly: false }) => {
   const { appealType } = data;
 
-  if (!isValid(appealType)) {
+  if (appealType && !isValid(appealType)) {
     throw new BusinessRulesError(`${appealType} is not a valid appeal type`);
   }
 
   switch (appealType) {
-    case APPEAL_ID.HOUSEHOLDER:
-      return householderAppeal[action].validate(data, config);
     case APPEAL_ID.PLANNING_SECTION_78:
       return fullAppeal[action].validate(data, config);
     default:
-      throw new BusinessRulesError(`No schema found for appeal type ${appealType}`);
+      return householderAppeal[action].validate(data, config);
   }
 };
 

--- a/packages/business-rules/src/schemas/validate.test.js
+++ b/packages/business-rules/src/schemas/validate.test.js
@@ -37,10 +37,16 @@ describe('schemas/validate', () => {
       expect(() => validate(action, appeal)).toThrow('100 is not a valid appeal type');
     });
 
-    it('should throw an error if no schema is found', () => {
-      appeal.appealType = APPEAL_ID.ENFORCEMENT_NOTICE;
+    it('should default to the householder appeal schema is an appeal type is not given', () => {
+      delete appeal.appealType;
 
-      expect(() => validate(action, appeal)).toThrow('No schema found for appeal type 1000');
+      householderAppeal.insert.validate.mockReturnValue(appeal);
+
+      const result = insert(appeal);
+
+      expect(householderAppeal.insert.validate).toHaveBeenCalledTimes(1);
+      expect(householderAppeal.insert.validate).toHaveBeenCalledWith(appeal, config);
+      expect(result).toEqual(appeal);
     });
 
     it('should throw an error for an appeal type when the data fails validation', () => {


### PR DESCRIPTION
## Ticket Number
https://pins-ds.atlassian.net/browse/AS-

## Description of change
Stop defaulting the appeal type to Householder so we can keep backwards compatible with the old Householder flow

This means that we'll know the user is on the old Householder flow as the appeal type won't be set and this can be used during the flow when the new flow differs from the old flow.

To help this the update schema has been changed from the appeal type being required to validating the appeal type if it's present in the payload otherwise allowing it to be null.

Also the Householder schema is now used as a default for the old Householder flow as the appeal type won't b set to select the schema.

## Checklist
<!-- Put an `x` in all the boxes that apply: -->
- [ ] Requires infrastructure changes
- [ ] If adding or remove environment variables (e.g. in `docker-compose.yaml`) then I have updated the appropriate Helm chart
- [ ] I have updated the documentation accordingly
- [ ] My commit history in this PR is linear
- [ ] New features have tests
- [ ] Breaking change (team conversation required)

## Important

Please do not merge from `master` (please only [rebase](https://github.com/foundry4/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
