### PR TITLE
fix(full appeal): identifying-the-owners 'other' word removed

### DIFF
--- a/packages/forms-web-app/src/views/full-appeal/submit-appeal/identifying-the-owners.njk
+++ b/packages/forms-web-app/src/views/full-appeal/submit-appeal/identifying-the-owners.njk
@@ -33,7 +33,7 @@
         <span class="govuk-caption-l">Tell us about the appeal site</span>
         <h1 data-cy="title" class="govuk-heading-l">{{ heading }}</h1>
         {% if knowsTheOwners == 'some' %}
-          <p class="govuk-body">You must have attempted to identify all the other landowners.</p>
+          <p class="govuk-body">You must have attempted to identify all the landowners.</p>
         {% endif %}
         {% if knowsTheOwners == 'no' %}
           <p class="govuk-body">You must have taken all reasonable steps to identify the landowners.</p>


### PR DESCRIPTION
## Ticket Number
https://pins-ds.atlassian.net/browse/AS-4505

## Description of change
identifying-the-owners 'other' word removed

## Checklist
<!-- Put an `x` in all the boxes that apply: -->
- [ ] Requires infrastructure changes
- [ ] If adding or remove environment variables (e.g. in `docker-compose.yaml`) then I have updated the appropriate Helm chart
- [ ] I have updated the documentation accordingly
- [ ] My commit history in this PR is linear
- [ ] New features have tests
- [ ] Breaking change (team conversation required)

## Important

Please do not merge from `master` (please only [rebase](https://github.com/foundry4/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
