### PR TITLE
feat(as-4328): add full appeal new plans and drawings page

### DIFF
--- a/packages/appeals-service-api/__tests__/unit/controllers/appeals.test.js
+++ b/packages/appeals-service-api/__tests__/unit/controllers/appeals.test.js
@@ -127,23 +127,5 @@ describe('appeals.controllers', () => {
       expect(res.send).toHaveBeenCalledWith(appeal);
       expect(res.status).toHaveBeenCalledWith(200);
     });
-
-    it('it responds with a updated appeal', async () => {
-      const appeal = await addInDatabase();
-      const appealId = appeal.id;
-
-      req.params.id = appealId;
-      req.body.horizonId = 'HORIZON123';
-
-      await updateAppeal(req, res);
-
-      const updatedAppeal = await getFromDatabase(appealId);
-
-      appeal.updatedAt = updatedAppeal.appeal.updatedAt;
-      expect(appeal).toEqual(updatedAppeal.appeal);
-
-      expect(res.send).toHaveBeenCalledWith(appeal);
-      expect(res.status).toHaveBeenCalledWith(200);
-    });
   });
 });

--- a/packages/appeals-service-api/src/controllers/appeals.js
+++ b/packages/appeals-service-api/src/controllers/appeals.js
@@ -75,14 +75,18 @@ module.exports = {
         throw ApiError.appealNotFound(idParam);
       }
 
-      const newAppeal = req.body;
+      let newAppeal = req.body;
       const oldAppeal = document.appeal;
 
       logger.debug({ newAppeal }, 'New appeal data in updateAppeal');
 
       const isFirstSubmission = oldAppeal.state === 'DRAFT' && newAppeal.state === 'SUBMITTED';
 
-      const updatedDocument = await updateAppeal(_.merge(oldAppeal, newAppeal), isFirstSubmission);
+      if (!featureFlag.newAppealJourney) {
+        newAppeal = _.merge(oldAppeal, newAppeal);
+      }
+
+      const updatedDocument = await updateAppeal(newAppeal, isFirstSubmission);
 
       logger.debug({ updatedDocument }, 'Updated appeal data in updateAppeal');
 

--- a/packages/business-rules/src/schemas/full-appeal/insert.js
+++ b/packages/business-rules/src/schemas/full-appeal/insert.js
@@ -237,17 +237,22 @@ const insert = pinsYup
           .object()
           .shape({
             hasPlansDrawings: pinsYup.bool().nullable().default(null),
-            uploadedFile: pinsYup
-              .object()
-              .shape({
-                id: pinsYup.string().trim().uuid().nullable().default(null),
-                name: pinsYup.string().trim().max(255).ensure(),
-                fileName: pinsYup.string().trim().max(255).ensure(),
-                originalFileName: pinsYup.string().trim().max(255).ensure(),
-                location: pinsYup.string().trim().nullable(),
-                size: pinsYup.number().nullable(),
-              })
-              .noUnknown(true),
+            uploadedFiles: pinsYup
+              .array()
+              .of(
+                pinsYup
+                  .object()
+                  .shape({
+                    id: pinsYup.string().trim().uuid().nullable().default(null),
+                    name: pinsYup.string().trim().max(255).ensure(),
+                    fileName: pinsYup.string().trim().max(255).ensure(),
+                    originalFileName: pinsYup.string().trim().max(255).ensure(),
+                    location: pinsYup.string().trim().nullable(),
+                    size: pinsYup.number().nullable(),
+                  })
+                  .noUnknown(true),
+              )
+              .ensure(),
           })
           .noUnknown(true),
         supportingDocuments: pinsYup

--- a/packages/business-rules/src/schemas/full-appeal/insert.test.js
+++ b/packages/business-rules/src/schemas/full-appeal/insert.test.js
@@ -542,83 +542,28 @@ describe('schemas/full-appeal/insert', () => {
           });
         });
 
-        describe('appealDocumentsSection.plansDrawings.uploadedFile', () => {
-          it('should remove unknown fields', async () => {
-            appeal2.appealDocumentsSection.plansDrawings.uploadedFile.unknownField =
-              'unknown field';
+        describe('appealDocumentsSection.plansDrawings.uploadedFiles', () => {
+          it('should not throw an error when given a null value', async () => {
+            appeal.appealDocumentsSection.plansDrawings.uploadedFiles = null;
+            appeal2.appealDocumentsSection.plansDrawings.uploadedFiles = [];
+
+            const result = await insert.validate(appeal, config);
+            expect(result).toEqual(appeal2);
+          });
+
+          it('should not throw an error when not given a value', async () => {
+            delete appeal.appealDocumentsSection.plansDrawings.uploadedFiles;
+            appeal2.appealDocumentsSection.plansDrawings.uploadedFiles = [];
 
             const result = await insert.validate(appeal2, config);
-            expect(result).toEqual(appeal);
+            expect(result).toEqual(appeal2);
           });
 
-          it('should throw an error when given a null value', async () => {
-            appeal.appealDocumentsSection.plansDrawings.uploadedFile = null;
-
-            await expect(() => insert.validate(appeal, config)).rejects.toThrow(
-              'appealDocumentsSection.plansDrawings.uploadedFile must be a `object` type, but the final value was: `null`',
-            );
-          });
-
-          describe('appealDocumentsSection.plansDrawings.uploadedFile.name', () => {
-            it('should throw an error when given a value with more than 255 characters', async () => {
-              appeal.appealDocumentsSection.plansDrawings.uploadedFile.name = 'a'.repeat(256);
-
-              await expect(() => insert.validate(appeal, config)).rejects.toThrow(
-                'appealDocumentsSection.plansDrawings.uploadedFile.name must be at most 255 characters',
-              );
-            });
-
+          describe('appealDocumentsSection.plansDrawings.uploadedFiles[0].id', () => {
             it('should strip leading/trailing spaces', async () => {
-              appeal2.appealDocumentsSection.plansDrawings.uploadedFile.name = '  test-pdf.pdf  ';
-              appeal.appealDocumentsSection.plansDrawings.uploadedFile.name = 'test-pdf.pdf';
-
-              const result = await insert.validate(appeal2, config);
-              expect(result).toEqual(appeal);
-            });
-
-            it('should not throw an error when not given a value', async () => {
-              delete appeal2.appealDocumentsSection.plansDrawings.uploadedFile.name;
-              appeal.appealDocumentsSection.plansDrawings.uploadedFile.name = '';
-
-              const result = await insert.validate(appeal, config);
-              expect(result).toEqual(appeal);
-            });
-          });
-
-          describe('appealDocumentsSection.plansDrawings.uploadedFile.originalFileName', () => {
-            it('should throw an error when given a value with more than 255 characters', async () => {
-              appeal.appealDocumentsSection.plansDrawings.uploadedFile.originalFileName =
-                'a'.repeat(256);
-
-              await expect(() => insert.validate(appeal, config)).rejects.toThrow(
-                'appealDocumentsSection.plansDrawings.uploadedFile.originalFileName must be at most 255 characters',
-              );
-            });
-
-            it('should strip leading/trailing spaces', async () => {
-              appeal2.appealDocumentsSection.plansDrawings.uploadedFile.originalFileName =
-                '  test-pdf.pdf  ';
-              appeal.appealDocumentsSection.plansDrawings.uploadedFile.originalFileName =
-                'test-pdf.pdf';
-
-              const result = await insert.validate(appeal2, config);
-              expect(result).toEqual(appeal);
-            });
-
-            it('should not throw an error when not given a value', async () => {
-              delete appeal2.appealDocumentsSection.plansDrawings.uploadedFile.originalFileName;
-              appeal.appealDocumentsSection.plansDrawings.uploadedFile.originalFileName = '';
-
-              const result = await insert.validate(appeal, config);
-              expect(result).toEqual(appeal);
-            });
-          });
-
-          describe('appealDocumentsSection.plansDrawings.uploadedFile.id', () => {
-            it('should strip leading/trailing spaces', async () => {
-              appeal2.appealDocumentsSection.plansDrawings.uploadedFile.id =
+              appeal2.appealDocumentsSection.plansDrawings.uploadedFiles[0].id =
                 '  271c9b5b-af90-4b45-b0e7-0a7882da1e03  ';
-              appeal.appealDocumentsSection.plansDrawings.uploadedFile.id =
+              appeal.appealDocumentsSection.plansDrawings.uploadedFiles[0].id =
                 '271c9b5b-af90-4b45-b0e7-0a7882da1e03';
 
               const result = await insert.validate(appeal2, config);
@@ -626,25 +571,137 @@ describe('schemas/full-appeal/insert', () => {
             });
 
             it('should throw an error when not given a UUID', async () => {
-              appeal.appealDocumentsSection.plansDrawings.uploadedFile.id = 'abc123';
+              appeal.appealDocumentsSection.plansDrawings.uploadedFiles[0].id = 'abc123';
 
               await expect(() => insert.validate(appeal, config)).rejects.toThrow(
-                'appealDocumentsSection.plansDrawings.uploadedFile.id must be a valid UUID',
+                'appealDocumentsSection.plansDrawings.uploadedFiles[0].id must be a valid UUID',
               );
             });
 
-            it('should not throw an error when given a null value', async () => {
-              appeal.appealDocumentsSection.plansDrawings.uploadedFile.id = null;
+            it('should not throw an error when not given a value', async () => {
+              delete appeal2.appealDocumentsSection.plansDrawings.uploadedFiles[0].id;
+              appeal.appealDocumentsSection.plansDrawings.uploadedFiles[0].id = null;
 
-              const result = await insert.validate(appeal, config);
+              const result = await insert.validate(appeal2, config);
+              expect(result).toEqual(appeal);
+            });
+          });
+
+          describe('appealDocumentsSection.plansDrawings.uploadedFiles[0].name', () => {
+            it('should throw an error when given a value with more than 255 characters', async () => {
+              appeal.appealDocumentsSection.plansDrawings.uploadedFiles[0].name = 'a'.repeat(256);
+
+              await expect(() => insert.validate(appeal, config)).rejects.toThrow(
+                'appealDocumentsSection.plansDrawings.uploadedFiles[0].name must be at most 255 characters',
+              );
+            });
+
+            it('should strip leading/trailing spaces', async () => {
+              appeal2.appealDocumentsSection.plansDrawings.uploadedFiles[0].name =
+                '  test-pdf.pdf  ';
+              appeal.appealDocumentsSection.plansDrawings.uploadedFiles[0].name = 'test-pdf.pdf';
+
+              const result = await insert.validate(appeal2, config);
               expect(result).toEqual(appeal);
             });
 
             it('should not throw an error when not given a value', async () => {
-              delete appeal2.appealDocumentsSection.plansDrawings.uploadedFile.id;
-              appeal.appealDocumentsSection.plansDrawings.uploadedFile.id = null;
+              appeal.appealDocumentsSection.plansDrawings.uploadedFiles[0].name = '';
+
+              const result = await insert.validate(appeal, config);
+              expect(result).toEqual(appeal);
+            });
+          });
+
+          describe('appealDocumentsSection.plansDrawings.uploadedFiles[0].fileName', () => {
+            it('should throw an error when given a value with more than 255 characters', async () => {
+              appeal.appealDocumentsSection.plansDrawings.uploadedFiles[0].fileName = 'a'.repeat(
+                256,
+              );
+
+              await expect(() => insert.validate(appeal, config)).rejects.toThrow(
+                'appealDocumentsSection.plansDrawings.uploadedFiles[0].fileName must be at most 255 characters',
+              );
+            });
+
+            it('should strip leading/trailing spaces', async () => {
+              appeal2.appealDocumentsSection.plansDrawings.uploadedFiles[0].fileName =
+                '  test-pdf.pdf  ';
+              appeal.appealDocumentsSection.plansDrawings.uploadedFiles[0].fileName =
+                'test-pdf.pdf';
 
               const result = await insert.validate(appeal2, config);
+              expect(result).toEqual(appeal);
+            });
+
+            it('should not throw an error when not given a value', async () => {
+              appeal.appealDocumentsSection.plansDrawings.uploadedFiles[0].fileName = '';
+
+              const result = await insert.validate(appeal, config);
+              expect(result).toEqual(appeal);
+            });
+          });
+
+          describe('appealDocumentsSection.plansDrawings.uploadedFiles[0].originalFileName', () => {
+            it('should throw an error when given a value with more than 255 characters', async () => {
+              appeal.appealDocumentsSection.plansDrawings.uploadedFiles[0].originalFileName =
+                'a'.repeat(256);
+
+              await expect(() => insert.validate(appeal, config)).rejects.toThrow(
+                'appealDocumentsSection.plansDrawings.uploadedFiles[0].originalFileName must be at most 255 characters',
+              );
+            });
+
+            it('should strip leading/trailing spaces', async () => {
+              appeal2.appealDocumentsSection.plansDrawings.uploadedFiles[0].originalFileName =
+                '  test-pdf.pdf  ';
+              appeal.appealDocumentsSection.plansDrawings.uploadedFiles[0].originalFileName =
+                'test-pdf.pdf';
+
+              const result = await insert.validate(appeal2, config);
+              expect(result).toEqual(appeal);
+            });
+
+            it('should not throw an error when not given a value', async () => {
+              appeal.appealDocumentsSection.plansDrawings.uploadedFiles[0].originalFileName = '';
+
+              const result = await insert.validate(appeal, config);
+              expect(result).toEqual(appeal);
+            });
+          });
+
+          describe('appealDocumentsSection.plansDrawings.uploadedFiles[0].location', () => {
+            it('should strip leading/trailing spaces', async () => {
+              appeal2.appealDocumentsSection.plansDrawings.uploadedFiles[0].location =
+                '  test-pdf.pdf  ';
+              appeal.appealDocumentsSection.plansDrawings.uploadedFiles[0].location =
+                'test-pdf.pdf';
+
+              const result = await insert.validate(appeal2, config);
+              expect(result).toEqual(appeal);
+            });
+
+            it('should not throw an error when not given a value', async () => {
+              appeal.appealDocumentsSection.plansDrawings.uploadedFiles[0].location = '';
+
+              const result = await insert.validate(appeal, config);
+              expect(result).toEqual(appeal);
+            });
+          });
+
+          describe('appealDocumentsSection.plansDrawings.uploadedFiles[0].size', () => {
+            it('should throw an error when not given a number', async () => {
+              appeal.appealDocumentsSection.plansDrawings.uploadedFiles[0].size = 'not-a-number';
+
+              await expect(() => insert.validate(appeal, config)).rejects.toThrow(
+                'appealDocumentsSection.plansDrawings.uploadedFiles[0].size must be a `number` type, but the final value was: `NaN` (cast from the value `1000`).',
+              );
+            });
+
+            it('should not throw an error when not given a value', async () => {
+              delete appeal.appealDocumentsSection.plansDrawings.uploadedFiles[0].size;
+
+              const result = await insert.validate(appeal, config);
               expect(result).toEqual(appeal);
             });
           });

--- a/packages/business-rules/src/schemas/full-appeal/update.js
+++ b/packages/business-rules/src/schemas/full-appeal/update.js
@@ -216,17 +216,22 @@ const update = pinsYup
           .object()
           .shape({
             hasPlansDrawings: pinsYup.bool().required(),
-            uploadedFile: pinsYup
-              .object()
-              .shape({
-                id: pinsYup.string().trim().uuid().required(),
-                name: pinsYup.string().trim().max(255).required(),
-                fileName: pinsYup.string().trim().max(255).required(),
-                originalFileName: pinsYup.string().trim().max(255).required(),
-                location: pinsYup.string().trim().required(),
-                size: pinsYup.number().required(),
-              })
-              .noUnknown(true),
+            uploadedFiles: pinsYup
+              .array()
+              .of(
+                pinsYup
+                  .object()
+                  .shape({
+                    id: pinsYup.string().trim().uuid().nullable(),
+                    name: pinsYup.string().trim().max(255).nullable(),
+                    fileName: pinsYup.string().trim().max(255).nullable(),
+                    originalFileName: pinsYup.string().trim().max(255).nullable(),
+                    location: pinsYup.string().trim().nullable(),
+                    size: pinsYup.number().nullable(),
+                  })
+                  .noUnknown(true),
+              )
+              .ensure(),
           })
           .noUnknown(true),
         supportingDocuments: pinsYup

--- a/packages/business-rules/src/schemas/full-appeal/update.test.js
+++ b/packages/business-rules/src/schemas/full-appeal/update.test.js
@@ -594,83 +594,20 @@ describe('schemas/full-appeal/update', () => {
           });
         });
 
-        describe('appealDocumentsSection.plansDrawings.uploadedFile', () => {
-          it('should remove unknown fields', async () => {
-            appeal2.appealDocumentsSection.plansDrawings.uploadedFile.unknownField =
-              'unknown field';
+        describe('appealDocumentsSection.plansDrawings.uploadedFiles', () => {
+          it('should not throw an error when not given a value', async () => {
+            delete appeal.appealDocumentsSection.plansDrawings.uploadedFiles;
+            appeal2.appealDocumentsSection.plansDrawings.uploadedFiles = [];
 
             const result = await update.validate(appeal2, config);
-            expect(result).toEqual(appeal);
+            expect(result).toEqual(appeal2);
           });
 
-          it('should throw an error when given a null value', async () => {
-            appeal.appealDocumentsSection.plansDrawings.uploadedFile = null;
-
-            await expect(() => update.validate(appeal, config)).rejects.toThrow(
-              'appealDocumentsSection.plansDrawings.uploadedFile must be a `object` type, but the final value was: `null`',
-            );
-          });
-
-          describe('appealDocumentsSection.plansDrawings.uploadedFile.name', () => {
-            it('should throw an error when given a value with more than 255 characters', async () => {
-              appeal.appealDocumentsSection.plansDrawings.uploadedFile.name = 'a'.repeat(256);
-
-              await expect(() => update.validate(appeal, config)).rejects.toThrow(
-                'appealDocumentsSection.plansDrawings.uploadedFile.name must be at most 255 characters',
-              );
-            });
-
+          describe('appealDocumentsSection.plansDrawings.uploadedFiles[0].id', () => {
             it('should strip leading/trailing spaces', async () => {
-              appeal2.appealDocumentsSection.plansDrawings.uploadedFile.name = '  test-pdf.pdf  ';
-              appeal.appealDocumentsSection.plansDrawings.uploadedFile.name = 'test-pdf.pdf';
-
-              const result = await update.validate(appeal2, config);
-              expect(result).toEqual(appeal);
-            });
-
-            it('should throw an error when not given a value', async () => {
-              delete appeal.appealDocumentsSection.plansDrawings.uploadedFile.name;
-
-              await expect(() => update.validate(appeal, config)).rejects.toThrow(
-                'appealDocumentsSection.plansDrawings.uploadedFile.name is a required field',
-              );
-            });
-          });
-
-          describe('appealDocumentsSection.plansDrawings.uploadedFile.originalFileName', () => {
-            it('should throw an error when given a value with more than 255 characters', async () => {
-              appeal.appealDocumentsSection.plansDrawings.uploadedFile.originalFileName =
-                'a'.repeat(256);
-
-              await expect(() => update.validate(appeal, config)).rejects.toThrow(
-                'appealDocumentsSection.plansDrawings.uploadedFile.originalFileName must be at most 255 characters',
-              );
-            });
-
-            it('should strip leading/trailing spaces', async () => {
-              appeal2.appealDocumentsSection.plansDrawings.uploadedFile.originalFileName =
-                '  test-pdf.pdf  ';
-              appeal.appealDocumentsSection.plansDrawings.uploadedFile.originalFileName =
-                'test-pdf.pdf';
-
-              const result = await update.validate(appeal2, config);
-              expect(result).toEqual(appeal);
-            });
-
-            it('should throw an error when not given a value', async () => {
-              delete appeal.appealDocumentsSection.plansDrawings.uploadedFile.originalFileName;
-
-              await expect(() => update.validate(appeal, config)).rejects.toThrow(
-                'appealDocumentsSection.plansDrawings.uploadedFile.originalFileName is a required field',
-              );
-            });
-          });
-
-          describe('appealDocumentsSection.plansDrawings.uploadedFile.id', () => {
-            it('should strip leading/trailing spaces', async () => {
-              appeal2.appealDocumentsSection.plansDrawings.uploadedFile.id =
+              appeal2.appealDocumentsSection.plansDrawings.uploadedFiles[0].id =
                 '  271c9b5b-af90-4b45-b0e7-0a7882da1e03  ';
-              appeal.appealDocumentsSection.plansDrawings.uploadedFile.id =
+              appeal.appealDocumentsSection.plansDrawings.uploadedFiles[0].id =
                 '271c9b5b-af90-4b45-b0e7-0a7882da1e03';
 
               const result = await update.validate(appeal2, config);
@@ -678,19 +615,137 @@ describe('schemas/full-appeal/update', () => {
             });
 
             it('should throw an error when not given a UUID', async () => {
-              appeal.appealDocumentsSection.plansDrawings.uploadedFile.id = 'abc123';
+              appeal.appealDocumentsSection.plansDrawings.uploadedFiles[0].id = 'abc123';
 
               await expect(() => update.validate(appeal, config)).rejects.toThrow(
-                'appealDocumentsSection.plansDrawings.uploadedFile.id must be a valid UUID',
+                'appealDocumentsSection.plansDrawings.uploadedFiles[0].id must be a valid UUID',
               );
             });
 
-            it('should throw an error when not given a value', async () => {
-              delete appeal.appealDocumentsSection.plansDrawings.uploadedFile.id;
+            it('should not throw an error when not given a value', async () => {
+              delete appeal.appealDocumentsSection.plansDrawings.uploadedFiles[0].id;
+
+              const result = await update.validate(appeal, config);
+              expect(result).toEqual(appeal);
+            });
+          });
+
+          describe('appealDocumentsSection.plansDrawings.uploadedFiles[0].name', () => {
+            it('should throw an error when given a value with more than 255 characters', async () => {
+              appeal.appealDocumentsSection.plansDrawings.uploadedFiles[0].name = 'a'.repeat(256);
 
               await expect(() => update.validate(appeal, config)).rejects.toThrow(
-                'appealDocumentsSection.plansDrawings.uploadedFile.id is a required field',
+                'appealDocumentsSection.plansDrawings.uploadedFiles[0].name must be at most 255 characters',
               );
+            });
+
+            it('should strip leading/trailing spaces', async () => {
+              appeal2.appealDocumentsSection.plansDrawings.uploadedFiles[0].name =
+                '  test-pdf.pdf  ';
+              appeal.appealDocumentsSection.plansDrawings.uploadedFiles[0].name = 'test-pdf.pdf';
+
+              const result = await update.validate(appeal2, config);
+              expect(result).toEqual(appeal);
+            });
+
+            it('should not throw an error when not given a value', async () => {
+              delete appeal.appealDocumentsSection.plansDrawings.uploadedFiles[0].name;
+
+              const result = await update.validate(appeal, config);
+              expect(result).toEqual(appeal);
+            });
+          });
+
+          describe('appealDocumentsSection.plansDrawings.uploadedFiles[0].fileName', () => {
+            it('should throw an error when given a value with more than 255 characters', async () => {
+              appeal.appealDocumentsSection.plansDrawings.uploadedFiles[0].fileName = 'a'.repeat(
+                256,
+              );
+
+              await expect(() => update.validate(appeal, config)).rejects.toThrow(
+                'appealDocumentsSection.plansDrawings.uploadedFiles[0].fileName must be at most 255 characters',
+              );
+            });
+
+            it('should strip leading/trailing spaces', async () => {
+              appeal2.appealDocumentsSection.plansDrawings.uploadedFiles[0].fileName =
+                '  test-pdf.pdf  ';
+              appeal.appealDocumentsSection.plansDrawings.uploadedFiles[0].fileName =
+                'test-pdf.pdf';
+
+              const result = await update.validate(appeal2, config);
+              expect(result).toEqual(appeal);
+            });
+
+            it('should not throw an error when not given a value', async () => {
+              delete appeal.appealDocumentsSection.plansDrawings.uploadedFiles[0].fileName;
+
+              const result = await update.validate(appeal, config);
+              expect(result).toEqual(appeal);
+            });
+          });
+
+          describe('appealDocumentsSection.plansDrawings.uploadedFiles[0].originalFileName', () => {
+            it('should throw an error when given a value with more than 255 characters', async () => {
+              appeal.appealDocumentsSection.plansDrawings.uploadedFiles[0].originalFileName =
+                'a'.repeat(256);
+
+              await expect(() => update.validate(appeal, config)).rejects.toThrow(
+                'appealDocumentsSection.plansDrawings.uploadedFiles[0].originalFileName must be at most 255 characters',
+              );
+            });
+
+            it('should strip leading/trailing spaces', async () => {
+              appeal2.appealDocumentsSection.plansDrawings.uploadedFiles[0].originalFileName =
+                '  test-pdf.pdf  ';
+              appeal.appealDocumentsSection.plansDrawings.uploadedFiles[0].originalFileName =
+                'test-pdf.pdf';
+
+              const result = await update.validate(appeal2, config);
+              expect(result).toEqual(appeal);
+            });
+
+            it('should not throw an error when not given a value', async () => {
+              delete appeal.appealDocumentsSection.plansDrawings.uploadedFiles[0].originalFileName;
+
+              const result = await update.validate(appeal, config);
+              expect(result).toEqual(appeal);
+            });
+          });
+
+          describe('appealDocumentsSection.plansDrawings.uploadedFiles[0].location', () => {
+            it('should strip leading/trailing spaces', async () => {
+              appeal2.appealDocumentsSection.plansDrawings.uploadedFiles[0].location =
+                '  test-pdf.pdf  ';
+              appeal.appealDocumentsSection.plansDrawings.uploadedFiles[0].location =
+                'test-pdf.pdf';
+
+              const result = await update.validate(appeal2, config);
+              expect(result).toEqual(appeal);
+            });
+
+            it('should not throw an error when not given a value', async () => {
+              delete appeal.appealDocumentsSection.plansDrawings.uploadedFiles[0].location;
+
+              const result = await update.validate(appeal, config);
+              expect(result).toEqual(appeal);
+            });
+          });
+
+          describe('appealDocumentsSection.plansDrawings.uploadedFiles[0].size', () => {
+            it('should throw an error when not given a number', async () => {
+              appeal.appealDocumentsSection.plansDrawings.uploadedFiles[0].size = 'not-a-number';
+
+              await expect(() => update.validate(appeal, config)).rejects.toThrow(
+                'appealDocumentsSection.plansDrawings.uploadedFiles[0].size must be a `number` type, but the final value was: `NaN` (cast from the value `1000`).',
+              );
+            });
+
+            it('should not throw an error when not given a value', async () => {
+              delete appeal.appealDocumentsSection.plansDrawings.uploadedFiles[0].size;
+
+              const result = await update.validate(appeal, config);
+              expect(result).toEqual(appeal);
             });
           });
         });

--- a/packages/business-rules/test/data/full-appeal.js
+++ b/packages/business-rules/test/data/full-appeal.js
@@ -99,14 +99,24 @@ const appeal = {
     },
     plansDrawings: {
       hasPlansDrawings: true,
-      uploadedFile: {
-        id: '89280aa4-d925-4525-8050-938d5db41a5a',
-        name: 'plansDrawings.pdf',
-        fileName: 'plansDrawings.pdf',
-        originalFileName: 'plansDrawings.pdf',
-        location: '89280aa4-d925-4525-8050-938d5db41a5a/plansDrawings.pdf',
-        size: 1000,
-      },
+      uploadedFiles: [
+        {
+          id: '89280aa4-d925-4525-8050-938d5db41a5a',
+          name: 'plansDrawings1.pdf',
+          fileName: 'plansDrawings1.pdf',
+          originalFileName: 'plansDrawings1.pdf',
+          location: '89280aa4-d925-4525-8050-938d5db41a5a/plansDrawings1.pdf',
+          size: 1000,
+        },
+        {
+          id: '5ac54094-4356-4dc4-ba33-efcdbccaa834',
+          name: 'plansDrawings2.pdf',
+          fileName: 'plansDrawings2.pdf',
+          originalFileName: 'plansDrawings2.pdf',
+          location: '5ac54094-4356-4dc4-ba33-efcdbccaa834/plansDrawings2.pdf',
+          size: 1000,
+        },
+      ],
     },
     supportingDocuments: {
       hasSupportingDocuments: true,

--- a/packages/forms-web-app/__tests__/unit/controllers/full-appeal/submit-appeal/new-plans-drawings.test.js
+++ b/packages/forms-web-app/__tests__/unit/controllers/full-appeal/submit-appeal/new-plans-drawings.test.js
@@ -1,0 +1,240 @@
+const appeal = require('@pins/business-rules/test/data/full-appeal');
+const v8 = require('v8');
+const { documentTypes } = require('@pins/common');
+const {
+  getNewPlansDrawings,
+  postNewPlansDrawings,
+} = require('../../../../../src/controllers/full-appeal/submit-appeal/new-plans-drawings');
+const { createOrUpdateAppeal } = require('../../../../../src/lib/appeals-api-wrapper');
+const { createDocument } = require('../../../../../src/lib/documents-api-wrapper');
+const { getTaskStatus } = require('../../../../../src/services/task.service');
+const TASK_STATUS = require('../../../../../src/services/task-status/task-statuses');
+const { mockReq, mockRes } = require('../../../mocks');
+const {
+  VIEW: {
+    FULL_APPEAL: { NEW_PLANS_DRAWINGS, SUPPORTING_DOCUMENTS },
+  },
+} = require('../../../../../src/lib/full-appeal/views');
+
+jest.mock('../../../../../src/lib/appeals-api-wrapper');
+jest.mock('../../../../../src/lib/documents-api-wrapper');
+jest.mock('../../../../../src/services/task.service');
+
+describe('controllers/full-appeal/submit-appeal/new-plans-drawings', () => {
+  let req;
+  let res;
+  let appealData;
+
+  const sectionName = 'appealDocumentsSection';
+  const taskName = 'plansDrawings';
+  const errors = { 'file-upload': 'Select a file upload' };
+  const errorSummary = [{ text: 'There was an error', href: '#' }];
+
+  beforeEach(() => {
+    req = v8.deserialize(
+      v8.serialize({
+        ...mockReq(appeal),
+        body: {},
+      })
+    );
+    res = mockRes();
+    appealData = v8.deserialize(v8.serialize(appeal));
+
+    jest.resetAllMocks();
+  });
+
+  describe('getNewPlansDrawings', () => {
+    it('should call the correct template', () => {
+      getNewPlansDrawings(req, res);
+
+      expect(res.render).toHaveBeenCalledTimes(1);
+      expect(res.render).toHaveBeenCalledWith(NEW_PLANS_DRAWINGS, {
+        appealId: appealData.id,
+        uploadedFiles: appealData[sectionName][taskName].uploadedFiles,
+      });
+    });
+  });
+
+  describe('postNewPlansDrawings', () => {
+    it('should re-render the template with errors if submission validation fails', async () => {
+      req = {
+        ...req,
+        body: {
+          errors,
+          errorSummary,
+        },
+        files: {
+          'file-upload': {},
+        },
+      };
+
+      await postNewPlansDrawings(req, res);
+
+      expect(res.redirect).not.toHaveBeenCalled();
+      expect(res.render).toHaveBeenCalledTimes(1);
+      expect(res.render).toHaveBeenCalledWith(NEW_PLANS_DRAWINGS, {
+        appealId: appealData.id,
+        uploadedFiles: appealData[sectionName][taskName].uploadedFiles,
+        errors,
+        errorSummary,
+      });
+    });
+
+    it('should re-render the template with errors if an error is thrown', async () => {
+      const error = new Error('Internal Server Error');
+
+      createOrUpdateAppeal.mockImplementation(() => Promise.reject(error));
+
+      await postNewPlansDrawings(req, res);
+
+      expect(res.redirect).not.toHaveBeenCalled();
+      expect(res.render).toHaveBeenCalledTimes(1);
+      expect(res.render).toHaveBeenCalledWith(NEW_PLANS_DRAWINGS, {
+        appealId: appealData.id,
+        uploadedFiles: appealData[sectionName][taskName].uploadedFiles,
+        errorSummary: [{ text: error.toString(), href: '#' }],
+      });
+    });
+
+    it('should redirect to the correct page if valid and a single file is being uploaded', async () => {
+      appealData[sectionName][taskName].uploadedFiles.pop();
+      req.session.appeal[sectionName][taskName].uploadedFiles = [];
+
+      const submittedAppeal = {
+        ...appealData,
+        state: 'SUBMITTED',
+      };
+
+      createDocument.mockReturnValue(appealData[sectionName][taskName].uploadedFiles[0]);
+      getTaskStatus.mockReturnValue(TASK_STATUS.NOT_STARTED);
+      createOrUpdateAppeal.mockReturnValue(submittedAppeal);
+
+      req = {
+        ...req,
+        body: {},
+        files: {
+          'file-upload': appealData[sectionName][taskName].uploadedFiles[0],
+        },
+      };
+
+      await postNewPlansDrawings(req, res);
+
+      expect(createDocument).toHaveBeenCalledWith(
+        appealData,
+        appealData[sectionName][taskName].uploadedFiles[0],
+        null,
+        documentTypes.decisionPlans.name
+      );
+      // expect(getTaskStatus).toHaveBeenCalledWith(appeal, sectionName, taskName);
+      expect(createOrUpdateAppeal).toHaveBeenCalledWith(appealData);
+      expect(res.redirect).toHaveBeenCalledWith(`/${SUPPORTING_DOCUMENTS}`);
+      expect(req.session.appeal).toEqual(submittedAppeal);
+    });
+
+    it('should redirect to the correct page if valid and multiple files are being uploaded', async () => {
+      req.session.appeal[sectionName][taskName].uploadedFiles = [];
+
+      const submittedAppeal = {
+        ...appealData,
+        state: 'SUBMITTED',
+      };
+
+      createDocument
+        .mockReturnValueOnce(appealData[sectionName][taskName].uploadedFiles[0])
+        .mockReturnValueOnce(appealData[sectionName][taskName].uploadedFiles[1]);
+      getTaskStatus.mockReturnValue(TASK_STATUS.NOT_STARTED);
+      createOrUpdateAppeal.mockReturnValue(submittedAppeal);
+
+      req = {
+        ...req,
+        body: {},
+        files: {
+          'file-upload': appealData[sectionName][taskName].uploadedFiles,
+        },
+      };
+
+      await postNewPlansDrawings(req, res);
+
+      expect(createDocument).toHaveBeenCalledWith(
+        appealData,
+        appealData[sectionName][taskName].uploadedFiles[0],
+        null,
+        documentTypes.decisionPlans.name
+      );
+      expect(createDocument).toHaveBeenCalledWith(
+        appealData,
+        appealData[sectionName][taskName].uploadedFiles[1],
+        null,
+        documentTypes.decisionPlans.name
+      );
+      // expect(getTaskStatus).toHaveBeenCalledWith(appeal, sectionName, taskName);
+      expect(createOrUpdateAppeal).toHaveBeenCalledWith(appealData);
+      expect(res.redirect).toHaveBeenCalledWith(`/${SUPPORTING_DOCUMENTS}`);
+      expect(req.session.appeal).toEqual(submittedAppeal);
+    });
+
+    it('should redirect to the correct page if valid and a file is not being uploaded', async () => {
+      const submittedAppeal = {
+        ...appealData,
+        state: 'SUBMITTED',
+      };
+
+      getTaskStatus.mockReturnValue(TASK_STATUS.NOT_STARTED);
+      createOrUpdateAppeal.mockReturnValue(submittedAppeal);
+
+      await postNewPlansDrawings(req, res);
+
+      expect(createDocument).not.toHaveBeenCalled();
+      // expect(getTaskStatus).toHaveBeenCalledWith(appeal, sectionName, taskName);
+      expect(createOrUpdateAppeal).toHaveBeenCalledWith(appealData);
+      expect(res.redirect).toHaveBeenCalledWith(`/${SUPPORTING_DOCUMENTS}`);
+      expect(req.session.appeal).toEqual(submittedAppeal);
+    });
+
+    it('should replace the previously uploaded files with the newly uploaded file', async () => {
+      req.session.appeal[sectionName][taskName].uploadedFiles = [
+        appealData[sectionName][taskName].uploadedFiles[0],
+        appealData[sectionName][taskName].uploadedFiles[1],
+      ];
+
+      const newFile = {
+        id: 'a7ef240f-59ec-4f84-9d15-1fc8ccc2de0a',
+        name: 'plansDrawings3.pdf',
+        fileName: 'plansDrawings3.pdf',
+        originalFileName: 'plansDrawings3.pdf',
+        location: 'a7ef240f-59ec-4f84-9d15-1fc8ccc2de0a/plansDrawings3.pdf',
+        size: 1000,
+      };
+      const submittedAppeal = {
+        ...appealData,
+        state: 'SUBMITTED',
+      };
+      submittedAppeal[sectionName][taskName].uploadedFiles = [newFile];
+
+      createDocument.mockReturnValue(newFile);
+      getTaskStatus.mockReturnValue(TASK_STATUS.NOT_STARTED);
+      createOrUpdateAppeal.mockReturnValue(submittedAppeal);
+
+      req = {
+        ...req,
+        body: {},
+        files: {
+          'file-upload': newFile,
+        },
+      };
+
+      await postNewPlansDrawings(req, res);
+
+      expect(createDocument).toHaveBeenCalledWith(
+        appealData,
+        newFile,
+        null,
+        documentTypes.decisionPlans.name
+      );
+      // expect(getTaskStatus).toHaveBeenCalledWith(appeal, sectionName, taskName);
+      expect(createOrUpdateAppeal).toHaveBeenCalledWith(appealData);
+      expect(res.redirect).toHaveBeenCalledWith(`/${SUPPORTING_DOCUMENTS}`);
+      expect(req.session.appeal).toEqual(submittedAppeal);
+    });
+  });
+});

--- a/packages/forms-web-app/__tests__/unit/routes/full-appeal/submit-appeal/appeal-statement.test.js
+++ b/packages/forms-web-app/__tests__/unit/routes/full-appeal/submit-appeal/appeal-statement.test.js
@@ -39,7 +39,7 @@ describe('routes/full-appeal/submit-appeal/appeal-statement', () => {
     );
     expect(appealStatementValidationRules).toHaveBeenCalledWith('Select your appeal statement');
     expect(setSectionAndTaskNames).toHaveBeenCalledWith(
-      'yourAppealSection',
+      'appealDocumentsSection',
       documentTypes.appealStatement.name
     );
   });

--- a/packages/forms-web-app/__tests__/unit/routes/full-appeal/submit-appeal/index.test.js
+++ b/packages/forms-web-app/__tests__/unit/routes/full-appeal/submit-appeal/index.test.js
@@ -25,6 +25,7 @@ const healthSafetyIssuesRouter = require('../../../../../src/routes/full-appeal/
 const identfyingTheOwnersRouter = require('../../../../../src/routes/full-appeal/submit-appeal/identifying-the-owners');
 const plansDrawingsRouter = require('../../../../../src/routes/full-appeal/submit-appeal/plans-drawings');
 const supportingDocumentsRouter = require('../../../../../src/routes/full-appeal/submit-appeal/supporting-documents');
+const newPlansDrawingsRouter = require('../../../../../src/routes/full-appeal/submit-appeal/new-plans-drawings');
 
 describe('routes/full-appeal/submit-appeal/index', () => {
   beforeEach(() => {
@@ -33,7 +34,7 @@ describe('routes/full-appeal/submit-appeal/index', () => {
   });
 
   it('should define the expected routes', () => {
-    expect(use.mock.calls.length).toBe(26);
+    expect(use.mock.calls.length).toBe(27);
     expect(use).toHaveBeenCalledWith(taskListRouter);
     expect(use).toHaveBeenCalledWith(checkAnswersRouter);
     expect(use).toHaveBeenCalledWith(contactDetailsRouter);
@@ -60,5 +61,6 @@ describe('routes/full-appeal/submit-appeal/index', () => {
     expect(use).toHaveBeenCalledWith(identfyingTheOwnersRouter);
     expect(use).toHaveBeenCalledWith(plansDrawingsRouter);
     expect(use).toHaveBeenCalledWith(supportingDocumentsRouter);
+    expect(use).toHaveBeenCalledWith(newPlansDrawingsRouter);
   });
 });

--- a/packages/forms-web-app/__tests__/unit/routes/full-appeal/submit-appeal/new-plans-drawings.test.js
+++ b/packages/forms-web-app/__tests__/unit/routes/full-appeal/submit-appeal/new-plans-drawings.test.js
@@ -1,0 +1,42 @@
+const { get, post } = require('../../router-mock');
+const {
+  getNewPlansDrawings,
+  postNewPlansDrawings,
+} = require('../../../../../src/controllers/full-appeal/submit-appeal/new-plans-drawings');
+const fetchExistingAppealMiddleware = require('../../../../../src/middleware/fetch-existing-appeal');
+const {
+  validationErrorHandler,
+} = require('../../../../../src/validators/validation-error-handler');
+const {
+  rules: fileUploadValidationRules,
+} = require('../../../../../src/validators/common/file-upload');
+const setSectionAndTaskNames = require('../../../../../src/middleware/set-section-and-task-names');
+
+jest.mock('../../../../../src/middleware/fetch-existing-appeal');
+jest.mock('../../../../../src/validators/common/file-upload');
+jest.mock('../../../../../src/middleware/set-section-and-task-names');
+
+describe('routes/full-appeal/submit-appeal/new-plans-drawings', () => {
+  beforeEach(() => {
+    // eslint-disable-next-line global-require
+    require('../../../../../src/routes/full-appeal/submit-appeal/new-plans-drawings');
+  });
+
+  it('should define the expected routes', () => {
+    expect(get).toHaveBeenCalledWith(
+      '/submit-appeal/new-plans-drawings',
+      [fetchExistingAppealMiddleware],
+      setSectionAndTaskNames(),
+      getNewPlansDrawings
+    );
+    expect(post).toHaveBeenCalledWith(
+      '/submit-appeal/new-plans-drawings',
+      setSectionAndTaskNames(),
+      fileUploadValidationRules(),
+      validationErrorHandler,
+      postNewPlansDrawings
+    );
+    expect(fileUploadValidationRules).toHaveBeenCalledWith('Select a plan or drawing');
+    expect(setSectionAndTaskNames).toHaveBeenCalledWith('appealDocumentsSection', 'plansDrawings');
+  });
+});

--- a/packages/forms-web-app/__tests__/unit/validators/common/schemas/file-upload.test.js
+++ b/packages/forms-web-app/__tests__/unit/validators/common/schemas/file-upload.test.js
@@ -41,13 +41,30 @@ describe('validators/common/schemas/file-upload', () => {
       schema = fileUploadSchema()['file-upload'].custom.options;
     });
 
-    it('should return true if req.files is null and a file has already been uploaded', async () => {
+    it('should return true if req.files is null and a single file has already been uploaded', async () => {
       req.files = null;
       req.session = {
         appeal: {
           [sectionName]: {
             [taskName]: {
               uploadedFile: file,
+            },
+          },
+        },
+      };
+
+      const result = schema(null, { req });
+
+      expect(result).toBeTruthy();
+    });
+
+    it('should return true if req.files is null and multiple files already been uploaded', async () => {
+      req.files = null;
+      req.session = {
+        appeal: {
+          [sectionName]: {
+            [taskName]: {
+              uploadedFiles: [file, file],
             },
           },
         },
@@ -171,7 +188,7 @@ describe('validators/common/schemas/file-upload', () => {
       expect(result).toBeTruthy();
     });
 
-    it('should return true when given a smultiple valid files', async () => {
+    it('should return true when given multiple valid files', async () => {
       req.files = { 'file-upload': [file, file, file] };
 
       const result = await schema(null, { req, path: 'file-upload' });

--- a/packages/forms-web-app/src/controllers/full-appeal/submit-appeal/new-plans-drawings.js
+++ b/packages/forms-web-app/src/controllers/full-appeal/submit-appeal/new-plans-drawings.js
@@ -1,0 +1,94 @@
+const {
+  documentTypes: {
+    decisionPlans: { name: documentType },
+  },
+} = require('@pins/common');
+const {
+  VIEW: {
+    FULL_APPEAL: { NEW_PLANS_DRAWINGS, SUPPORTING_DOCUMENTS },
+  },
+} = require('../../../lib/full-appeal/views');
+const logger = require('../../../lib/logger');
+const { createDocument } = require('../../../lib/documents-api-wrapper');
+const { createOrUpdateAppeal } = require('../../../lib/appeals-api-wrapper');
+// const { getTaskStatus } = require('../../../services/task.service');
+const { NOT_STARTED } = require('../../../services/task-status/task-statuses');
+
+const sectionName = 'appealDocumentsSection';
+const taskName = 'plansDrawings';
+
+const getNewPlansDrawings = (req, res) => {
+  const {
+    session: {
+      appeal: {
+        id: appealId,
+        [sectionName]: {
+          [taskName]: { uploadedFiles },
+        },
+      },
+    },
+  } = req;
+  res.render(NEW_PLANS_DRAWINGS, {
+    appealId,
+    uploadedFiles,
+  });
+};
+
+const postNewPlansDrawings = async (req, res) => {
+  const {
+    body: { errors = {}, errorSummary = [] },
+    files,
+    session: {
+      appeal,
+      appeal: { id: appealId },
+    },
+  } = req;
+
+  if (Object.keys(errors).length > 0) {
+    return res.render(NEW_PLANS_DRAWINGS, {
+      appealId,
+      uploadedFiles: appeal[sectionName][taskName].uploadedFiles,
+      errorSummary,
+      errors,
+    });
+  }
+
+  try {
+    if (files) {
+      appeal[sectionName][taskName].uploadedFiles = [];
+      const fileUpload = files['file-upload'];
+      const uploadedFiles = Array.isArray(fileUpload) ? fileUpload : [fileUpload];
+      await Promise.all(
+        uploadedFiles.map(async (file) => {
+          const { id, location, size } = await createDocument(appeal, file, null, documentType);
+          appeal[sectionName][taskName].uploadedFiles.push({
+            id,
+            name: file.name,
+            fileName: file.name,
+            originalFileName: file.name,
+            location,
+            size,
+          });
+        })
+      );
+    }
+
+    // appeal.sectionStates[sectionName][taskName] = getTaskStatus(appeal, sectionName, taskName);
+    appeal.sectionStates[sectionName][taskName] = NOT_STARTED;
+    req.session.appeal = await createOrUpdateAppeal(appeal);
+  } catch (err) {
+    logger.error(err);
+    return res.render(NEW_PLANS_DRAWINGS, {
+      appealId,
+      uploadedFiles: appeal[sectionName][taskName].uploadedFiles,
+      errorSummary: [{ text: err.toString(), href: '#' }],
+    });
+  }
+
+  return res.redirect(`/${SUPPORTING_DOCUMENTS}`);
+};
+
+module.exports = {
+  getNewPlansDrawings,
+  postNewPlansDrawings,
+};

--- a/packages/forms-web-app/src/routes/full-appeal/submit-appeal/index.js
+++ b/packages/forms-web-app/src/routes/full-appeal/submit-appeal/index.js
@@ -22,9 +22,10 @@ const appealSubmittedRouter = require('./appeal-submitted');
 const declarationInformationRouter = require('./declaration-information');
 const visibleFromRoadRouter = require('./visible-from-road');
 const healthSafetyIssuesRouter = require('./health-safety-issues');
-const identifyingTheOwners = require('./identifying-the-owners');
+const identifyingTheOwnersRouter = require('./identifying-the-owners');
 const plansDrawingsRouter = require('./plans-drawings');
 const supportingDocumentsRouter = require('./supporting-documents');
+const newPlansDrawingsRouter = require('./new-plans-drawings');
 
 const router = express.Router();
 
@@ -51,8 +52,9 @@ router.use(appealSubmittedRouter);
 router.use(declarationInformationRouter);
 router.use(visibleFromRoadRouter);
 router.use(healthSafetyIssuesRouter);
-router.use(identifyingTheOwners);
+router.use(identifyingTheOwnersRouter);
 router.use(plansDrawingsRouter);
 router.use(supportingDocumentsRouter);
+router.use(newPlansDrawingsRouter);
 
 module.exports = router;

--- a/packages/forms-web-app/src/routes/full-appeal/submit-appeal/new-plans-drawings.js
+++ b/packages/forms-web-app/src/routes/full-appeal/submit-appeal/new-plans-drawings.js
@@ -1,32 +1,29 @@
 const express = require('express');
-const { documentTypes } = require('@pins/common');
 const {
-  getAppealStatement,
-  postAppealStatement,
-} = require('../../../controllers/full-appeal/submit-appeal/appeal-statement');
+  getNewPlansDrawings,
+  postNewPlansDrawings,
+} = require('../../../controllers/full-appeal/submit-appeal/new-plans-drawings');
 const fetchExistingAppealMiddleware = require('../../../middleware/fetch-existing-appeal');
 const { validationErrorHandler } = require('../../../validators/validation-error-handler');
-const {
-  rules: appealStatementValidationRules,
-} = require('../../../validators/common/appeal-statement');
+const { rules: fileUploadValidationRules } = require('../../../validators/common/file-upload');
 const setSectionAndTaskNames = require('../../../middleware/set-section-and-task-names');
 
 const router = express.Router();
 const sectionName = 'appealDocumentsSection';
-const taskName = documentTypes.appealStatement.name;
+const taskName = 'plansDrawings';
 
 router.get(
-  '/submit-appeal/appeal-statement',
+  '/submit-appeal/new-plans-drawings',
   [fetchExistingAppealMiddleware],
   setSectionAndTaskNames(sectionName, taskName),
-  getAppealStatement
+  getNewPlansDrawings
 );
 router.post(
-  '/submit-appeal/appeal-statement',
+  '/submit-appeal/new-plans-drawings',
   setSectionAndTaskNames(sectionName, taskName),
-  appealStatementValidationRules('Select your appeal statement'),
+  fileUploadValidationRules('Select a plan or drawing'),
   validationErrorHandler,
-  postAppealStatement
+  postNewPlansDrawings
 );
 
 module.exports = router;

--- a/packages/forms-web-app/src/validators/common/schemas/file-upload.js
+++ b/packages/forms-web-app/src/validators/common/schemas/file-upload.js
@@ -8,6 +8,11 @@ const {
 const validateFileSize = require('../../custom/file-size');
 const mimeTypes = require('../../../lib/mime-types');
 
+const hasAlreadyUploadedFile = (task) => {
+  const { uploadedFile = {}, uploadedFiles = [] } = task;
+  return !!uploadedFile.id || (uploadedFiles[0] && !!uploadedFiles[0].id);
+};
+
 const schema = (noFilesError) => ({
   'file-upload': {
     custom: {
@@ -20,7 +25,7 @@ const schema = (noFilesError) => ({
         } = req;
 
         if (!files) {
-          if (appeal[sectionName] && appeal[sectionName][taskName]?.uploadedFile.id) {
+          if (appeal[sectionName] && hasAlreadyUploadedFile(appeal[sectionName][taskName])) {
             return true;
           }
 

--- a/packages/forms-web-app/src/views/full-appeal/submit-appeal/new-plans-drawings.njk
+++ b/packages/forms-web-app/src/views/full-appeal/submit-appeal/new-plans-drawings.njk
@@ -1,0 +1,83 @@
+{% extends "layouts/main.njk" %}
+
+{% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
+{% from "govuk/components/file-upload/macro.njk" import govukFileUpload %}
+{% from "govuk/components/details/macro.njk" import govukDetails %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
+
+{% set labelText = "Drag and drop or choose files" %}
+{% set title = "New plans and drawings - Appeal a planning decision - GOV.UK" %}
+{% block pageTitle %}{{ "Error: " + title if errors else title }}{% endblock %}
+
+{% block backButton %}
+  {{ govukBackLink({
+    text: 'Back',
+    href: '/full-appeal/submit-appeal/plans-drawings',
+    attributes: {
+      'data-cy': 'back'
+    }
+  }) }}
+{% endblock %}
+
+{% block content %}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      {% if errorSummary %}
+        {{ govukErrorSummary({
+          titleText: "There is a problem",
+          errorList: errorSummary,
+          attributes: {"data-cy": "error-wrapper"}
+        }) }}
+      {% endif %}
+      <span class="govuk-caption-l">Upload documents for your appeal</span>
+      <h1 class="govuk-heading-l">New plans and drawings</h1>
+      {% if uploadedFiles.length %}
+        <h2 class="govuk-heading-m govuk-!-margin-top-8">Uploaded files</h2>
+        <ul class="govuk-list">
+        {%- for file in uploadedFiles %}
+          <li><a href="/document/{{appealId}}/{{file.id}}" class="govuk-link">{{ file.name }}</a></li>
+        {%- endfor %}
+        </ul>
+        {% set labelText = "Replace the files" %}
+      {% endif %}
+      <form action="" method="post" novalidate enctype="multipart/form-data">
+        {{ govukFileUpload({
+          id: "file-upload",
+          name: "file-upload",
+          classes: "pins-file-upload",
+          attributes: {
+            'multiple': true
+          },
+          label: {
+            text: labelText,
+            classes: "govuk-label--m"
+          },
+          errorMessage: errors['file-upload'] and { text: errors['file-upload'].msg }
+        }) }}
+
+        {{ govukDetails({
+          summaryText: "Files you can upload",
+          html: '<p class="govuk-body">
+                  You can upload the following types of file:
+                </p>
+                <ul class="govuk-list govuk-list--bullet">
+                  <li>DOC or DOCX</li>
+                  <li>JPG or JPEG</li>
+                  <li>PDF</li>
+                  <li>PNG</li>
+                  <li>TIF or TIFF</li>
+                </ul>
+                <p class="govuk-body">
+                  Your file must be smaller than 15MB.
+                </p>'
+        }) }}
+
+        {{ govukButton({
+          text: "Continue",
+          type: "submit",
+          attributes: { "data-cy":"button-save-and-continue"}
+        }) }}
+      </form>
+    </div>
+  </div>
+{% endblock %}


### PR DESCRIPTION
## Ticket Number
https://pins-ds.atlassian.net/browse/AS-4328

## Description of change
Add the Full Appeal New Plans and Drawings page

![Screenshot from 2022-02-15 14-51-12](https://user-images.githubusercontent.com/6839214/154086601-b668e486-ff35-4fa9-82fa-52dd5c87e333.png)

## Checklist
<!-- Put an `x` in all the boxes that apply: -->
- [ ] Requires infrastructure changes
- [ ] If adding or remove environment variables (e.g. in `docker-compose.yaml`) then I have updated the appropriate Helm chart
- [ ] I have updated the documentation accordingly
- [ ] My commit history in this PR is linear
- [ ] New features have tests
- [ ] Breaking change (team conversation required)

## Important

Please do not merge from `master` (please only [rebase](https://github.com/foundry4/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
