### PR TITLE
feat(as-4335): add full appeal supporting documents page

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "main": "index.js",
   "scripts": {
     "commit": "cz",
-    "commitlint": "commitlint --from 052ebfdc --to HEAD",
+    "commitlint": "commitlint --from 58844f55ff --to HEAD",
     "format": "prettier --write \"*.js\" \"data/*.js\"",
     "semantic-release": "semantic-release",
     "test:e2e": "cd ./packages/e2e-tests && npm run test:e2e",

--- a/packages/business-rules/src/schemas/full-appeal/insert.js
+++ b/packages/business-rules/src/schemas/full-appeal/insert.js
@@ -250,6 +250,12 @@ const insert = pinsYup
               .noUnknown(true),
           })
           .noUnknown(true),
+        supportingDocuments: pinsYup
+          .object()
+          .shape({
+            hasSupportingDocuments: pinsYup.bool().nullable().default(null),
+          })
+          .noUnknown(true),
       })
       .noUnknown(true),
     appealSubmission: pinsYup
@@ -344,6 +350,10 @@ const insert = pinsYup
               .oneOf(Object.values(SECTION_STATE))
               .default('NOT STARTED'),
             plansDrawings: pinsYup
+              .string()
+              .oneOf(Object.values(SECTION_STATE))
+              .default('NOT STARTED'),
+            supportingDocuments: pinsYup
               .string()
               .oneOf(Object.values(SECTION_STATE))
               .default('NOT STARTED'),

--- a/packages/business-rules/src/schemas/full-appeal/insert.test.js
+++ b/packages/business-rules/src/schemas/full-appeal/insert.test.js
@@ -650,6 +650,48 @@ describe('schemas/full-appeal/insert', () => {
           });
         });
       });
+
+      describe('appealDocumentsSection.supportingDocuments', () => {
+        it('should remove unknown fields', async () => {
+          appeal2.appealDocumentsSection.supportingDocuments.unknownField = 'unknown field';
+
+          const result = await insert.validate(appeal2, config);
+          expect(result).toEqual(appeal);
+        });
+
+        it('should throw an error when given a null value', async () => {
+          appeal.appealDocumentsSection.supportingDocuments = null;
+
+          await expect(() => insert.validate(appeal, config)).rejects.toThrow(
+            'appealDocumentsSection.supportingDocuments must be a `object` type, but the final value was: `null`',
+          );
+        });
+
+        describe('appealDocumentsSection.supportingDocuments.hasSupportingDocuments', () => {
+          it('should throw an error when not given a boolean', async () => {
+            appeal.appealDocumentsSection.supportingDocuments.hasSupportingDocuments = 'true ';
+
+            await expect(() => insert.validate(appeal, config)).rejects.toThrow(
+              'appealDocumentsSection.supportingDocuments.hasSupportingDocuments must be a `boolean` type, but the final value was: `"true "` (cast from the value `true`).',
+            );
+          });
+
+          it('should not throw an error when given a null value', async () => {
+            appeal.appealDocumentsSection.supportingDocuments.hasSupportingDocuments = null;
+
+            const result = await insert.validate(appeal, config);
+            expect(result).toEqual(appeal);
+          });
+
+          it('should not throw an error when not given a value', async () => {
+            delete appeal2.appealDocumentsSection.supportingDocuments.hasSupportingDocuments;
+            appeal.appealDocumentsSection.supportingDocuments.hasSupportingDocuments = null;
+
+            const result = await insert.validate(appeal2, config);
+            expect(result).toEqual(appeal);
+          });
+        });
+      });
     });
 
     describe('contactDetailsSection', () => {

--- a/packages/business-rules/src/schemas/full-appeal/update.js
+++ b/packages/business-rules/src/schemas/full-appeal/update.js
@@ -229,6 +229,12 @@ const update = pinsYup
               .noUnknown(true),
           })
           .noUnknown(true),
+        supportingDocuments: pinsYup
+          .object()
+          .shape({
+            hasSupportingDocuments: pinsYup.bool().required(),
+          })
+          .noUnknown(true),
       })
       .noUnknown(true),
     appealSubmission: pinsYup
@@ -287,6 +293,7 @@ const update = pinsYup
           .shape({
             appealStatement: pinsYup.string().oneOf(Object.values(SECTION_STATE)).required(),
             plansDrawings: pinsYup.string().oneOf(Object.values(SECTION_STATE)).required(),
+            supportingDocuments: pinsYup.string().oneOf(Object.values(SECTION_STATE)).required(),
           })
           .noUnknown(true),
       })

--- a/packages/business-rules/src/schemas/full-appeal/update.test.js
+++ b/packages/business-rules/src/schemas/full-appeal/update.test.js
@@ -695,6 +695,41 @@ describe('schemas/full-appeal/update', () => {
           });
         });
       });
+
+      describe('appealDocumentsSection.supportingDocuments', () => {
+        it('should remove unknown fields', async () => {
+          appeal2.appealDocumentsSection.supportingDocuments.unknownField = 'unknown field';
+
+          const result = await update.validate(appeal2, config);
+          expect(result).toEqual(appeal);
+        });
+
+        it('should throw an error when given a null value', async () => {
+          appeal.appealDocumentsSection.supportingDocuments = null;
+
+          await expect(() => update.validate(appeal, config)).rejects.toThrow(
+            'appealDocumentsSection.supportingDocuments must be a `object` type, but the final value was: `null`',
+          );
+        });
+
+        describe('appealDocumentsSection.supportingDocuments.hasSupportingDocuments', () => {
+          it('should throw an error when not given a boolean', async () => {
+            appeal.appealDocumentsSection.supportingDocuments.hasSupportingDocuments = 'true ';
+
+            await expect(() => update.validate(appeal, config)).rejects.toThrow(
+              'appealDocumentsSection.supportingDocuments.hasSupportingDocuments must be a `boolean` type, but the final value was: `"true "` (cast from the value `true`).',
+            );
+          });
+
+          it('should throw an error when not given a value', async () => {
+            delete appeal.appealDocumentsSection.supportingDocuments.hasSupportingDocuments;
+
+            await expect(() => update.validate(appeal, config)).rejects.toThrow(
+              'appealDocumentsSection.supportingDocuments.hasSupportingDocuments is a required field',
+            );
+          });
+        });
+      });
     });
 
     describe('contactDetailsSection', () => {

--- a/packages/business-rules/test/data/full-appeal.js
+++ b/packages/business-rules/test/data/full-appeal.js
@@ -108,6 +108,9 @@ const appeal = {
         size: 1000,
       },
     },
+    supportingDocuments: {
+      hasSupportingDocuments: true,
+    },
   },
   appealSubmission: {
     appealPDFStatement: {
@@ -143,6 +146,7 @@ const appeal = {
     appealDocumentsSection: {
       appealStatement: 'NOT STARTED',
       plansDrawings: 'NOT STARTED',
+      supportingDocuments: 'NOT STARTED',
     },
   },
 };

--- a/packages/forms-web-app/__tests__/unit/controllers/full-appeal/submit-appeal/supporting-documents.test.js
+++ b/packages/forms-web-app/__tests__/unit/controllers/full-appeal/submit-appeal/supporting-documents.test.js
@@ -1,0 +1,139 @@
+const appeal = require('@pins/business-rules/test/data/full-appeal');
+const v8 = require('v8');
+const {
+  getSupportingDocuments,
+  postSupportingDocuments,
+} = require('../../../../../src/controllers/full-appeal/submit-appeal/supporting-documents');
+const { createOrUpdateAppeal } = require('../../../../../src/lib/appeals-api-wrapper');
+const { getTaskStatus } = require('../../../../../src/services/task.service');
+const { mockReq, mockRes } = require('../../../mocks');
+const {
+  VIEW: {
+    FULL_APPEAL: { NEW_SUPPORTING_DOCUMENTS, SUPPORTING_DOCUMENTS, TASK_LIST },
+  },
+} = require('../../../../../src/lib/full-appeal/views');
+
+jest.mock('../../../../../src/lib/appeals-api-wrapper');
+jest.mock('../../../../../src/services/task.service');
+
+describe('controllers/full-appeal/submit-appeal/supporting-documents', () => {
+  let req;
+  let res;
+
+  const sectionName = 'appealDocumentsSection';
+  const taskName = 'supportingDocuments';
+  const errors = { 'supporting-documents': 'Select an option' };
+  const errorSummary = [{ text: 'There was an error', href: '#' }];
+
+  beforeEach(() => {
+    req = v8.deserialize(
+      v8.serialize({
+        ...mockReq(appeal),
+        body: {},
+      })
+    );
+    res = mockRes();
+
+    jest.resetAllMocks();
+  });
+
+  describe('getSupportingDocuments', () => {
+    it('should call the correct template', () => {
+      getSupportingDocuments(req, res);
+
+      expect(res.render).toHaveBeenCalledTimes(1);
+      expect(res.render).toHaveBeenCalledWith(SUPPORTING_DOCUMENTS, {
+        hasSupportingDocuments: true,
+      });
+    });
+  });
+
+  describe('postSupportingDocuments', () => {
+    it('should re-render the template with errors if submission validation fails', async () => {
+      req = {
+        ...req,
+        body: {
+          'supporting-documents': undefined,
+          errors,
+          errorSummary,
+        },
+      };
+
+      await postSupportingDocuments(req, res);
+
+      expect(res.redirect).not.toHaveBeenCalled();
+      expect(res.render).toHaveBeenCalledTimes(1);
+      expect(res.render).toHaveBeenCalledWith(SUPPORTING_DOCUMENTS, {
+        errors,
+        errorSummary,
+      });
+    });
+
+    it('should re-render the template with errors if an error is thrown', async () => {
+      const error = new Error('Internal Server Error');
+
+      createOrUpdateAppeal.mockImplementation(() => {
+        throw error;
+      });
+
+      await postSupportingDocuments(req, res);
+
+      expect(res.redirect).not.toHaveBeenCalled();
+      expect(res.render).toHaveBeenCalledTimes(1);
+      expect(res.render).toHaveBeenCalledWith(SUPPORTING_DOCUMENTS, {
+        hasSupportingDocuments: false,
+        errors: {},
+        errorSummary: [{ text: error.toString(), href: '#' }],
+      });
+    });
+
+    it('should redirect to the correct page if `yes` has been selected', async () => {
+      const submittedAppeal = {
+        ...appeal,
+        state: 'SUBMITTED',
+      };
+
+      createOrUpdateAppeal.mockReturnValue(submittedAppeal);
+      getTaskStatus.mockReturnValue('NOT STARTED');
+
+      req = {
+        ...req,
+        body: {
+          'supporting-documents': 'yes',
+        },
+      };
+
+      await postSupportingDocuments(req, res);
+
+      // expect(getTaskStatus).toHaveBeenCalledWith(appeal, sectionName, taskName);
+      expect(createOrUpdateAppeal).toHaveBeenCalledWith(appeal);
+      expect(res.redirect).toHaveBeenCalledWith(`/${NEW_SUPPORTING_DOCUMENTS}`);
+      expect(req.session.appeal).toEqual(submittedAppeal);
+    });
+
+    it('should redirect to the correct page if `no` has been selected', async () => {
+      const submittedAppeal = {
+        ...appeal,
+        state: 'SUBMITTED',
+      };
+      submittedAppeal[sectionName][taskName].hasSupportingDocuments = false;
+
+      createOrUpdateAppeal.mockReturnValue(submittedAppeal);
+      getTaskStatus.mockReturnValue('NOT STARTED');
+
+      req = {
+        ...req,
+        body: {
+          'supporting-documents': 'no',
+        },
+      };
+
+      await postSupportingDocuments(req, res);
+
+      // expect(getTaskStatus).toHaveBeenCalledWith(appeal, sectionName, taskName);
+      expect(createOrUpdateAppeal).toHaveBeenCalledWith(appeal);
+      expect(res.redirect).toHaveBeenCalledWith(`/${TASK_LIST}`);
+      expect(req.session.appeal).toEqual(submittedAppeal);
+    });
+  });
+});

--- a/packages/forms-web-app/__tests__/unit/lib/full-appeal/views.test.js
+++ b/packages/forms-web-app/__tests__/unit/lib/full-appeal/views.test.js
@@ -35,6 +35,7 @@ describe('/lib/full-appeal/views', () => {
         ADVERTISING_YOUR_APPEAL: 'full-appeal/submit-appeal/advertising-your-appeal',
         NEW_PLANS_DRAWINGS: 'full-appeal/submit-appeal/new-plans-drawings',
         SUPPORTING_DOCUMENTS: 'full-appeal/submit-appeal/supporting-documents',
+        NEW_SUPPORTING_DOCUMENTS: 'full-appeal/submit-appeal/new-supporting-documents',
       },
     });
   });

--- a/packages/forms-web-app/__tests__/unit/routes/full-appeal/submit-appeal/index.test.js
+++ b/packages/forms-web-app/__tests__/unit/routes/full-appeal/submit-appeal/index.test.js
@@ -24,6 +24,7 @@ const visibleFromRoadRouter = require('../../../../../src/routes/full-appeal/sub
 const healthSafetyIssuesRouter = require('../../../../../src/routes/full-appeal/submit-appeal/health-safety-issues');
 const identfyingTheOwnersRouter = require('../../../../../src/routes/full-appeal/submit-appeal/identifying-the-owners');
 const plansDrawingsRouter = require('../../../../../src/routes/full-appeal/submit-appeal/plans-drawings');
+const supportingDocumentsRouter = require('../../../../../src/routes/full-appeal/submit-appeal/supporting-documents');
 
 describe('routes/full-appeal/submit-appeal/index', () => {
   beforeEach(() => {
@@ -32,7 +33,7 @@ describe('routes/full-appeal/submit-appeal/index', () => {
   });
 
   it('should define the expected routes', () => {
-    expect(use.mock.calls.length).toBe(25);
+    expect(use.mock.calls.length).toBe(26);
     expect(use).toHaveBeenCalledWith(taskListRouter);
     expect(use).toHaveBeenCalledWith(checkAnswersRouter);
     expect(use).toHaveBeenCalledWith(contactDetailsRouter);
@@ -58,5 +59,6 @@ describe('routes/full-appeal/submit-appeal/index', () => {
     expect(use).toHaveBeenCalledWith(healthSafetyIssuesRouter);
     expect(use).toHaveBeenCalledWith(identfyingTheOwnersRouter);
     expect(use).toHaveBeenCalledWith(plansDrawingsRouter);
+    expect(use).toHaveBeenCalledWith(supportingDocumentsRouter);
   });
 });

--- a/packages/forms-web-app/__tests__/unit/routes/full-appeal/submit-appeal/supporting-documents.test.js
+++ b/packages/forms-web-app/__tests__/unit/routes/full-appeal/submit-appeal/supporting-documents.test.js
@@ -1,0 +1,38 @@
+const { get, post } = require('../../router-mock');
+const {
+  getSupportingDocuments,
+  postSupportingDocuments,
+} = require('../../../../../src/controllers/full-appeal/submit-appeal/supporting-documents');
+const fetchExistingAppealMiddleware = require('../../../../../src/middleware/fetch-existing-appeal');
+const {
+  validationErrorHandler,
+} = require('../../../../../src/validators/validation-error-handler');
+const { rules: optionsValidationRules } = require('../../../../../src/validators/common/options');
+
+jest.mock('../../../../../src/middleware/fetch-existing-appeal');
+jest.mock('../../../../../src/validators/common/options');
+
+describe('routes/full-appeal/submit-appeal/supporting-documents', () => {
+  beforeEach(() => {
+    // eslint-disable-next-line global-require
+    require('../../../../../src/routes/full-appeal/submit-appeal/supporting-documents');
+  });
+
+  it('should define the expected routes', () => {
+    expect(get).toHaveBeenCalledWith(
+      '/submit-appeal/supporting-documents',
+      [fetchExistingAppealMiddleware],
+      getSupportingDocuments
+    );
+    expect(post).toHaveBeenCalledWith(
+      '/submit-appeal/supporting-documents',
+      optionsValidationRules(),
+      validationErrorHandler,
+      postSupportingDocuments
+    );
+    expect(optionsValidationRules).toHaveBeenCalledWith({
+      fieldName: 'supporting-documents',
+      emptyError: 'Select yes if you want to submit any new supporting documents with your appeal',
+    });
+  });
+});

--- a/packages/forms-web-app/src/controllers/full-appeal/submit-appeal/declaration.js
+++ b/packages/forms-web-app/src/controllers/full-appeal/submit-appeal/declaration.js
@@ -85,6 +85,9 @@ exports.postDeclaration = async (req, res) => {
       size: 1000,
     },
   };
+  req.session.appeal.appealDocumentsSection.supportingDocuments = {
+    hasSupportingDocuments: false,
+  };
   req.session.appeal.sectionStates = {
     contactDetailsSection: {
       isOriginalApplicant: 'COMPLETED',
@@ -107,6 +110,7 @@ exports.postDeclaration = async (req, res) => {
     appealDocumentsSection: {
       appealStatement: 'COMPLETED',
       plansDrawings: 'COMPLETED',
+      supportingDocuments: 'COMPLETED',
     },
   };
 

--- a/packages/forms-web-app/src/controllers/full-appeal/submit-appeal/supporting-documents.js
+++ b/packages/forms-web-app/src/controllers/full-appeal/submit-appeal/supporting-documents.js
@@ -1,0 +1,61 @@
+const logger = require('../../../lib/logger');
+const { createOrUpdateAppeal } = require('../../../lib/appeals-api-wrapper');
+const {
+  VIEW: {
+    FULL_APPEAL: { NEW_SUPPORTING_DOCUMENTS, SUPPORTING_DOCUMENTS, TASK_LIST },
+  },
+} = require('../../../lib/full-appeal/views');
+// const { getTaskStatus } = require('../../../services/task.service');
+const { NOT_STARTED } = require('../../../services/task-status/task-statuses');
+
+const sectionName = 'appealDocumentsSection';
+const taskName = 'supportingDocuments';
+
+const getSupportingDocuments = (req, res) => {
+  const { hasSupportingDocuments } = req.session.appeal[sectionName][taskName];
+  res.render(SUPPORTING_DOCUMENTS, {
+    hasSupportingDocuments,
+  });
+};
+
+const postSupportingDocuments = async (req, res) => {
+  const {
+    body,
+    body: { errors = {}, errorSummary = [] },
+    session: { appeal },
+  } = req;
+
+  if (Object.keys(errors).length > 0) {
+    return res.render(SUPPORTING_DOCUMENTS, {
+      errors,
+      errorSummary,
+    });
+  }
+
+  const hasSupportingDocuments = body['supporting-documents'] === 'yes';
+
+  try {
+    appeal[sectionName][taskName].hasSupportingDocuments = hasSupportingDocuments;
+    // appeal.sectionStates[sectionName][taskName] = getTaskStatus(appeal, sectionName, taskName);
+    appeal.sectionStates[sectionName][taskName] = NOT_STARTED;
+
+    req.session.appeal = await createOrUpdateAppeal(appeal);
+  } catch (err) {
+    logger.error(err);
+
+    return res.render(SUPPORTING_DOCUMENTS, {
+      hasSupportingDocuments,
+      errors,
+      errorSummary: [{ text: err.toString(), href: '#' }],
+    });
+  }
+
+  return hasSupportingDocuments
+    ? res.redirect(`/${NEW_SUPPORTING_DOCUMENTS}`)
+    : res.redirect(`/${TASK_LIST}`);
+};
+
+module.exports = {
+  getSupportingDocuments,
+  postSupportingDocuments,
+};

--- a/packages/forms-web-app/src/lib/full-appeal/views.js
+++ b/packages/forms-web-app/src/lib/full-appeal/views.js
@@ -31,6 +31,7 @@ const VIEW = {
     ADVERTISING_YOUR_APPEAL: 'full-appeal/submit-appeal/advertising-your-appeal',
     NEW_PLANS_DRAWINGS: 'full-appeal/submit-appeal/new-plans-drawings',
     SUPPORTING_DOCUMENTS: 'full-appeal/submit-appeal/supporting-documents',
+    NEW_SUPPORTING_DOCUMENTS: 'full-appeal/submit-appeal/new-supporting-documents',
   },
 };
 

--- a/packages/forms-web-app/src/routes/full-appeal/submit-appeal/index.js
+++ b/packages/forms-web-app/src/routes/full-appeal/submit-appeal/index.js
@@ -24,6 +24,7 @@ const visibleFromRoadRouter = require('./visible-from-road');
 const healthSafetyIssuesRouter = require('./health-safety-issues');
 const identifyingTheOwners = require('./identifying-the-owners');
 const plansDrawingsRouter = require('./plans-drawings');
+const supportingDocumentsRouter = require('./supporting-documents');
 
 const router = express.Router();
 
@@ -52,5 +53,6 @@ router.use(visibleFromRoadRouter);
 router.use(healthSafetyIssuesRouter);
 router.use(identifyingTheOwners);
 router.use(plansDrawingsRouter);
+router.use(supportingDocumentsRouter);
 
 module.exports = router;

--- a/packages/forms-web-app/src/routes/full-appeal/submit-appeal/supporting-documents.js
+++ b/packages/forms-web-app/src/routes/full-appeal/submit-appeal/supporting-documents.js
@@ -1,0 +1,27 @@
+const express = require('express');
+const {
+  getSupportingDocuments,
+  postSupportingDocuments,
+} = require('../../../controllers/full-appeal/submit-appeal/supporting-documents');
+const fetchExistingAppealMiddleware = require('../../../middleware/fetch-existing-appeal');
+const { validationErrorHandler } = require('../../../validators/validation-error-handler');
+const { rules: optionsValidationRules } = require('../../../validators/common/options');
+
+const router = express.Router();
+
+router.get(
+  '/submit-appeal/supporting-documents',
+  [fetchExistingAppealMiddleware],
+  getSupportingDocuments
+);
+router.post(
+  '/submit-appeal/supporting-documents',
+  optionsValidationRules({
+    fieldName: 'supporting-documents',
+    emptyError: 'Select yes if you want to submit any new supporting documents with your appeal',
+  }),
+  validationErrorHandler,
+  postSupportingDocuments
+);
+
+module.exports = router;

--- a/packages/forms-web-app/src/views/full-appeal/submit-appeal/supporting-documents.njk
+++ b/packages/forms-web-app/src/views/full-appeal/submit-appeal/supporting-documents.njk
@@ -1,0 +1,78 @@
+{% extends "layouts/main.njk" %}
+
+{% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
+{% from "govuk/components/radios/macro.njk" import govukRadios %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
+
+{% set title = "Supporting documents - Appeal a planning decision - GOV.UK" %}
+{% block pageTitle %}{{ "Error: " + title if errors else title }}{% endblock %}
+
+{% block backButton %}
+  {{ govukBackLink({
+    text: 'Back',
+    href: '/full-appeal/submit-appeal/new-plans-drawings',
+    attributes: {
+      'data-cy': 'back'
+    }
+  }) }}
+{% endblock %}
+
+{% block content %}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      {% if errorSummary %}
+        {{ govukErrorSummary({
+          titleText: "There is a problem",
+          errorList: errorSummary,
+          attributes: {"data-cy": "error-wrapper"}
+        }) }}
+      {% endif %}
+      <form action="" method="post" novalidate>
+        <span class="govuk-caption-l">Upload documents for your appeal</span>
+        <h1 class="govuk-heading-l">Supporting documents</h1>
+        <p class="govk-body">
+          You do not need to submit the supporting documents from your planning application.
+          We'll get these from the local planning department.
+        </p>
+        <p class="govk-body">
+          You can submit new or updated documents that support your appeal.
+        </p>
+        {{ govukRadios({
+          classes: "govuk-radios",
+          idPrefix: "supporting-documents",
+          name: "supporting-documents",
+          errorMessage: errors['supporting-documents'] and {
+            text: errors['supporting-documents'].msg
+          },
+          fieldset: {
+            legend: {
+              text: "Do you want to submit any new supporting documents with your appeal?",
+              isPageHeading: true,
+              classes: "govuk-fieldset__legend--m"
+            }
+          },
+          items: [
+            {
+              value: "yes",
+              text: "Yes",
+              attributes: { "data-cy": "answer-yes" },
+              checked: hasSupportingDocuments == true
+            },
+            {
+              value: "no",
+              text: "No",
+              attributes: { "data-cy": "answer-no" },
+              checked: hasSupportingDocuments == false
+            }
+          ]
+        }) }}
+        {{ govukButton({
+          text: "Continue",
+          type: "submit",
+          attributes: { "data-cy":"button-save-and-continue"}
+        }) }}
+      </form>
+    </div>
+  </div>
+
+{% endblock %}


### PR DESCRIPTION
## Ticket Number
https://pins-ds.atlassian.net/browse/AS-4335

## Description of change
Add Full Appeal Supporting Documents page

![Screenshot from 2022-02-13 17-08-46](https://user-images.githubusercontent.com/6839214/153766256-bd73f3e7-35d3-4dff-b6a1-badc793d4849.png)

## Checklist
<!-- Put an `x` in all the boxes that apply: -->
- [ ] Requires infrastructure changes
- [ ] If adding or remove environment variables (e.g. in `docker-compose.yaml`) then I have updated the appropriate Helm chart
- [ ] I have updated the documentation accordingly
- [ ] My commit history in this PR is linear
- [ ] New features have tests
- [ ] Breaking change (team conversation required)

## Important

Please do not merge from `master` (please only [rebase](https://github.com/foundry4/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
