### PR TITLE
fix(as-4537): update householder schema to not require the planning permission to be complete

### DIFF
--- a/packages/business-rules/src/schemas/householder-appeal/update.js
+++ b/packages/business-rules/src/schemas/householder-appeal/update.js
@@ -64,7 +64,7 @@ const update = pinsYup
             },
           ),
         enforcementNotice: pinsYup.bool().required(),
-        householderPlanningPermission: pinsYup.bool().required(),
+        householderPlanningPermission: pinsYup.bool().nullable(),
         isClaimingCosts: pinsYup.bool().required(),
         isListedBuilding: pinsYup.bool().required(),
       })

--- a/packages/business-rules/src/schemas/householder-appeal/update.test.js
+++ b/packages/business-rules/src/schemas/householder-appeal/update.test.js
@@ -348,20 +348,11 @@ describe('schemas/householder-appeal/update', () => {
         );
       });
 
-      it('should throw an error when given a null value', async () => {
-        appeal.eligibility.householderPlanningPermission = null;
-
-        await expect(() => update.validate(appeal, config)).rejects.toThrow(
-          'eligibility.householderPlanningPermission must be a `boolean` type, but the final value was: `null`',
-        );
-      });
-
-      it('should throw an error when not given a value', async () => {
+      it('should not throw an error when not given a value', async () => {
         delete appeal.eligibility.householderPlanningPermission;
 
-        await expect(() => update.validate(appeal, config)).rejects.toThrow(
-          'eligibility.householderPlanningPermission is a required field',
-        );
+        const result = await update.validate(appeal, config);
+        expect(result).toEqual(appeal);
       });
     });
 


### PR DESCRIPTION
## Ticket Number
<!-- Add the number from the Jira board -->
https://pins-ds.atlassian.net/browse/AS-4537

## Description of change
Change the Householder schema validation to make the Householder Planning Permission question nullable as it is not in the new Householder journey and when it's a required field it prevents the appeal from being submitted.

We need to keep the field for backwards compatibility and it could be removed with the old Householder journey.

## Checklist
<!-- Put an `x` in all the boxes that apply: -->
- [ ] Requires infrastructure changes
- [ ] If adding or remove environment variables (e.g. in `docker-compose.yaml`) then I have updated the appropriate Helm chart
- [ ] I have updated the documentation accordingly
- [ ] My commit history in this PR is linear
- [ ] New features have tests
- [ ] Breaking change (team conversation required)

## Important

Please do not merge from `master` (please only [rebase](https://github.com/foundry4/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
