### PR TITLE
feat(as-4539): update the back link on the full appeal supporting documents page

### DIFF
--- a/packages/forms-web-app/__tests__/unit/controllers/full-appeal/submit-appeal/supporting-documents.test.js
+++ b/packages/forms-web-app/__tests__/unit/controllers/full-appeal/submit-appeal/supporting-documents.test.js
@@ -44,6 +44,7 @@ describe('controllers/full-appeal/submit-appeal/supporting-documents', () => {
       expect(res.render).toHaveBeenCalledTimes(1);
       expect(res.render).toHaveBeenCalledWith(SUPPORTING_DOCUMENTS, {
         hasSupportingDocuments: true,
+        hasPlansDrawings: true,
       });
     });
   });
@@ -64,6 +65,7 @@ describe('controllers/full-appeal/submit-appeal/supporting-documents', () => {
       expect(res.redirect).not.toHaveBeenCalled();
       expect(res.render).toHaveBeenCalledTimes(1);
       expect(res.render).toHaveBeenCalledWith(SUPPORTING_DOCUMENTS, {
+        hasPlansDrawings: true,
         errors,
         errorSummary,
       });
@@ -82,6 +84,7 @@ describe('controllers/full-appeal/submit-appeal/supporting-documents', () => {
       expect(res.render).toHaveBeenCalledTimes(1);
       expect(res.render).toHaveBeenCalledWith(SUPPORTING_DOCUMENTS, {
         hasSupportingDocuments: false,
+        hasPlansDrawings: true,
         errors: {},
         errorSummary: [{ text: error.toString(), href: '#' }],
       });

--- a/packages/forms-web-app/src/controllers/full-appeal/submit-appeal/supporting-documents.js
+++ b/packages/forms-web-app/src/controllers/full-appeal/submit-appeal/supporting-documents.js
@@ -12,9 +12,15 @@ const sectionName = 'appealDocumentsSection';
 const taskName = 'supportingDocuments';
 
 const getSupportingDocuments = (req, res) => {
-  const { hasSupportingDocuments } = req.session.appeal[sectionName][taskName];
+  const {
+    [sectionName]: {
+      [taskName]: { hasSupportingDocuments },
+      plansDrawings: { hasPlansDrawings },
+    },
+  } = req.session.appeal;
   res.render(SUPPORTING_DOCUMENTS, {
     hasSupportingDocuments,
+    hasPlansDrawings,
   });
 };
 
@@ -22,11 +28,19 @@ const postSupportingDocuments = async (req, res) => {
   const {
     body,
     body: { errors = {}, errorSummary = [] },
-    session: { appeal },
+    session: {
+      appeal,
+      appeal: {
+        [sectionName]: {
+          plansDrawings: { hasPlansDrawings },
+        },
+      },
+    },
   } = req;
 
   if (Object.keys(errors).length > 0) {
     return res.render(SUPPORTING_DOCUMENTS, {
+      hasPlansDrawings,
       errors,
       errorSummary,
     });
@@ -45,6 +59,7 @@ const postSupportingDocuments = async (req, res) => {
 
     return res.render(SUPPORTING_DOCUMENTS, {
       hasSupportingDocuments,
+      hasPlansDrawings,
       errors,
       errorSummary: [{ text: err.toString(), href: '#' }],
     });

--- a/packages/forms-web-app/src/views/full-appeal/submit-appeal/supporting-documents.njk
+++ b/packages/forms-web-app/src/views/full-appeal/submit-appeal/supporting-documents.njk
@@ -4,13 +4,15 @@
 {% from "govuk/components/radios/macro.njk" import govukRadios %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
 
+{% set backLink = '/full-appeal/submit-appeal/' %}
+{% set backLink = backLink + 'new-plans-drawings' if hasPlansDrawings else backLink + 'plans-drawings' %}
 {% set title = "Supporting documents - Appeal a planning decision - GOV.UK" %}
 {% block pageTitle %}{{ "Error: " + title if errors else title }}{% endblock %}
 
 {% block backButton %}
   {{ govukBackLink({
     text: 'Back',
-    href: '/full-appeal/submit-appeal/plans-drawings',
+    href: backLink,
     attributes: {
       'data-cy': 'back'
     }


### PR DESCRIPTION
## Ticket Number
https://pins-ds.atlassian.net/browse/AS-4539

## Description of change
Update the back link on the Full Appeal Supporting Documents page to it returns to the correct page depending on the path the user has taken.

1. If the user selects `Yes` on the Plans and Drawings page then the back link returns to `/new-plans-drawings`
2. is the user selects `No` on the Plans and Drawings page then the back link returns to `/plans-drawings`

## Checklist
<!-- Put an `x` in all the boxes that apply: -->
- [ ] Requires infrastructure changes
- [ ] If adding or remove environment variables (e.g. in `docker-compose.yaml`) then I have updated the appropriate Helm chart
- [ ] I have updated the documentation accordingly
- [ ] My commit history in this PR is linear
- [ ] New features have tests
- [ ] Breaking change (team conversation required)

## Important

Please do not merge from `master` (please only [rebase](https://github.com/foundry4/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
