### PR TITLE
feat(as-4327): add full appeal plans drawings page

### DIFF
--- a/packages/business-rules/src/schemas/full-appeal/insert.js
+++ b/packages/business-rules/src/schemas/full-appeal/insert.js
@@ -233,6 +233,23 @@ const insert = pinsYup
             hasSensitiveInformation: pinsYup.bool().nullable().default(null),
           })
           .noUnknown(true),
+        plansDrawings: pinsYup
+          .object()
+          .shape({
+            hasPlansDrawings: pinsYup.bool().nullable().default(null),
+            uploadedFile: pinsYup
+              .object()
+              .shape({
+                id: pinsYup.string().trim().uuid().nullable().default(null),
+                name: pinsYup.string().trim().max(255).ensure(),
+                fileName: pinsYup.string().trim().max(255).ensure(),
+                originalFileName: pinsYup.string().trim().max(255).ensure(),
+                location: pinsYup.string().trim().nullable(),
+                size: pinsYup.number().nullable(),
+              })
+              .noUnknown(true),
+          })
+          .noUnknown(true),
       })
       .noUnknown(true),
     appealSubmission: pinsYup
@@ -323,6 +340,10 @@ const insert = pinsYup
           .object()
           .shape({
             appealStatement: pinsYup
+              .string()
+              .oneOf(Object.values(SECTION_STATE))
+              .default('NOT STARTED'),
+            plansDrawings: pinsYup
               .string()
               .oneOf(Object.values(SECTION_STATE))
               .default('NOT STARTED'),

--- a/packages/business-rules/src/schemas/full-appeal/insert.test.js
+++ b/packages/business-rules/src/schemas/full-appeal/insert.test.js
@@ -500,6 +500,156 @@ describe('schemas/full-appeal/insert', () => {
           });
         });
       });
+
+      describe('appealDocumentsSection.plansDrawings', () => {
+        it('should remove unknown fields', async () => {
+          appeal2.appealDocumentsSection.plansDrawings.unknownField = 'unknown field';
+
+          const result = await insert.validate(appeal2, config);
+          expect(result).toEqual(appeal);
+        });
+
+        it('should throw an error when given a null value', async () => {
+          appeal.appealDocumentsSection.plansDrawings = null;
+
+          await expect(() => insert.validate(appeal, config)).rejects.toThrow(
+            'appealDocumentsSection.plansDrawings must be a `object` type, but the final value was: `null`',
+          );
+        });
+
+        describe('appealDocumentsSection.plansDrawings.hasPlansDrawings', () => {
+          it('should throw an error when not given a boolean', async () => {
+            appeal.appealDocumentsSection.plansDrawings.hasPlansDrawings = 'true ';
+
+            await expect(() => insert.validate(appeal, config)).rejects.toThrow(
+              'appealDocumentsSection.plansDrawings.hasPlansDrawings must be a `boolean` type, but the final value was: `"true "` (cast from the value `true`).',
+            );
+          });
+
+          it('should not throw an error when given a null value', async () => {
+            appeal.appealDocumentsSection.plansDrawings.hasPlansDrawings = null;
+
+            const result = await insert.validate(appeal, config);
+            expect(result).toEqual(appeal);
+          });
+
+          it('should not throw an error when not given a value', async () => {
+            delete appeal2.appealDocumentsSection.plansDrawings.hasPlansDrawings;
+            appeal.appealDocumentsSection.plansDrawings.hasPlansDrawings = null;
+
+            const result = await insert.validate(appeal2, config);
+            expect(result).toEqual(appeal);
+          });
+        });
+
+        describe('appealDocumentsSection.plansDrawings.uploadedFile', () => {
+          it('should remove unknown fields', async () => {
+            appeal2.appealDocumentsSection.plansDrawings.uploadedFile.unknownField =
+              'unknown field';
+
+            const result = await insert.validate(appeal2, config);
+            expect(result).toEqual(appeal);
+          });
+
+          it('should throw an error when given a null value', async () => {
+            appeal.appealDocumentsSection.plansDrawings.uploadedFile = null;
+
+            await expect(() => insert.validate(appeal, config)).rejects.toThrow(
+              'appealDocumentsSection.plansDrawings.uploadedFile must be a `object` type, but the final value was: `null`',
+            );
+          });
+
+          describe('appealDocumentsSection.plansDrawings.uploadedFile.name', () => {
+            it('should throw an error when given a value with more than 255 characters', async () => {
+              appeal.appealDocumentsSection.plansDrawings.uploadedFile.name = 'a'.repeat(256);
+
+              await expect(() => insert.validate(appeal, config)).rejects.toThrow(
+                'appealDocumentsSection.plansDrawings.uploadedFile.name must be at most 255 characters',
+              );
+            });
+
+            it('should strip leading/trailing spaces', async () => {
+              appeal2.appealDocumentsSection.plansDrawings.uploadedFile.name = '  test-pdf.pdf  ';
+              appeal.appealDocumentsSection.plansDrawings.uploadedFile.name = 'test-pdf.pdf';
+
+              const result = await insert.validate(appeal2, config);
+              expect(result).toEqual(appeal);
+            });
+
+            it('should not throw an error when not given a value', async () => {
+              delete appeal2.appealDocumentsSection.plansDrawings.uploadedFile.name;
+              appeal.appealDocumentsSection.plansDrawings.uploadedFile.name = '';
+
+              const result = await insert.validate(appeal, config);
+              expect(result).toEqual(appeal);
+            });
+          });
+
+          describe('appealDocumentsSection.plansDrawings.uploadedFile.originalFileName', () => {
+            it('should throw an error when given a value with more than 255 characters', async () => {
+              appeal.appealDocumentsSection.plansDrawings.uploadedFile.originalFileName =
+                'a'.repeat(256);
+
+              await expect(() => insert.validate(appeal, config)).rejects.toThrow(
+                'appealDocumentsSection.plansDrawings.uploadedFile.originalFileName must be at most 255 characters',
+              );
+            });
+
+            it('should strip leading/trailing spaces', async () => {
+              appeal2.appealDocumentsSection.plansDrawings.uploadedFile.originalFileName =
+                '  test-pdf.pdf  ';
+              appeal.appealDocumentsSection.plansDrawings.uploadedFile.originalFileName =
+                'test-pdf.pdf';
+
+              const result = await insert.validate(appeal2, config);
+              expect(result).toEqual(appeal);
+            });
+
+            it('should not throw an error when not given a value', async () => {
+              delete appeal2.appealDocumentsSection.plansDrawings.uploadedFile.originalFileName;
+              appeal.appealDocumentsSection.plansDrawings.uploadedFile.originalFileName = '';
+
+              const result = await insert.validate(appeal, config);
+              expect(result).toEqual(appeal);
+            });
+          });
+
+          describe('appealDocumentsSection.plansDrawings.uploadedFile.id', () => {
+            it('should strip leading/trailing spaces', async () => {
+              appeal2.appealDocumentsSection.plansDrawings.uploadedFile.id =
+                '  271c9b5b-af90-4b45-b0e7-0a7882da1e03  ';
+              appeal.appealDocumentsSection.plansDrawings.uploadedFile.id =
+                '271c9b5b-af90-4b45-b0e7-0a7882da1e03';
+
+              const result = await insert.validate(appeal2, config);
+              expect(result).toEqual(appeal);
+            });
+
+            it('should throw an error when not given a UUID', async () => {
+              appeal.appealDocumentsSection.plansDrawings.uploadedFile.id = 'abc123';
+
+              await expect(() => insert.validate(appeal, config)).rejects.toThrow(
+                'appealDocumentsSection.plansDrawings.uploadedFile.id must be a valid UUID',
+              );
+            });
+
+            it('should not throw an error when given a null value', async () => {
+              appeal.appealDocumentsSection.plansDrawings.uploadedFile.id = null;
+
+              const result = await insert.validate(appeal, config);
+              expect(result).toEqual(appeal);
+            });
+
+            it('should not throw an error when not given a value', async () => {
+              delete appeal2.appealDocumentsSection.plansDrawings.uploadedFile.id;
+              appeal.appealDocumentsSection.plansDrawings.uploadedFile.id = null;
+
+              const result = await insert.validate(appeal2, config);
+              expect(result).toEqual(appeal);
+            });
+          });
+        });
+      });
     });
 
     describe('contactDetailsSection', () => {
@@ -2115,6 +2265,27 @@ describe('schemas/full-appeal/insert', () => {
 
             appeal2.sectionStates.appealDocumentsSection.appealStatement =
               SECTION_STATE.NOT_STARTED;
+
+            const result = await insert.validate(appeal, config);
+            expect(result).toEqual(appeal2);
+          });
+        });
+
+        describe('sectionStates.appealDocumentsSection.plansDrawings', () => {
+          it('should throw an error when given an invalid value', async () => {
+            appeal.sectionStates.appealDocumentsSection.plansDrawings = 'NOT COMPLETE';
+
+            await expect(() => insert.validate(appeal, config)).rejects.toThrow(
+              `sectionStates.appealDocumentsSection.plansDrawings must be one of the following values: ${Object.values(
+                SECTION_STATE,
+              ).join(', ')}`,
+            );
+          });
+
+          it('should set a default value of `NOT STARTED` when not given a value', async () => {
+            delete appeal.sectionStates.appealDocumentsSection.plansDrawings;
+
+            appeal2.sectionStates.appealDocumentsSection.plansDrawings = SECTION_STATE.NOT_STARTED;
 
             const result = await insert.validate(appeal, config);
             expect(result).toEqual(appeal2);

--- a/packages/business-rules/src/schemas/full-appeal/update.js
+++ b/packages/business-rules/src/schemas/full-appeal/update.js
@@ -212,6 +212,23 @@ const update = pinsYup
             hasSensitiveInformation: pinsYup.bool().required(),
           })
           .noUnknown(true),
+        plansDrawings: pinsYup
+          .object()
+          .shape({
+            hasPlansDrawings: pinsYup.bool().required(),
+            uploadedFile: pinsYup
+              .object()
+              .shape({
+                id: pinsYup.string().trim().uuid().required(),
+                name: pinsYup.string().trim().max(255).required(),
+                fileName: pinsYup.string().trim().max(255).required(),
+                originalFileName: pinsYup.string().trim().max(255).required(),
+                location: pinsYup.string().trim().required(),
+                size: pinsYup.number().required(),
+              })
+              .noUnknown(true),
+          })
+          .noUnknown(true),
       })
       .noUnknown(true),
     appealSubmission: pinsYup
@@ -269,6 +286,7 @@ const update = pinsYup
           .object()
           .shape({
             appealStatement: pinsYup.string().oneOf(Object.values(SECTION_STATE)).required(),
+            plansDrawings: pinsYup.string().oneOf(Object.values(SECTION_STATE)).required(),
           })
           .noUnknown(true),
       })

--- a/packages/business-rules/src/schemas/full-appeal/update.test.js
+++ b/packages/business-rules/src/schemas/full-appeal/update.test.js
@@ -559,6 +559,142 @@ describe('schemas/full-appeal/update', () => {
           });
         });
       });
+
+      describe('appealDocumentsSection.plansDrawings', () => {
+        it('should remove unknown fields', async () => {
+          appeal2.appealDocumentsSection.plansDrawings.unknownField = 'unknown field';
+
+          const result = await update.validate(appeal2, config);
+          expect(result).toEqual(appeal);
+        });
+
+        it('should throw an error when given a null value', async () => {
+          appeal.appealDocumentsSection.plansDrawings = null;
+
+          await expect(() => update.validate(appeal, config)).rejects.toThrow(
+            'appealDocumentsSection.plansDrawings must be a `object` type, but the final value was: `null`',
+          );
+        });
+
+        describe('appealDocumentsSection.plansDrawings.hasPlansDrawings', () => {
+          it('should throw an error when not given a boolean', async () => {
+            appeal.appealDocumentsSection.plansDrawings.hasPlansDrawings = 'true ';
+
+            await expect(() => update.validate(appeal, config)).rejects.toThrow(
+              'appealDocumentsSection.plansDrawings.hasPlansDrawings must be a `boolean` type, but the final value was: `"true "` (cast from the value `true`).',
+            );
+          });
+
+          it('should throw an error when not given a value', async () => {
+            delete appeal.appealDocumentsSection.plansDrawings.hasPlansDrawings;
+
+            await expect(() => update.validate(appeal, config)).rejects.toThrow(
+              'appealDocumentsSection.plansDrawings.hasPlansDrawings is a required field',
+            );
+          });
+        });
+
+        describe('appealDocumentsSection.plansDrawings.uploadedFile', () => {
+          it('should remove unknown fields', async () => {
+            appeal2.appealDocumentsSection.plansDrawings.uploadedFile.unknownField =
+              'unknown field';
+
+            const result = await update.validate(appeal2, config);
+            expect(result).toEqual(appeal);
+          });
+
+          it('should throw an error when given a null value', async () => {
+            appeal.appealDocumentsSection.plansDrawings.uploadedFile = null;
+
+            await expect(() => update.validate(appeal, config)).rejects.toThrow(
+              'appealDocumentsSection.plansDrawings.uploadedFile must be a `object` type, but the final value was: `null`',
+            );
+          });
+
+          describe('appealDocumentsSection.plansDrawings.uploadedFile.name', () => {
+            it('should throw an error when given a value with more than 255 characters', async () => {
+              appeal.appealDocumentsSection.plansDrawings.uploadedFile.name = 'a'.repeat(256);
+
+              await expect(() => update.validate(appeal, config)).rejects.toThrow(
+                'appealDocumentsSection.plansDrawings.uploadedFile.name must be at most 255 characters',
+              );
+            });
+
+            it('should strip leading/trailing spaces', async () => {
+              appeal2.appealDocumentsSection.plansDrawings.uploadedFile.name = '  test-pdf.pdf  ';
+              appeal.appealDocumentsSection.plansDrawings.uploadedFile.name = 'test-pdf.pdf';
+
+              const result = await update.validate(appeal2, config);
+              expect(result).toEqual(appeal);
+            });
+
+            it('should throw an error when not given a value', async () => {
+              delete appeal.appealDocumentsSection.plansDrawings.uploadedFile.name;
+
+              await expect(() => update.validate(appeal, config)).rejects.toThrow(
+                'appealDocumentsSection.plansDrawings.uploadedFile.name is a required field',
+              );
+            });
+          });
+
+          describe('appealDocumentsSection.plansDrawings.uploadedFile.originalFileName', () => {
+            it('should throw an error when given a value with more than 255 characters', async () => {
+              appeal.appealDocumentsSection.plansDrawings.uploadedFile.originalFileName =
+                'a'.repeat(256);
+
+              await expect(() => update.validate(appeal, config)).rejects.toThrow(
+                'appealDocumentsSection.plansDrawings.uploadedFile.originalFileName must be at most 255 characters',
+              );
+            });
+
+            it('should strip leading/trailing spaces', async () => {
+              appeal2.appealDocumentsSection.plansDrawings.uploadedFile.originalFileName =
+                '  test-pdf.pdf  ';
+              appeal.appealDocumentsSection.plansDrawings.uploadedFile.originalFileName =
+                'test-pdf.pdf';
+
+              const result = await update.validate(appeal2, config);
+              expect(result).toEqual(appeal);
+            });
+
+            it('should throw an error when not given a value', async () => {
+              delete appeal.appealDocumentsSection.plansDrawings.uploadedFile.originalFileName;
+
+              await expect(() => update.validate(appeal, config)).rejects.toThrow(
+                'appealDocumentsSection.plansDrawings.uploadedFile.originalFileName is a required field',
+              );
+            });
+          });
+
+          describe('appealDocumentsSection.plansDrawings.uploadedFile.id', () => {
+            it('should strip leading/trailing spaces', async () => {
+              appeal2.appealDocumentsSection.plansDrawings.uploadedFile.id =
+                '  271c9b5b-af90-4b45-b0e7-0a7882da1e03  ';
+              appeal.appealDocumentsSection.plansDrawings.uploadedFile.id =
+                '271c9b5b-af90-4b45-b0e7-0a7882da1e03';
+
+              const result = await update.validate(appeal2, config);
+              expect(result).toEqual(appeal);
+            });
+
+            it('should throw an error when not given a UUID', async () => {
+              appeal.appealDocumentsSection.plansDrawings.uploadedFile.id = 'abc123';
+
+              await expect(() => update.validate(appeal, config)).rejects.toThrow(
+                'appealDocumentsSection.plansDrawings.uploadedFile.id must be a valid UUID',
+              );
+            });
+
+            it('should throw an error when not given a value', async () => {
+              delete appeal.appealDocumentsSection.plansDrawings.uploadedFile.id;
+
+              await expect(() => update.validate(appeal, config)).rejects.toThrow(
+                'appealDocumentsSection.plansDrawings.uploadedFile.id is a required field',
+              );
+            });
+          });
+        });
+      });
     });
 
     describe('contactDetailsSection', () => {
@@ -2120,6 +2256,26 @@ describe('schemas/full-appeal/update', () => {
 
             await expect(() => update.validate(appeal, config)).rejects.toThrow(
               'sectionStates.appealDocumentsSection.appealStatement is a required field',
+            );
+          });
+        });
+
+        describe('sectionStates.appealDocumentsSection.plansDrawings', () => {
+          it('should throw an error when given an invalid value', async () => {
+            appeal.sectionStates.appealDocumentsSection.plansDrawings = 'NOT COMPLETE';
+
+            await expect(() => update.validate(appeal, config)).rejects.toThrow(
+              `sectionStates.appealDocumentsSection.plansDrawings must be one of the following values: ${Object.values(
+                SECTION_STATE,
+              ).join(', ')}`,
+            );
+          });
+
+          it('should throw an error when not given a value', async () => {
+            delete appeal.sectionStates.appealDocumentsSection.plansDrawings;
+
+            await expect(() => update.validate(appeal, config)).rejects.toThrow(
+              'sectionStates.appealDocumentsSection.plansDrawings is a required field',
             );
           });
         });

--- a/packages/business-rules/test/data/full-appeal.js
+++ b/packages/business-rules/test/data/full-appeal.js
@@ -97,6 +97,17 @@ const appeal = {
       },
       hasSensitiveInformation: false,
     },
+    plansDrawings: {
+      hasPlansDrawings: true,
+      uploadedFile: {
+        id: '89280aa4-d925-4525-8050-938d5db41a5a',
+        name: 'plansDrawings.pdf',
+        fileName: 'plansDrawings.pdf',
+        originalFileName: 'plansDrawings.pdf',
+        location: '89280aa4-d925-4525-8050-938d5db41a5a/plansDrawings.pdf',
+        size: 1000,
+      },
+    },
   },
   appealSubmission: {
     appealPDFStatement: {
@@ -131,6 +142,7 @@ const appeal = {
     },
     appealDocumentsSection: {
       appealStatement: 'NOT STARTED',
+      plansDrawings: 'NOT STARTED',
     },
   },
 };

--- a/packages/forms-web-app/__tests__/unit/controllers/full-appeal/submit-appeal/plans-drawings.test.js
+++ b/packages/forms-web-app/__tests__/unit/controllers/full-appeal/submit-appeal/plans-drawings.test.js
@@ -1,0 +1,139 @@
+const appeal = require('@pins/business-rules/test/data/full-appeal');
+const v8 = require('v8');
+const {
+  getPlansDrawings,
+  postPlansDrawings,
+} = require('../../../../../src/controllers/full-appeal/submit-appeal/plans-drawings');
+const { createOrUpdateAppeal } = require('../../../../../src/lib/appeals-api-wrapper');
+const { getTaskStatus } = require('../../../../../src/services/task.service');
+const { mockReq, mockRes } = require('../../../mocks');
+const {
+  VIEW: {
+    FULL_APPEAL: { PLANS_DRAWINGS, NEW_PLANS_DRAWINGS, SUPPORTING_DOCUMENTS },
+  },
+} = require('../../../../../src/lib/full-appeal/views');
+
+jest.mock('../../../../../src/lib/appeals-api-wrapper');
+jest.mock('../../../../../src/services/task.service');
+
+describe('controllers/full-appeal/submit-appeal/plans-drawings', () => {
+  let req;
+  let res;
+
+  const sectionName = 'appealDocumentsSection';
+  const taskName = 'plansDrawings';
+  const errors = { 'plans-drawings': 'Select an option' };
+  const errorSummary = [{ text: 'There was an error', href: '#' }];
+
+  beforeEach(() => {
+    req = v8.deserialize(
+      v8.serialize({
+        ...mockReq(appeal),
+        body: {},
+      })
+    );
+    res = mockRes();
+
+    jest.resetAllMocks();
+  });
+
+  describe('getPlansDrawings', () => {
+    it('should call the correct template', () => {
+      getPlansDrawings(req, res);
+
+      expect(res.render).toHaveBeenCalledTimes(1);
+      expect(res.render).toHaveBeenCalledWith(PLANS_DRAWINGS, {
+        hasPlansDrawings: true,
+      });
+    });
+  });
+
+  describe('postPlansDrawings', () => {
+    it('should re-render the template with errors if submission validation fails', async () => {
+      req = {
+        ...req,
+        body: {
+          'plans-drawings': undefined,
+          errors,
+          errorSummary,
+        },
+      };
+
+      await postPlansDrawings(req, res);
+
+      expect(res.redirect).not.toHaveBeenCalled();
+      expect(res.render).toHaveBeenCalledTimes(1);
+      expect(res.render).toHaveBeenCalledWith(PLANS_DRAWINGS, {
+        errors,
+        errorSummary,
+      });
+    });
+
+    it('should re-render the template with errors if an error is thrown', async () => {
+      const error = new Error('Internal Server Error');
+
+      createOrUpdateAppeal.mockImplementation(() => {
+        throw error;
+      });
+
+      await postPlansDrawings(req, res);
+
+      expect(res.redirect).not.toHaveBeenCalled();
+      expect(res.render).toHaveBeenCalledTimes(1);
+      expect(res.render).toHaveBeenCalledWith(PLANS_DRAWINGS, {
+        hasPlansDrawings: false,
+        errors: {},
+        errorSummary: [{ text: error.toString(), href: '#' }],
+      });
+    });
+
+    it('should redirect to the correct page if `yes` has been selected', async () => {
+      const submittedAppeal = {
+        ...appeal,
+        state: 'SUBMITTED',
+      };
+
+      createOrUpdateAppeal.mockReturnValue(submittedAppeal);
+      getTaskStatus.mockReturnValue('NOT STARTED');
+
+      req = {
+        ...req,
+        body: {
+          'plans-drawings': 'yes',
+        },
+      };
+
+      await postPlansDrawings(req, res);
+
+      // expect(getTaskStatus).toHaveBeenCalledWith(appeal, sectionName, taskName);
+      expect(createOrUpdateAppeal).toHaveBeenCalledWith(appeal);
+      expect(res.redirect).toHaveBeenCalledWith(`/${NEW_PLANS_DRAWINGS}`);
+      expect(req.session.appeal).toEqual(submittedAppeal);
+    });
+
+    it('should redirect to the correct page if `no` has been selected', async () => {
+      const submittedAppeal = {
+        ...appeal,
+        state: 'SUBMITTED',
+      };
+      submittedAppeal[sectionName][taskName].hasPlansDrawings = false;
+
+      createOrUpdateAppeal.mockReturnValue(submittedAppeal);
+      getTaskStatus.mockReturnValue('NOT STARTED');
+
+      req = {
+        ...req,
+        body: {
+          'plans-drawings': 'no',
+        },
+      };
+
+      await postPlansDrawings(req, res);
+
+      // expect(getTaskStatus).toHaveBeenCalledWith(appeal, sectionName, taskName);
+      expect(createOrUpdateAppeal).toHaveBeenCalledWith(appeal);
+      expect(res.redirect).toHaveBeenCalledWith(`/${SUPPORTING_DOCUMENTS}`);
+      expect(req.session.appeal).toEqual(submittedAppeal);
+    });
+  });
+});

--- a/packages/forms-web-app/__tests__/unit/lib/full-appeal/views.test.js
+++ b/packages/forms-web-app/__tests__/unit/lib/full-appeal/views.test.js
@@ -17,7 +17,7 @@ describe('/lib/full-appeal/views', () => {
         OWN_ALL_THE_LAND: 'full-appeal/submit-appeal/own-all-the-land',
         APPLICANT_NAME: 'full-appeal/submit-appeal/applicant-name',
         APPEAL_STATEMENT: 'full-appeal/submit-appeal/appeal-statement',
-        PLANS_DRAWINGS: 'full-appeal/plans-drawings',
+        PLANS_DRAWINGS: 'full-appeal/submit-appeal/plans-drawings',
         ORIGINAL_APPLICANT: 'full-appeal/submit-appeal/original-applicant',
         OWN_SOME_OF_THE_LAND: 'full-appeal/submit-appeal/own-some-of-the-land',
         KNOW_THE_OWNERS: 'full-appeal/submit-appeal/know-the-owners',
@@ -33,6 +33,8 @@ describe('/lib/full-appeal/views', () => {
         DECLARATION_INFORMATION: 'full-appeal/submit-appeal/declaration-information',
         HEALTH_SAFETY_ISSUES: 'full-appeal/submit-appeal/health-safety-issues',
         ADVERTISING_YOUR_APPEAL: 'full-appeal/submit-appeal/advertising-your-appeal',
+        NEW_PLANS_DRAWINGS: 'full-appeal/submit-appeal/new-plans-drawings',
+        SUPPORTING_DOCUMENTS: 'full-appeal/submit-appeal/supporting-documents',
       },
     });
   });

--- a/packages/forms-web-app/__tests__/unit/routes/full-appeal/submit-appeal/index.test.js
+++ b/packages/forms-web-app/__tests__/unit/routes/full-appeal/submit-appeal/index.test.js
@@ -23,6 +23,7 @@ const appealSubmittedRouter = require('../../../../../src/routes/full-appeal/sub
 const visibleFromRoadRouter = require('../../../../../src/routes/full-appeal/submit-appeal/visible-from-road');
 const healthSafetyIssuesRouter = require('../../../../../src/routes/full-appeal/submit-appeal/health-safety-issues');
 const identfyingTheOwnersRouter = require('../../../../../src/routes/full-appeal/submit-appeal/identifying-the-owners');
+const plansDrawingsRouter = require('../../../../../src/routes/full-appeal/submit-appeal/plans-drawings');
 
 describe('routes/full-appeal/submit-appeal/index', () => {
   beforeEach(() => {
@@ -31,7 +32,7 @@ describe('routes/full-appeal/submit-appeal/index', () => {
   });
 
   it('should define the expected routes', () => {
-    expect(use.mock.calls.length).toBe(24);
+    expect(use.mock.calls.length).toBe(25);
     expect(use).toHaveBeenCalledWith(taskListRouter);
     expect(use).toHaveBeenCalledWith(checkAnswersRouter);
     expect(use).toHaveBeenCalledWith(contactDetailsRouter);
@@ -56,5 +57,6 @@ describe('routes/full-appeal/submit-appeal/index', () => {
     expect(use).toHaveBeenCalledWith(visibleFromRoadRouter);
     expect(use).toHaveBeenCalledWith(healthSafetyIssuesRouter);
     expect(use).toHaveBeenCalledWith(identfyingTheOwnersRouter);
+    expect(use).toHaveBeenCalledWith(plansDrawingsRouter);
   });
 });

--- a/packages/forms-web-app/__tests__/unit/routes/full-appeal/submit-appeal/plans-drawings.test.js
+++ b/packages/forms-web-app/__tests__/unit/routes/full-appeal/submit-appeal/plans-drawings.test.js
@@ -1,0 +1,38 @@
+const { get, post } = require('../../router-mock');
+const {
+  getPlansDrawings,
+  postPlansDrawings,
+} = require('../../../../../src/controllers/full-appeal/submit-appeal/plans-drawings');
+const fetchExistingAppealMiddleware = require('../../../../../src/middleware/fetch-existing-appeal');
+const {
+  validationErrorHandler,
+} = require('../../../../../src/validators/validation-error-handler');
+const { rules: optionsValidationRules } = require('../../../../../src/validators/common/options');
+
+jest.mock('../../../../../src/middleware/fetch-existing-appeal');
+jest.mock('../../../../../src/validators/common/options');
+
+describe('routes/full-appeal/submit-appeal/plans-drawings', () => {
+  beforeEach(() => {
+    // eslint-disable-next-line global-require
+    require('../../../../../src/routes/full-appeal/submit-appeal/plans-drawings');
+  });
+
+  it('should define the expected routes', () => {
+    expect(get).toHaveBeenCalledWith(
+      '/submit-appeal/plans-drawings',
+      [fetchExistingAppealMiddleware],
+      getPlansDrawings
+    );
+    expect(post).toHaveBeenCalledWith(
+      '/submit-appeal/plans-drawings',
+      optionsValidationRules(),
+      validationErrorHandler,
+      postPlansDrawings
+    );
+    expect(optionsValidationRules).toHaveBeenCalledWith({
+      fieldName: 'plans-drawings',
+      emptyError: 'Select yes if you want to submit any new plans and drawings with your appeal',
+    });
+  });
+});

--- a/packages/forms-web-app/src/controllers/full-appeal/submit-appeal/plans-drawings.js
+++ b/packages/forms-web-app/src/controllers/full-appeal/submit-appeal/plans-drawings.js
@@ -1,0 +1,61 @@
+const logger = require('../../../lib/logger');
+const { createOrUpdateAppeal } = require('../../../lib/appeals-api-wrapper');
+const {
+  VIEW: {
+    FULL_APPEAL: { PLANS_DRAWINGS, NEW_PLANS_DRAWINGS, SUPPORTING_DOCUMENTS },
+  },
+} = require('../../../lib/full-appeal/views');
+// const { getTaskStatus } = require('../../../services/task.service');
+const { NOT_STARTED } = require('../../../services/task-status/task-statuses');
+
+const sectionName = 'appealDocumentsSection';
+const taskName = 'plansDrawings';
+
+const getPlansDrawings = (req, res) => {
+  const { hasPlansDrawings } = req.session.appeal[sectionName][taskName];
+  res.render(PLANS_DRAWINGS, {
+    hasPlansDrawings,
+  });
+};
+
+const postPlansDrawings = async (req, res) => {
+  const {
+    body,
+    body: { errors = {}, errorSummary = [] },
+    session: { appeal },
+  } = req;
+
+  if (Object.keys(errors).length > 0) {
+    return res.render(PLANS_DRAWINGS, {
+      errors,
+      errorSummary,
+    });
+  }
+
+  const hasPlansDrawings = body['plans-drawings'] === 'yes';
+
+  try {
+    appeal[sectionName][taskName].hasPlansDrawings = hasPlansDrawings;
+    // appeal.sectionStates[sectionName][taskName] = getTaskStatus(appeal, sectionName, taskName);
+    appeal.sectionStates[sectionName][taskName] = NOT_STARTED;
+
+    req.session.appeal = await createOrUpdateAppeal(appeal);
+  } catch (err) {
+    logger.error(err);
+
+    return res.render(PLANS_DRAWINGS, {
+      hasPlansDrawings,
+      errors,
+      errorSummary: [{ text: err.toString(), href: '#' }],
+    });
+  }
+
+  return hasPlansDrawings
+    ? res.redirect(`/${NEW_PLANS_DRAWINGS}`)
+    : res.redirect(`/${SUPPORTING_DOCUMENTS}`);
+};
+
+module.exports = {
+  getPlansDrawings,
+  postPlansDrawings,
+};

--- a/packages/forms-web-app/src/lib/full-appeal/views.js
+++ b/packages/forms-web-app/src/lib/full-appeal/views.js
@@ -13,7 +13,7 @@ const VIEW = {
     OWN_ALL_THE_LAND: 'full-appeal/submit-appeal/own-all-the-land',
     APPLICANT_NAME: 'full-appeal/submit-appeal/applicant-name',
     APPEAL_STATEMENT: 'full-appeal/submit-appeal/appeal-statement',
-    PLANS_DRAWINGS: 'full-appeal/plans-drawings',
+    PLANS_DRAWINGS: 'full-appeal/submit-appeal/plans-drawings',
     ORIGINAL_APPLICANT: 'full-appeal/submit-appeal/original-applicant',
     OWN_SOME_OF_THE_LAND: 'full-appeal/submit-appeal/own-some-of-the-land',
     KNOW_THE_OWNERS: 'full-appeal/submit-appeal/know-the-owners',
@@ -29,6 +29,8 @@ const VIEW = {
     DECLARATION_INFORMATION: 'full-appeal/submit-appeal/declaration-information',
     HEALTH_SAFETY_ISSUES: 'full-appeal/submit-appeal/health-safety-issues',
     ADVERTISING_YOUR_APPEAL: 'full-appeal/submit-appeal/advertising-your-appeal',
+    NEW_PLANS_DRAWINGS: 'full-appeal/submit-appeal/new-plans-drawings',
+    SUPPORTING_DOCUMENTS: 'full-appeal/submit-appeal/supporting-documents',
   },
 };
 

--- a/packages/forms-web-app/src/routes/full-appeal/submit-appeal/index.js
+++ b/packages/forms-web-app/src/routes/full-appeal/submit-appeal/index.js
@@ -23,6 +23,7 @@ const declarationInformationRouter = require('./declaration-information');
 const visibleFromRoadRouter = require('./visible-from-road');
 const healthSafetyIssuesRouter = require('./health-safety-issues');
 const identifyingTheOwners = require('./identifying-the-owners');
+const plansDrawingsRouter = require('./plans-drawings');
 
 const router = express.Router();
 
@@ -50,5 +51,6 @@ router.use(declarationInformationRouter);
 router.use(visibleFromRoadRouter);
 router.use(healthSafetyIssuesRouter);
 router.use(identifyingTheOwners);
+router.use(plansDrawingsRouter);
 
 module.exports = router;

--- a/packages/forms-web-app/src/routes/full-appeal/submit-appeal/plans-drawings.js
+++ b/packages/forms-web-app/src/routes/full-appeal/submit-appeal/plans-drawings.js
@@ -1,0 +1,23 @@
+const express = require('express');
+const {
+  getPlansDrawings,
+  postPlansDrawings,
+} = require('../../../controllers/full-appeal/submit-appeal/plans-drawings');
+const fetchExistingAppealMiddleware = require('../../../middleware/fetch-existing-appeal');
+const { validationErrorHandler } = require('../../../validators/validation-error-handler');
+const { rules: optionsValidationRules } = require('../../../validators/common/options');
+
+const router = express.Router();
+
+router.get('/submit-appeal/plans-drawings', [fetchExistingAppealMiddleware], getPlansDrawings);
+router.post(
+  '/submit-appeal/plans-drawings',
+  optionsValidationRules({
+    fieldName: 'plans-drawings',
+    emptyError: 'Select yes if you want to submit any new plans and drawings with your appeal',
+  }),
+  validationErrorHandler,
+  postPlansDrawings
+);
+
+module.exports = router;

--- a/packages/forms-web-app/src/views/full-appeal/submit-appeal/plans-drawings.njk
+++ b/packages/forms-web-app/src/views/full-appeal/submit-appeal/plans-drawings.njk
@@ -1,0 +1,70 @@
+{% extends "layouts/main.njk" %}
+
+{% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
+{% from "govuk/components/radios/macro.njk" import govukRadios %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
+
+{% set title = "Plans and drawings - Appeal a planning decision - GOV.UK" %}
+{% block pageTitle %}{{ "Error: " + title if errors else title }}{% endblock %}
+
+{% block backButton %}
+  {{ govukBackLink({
+    text: 'Back',
+    href: '/full-appeal/submit-appeal/appeal-statement',
+    attributes: {
+      'data-cy': 'back'
+    }
+  }) }}
+{% endblock %}
+
+{% block content %}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      {% if errorSummary %}
+        {{ govukErrorSummary({
+          titleText: "There is a problem",
+          errorList: errorSummary,
+          attributes: {"data-cy": "error-wrapper"}
+        }) }}
+      {% endif %}
+      <form action="" method="post" novalidate>
+        <span class="govuk-caption-l">Upload documents for your appeal</span>
+        {{ govukRadios({
+          classes: "govuk-radios",
+          idPrefix: "plans-drawings",
+          name: "plans-drawings",
+          errorMessage: errors['plans-drawings'] and {
+            text: errors['plans-drawings'].msg
+          },
+          fieldset: {
+            legend: {
+              text: "Do you have any new plans or drawings that support your appeal?",
+              isPageHeading: true,
+              classes: "govuk-fieldset__legend--l"
+            }
+          },
+          items: [
+            {
+              value: "yes",
+              text: "Yes",
+              attributes: { "data-cy": "answer-yes" },
+              checked: hasPlansDrawings == true
+            },
+            {
+              value: "no",
+              text: "No",
+              attributes: { "data-cy": "answer-no" },
+              checked: hasPlansDrawings == false
+            }
+          ]
+        }) }}
+        {{ govukButton({
+          text: "Continue",
+          type: "submit",
+          attributes: { "data-cy":"button-save-and-continue"}
+        }) }}
+      </form>
+    </div>
+  </div>
+
+{% endblock %}


### PR DESCRIPTION
## Ticket Number
https://pins-ds.atlassian.net/browse/AS-4327

## Description of change
Add Full Appeal Plans Drawings page

![Screenshot from 2022-02-12 17-46-25](https://user-images.githubusercontent.com/6839214/153722258-b912eee6-30da-4f06-9c4f-01ab4f057b84.png)

## Checklist
<!-- Put an `x` in all the boxes that apply: -->
- [ ] Requires infrastructure changes
- [ ] If adding or remove environment variables (e.g. in `docker-compose.yaml`) then I have updated the appropriate Helm chart
- [ ] I have updated the documentation accordingly
- [ ] My commit history in this PR is linear
- [ ] New features have tests
- [ ] Breaking change (team conversation required)

## Important

Please do not merge from `master` (please only [rebase](https://github.com/foundry4/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
