### PR TITLE
feat(as-4334): add full appeal new supporting documents page

### DIFF
--- a/packages/business-rules/src/schemas/full-appeal/insert.js
+++ b/packages/business-rules/src/schemas/full-appeal/insert.js
@@ -259,6 +259,22 @@ const insert = pinsYup
           .object()
           .shape({
             hasSupportingDocuments: pinsYup.bool().nullable().default(null),
+            uploadedFiles: pinsYup
+              .array()
+              .of(
+                pinsYup
+                  .object()
+                  .shape({
+                    id: pinsYup.string().trim().uuid().nullable().default(null),
+                    name: pinsYup.string().trim().max(255).ensure(),
+                    fileName: pinsYup.string().trim().max(255).ensure(),
+                    originalFileName: pinsYup.string().trim().max(255).ensure(),
+                    location: pinsYup.string().trim().nullable(),
+                    size: pinsYup.number().nullable(),
+                  })
+                  .noUnknown(true),
+              )
+              .ensure(),
           })
           .noUnknown(true),
       })

--- a/packages/business-rules/src/schemas/full-appeal/insert.test.js
+++ b/packages/business-rules/src/schemas/full-appeal/insert.test.js
@@ -748,6 +748,175 @@ describe('schemas/full-appeal/insert', () => {
             expect(result).toEqual(appeal);
           });
         });
+
+        describe('appealDocumentsSection.supportingDocuments.uploadedFiles', () => {
+          it('should not throw an error when given a null value', async () => {
+            appeal.appealDocumentsSection.supportingDocuments.uploadedFiles = null;
+            appeal2.appealDocumentsSection.supportingDocuments.uploadedFiles = [];
+
+            const result = await insert.validate(appeal, config);
+            expect(result).toEqual(appeal2);
+          });
+
+          it('should not throw an error when not given a value', async () => {
+            delete appeal.appealDocumentsSection.supportingDocuments.uploadedFiles;
+            appeal2.appealDocumentsSection.supportingDocuments.uploadedFiles = [];
+
+            const result = await insert.validate(appeal2, config);
+            expect(result).toEqual(appeal2);
+          });
+
+          describe('appealDocumentsSection.supportingDocuments.uploadedFiles[0].id', () => {
+            it('should strip leading/trailing spaces', async () => {
+              appeal2.appealDocumentsSection.supportingDocuments.uploadedFiles[0].id =
+                '  271c9b5b-af90-4b45-b0e7-0a7882da1e03  ';
+              appeal.appealDocumentsSection.supportingDocuments.uploadedFiles[0].id =
+                '271c9b5b-af90-4b45-b0e7-0a7882da1e03';
+
+              const result = await insert.validate(appeal2, config);
+              expect(result).toEqual(appeal);
+            });
+
+            it('should throw an error when not given a UUID', async () => {
+              appeal.appealDocumentsSection.supportingDocuments.uploadedFiles[0].id = 'abc123';
+
+              await expect(() => insert.validate(appeal, config)).rejects.toThrow(
+                'appealDocumentsSection.supportingDocuments.uploadedFiles[0].id must be a valid UUID',
+              );
+            });
+
+            it('should not throw an error when not given a value', async () => {
+              delete appeal2.appealDocumentsSection.supportingDocuments.uploadedFiles[0].id;
+              appeal.appealDocumentsSection.supportingDocuments.uploadedFiles[0].id = null;
+
+              const result = await insert.validate(appeal2, config);
+              expect(result).toEqual(appeal);
+            });
+          });
+
+          describe('appealDocumentsSection.supportingDocuments.uploadedFiles[0].name', () => {
+            it('should throw an error when given a value with more than 255 characters', async () => {
+              appeal.appealDocumentsSection.supportingDocuments.uploadedFiles[0].name = 'a'.repeat(
+                256,
+              );
+
+              await expect(() => insert.validate(appeal, config)).rejects.toThrow(
+                'appealDocumentsSection.supportingDocuments.uploadedFiles[0].name must be at most 255 characters',
+              );
+            });
+
+            it('should strip leading/trailing spaces', async () => {
+              appeal2.appealDocumentsSection.supportingDocuments.uploadedFiles[0].name =
+                '  test-pdf.pdf  ';
+              appeal.appealDocumentsSection.supportingDocuments.uploadedFiles[0].name =
+                'test-pdf.pdf';
+
+              const result = await insert.validate(appeal2, config);
+              expect(result).toEqual(appeal);
+            });
+
+            it('should not throw an error when not given a value', async () => {
+              appeal.appealDocumentsSection.supportingDocuments.uploadedFiles[0].name = '';
+
+              const result = await insert.validate(appeal, config);
+              expect(result).toEqual(appeal);
+            });
+          });
+
+          describe('appealDocumentsSection.supportingDocuments.uploadedFiles[0].fileName', () => {
+            it('should throw an error when given a value with more than 255 characters', async () => {
+              appeal.appealDocumentsSection.supportingDocuments.uploadedFiles[0].fileName =
+                'a'.repeat(256);
+
+              await expect(() => insert.validate(appeal, config)).rejects.toThrow(
+                'appealDocumentsSection.supportingDocuments.uploadedFiles[0].fileName must be at most 255 characters',
+              );
+            });
+
+            it('should strip leading/trailing spaces', async () => {
+              appeal2.appealDocumentsSection.supportingDocuments.uploadedFiles[0].fileName =
+                '  test-pdf.pdf  ';
+              appeal.appealDocumentsSection.supportingDocuments.uploadedFiles[0].fileName =
+                'test-pdf.pdf';
+
+              const result = await insert.validate(appeal2, config);
+              expect(result).toEqual(appeal);
+            });
+
+            it('should not throw an error when not given a value', async () => {
+              appeal.appealDocumentsSection.supportingDocuments.uploadedFiles[0].fileName = '';
+
+              const result = await insert.validate(appeal, config);
+              expect(result).toEqual(appeal);
+            });
+          });
+
+          describe('appealDocumentsSection.supportingDocuments.uploadedFiles[0].originalFileName', () => {
+            it('should throw an error when given a value with more than 255 characters', async () => {
+              appeal.appealDocumentsSection.supportingDocuments.uploadedFiles[0].originalFileName =
+                'a'.repeat(256);
+
+              await expect(() => insert.validate(appeal, config)).rejects.toThrow(
+                'appealDocumentsSection.supportingDocuments.uploadedFiles[0].originalFileName must be at most 255 characters',
+              );
+            });
+
+            it('should strip leading/trailing spaces', async () => {
+              appeal2.appealDocumentsSection.supportingDocuments.uploadedFiles[0].originalFileName =
+                '  test-pdf.pdf  ';
+              appeal.appealDocumentsSection.supportingDocuments.uploadedFiles[0].originalFileName =
+                'test-pdf.pdf';
+
+              const result = await insert.validate(appeal2, config);
+              expect(result).toEqual(appeal);
+            });
+
+            it('should not throw an error when not given a value', async () => {
+              appeal.appealDocumentsSection.supportingDocuments.uploadedFiles[0].originalFileName =
+                '';
+
+              const result = await insert.validate(appeal, config);
+              expect(result).toEqual(appeal);
+            });
+          });
+
+          describe('appealDocumentsSection.supportingDocuments.uploadedFiles[0].location', () => {
+            it('should strip leading/trailing spaces', async () => {
+              appeal2.appealDocumentsSection.supportingDocuments.uploadedFiles[0].location =
+                '  test-pdf.pdf  ';
+              appeal.appealDocumentsSection.supportingDocuments.uploadedFiles[0].location =
+                'test-pdf.pdf';
+
+              const result = await insert.validate(appeal2, config);
+              expect(result).toEqual(appeal);
+            });
+
+            it('should not throw an error when not given a value', async () => {
+              appeal.appealDocumentsSection.supportingDocuments.uploadedFiles[0].location = '';
+
+              const result = await insert.validate(appeal, config);
+              expect(result).toEqual(appeal);
+            });
+          });
+
+          describe('appealDocumentsSection.supportingDocuments.uploadedFiles[0].size', () => {
+            it('should throw an error when not given a number', async () => {
+              appeal.appealDocumentsSection.supportingDocuments.uploadedFiles[0].size =
+                'not-a-number';
+
+              await expect(() => insert.validate(appeal, config)).rejects.toThrow(
+                'appealDocumentsSection.supportingDocuments.uploadedFiles[0].size must be a `number` type, but the final value was: `NaN` (cast from the value `1000`).',
+              );
+            });
+
+            it('should not throw an error when not given a value', async () => {
+              delete appeal.appealDocumentsSection.supportingDocuments.uploadedFiles[0].size;
+
+              const result = await insert.validate(appeal, config);
+              expect(result).toEqual(appeal);
+            });
+          });
+        });
       });
     });
 

--- a/packages/business-rules/src/schemas/full-appeal/update.js
+++ b/packages/business-rules/src/schemas/full-appeal/update.js
@@ -238,6 +238,22 @@ const update = pinsYup
           .object()
           .shape({
             hasSupportingDocuments: pinsYup.bool().required(),
+            uploadedFiles: pinsYup
+              .array()
+              .of(
+                pinsYup
+                  .object()
+                  .shape({
+                    id: pinsYup.string().trim().uuid().nullable(),
+                    name: pinsYup.string().trim().max(255).nullable(),
+                    fileName: pinsYup.string().trim().max(255).nullable(),
+                    originalFileName: pinsYup.string().trim().max(255).nullable(),
+                    location: pinsYup.string().trim().nullable(),
+                    size: pinsYup.number().nullable(),
+                  })
+                  .noUnknown(true),
+              )
+              .ensure(),
           })
           .noUnknown(true),
       })

--- a/packages/business-rules/src/schemas/full-appeal/update.test.js
+++ b/packages/business-rules/src/schemas/full-appeal/update.test.js
@@ -784,6 +784,166 @@ describe('schemas/full-appeal/update', () => {
             );
           });
         });
+
+        describe('appealDocumentsSection.supportingDocuments.uploadedFiles', () => {
+          it('should not throw an error when not given a value', async () => {
+            delete appeal.appealDocumentsSection.supportingDocuments.uploadedFiles;
+            appeal2.appealDocumentsSection.supportingDocuments.uploadedFiles = [];
+
+            const result = await update.validate(appeal2, config);
+            expect(result).toEqual(appeal2);
+          });
+
+          describe('appealDocumentsSection.supportingDocuments.uploadedFiles[0].id', () => {
+            it('should strip leading/trailing spaces', async () => {
+              appeal2.appealDocumentsSection.supportingDocuments.uploadedFiles[0].id =
+                '  271c9b5b-af90-4b45-b0e7-0a7882da1e03  ';
+              appeal.appealDocumentsSection.supportingDocuments.uploadedFiles[0].id =
+                '271c9b5b-af90-4b45-b0e7-0a7882da1e03';
+
+              const result = await update.validate(appeal2, config);
+              expect(result).toEqual(appeal);
+            });
+
+            it('should throw an error when not given a UUID', async () => {
+              appeal.appealDocumentsSection.supportingDocuments.uploadedFiles[0].id = 'abc123';
+
+              await expect(() => update.validate(appeal, config)).rejects.toThrow(
+                'appealDocumentsSection.supportingDocuments.uploadedFiles[0].id must be a valid UUID',
+              );
+            });
+
+            it('should not throw an error when not given a value', async () => {
+              delete appeal.appealDocumentsSection.supportingDocuments.uploadedFiles[0].id;
+
+              const result = await update.validate(appeal, config);
+              expect(result).toEqual(appeal);
+            });
+          });
+
+          describe('appealDocumentsSection.supportingDocuments.uploadedFiles[0].name', () => {
+            it('should throw an error when given a value with more than 255 characters', async () => {
+              appeal.appealDocumentsSection.supportingDocuments.uploadedFiles[0].name = 'a'.repeat(
+                256,
+              );
+
+              await expect(() => update.validate(appeal, config)).rejects.toThrow(
+                'appealDocumentsSection.supportingDocuments.uploadedFiles[0].name must be at most 255 characters',
+              );
+            });
+
+            it('should strip leading/trailing spaces', async () => {
+              appeal2.appealDocumentsSection.supportingDocuments.uploadedFiles[0].name =
+                '  test-pdf.pdf  ';
+              appeal.appealDocumentsSection.supportingDocuments.uploadedFiles[0].name =
+                'test-pdf.pdf';
+
+              const result = await update.validate(appeal2, config);
+              expect(result).toEqual(appeal);
+            });
+
+            it('should not throw an error when not given a value', async () => {
+              delete appeal.appealDocumentsSection.supportingDocuments.uploadedFiles[0].name;
+
+              const result = await update.validate(appeal, config);
+              expect(result).toEqual(appeal);
+            });
+          });
+
+          describe('appealDocumentsSection.supportingDocuments.uploadedFiles[0].fileName', () => {
+            it('should throw an error when given a value with more than 255 characters', async () => {
+              appeal.appealDocumentsSection.supportingDocuments.uploadedFiles[0].fileName =
+                'a'.repeat(256);
+
+              await expect(() => update.validate(appeal, config)).rejects.toThrow(
+                'appealDocumentsSection.supportingDocuments.uploadedFiles[0].fileName must be at most 255 characters',
+              );
+            });
+
+            it('should strip leading/trailing spaces', async () => {
+              appeal2.appealDocumentsSection.supportingDocuments.uploadedFiles[0].fileName =
+                '  test-pdf.pdf  ';
+              appeal.appealDocumentsSection.supportingDocuments.uploadedFiles[0].fileName =
+                'test-pdf.pdf';
+
+              const result = await update.validate(appeal2, config);
+              expect(result).toEqual(appeal);
+            });
+
+            it('should not throw an error when not given a value', async () => {
+              delete appeal.appealDocumentsSection.supportingDocuments.uploadedFiles[0].fileName;
+
+              const result = await update.validate(appeal, config);
+              expect(result).toEqual(appeal);
+            });
+          });
+
+          describe('appealDocumentsSection.supportingDocuments.uploadedFiles[0].originalFileName', () => {
+            it('should throw an error when given a value with more than 255 characters', async () => {
+              appeal.appealDocumentsSection.supportingDocuments.uploadedFiles[0].originalFileName =
+                'a'.repeat(256);
+
+              await expect(() => update.validate(appeal, config)).rejects.toThrow(
+                'appealDocumentsSection.supportingDocuments.uploadedFiles[0].originalFileName must be at most 255 characters',
+              );
+            });
+
+            it('should strip leading/trailing spaces', async () => {
+              appeal2.appealDocumentsSection.supportingDocuments.uploadedFiles[0].originalFileName =
+                '  test-pdf.pdf  ';
+              appeal.appealDocumentsSection.supportingDocuments.uploadedFiles[0].originalFileName =
+                'test-pdf.pdf';
+
+              const result = await update.validate(appeal2, config);
+              expect(result).toEqual(appeal);
+            });
+
+            it('should not throw an error when not given a value', async () => {
+              delete appeal.appealDocumentsSection.supportingDocuments.uploadedFiles[0]
+                .originalFileName;
+
+              const result = await update.validate(appeal, config);
+              expect(result).toEqual(appeal);
+            });
+          });
+
+          describe('appealDocumentsSection.supportingDocuments.uploadedFiles[0].location', () => {
+            it('should strip leading/trailing spaces', async () => {
+              appeal2.appealDocumentsSection.supportingDocuments.uploadedFiles[0].location =
+                '  test-pdf.pdf  ';
+              appeal.appealDocumentsSection.supportingDocuments.uploadedFiles[0].location =
+                'test-pdf.pdf';
+
+              const result = await update.validate(appeal2, config);
+              expect(result).toEqual(appeal);
+            });
+
+            it('should not throw an error when not given a value', async () => {
+              delete appeal.appealDocumentsSection.supportingDocuments.uploadedFiles[0].location;
+
+              const result = await update.validate(appeal, config);
+              expect(result).toEqual(appeal);
+            });
+          });
+
+          describe('appealDocumentsSection.supportingDocuments.uploadedFiles[0].size', () => {
+            it('should throw an error when not given a number', async () => {
+              appeal.appealDocumentsSection.supportingDocuments.uploadedFiles[0].size =
+                'not-a-number';
+
+              await expect(() => update.validate(appeal, config)).rejects.toThrow(
+                'appealDocumentsSection.supportingDocuments.uploadedFiles[0].size must be a `number` type, but the final value was: `NaN` (cast from the value `1000`).',
+              );
+            });
+
+            it('should not throw an error when not given a value', async () => {
+              delete appeal.appealDocumentsSection.supportingDocuments.uploadedFiles[0].size;
+
+              const result = await update.validate(appeal, config);
+              expect(result).toEqual(appeal);
+            });
+          });
+        });
       });
     });
 

--- a/packages/business-rules/test/data/full-appeal.js
+++ b/packages/business-rules/test/data/full-appeal.js
@@ -120,6 +120,24 @@ const appeal = {
     },
     supportingDocuments: {
       hasSupportingDocuments: true,
+      uploadedFiles: [
+        {
+          id: '059c3060-b112-4520-bf85-21a3894016ab',
+          name: 'supportingDocuments1.pdf',
+          fileName: 'supportingDocuments1.pdf',
+          originalFileName: 'supportingDocuments1.pdf',
+          location: '059c3060-b112-4520-bf85-21a3894016ab/supportingDocuments1.pdf',
+          size: 1000,
+        },
+        {
+          id: '4e501f91-0572-4c50-b0d2-28748b46454a',
+          name: 'supportingDocuments2.pdf',
+          fileName: 'supportingDocuments2.pdf',
+          originalFileName: 'supportingDocuments2.pdf',
+          location: '4e501f91-0572-4c50-b0d2-28748b46454a/supportingDocuments2.pdf',
+          size: 1000,
+        },
+      ],
     },
   },
   appealSubmission: {

--- a/packages/forms-web-app/__tests__/unit/controllers/full-appeal/submit-appeal/new-supporting-documents.test.js
+++ b/packages/forms-web-app/__tests__/unit/controllers/full-appeal/submit-appeal/new-supporting-documents.test.js
@@ -1,0 +1,240 @@
+const appeal = require('@pins/business-rules/test/data/full-appeal');
+const v8 = require('v8');
+const { documentTypes } = require('@pins/common');
+const {
+  getNewSupportingDocuments,
+  postNewSupportingDocuments,
+} = require('../../../../../src/controllers/full-appeal/submit-appeal/new-supporting-documents');
+const { createOrUpdateAppeal } = require('../../../../../src/lib/appeals-api-wrapper');
+const { createDocument } = require('../../../../../src/lib/documents-api-wrapper');
+const { getTaskStatus } = require('../../../../../src/services/task.service');
+const TASK_STATUS = require('../../../../../src/services/task-status/task-statuses');
+const { mockReq, mockRes } = require('../../../mocks');
+const {
+  VIEW: {
+    FULL_APPEAL: { NEW_SUPPORTING_DOCUMENTS, TASK_LIST },
+  },
+} = require('../../../../../src/lib/full-appeal/views');
+
+jest.mock('../../../../../src/lib/appeals-api-wrapper');
+jest.mock('../../../../../src/lib/documents-api-wrapper');
+jest.mock('../../../../../src/services/task.service');
+
+describe('controllers/full-appeal/submit-appeal/new-supporting-documents', () => {
+  let req;
+  let res;
+  let appealData;
+
+  const sectionName = 'appealDocumentsSection';
+  const taskName = 'supportingDocuments';
+  const errors = { 'file-upload': 'Select a file upload' };
+  const errorSummary = [{ text: 'There was an error', href: '#' }];
+
+  beforeEach(() => {
+    req = v8.deserialize(
+      v8.serialize({
+        ...mockReq(appeal),
+        body: {},
+      })
+    );
+    res = mockRes();
+    appealData = v8.deserialize(v8.serialize(appeal));
+
+    jest.resetAllMocks();
+  });
+
+  describe('getNewSupportingDocuments', () => {
+    it('should call the correct template', () => {
+      getNewSupportingDocuments(req, res);
+
+      expect(res.render).toHaveBeenCalledTimes(1);
+      expect(res.render).toHaveBeenCalledWith(NEW_SUPPORTING_DOCUMENTS, {
+        appealId: appealData.id,
+        uploadedFiles: appealData[sectionName][taskName].uploadedFiles,
+      });
+    });
+  });
+
+  describe('postNewSupportingDocuments', () => {
+    it('should re-render the template with errors if submission validation fails', async () => {
+      req = {
+        ...req,
+        body: {
+          errors,
+          errorSummary,
+        },
+        files: {
+          'file-upload': {},
+        },
+      };
+
+      await postNewSupportingDocuments(req, res);
+
+      expect(res.redirect).not.toHaveBeenCalled();
+      expect(res.render).toHaveBeenCalledTimes(1);
+      expect(res.render).toHaveBeenCalledWith(NEW_SUPPORTING_DOCUMENTS, {
+        appealId: appealData.id,
+        uploadedFiles: appealData[sectionName][taskName].uploadedFiles,
+        errors,
+        errorSummary,
+      });
+    });
+
+    it('should re-render the template with errors if an error is thrown', async () => {
+      const error = new Error('Internal Server Error');
+
+      createOrUpdateAppeal.mockImplementation(() => Promise.reject(error));
+
+      await postNewSupportingDocuments(req, res);
+
+      expect(res.redirect).not.toHaveBeenCalled();
+      expect(res.render).toHaveBeenCalledTimes(1);
+      expect(res.render).toHaveBeenCalledWith(NEW_SUPPORTING_DOCUMENTS, {
+        appealId: appealData.id,
+        uploadedFiles: appealData[sectionName][taskName].uploadedFiles,
+        errorSummary: [{ text: error.toString(), href: '#' }],
+      });
+    });
+
+    it('should redirect to the correct page if valid and a single file is being uploaded', async () => {
+      appealData[sectionName][taskName].uploadedFiles.pop();
+      req.session.appeal[sectionName][taskName].uploadedFiles = [];
+
+      const submittedAppeal = {
+        ...appealData,
+        state: 'SUBMITTED',
+      };
+
+      createDocument.mockReturnValue(appealData[sectionName][taskName].uploadedFiles[0]);
+      getTaskStatus.mockReturnValue(TASK_STATUS.NOT_STARTED);
+      createOrUpdateAppeal.mockReturnValue(submittedAppeal);
+
+      req = {
+        ...req,
+        body: {},
+        files: {
+          'file-upload': appealData[sectionName][taskName].uploadedFiles[0],
+        },
+      };
+
+      await postNewSupportingDocuments(req, res);
+
+      expect(createDocument).toHaveBeenCalledWith(
+        appealData,
+        appealData[sectionName][taskName].uploadedFiles[0],
+        null,
+        documentTypes.otherDocuments.name
+      );
+      // expect(getTaskStatus).toHaveBeenCalledWith(appeal, sectionName, taskName);
+      expect(createOrUpdateAppeal).toHaveBeenCalledWith(appealData);
+      expect(res.redirect).toHaveBeenCalledWith(`/${TASK_LIST}`);
+      expect(req.session.appeal).toEqual(submittedAppeal);
+    });
+
+    it('should redirect to the correct page if valid and multiple files are being uploaded', async () => {
+      req.session.appeal[sectionName][taskName].uploadedFiles = [];
+
+      const submittedAppeal = {
+        ...appealData,
+        state: 'SUBMITTED',
+      };
+
+      createDocument
+        .mockReturnValueOnce(appealData[sectionName][taskName].uploadedFiles[0])
+        .mockReturnValueOnce(appealData[sectionName][taskName].uploadedFiles[1]);
+      getTaskStatus.mockReturnValue(TASK_STATUS.NOT_STARTED);
+      createOrUpdateAppeal.mockReturnValue(submittedAppeal);
+
+      req = {
+        ...req,
+        body: {},
+        files: {
+          'file-upload': appealData[sectionName][taskName].uploadedFiles,
+        },
+      };
+
+      await postNewSupportingDocuments(req, res);
+
+      expect(createDocument).toHaveBeenCalledWith(
+        appealData,
+        appealData[sectionName][taskName].uploadedFiles[0],
+        null,
+        documentTypes.otherDocuments.name
+      );
+      expect(createDocument).toHaveBeenCalledWith(
+        appealData,
+        appealData[sectionName][taskName].uploadedFiles[1],
+        null,
+        documentTypes.otherDocuments.name
+      );
+      // expect(getTaskStatus).toHaveBeenCalledWith(appeal, sectionName, taskName);
+      expect(createOrUpdateAppeal).toHaveBeenCalledWith(appealData);
+      expect(res.redirect).toHaveBeenCalledWith(`/${TASK_LIST}`);
+      expect(req.session.appeal).toEqual(submittedAppeal);
+    });
+
+    it('should redirect to the correct page if valid and a file is not being uploaded', async () => {
+      const submittedAppeal = {
+        ...appealData,
+        state: 'SUBMITTED',
+      };
+
+      getTaskStatus.mockReturnValue(TASK_STATUS.NOT_STARTED);
+      createOrUpdateAppeal.mockReturnValue(submittedAppeal);
+
+      await postNewSupportingDocuments(req, res);
+
+      expect(createDocument).not.toHaveBeenCalled();
+      // expect(getTaskStatus).toHaveBeenCalledWith(appeal, sectionName, taskName);
+      expect(createOrUpdateAppeal).toHaveBeenCalledWith(appealData);
+      expect(res.redirect).toHaveBeenCalledWith(`/${TASK_LIST}`);
+      expect(req.session.appeal).toEqual(submittedAppeal);
+    });
+
+    it('should replace the previously uploaded files with the newly uploaded file', async () => {
+      req.session.appeal[sectionName][taskName].uploadedFiles = [
+        appealData[sectionName][taskName].uploadedFiles[0],
+        appealData[sectionName][taskName].uploadedFiles[1],
+      ];
+
+      const newFile = {
+        id: 'a7ef240f-59ec-4f84-9d15-1fc8ccc2de0a',
+        name: 'supportingDocuments3.pdf',
+        fileName: 'supportingDocuments3.pdf',
+        originalFileName: 'supportingDocuments3.pdf',
+        location: 'a7ef240f-59ec-4f84-9d15-1fc8ccc2de0a/supportingDocuments3.pdf',
+        size: 1000,
+      };
+      const submittedAppeal = {
+        ...appealData,
+        state: 'SUBMITTED',
+      };
+      submittedAppeal[sectionName][taskName].uploadedFiles = [newFile];
+
+      createDocument.mockReturnValue(newFile);
+      getTaskStatus.mockReturnValue(TASK_STATUS.NOT_STARTED);
+      createOrUpdateAppeal.mockReturnValue(submittedAppeal);
+
+      req = {
+        ...req,
+        body: {},
+        files: {
+          'file-upload': newFile,
+        },
+      };
+
+      await postNewSupportingDocuments(req, res);
+
+      expect(createDocument).toHaveBeenCalledWith(
+        appealData,
+        newFile,
+        null,
+        documentTypes.otherDocuments.name
+      );
+      // expect(getTaskStatus).toHaveBeenCalledWith(appeal, sectionName, taskName);
+      expect(createOrUpdateAppeal).toHaveBeenCalledWith(appealData);
+      expect(res.redirect).toHaveBeenCalledWith(`/${TASK_LIST}`);
+      expect(req.session.appeal).toEqual(submittedAppeal);
+    });
+  });
+});

--- a/packages/forms-web-app/__tests__/unit/routes/full-appeal/submit-appeal/index.test.js
+++ b/packages/forms-web-app/__tests__/unit/routes/full-appeal/submit-appeal/index.test.js
@@ -26,6 +26,7 @@ const identfyingTheOwnersRouter = require('../../../../../src/routes/full-appeal
 const plansDrawingsRouter = require('../../../../../src/routes/full-appeal/submit-appeal/plans-drawings');
 const supportingDocumentsRouter = require('../../../../../src/routes/full-appeal/submit-appeal/supporting-documents');
 const newPlansDrawingsRouter = require('../../../../../src/routes/full-appeal/submit-appeal/new-plans-drawings');
+const newSupportingDocumentsRouter = require('../../../../../src/routes/full-appeal/submit-appeal/new-supporting-documents');
 
 describe('routes/full-appeal/submit-appeal/index', () => {
   beforeEach(() => {
@@ -34,7 +35,7 @@ describe('routes/full-appeal/submit-appeal/index', () => {
   });
 
   it('should define the expected routes', () => {
-    expect(use.mock.calls.length).toBe(27);
+    expect(use.mock.calls.length).toBe(28);
     expect(use).toHaveBeenCalledWith(taskListRouter);
     expect(use).toHaveBeenCalledWith(checkAnswersRouter);
     expect(use).toHaveBeenCalledWith(contactDetailsRouter);
@@ -62,5 +63,6 @@ describe('routes/full-appeal/submit-appeal/index', () => {
     expect(use).toHaveBeenCalledWith(plansDrawingsRouter);
     expect(use).toHaveBeenCalledWith(supportingDocumentsRouter);
     expect(use).toHaveBeenCalledWith(newPlansDrawingsRouter);
+    expect(use).toHaveBeenCalledWith(newSupportingDocumentsRouter);
   });
 });

--- a/packages/forms-web-app/__tests__/unit/routes/full-appeal/submit-appeal/new-supporting-documents.test.js
+++ b/packages/forms-web-app/__tests__/unit/routes/full-appeal/submit-appeal/new-supporting-documents.test.js
@@ -1,0 +1,45 @@
+const { get, post } = require('../../router-mock');
+const {
+  getNewSupportingDocuments,
+  postNewSupportingDocuments,
+} = require('../../../../../src/controllers/full-appeal/submit-appeal/new-supporting-documents');
+const fetchExistingAppealMiddleware = require('../../../../../src/middleware/fetch-existing-appeal');
+const {
+  validationErrorHandler,
+} = require('../../../../../src/validators/validation-error-handler');
+const {
+  rules: fileUploadValidationRules,
+} = require('../../../../../src/validators/common/file-upload');
+const setSectionAndTaskNames = require('../../../../../src/middleware/set-section-and-task-names');
+
+jest.mock('../../../../../src/middleware/fetch-existing-appeal');
+jest.mock('../../../../../src/validators/common/file-upload');
+jest.mock('../../../../../src/middleware/set-section-and-task-names');
+
+describe('routes/full-appeal/submit-appeal/new-supporting-documents', () => {
+  beforeEach(() => {
+    // eslint-disable-next-line global-require
+    require('../../../../../src/routes/full-appeal/submit-appeal/new-supporting-documents');
+  });
+
+  it('should define the expected routes', () => {
+    expect(get).toHaveBeenCalledWith(
+      '/submit-appeal/new-supporting-documents',
+      [fetchExistingAppealMiddleware],
+      setSectionAndTaskNames(),
+      getNewSupportingDocuments
+    );
+    expect(post).toHaveBeenCalledWith(
+      '/submit-appeal/new-supporting-documents',
+      setSectionAndTaskNames(),
+      fileUploadValidationRules(),
+      validationErrorHandler,
+      postNewSupportingDocuments
+    );
+    expect(fileUploadValidationRules).toHaveBeenCalledWith('Select a supporting document');
+    expect(setSectionAndTaskNames).toHaveBeenCalledWith(
+      'appealDocumentsSection',
+      'supportingDocuments'
+    );
+  });
+});

--- a/packages/forms-web-app/src/controllers/full-appeal/submit-appeal/new-supporting-documents.js
+++ b/packages/forms-web-app/src/controllers/full-appeal/submit-appeal/new-supporting-documents.js
@@ -1,0 +1,94 @@
+const {
+  documentTypes: {
+    otherDocuments: { name: documentType },
+  },
+} = require('@pins/common');
+const {
+  VIEW: {
+    FULL_APPEAL: { NEW_SUPPORTING_DOCUMENTS, TASK_LIST },
+  },
+} = require('../../../lib/full-appeal/views');
+const logger = require('../../../lib/logger');
+const { createDocument } = require('../../../lib/documents-api-wrapper');
+const { createOrUpdateAppeal } = require('../../../lib/appeals-api-wrapper');
+// const { getTaskStatus } = require('../../../services/task.service');
+const { NOT_STARTED } = require('../../../services/task-status/task-statuses');
+
+const sectionName = 'appealDocumentsSection';
+const taskName = 'supportingDocuments';
+
+const getNewSupportingDocuments = (req, res) => {
+  const {
+    session: {
+      appeal: {
+        id: appealId,
+        [sectionName]: {
+          [taskName]: { uploadedFiles },
+        },
+      },
+    },
+  } = req;
+  res.render(NEW_SUPPORTING_DOCUMENTS, {
+    appealId,
+    uploadedFiles,
+  });
+};
+
+const postNewSupportingDocuments = async (req, res) => {
+  const {
+    body: { errors = {}, errorSummary = [] },
+    files,
+    session: {
+      appeal,
+      appeal: { id: appealId },
+    },
+  } = req;
+
+  if (Object.keys(errors).length > 0) {
+    return res.render(NEW_SUPPORTING_DOCUMENTS, {
+      appealId,
+      uploadedFiles: appeal[sectionName][taskName].uploadedFiles,
+      errorSummary,
+      errors,
+    });
+  }
+
+  try {
+    if (files) {
+      appeal[sectionName][taskName].uploadedFiles = [];
+      const fileUpload = files['file-upload'];
+      const uploadedFiles = Array.isArray(fileUpload) ? fileUpload : [fileUpload];
+      await Promise.all(
+        uploadedFiles.map(async (file) => {
+          const { id, location, size } = await createDocument(appeal, file, null, documentType);
+          appeal[sectionName][taskName].uploadedFiles.push({
+            id,
+            name: file.name,
+            fileName: file.name,
+            originalFileName: file.name,
+            location,
+            size,
+          });
+        })
+      );
+    }
+
+    // appeal.sectionStates[sectionName][taskName] = getTaskStatus(appeal, sectionName, taskName);
+    appeal.sectionStates[sectionName][taskName] = NOT_STARTED;
+    req.session.appeal = await createOrUpdateAppeal(appeal);
+  } catch (err) {
+    logger.error(err);
+    return res.render(NEW_SUPPORTING_DOCUMENTS, {
+      appealId,
+      uploadedFiles: appeal[sectionName][taskName].uploadedFiles,
+      errorSummary: [{ text: err.toString(), href: '#' }],
+    });
+  }
+
+  return res.redirect(`/${TASK_LIST}`);
+};
+
+module.exports = {
+  getNewSupportingDocuments,
+  postNewSupportingDocuments,
+};

--- a/packages/forms-web-app/src/routes/full-appeal/submit-appeal/index.js
+++ b/packages/forms-web-app/src/routes/full-appeal/submit-appeal/index.js
@@ -26,6 +26,7 @@ const identifyingTheOwnersRouter = require('./identifying-the-owners');
 const plansDrawingsRouter = require('./plans-drawings');
 const supportingDocumentsRouter = require('./supporting-documents');
 const newPlansDrawingsRouter = require('./new-plans-drawings');
+const newSupportingDocumentsRouter = require('./new-supporting-documents');
 
 const router = express.Router();
 
@@ -56,5 +57,6 @@ router.use(identifyingTheOwnersRouter);
 router.use(plansDrawingsRouter);
 router.use(supportingDocumentsRouter);
 router.use(newPlansDrawingsRouter);
+router.use(newSupportingDocumentsRouter);
 
 module.exports = router;

--- a/packages/forms-web-app/src/routes/full-appeal/submit-appeal/new-supporting-documents.js
+++ b/packages/forms-web-app/src/routes/full-appeal/submit-appeal/new-supporting-documents.js
@@ -1,0 +1,29 @@
+const express = require('express');
+const {
+  getNewSupportingDocuments,
+  postNewSupportingDocuments,
+} = require('../../../controllers/full-appeal/submit-appeal/new-supporting-documents');
+const fetchExistingAppealMiddleware = require('../../../middleware/fetch-existing-appeal');
+const { validationErrorHandler } = require('../../../validators/validation-error-handler');
+const { rules: fileUploadValidationRules } = require('../../../validators/common/file-upload');
+const setSectionAndTaskNames = require('../../../middleware/set-section-and-task-names');
+
+const router = express.Router();
+const sectionName = 'appealDocumentsSection';
+const taskName = 'supportingDocuments';
+
+router.get(
+  '/submit-appeal/new-supporting-documents',
+  [fetchExistingAppealMiddleware],
+  setSectionAndTaskNames(sectionName, taskName),
+  getNewSupportingDocuments
+);
+router.post(
+  '/submit-appeal/new-supporting-documents',
+  setSectionAndTaskNames(sectionName, taskName),
+  fileUploadValidationRules('Select a supporting document'),
+  validationErrorHandler,
+  postNewSupportingDocuments
+);
+
+module.exports = router;

--- a/packages/forms-web-app/src/views/full-appeal/submit-appeal/new-supporting-documents.njk
+++ b/packages/forms-web-app/src/views/full-appeal/submit-appeal/new-supporting-documents.njk
@@ -1,0 +1,83 @@
+{% extends "layouts/main.njk" %}
+
+{% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
+{% from "govuk/components/file-upload/macro.njk" import govukFileUpload %}
+{% from "govuk/components/details/macro.njk" import govukDetails %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
+
+{% set labelText = "Drag and drop or choose files" %}
+{% set title = "New supporting documents - Appeal a planning decision - GOV.UK" %}
+{% block pageTitle %}{{ "Error: " + title if errors else title }}{% endblock %}
+
+{% block backButton %}
+  {{ govukBackLink({
+    text: 'Back',
+    href: '/full-appeal/submit-appeal/supporting-documents',
+    attributes: {
+      'data-cy': 'back'
+    }
+  }) }}
+{% endblock %}
+
+{% block content %}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      {% if errorSummary %}
+        {{ govukErrorSummary({
+          titleText: "There is a problem",
+          errorList: errorSummary,
+          attributes: {"data-cy": "error-wrapper"}
+        }) }}
+      {% endif %}
+      <span class="govuk-caption-l">Upload documents for your appeal</span>
+      <h1 class="govuk-heading-l">New supporting documents</h1>
+      {% if uploadedFiles.length %}
+        <h2 class="govuk-heading-m govuk-!-margin-top-8">Uploaded files</h2>
+        <ul class="govuk-list">
+        {%- for file in uploadedFiles %}
+          <li><a href="/document/{{appealId}}/{{file.id}}" class="govuk-link">{{ file.name }}</a></li>
+        {%- endfor %}
+        </ul>
+        {% set labelText = "Replace the files" %}
+      {% endif %}
+      <form action="" method="post" novalidate enctype="multipart/form-data">
+        {{ govukFileUpload({
+          id: "file-upload",
+          name: "file-upload",
+          classes: "pins-file-upload",
+          attributes: {
+            'multiple': true
+          },
+          label: {
+            text: labelText,
+            classes: "govuk-label--m"
+          },
+          errorMessage: errors['file-upload'] and { text: errors['file-upload'].msg }
+        }) }}
+
+        {{ govukDetails({
+          summaryText: "Files you can upload",
+          html: '<p class="govuk-body">
+                  You can upload the following types of file:
+                </p>
+                <ul class="govuk-list govuk-list--bullet">
+                  <li>DOC or DOCX</li>
+                  <li>JPG or JPEG</li>
+                  <li>PDF</li>
+                  <li>PNG</li>
+                  <li>TIF or TIFF</li>
+                </ul>
+                <p class="govuk-body">
+                  Your file must be smaller than 15MB.
+                </p>'
+        }) }}
+
+        {{ govukButton({
+          text: "Continue",
+          type: "submit",
+          attributes: { "data-cy":"button-save-and-continue"}
+        }) }}
+      </form>
+    </div>
+  </div>
+{% endblock %}

--- a/packages/forms-web-app/src/views/full-appeal/submit-appeal/supporting-documents.njk
+++ b/packages/forms-web-app/src/views/full-appeal/submit-appeal/supporting-documents.njk
@@ -10,7 +10,7 @@
 {% block backButton %}
   {{ govukBackLink({
     text: 'Back',
-    href: '/full-appeal/submit-appeal/new-plans-drawings',
+    href: '/full-appeal/submit-appeal/plans-drawings',
     attributes: {
       'data-cy': 'back'
     }


### PR DESCRIPTION
## Ticket Number
https://pins-ds.atlassian.net/browse/AS-4334

## Description of change
Add the Full Appeal New Supporting Documents page

![Screenshot from 2022-02-15 17-48-20](https://user-images.githubusercontent.com/6839214/154119596-3a00d857-2de8-4b08-b5e2-6b7900a8b922.png)

## Checklist
<!-- Put an `x` in all the boxes that apply: -->
- [ ] Requires infrastructure changes
- [ ] If adding or remove environment variables (e.g. in `docker-compose.yaml`) then I have updated the appropriate Helm chart
- [ ] I have updated the documentation accordingly
- [ ] My commit history in this PR is linear
- [ ] New features have tests
- [ ] Breaking change (team conversation required)

## Important

Please do not merge from `master` (please only [rebase](https://github.com/foundry4/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
