### PR TITLE
fix(as-4505): add two missing data-cy attributes on full appeal check your answers page

### DIFF
--- a/packages/forms-web-app/src/views/full-appeal/submit-appeal/check-your-answers.njk
+++ b/packages/forms-web-app/src/views/full-appeal/submit-appeal/check-your-answers.njk
@@ -568,7 +568,10 @@
           {
             href: "/full-appeal/submit-appeal/draft-statement-common-ground",
             text: "Change",
-            visuallyHiddenText: "Change the draft statement of common ground"
+            visuallyHiddenText: "Change the draft statement of common ground",
+            attributes: {
+              "data-cy": "change-draft-statement-of-common-ground"
+            }
           }
         ]
       } %}
@@ -730,7 +733,10 @@
           {
             href: "/full-appeal/submit-appeal/appeal-statement",
             text: "Change",
-            visuallyHiddenText: "Change the appeal statement"
+            visuallyHiddenText: "Change the appeal statement",
+            attributes: {
+              "data-cy": "change-appeal-statement"
+            }
           }
         ]
       } %}


### PR DESCRIPTION
## Ticket Number
https://pins-ds.atlassian.net/browse/AS-4504

## Description of change
Added two missing `data-cy` attributes on the Full Appeal Check Your Answers page

## Checklist
<!-- Put an `x` in all the boxes that apply: -->
- [ ] Requires infrastructure changes
- [ ] If adding or remove environment variables (e.g. in `docker-compose.yaml`) then I have updated the appropriate Helm chart
- [ ] I have updated the documentation accordingly
- [ ] My commit history in this PR is linear
- [ ] New features have tests
- [ ] Breaking change (team conversation required)

## Important

Please do not merge from `master` (please only [rebase](https://github.com/foundry4/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
