### PR TITLE
fix(as-4537): fix the appeal type redirection for entering a second appeal

### DIFF
--- a/packages/forms-web-app/__tests__/unit/middleware/check-appeal-type-exists.test.js
+++ b/packages/forms-web-app/__tests__/unit/middleware/check-appeal-type-exists.test.js
@@ -60,20 +60,25 @@ describe('middleware/check-appeal-type-exists', () => {
     expect(res.redirect).toBeCalledWith('/before-you-start/local-planning-depart');
   });
 
-  it('should call next() if req.session is not set', () => {
+  it('should redirect to the `/before-you-start/local-planning-depart` page if req.session is not set', () => {
     delete req.session;
-    req.originalUrl = '/before-you-start/local-planning-depart';
+    req.originalUrl = '/full-appeal/submit-appeal/task-list';
     checkAppealTypeExists(req, res, next);
-    expect(next).toBeCalled();
-    expect(res.redirect).not.toBeCalled();
+    expect(res.redirect).toBeCalledWith('/before-you-start/local-planning-depart');
   });
 
-  it('should call next() if req.session.appeal is not set', () => {
+  it('should redirect to the `/before-you-start/local-planning-depart` page if req.session.appeal is not set', () => {
     delete req.session.appeal;
-    req.originalUrl = '/before-you-start/local-planning-depart';
+    req.originalUrl = '/full-appeal/submit-appeal/task-list';
     checkAppealTypeExists(req, res, next);
-    expect(next).toBeCalled();
-    expect(res.redirect).not.toBeCalled();
+    expect(res.redirect).toBeCalledWith('/before-you-start/local-planning-depart');
+  });
+
+  it('should redirect to the `/before-you-start/local-planning-depart` page if req.session.appeal is null', () => {
+    req.session.appeal = null;
+    req.originalUrl = '/full-appeal/submit-appeal/task-list';
+    checkAppealTypeExists(req, res, next);
+    expect(res.redirect).toBeCalledWith('/before-you-start/local-planning-depart');
   });
 
   it('should call next() if featureFlag.newAppealJourney is not set', () => {

--- a/packages/forms-web-app/src/middleware/check-appeal-type-exists.js
+++ b/packages/forms-web-app/src/middleware/check-appeal-type-exists.js
@@ -2,7 +2,7 @@ const { featureFlag } = require('../config');
 const logger = require('../lib/logger');
 
 const checkAppealTypeExists = (req, res, next) => {
-  const { session: { appeal, appeal: { appealType } = {} } = {} } = req;
+  const { session: { appeal } = {} } = req;
 
   logger.debug({ appeal }, 'Appeal data in checkAppealTypeExists');
   logger.debug({ featureFlag }, 'Feature flag in checkAppealTypeExists');
@@ -21,7 +21,7 @@ const checkAppealTypeExists = (req, res, next) => {
     return next();
   }
 
-  if (appealType) {
+  if (appeal && appeal.appealType) {
     return next();
   }
 


### PR DESCRIPTION
## Ticket Number
https://pins-ds.atlassian.net/browse/AS-4537

## Description of change
Fix the Internal Server Error caused when a user submits an appeal then returns the beginning to start a new appeal.

## Checklist
<!-- Put an `x` in all the boxes that apply: -->
- [ ] Requires infrastructure changes
- [ ] If adding or remove environment variables (e.g. in `docker-compose.yaml`) then I have updated the appropriate Helm chart
- [ ] I have updated the documentation accordingly
- [ ] My commit history in this PR is linear
- [ ] New features have tests
- [ ] Breaking change (team conversation required)

## Important

Please do not merge from `master` (please only [rebase](https://github.com/foundry4/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
