### PR TITLE
Feature: Branch tags for docker images

### DIFF
--- a/packages/appeal-reply-service-api/azure-appeal-reply-service-api-build.yml
+++ b/packages/appeal-reply-service-api/azure-appeal-reply-service-api-build.yml
@@ -20,6 +20,8 @@ variables:
   version.MajorMinor: '1.0' # Manually adjust the version number as needed for semantic versioning. Revision is auto-incremented.
   version.Revision: $[counter(variables['version.MajorMinor'], 0)]
   versionNumber: '$(version.MajorMinor).$(version.Revision)'
+  simpleBranchName: $[replace(variables['Build.SourceBranch'], 'refs/heads/', '')]
+  branchTag: $[replace(variables['simpleBranchName'], '/', '_')]
   # -----------------------------------------------------------------------
 
   # Container registry service connection established during pipeline creation
@@ -72,7 +74,7 @@ stages:
                 --build-arg VERSION=$(versionNumber)
               tags: |
                 $(versionNumber)
-                appeal-reply-service-api
+                $(branchTag)
                 latest
           - task: PowerShell@2
             displayName: Copy Test Results
@@ -137,12 +139,23 @@ stages:
                       exit $exitCode
                   }
           - task: Docker@2
-            displayName: Push Image
+            displayName: Push Image with latest tag
+            condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/master'))
             inputs:
               command: push
               repository: $(imageRepository)
               containerRegistry: $(dockerRegistryServiceConnection)
               tags: |
                 $(versionNumber)
-                appeal-reply-service-api
+                $(branchTag)
                 latest
+          - task: Docker@2
+            displayName: Push Image without latest tag
+            condition: and(succeeded(), not(eq(variables['Build.SourceBranch'], 'refs/heads/master')))
+            inputs:
+              command: push
+              repository: $(imageRepository)
+              containerRegistry: $(dockerRegistryServiceConnection)
+              tags: |
+                $(versionNumber)
+                $(branchTag)

--- a/packages/appeals-service-api/azure-appeals-service-api-build.yml
+++ b/packages/appeals-service-api/azure-appeals-service-api-build.yml
@@ -20,7 +20,7 @@ variables:
   version.MajorMinor: '1.0' # Manually adjust the version number as needed for semantic versioning. Revision is auto-incremented.
   version.Revision: $[counter(variables['version.MajorMinor'], 0)]
   versionNumber: '$(version.MajorMinor).$(version.Revision)'
-  simpleBranchName: $[replace(variables['Build.SourceBranchName'], 'refs/heads/', '')]
+  simpleBranchName: $[replace(variables['Build.SourceBranch'], 'refs/heads/', '')]
   branchTag: $[replace(variables['simpleBranchName'], '/', '_')]
   # -----------------------------------------------------------------------
 

--- a/packages/appeals-service-api/azure-appeals-service-api-build.yml
+++ b/packages/appeals-service-api/azure-appeals-service-api-build.yml
@@ -20,6 +20,7 @@ variables:
   version.MajorMinor: '1.0' # Manually adjust the version number as needed for semantic versioning. Revision is auto-incremented.
   version.Revision: $[counter(variables['version.MajorMinor'], 0)]
   versionNumber: '$(version.MajorMinor).$(version.Revision)'
+  branchTag: $[replace(variables['Build.SourceBranch'], '/', '_')]
   # -----------------------------------------------------------------------
 
   # Container registry service connection established during pipeline creation
@@ -69,7 +70,7 @@ stages:
                 --build-arg VERSION=$(versionNumber)
               tags: |
                 $(versionNumber)
-                appeals-service-api
+                $(branchTag)
                 latest
           - task: PowerShell@2
             displayName: Copy Test Results
@@ -134,12 +135,23 @@ stages:
                       exit $exitCode
                   }
           - task: Docker@2
-            displayName: Push Image
+            displayName: Push Image with latest tag
+            condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/master'))
             inputs:
               command: push
               repository: $(imageRepository)
               containerRegistry: $(dockerRegistryServiceConnection)
               tags: |
                 $(versionNumber)
-                appeals-service-api
+                $(branchTag)
                 latest
+          - task: Docker@2
+            displayName: Push Image without latest tag
+            condition: and(succeeded(), not(eq(variables['Build.SourceBranch'], 'refs/heads/master')))
+            inputs:
+              command: push
+              repository: $(imageRepository)
+              containerRegistry: $(dockerRegistryServiceConnection)
+              tags: |
+                $(versionNumber)
+                $(branchTag)

--- a/packages/appeals-service-api/azure-appeals-service-api-build.yml
+++ b/packages/appeals-service-api/azure-appeals-service-api-build.yml
@@ -20,7 +20,7 @@ variables:
   version.MajorMinor: '1.0' # Manually adjust the version number as needed for semantic versioning. Revision is auto-incremented.
   version.Revision: $[counter(variables['version.MajorMinor'], 0)]
   versionNumber: '$(version.MajorMinor).$(version.Revision)'
-  branchTag: $[replace(variables['Build.SourceBranch'], '/', '_')]
+  branchTag: $[replace(replace(variables['Build.SourceBranchName'], 'refs/heads', ''), '/', '_')]
   # -----------------------------------------------------------------------
 
   # Container registry service connection established during pipeline creation

--- a/packages/appeals-service-api/azure-appeals-service-api-build.yml
+++ b/packages/appeals-service-api/azure-appeals-service-api-build.yml
@@ -20,7 +20,8 @@ variables:
   version.MajorMinor: '1.0' # Manually adjust the version number as needed for semantic versioning. Revision is auto-incremented.
   version.Revision: $[counter(variables['version.MajorMinor'], 0)]
   versionNumber: '$(version.MajorMinor).$(version.Revision)'
-  branchTag: $[replace(replace(variables['Build.SourceBranchName'], 'refs/heads', ''), '/', '_')]
+  simpleBranchName: $[replace(variables['Build.SourceBranchName'], 'refs/heads/', '')]
+  branchTag: $[replace(variables['simpleBranchName'], '/', '_')]
   # -----------------------------------------------------------------------
 
   # Container registry service connection established during pipeline creation

--- a/packages/document-service-api/azure-document-service-api-build.yml
+++ b/packages/document-service-api/azure-document-service-api-build.yml
@@ -20,6 +20,8 @@ variables:
   version.MajorMinor: '1.0' # Manually adjust the version number as needed for semantic versioning. Revision is auto-incremented.
   version.Revision: $[counter(variables['version.MajorMinor'], 0)]
   versionNumber: '$(version.MajorMinor).$(version.Revision)'
+  simpleBranchName: $[replace(variables['Build.SourceBranch'], 'refs/heads/', '')]
+  branchTag: $[replace(variables['simpleBranchName'], '/', '_')]
   # -----------------------------------------------------------------------
 
   # Container registry service connection established during pipeline creation
@@ -125,7 +127,7 @@ stages:
                 --build-arg VERSION=$(versionNumber)
               tags: |
                 $(versionNumber)
-                document-service-api
+                $(branchTag)
                 latest
           - task: PowerShell@2
             displayName: Copy Test Results
@@ -190,12 +192,23 @@ stages:
                       exit $exitCode
                   }
           - task: Docker@2
-            displayName: Push Image
+            displayName: Push Image with latest tag
+            condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/master'))
             inputs:
               command: push
               repository: $(imageRepository)
               containerRegistry: $(dockerRegistryServiceConnection)
               tags: |
                 $(versionNumber)
-                document-service-api
+                $(branchTag)
                 latest
+          - task: Docker@2
+            displayName: Push Image without latest tag
+            condition: and(succeeded(), not(eq(variables['Build.SourceBranch'], 'refs/heads/master')))
+            inputs:
+              command: push
+              repository: $(imageRepository)
+              containerRegistry: $(dockerRegistryServiceConnection)
+              tags: |
+                $(versionNumber)
+                $(branchTag)

--- a/packages/forms-web-app/azure-forms-web-app-build.yml
+++ b/packages/forms-web-app/azure-forms-web-app-build.yml
@@ -20,6 +20,8 @@ variables:
   version.MajorMinor: '1.0' # Manually adjust the version number as needed for semantic versioning. Revision is auto-incremented.
   version.Revision: $[counter(variables['version.MajorMinor'], 0)]
   versionNumber: '$(version.MajorMinor).$(version.Revision)'
+  simpleBranchName: $[replace(variables['Build.SourceBranch'], 'refs/heads/', '')]
+  branchTag: $[replace(variables['simpleBranchName'], '/', '_')]
   # -----------------------------------------------------------------------
 
   # Container registry service connection established during pipeline creation
@@ -69,7 +71,7 @@ stages:
                 --build-arg VERSION=$(versionNumber)
               tags: |
                 $(versionNumber)
-                forms-web-app
+                $(branchTag)
                 latest
           - task: PowerShell@2
             displayName: Copy Test Results
@@ -134,12 +136,23 @@ stages:
                       exit $exitCode
                   }
           - task: Docker@2
-            displayName: Push Image
+            displayName: Push Image with latest tag
+            condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/master'))
             inputs:
               command: push
               repository: $(imageRepository)
               containerRegistry: $(dockerRegistryServiceConnection)
               tags: |
                 $(versionNumber)
-                forms-web-app
+                $(branchTag)
                 latest
+          - task: Docker@2
+            displayName: Push Image without latest tag
+            condition: and(succeeded(), not(eq(variables['Build.SourceBranch'], 'refs/heads/master')))
+            inputs:
+              command: push
+              repository: $(imageRepository)
+              containerRegistry: $(dockerRegistryServiceConnection)
+              tags: |
+                $(versionNumber)
+                $(branchTag)

--- a/packages/horizon-functions/azure-functions-pipeline.yml
+++ b/packages/horizon-functions/azure-functions-pipeline.yml
@@ -17,6 +17,8 @@ variables:
   version.MajorMinor: '1.0' # Manually adjust the version number as needed for semantic versioning. Revision is auto-incremented.
   version.Revision: $[counter(variables['version.MajorMinor'], 0)]
   versionNumber: '$(version.MajorMinor).$(version.Revision)'
+  simpleBranchName: $[replace(variables['Build.SourceBranch'], 'refs/heads/', '')]
+  branchTag: $[replace(variables['simpleBranchName'], '/', '_')]
   # -----------------------------------------------------------------------
 
   # Container registry service connection established during pipeline creation
@@ -44,13 +46,18 @@ stages:
               includeRootFolder: false
               archiveFile: "$(System.DefaultWorkingDirectory)/build/horizon-functions.zip"
           - task: PublishBuildArtifacts@1
+            displayName: Publish build artifact with latest tag
+            condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/master'))
             inputs:
               PathtoPublish: '$(System.DefaultWorkingDirectory)/build/horizon-functions.zip'
-              artifactName: 'horizon-functions-artifact'
-          - task: AzureFunctionApp@1
+              artifactName: 'horizon-functions-artifact-latest'
+          - task: PublishBuildArtifacts@1
+            displayName: Publish build artifact with branch name
             inputs:
-              azureSubscription: 'PINS ODTDEV (38602df9-8f79-41d1-a971-50c7672ba6f1)'
-              appType: functionApp
-              appName: 'pins-dev-fn'
-              package: $(System.DefaultWorkingDirectory)/build/horizon-functions.zip
-              deploymentMethod: zipDeploy
+              PathtoPublish: '$(System.DefaultWorkingDirectory)/build/horizon-functions.zip'
+              artifactName: 'horizon-functions-artifact-$(branchTag)'
+          - task: PublishBuildArtifacts@1
+            displayName: Publish build artifact with version number
+            inputs:
+              PathtoPublish: '$(System.DefaultWorkingDirectory)/build/horizon-functions.zip'
+              artifactName: 'horizon-functions-artifact-$(versionNumber)'

--- a/packages/lpa-questionnaire-web-app/azure-lpa-questionnaire-web-app-build.yml
+++ b/packages/lpa-questionnaire-web-app/azure-lpa-questionnaire-web-app-build.yml
@@ -20,6 +20,8 @@ variables:
   version.MajorMinor: '1.0' # Manually adjust the version number as needed for semantic versioning. Revision is auto-incremented.
   version.Revision: $[counter(variables['version.MajorMinor'], 0)]
   versionNumber: '$(version.MajorMinor).$(version.Revision)'
+  simpleBranchName: $[replace(variables['Build.SourceBranch'], 'refs/heads/', '')]
+  branchTag: $[replace(variables['simpleBranchName'], '/', '_')]
   # -----------------------------------------------------------------------
 
   # Container registry service connection established during pipeline creation
@@ -71,7 +73,7 @@ stages:
                 --build-arg VERSION=$(versionNumber)
               tags: |
                 $(versionNumber)
-                lpa-questionnaire-web-app
+                $(branchTag)
                 latest
           - task: PowerShell@2
             displayName: Copy Test Results
@@ -136,12 +138,23 @@ stages:
                       exit $exitCode
                   }
           - task: Docker@2
-            displayName: Push Image
+            displayName: Push Image with latest tag
+            condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/master'))
             inputs:
               command: push
               repository: $(imageRepository)
               containerRegistry: $(dockerRegistryServiceConnection)
               tags: |
                 $(versionNumber)
-                lpa-questionnaire-web-app
+                $(branchTag)
                 latest
+          - task: Docker@2
+            displayName: Push Image without latest tag
+            condition: and(succeeded(), not(eq(variables['Build.SourceBranch'], 'refs/heads/master')))
+            inputs:
+              command: push
+              repository: $(imageRepository)
+              containerRegistry: $(dockerRegistryServiceConnection)
+              tags: |
+                $(versionNumber)
+                $(branchTag)

--- a/packages/pdf-service-api/azure-pdf-service-api-build.yml
+++ b/packages/pdf-service-api/azure-pdf-service-api-build.yml
@@ -23,6 +23,8 @@ variables:
   version.MajorMinor: '1.0' # Manually adjust the version number as needed for semantic versioning. Revision is auto-incremented.
   version.Revision: $[counter(variables['version.MajorMinor'], 0)]
   versionNumber: '$(version.MajorMinor).$(version.Revision)'
+  simpleBranchName: $[replace(variables['Build.SourceBranch'], 'refs/heads/', '')]
+  branchTag: $[replace(variables['simpleBranchName'], '/', '_')]
   # -----------------------------------------------------------------------
 
   # Container registry service connection established during pipeline creation
@@ -72,7 +74,7 @@ stages:
                 --build-arg VERSION=$(versionNumber)
               tags: |
                 $(versionNumber)
-                pdf-service-api
+                $(branchTag)
                 latest
           - task: PowerShell@2
             displayName: Copy Test Results
@@ -137,12 +139,23 @@ stages:
                       exit $exitCode
                   }
           - task: Docker@2
-            displayName: Push Image
+            displayName: Push Image with latest tag
+            condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/master'))
             inputs:
               command: push
               repository: $(imageRepository)
               containerRegistry: $(dockerRegistryServiceConnection)
               tags: |
                 $(versionNumber)
-                pdf-service-api
+                $(branchTag)
                 latest
+          - task: Docker@2
+            displayName: Push Image without latest tag
+            condition: and(succeeded(), not(eq(variables['Build.SourceBranch'], 'refs/heads/master')))
+            inputs:
+              command: push
+              repository: $(imageRepository)
+              containerRegistry: $(dockerRegistryServiceConnection)
+              tags: |
+                $(versionNumber)
+                $(branchTag)


### PR DESCRIPTION
## Ticket Number
None

## Description of change
Added branch name as a tag on docker images and artifacts published from Azure pipelines.  The latest tag will only be published from the mainline branch - master.  Critically, this resolves the issue of having the "latest" version of an image being overwritten with a build from branches other than the mainline, e.g. feature branches, hotfixes, etc.

For deployments it will now be possible to use the slugified version of a branch name as an image tag in order to deploy the latest build from a particular branch, e.g. images from branch `feature/abc-123` will be published with the tag `feature_abc-123`

> Importantly, the pipeline for Horizon Functions has been changed to no longer automatically deploy to dev but rather publish artifacts which can be used in subsequent deployments.

This change has been made in a backwards-compatible manner (i.e. non-breaking) since the "latest" tag is still published from each pipeline.


## Checklist
<!-- Put an `x` in all the boxes that apply: -->
- [ ] Requires infrastructure changes
- [ ] If adding or remove environment variables (e.g. in `docker-compose.yaml`) then I have updated the appropriate Helm chart
- [ ] I have updated the documentation accordingly
- [ ] My commit history in this PR is linear
- [ ] New features have tests
- [ ] Breaking change (team conversation required)

## Important

Please do not merge from `master` (please only [rebase](https://github.com/foundry4/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
