### PR TITLE
feat(as-4540): update the schemas to ensure createdAt and updatedAt dates are at the top level

### DIFF
--- a/packages/business-rules/src/schemas/full-appeal/insert.js
+++ b/packages/business-rules/src/schemas/full-appeal/insert.js
@@ -20,6 +20,8 @@ const insert = pinsYup
     horizonId: pinsYup.string().trim().max(20).nullable(),
     lpaCode: pinsYup.string().trim().max(20).nullable(),
     decisionDate: pinsYup.date().transform(parseDateString).nullable(),
+    createdAt: pinsYup.date().transform(parseDateString).required(),
+    updatedAt: pinsYup.date().transform(parseDateString).required(),
     state: pinsYup.string().oneOf(Object.values(APPEAL_STATE)).default(APPEAL_STATE.DRAFT),
     appealType: pinsYup.lazy((appealType) => {
       if (appealType) {

--- a/packages/business-rules/src/schemas/full-appeal/insert.test.js
+++ b/packages/business-rules/src/schemas/full-appeal/insert.test.js
@@ -143,6 +143,42 @@ describe('schemas/full-appeal/insert', () => {
       });
     });
 
+    describe('createdAt', () => {
+      it('should throw an error when given a value which is in an incorrect format', async () => {
+        appeal.createdAt = '03/07/2021';
+
+        await expect(() => insert.validate(appeal, config)).rejects.toThrow(
+          'Invalid Date or string not ISO format',
+        );
+      });
+
+      it('should throw an error when not given a value', async () => {
+        delete appeal.createdAt;
+
+        await expect(() => insert.validate(appeal, config)).rejects.toThrow(
+          'createdAt is a required field',
+        );
+      });
+    });
+
+    describe('updatedAt', () => {
+      it('should throw an error when given a value which is in an incorrect format', async () => {
+        appeal.updatedAt = '03/07/2021';
+
+        await expect(() => insert.validate(appeal, config)).rejects.toThrow(
+          'Invalid Date or string not ISO format',
+        );
+      });
+
+      it('should throw an error when not given a value', async () => {
+        delete appeal.updatedAt;
+
+        await expect(() => insert.validate(appeal, config)).rejects.toThrow(
+          'updatedAt is a required field',
+        );
+      });
+    });
+
     describe('state', () => {
       it('should throw an error when given an invalid value', async () => {
         appeal.state = 'PENDING';

--- a/packages/business-rules/src/schemas/full-appeal/update.js
+++ b/packages/business-rules/src/schemas/full-appeal/update.js
@@ -26,6 +26,8 @@ const update = pinsYup
         .transform(parseDateString)
         .required();
     }),
+    createdAt: pinsYup.date().transform(parseDateString).required(),
+    updatedAt: pinsYup.date().transform(parseDateString).required(),
     state: pinsYup.string().oneOf(Object.values(APPEAL_STATE)).required(),
     appealType: pinsYup.string().oneOf(Object.values(APPEAL_ID)).required(),
     typeOfPlanningApplication: pinsYup

--- a/packages/business-rules/src/schemas/full-appeal/update.test.js
+++ b/packages/business-rules/src/schemas/full-appeal/update.test.js
@@ -166,6 +166,42 @@ describe('schemas/full-appeal/update', () => {
       });
     });
 
+    describe('createdAt', () => {
+      it('should throw an error when given a value which is in an incorrect format', async () => {
+        appeal.createdAt = '03/07/2021';
+
+        await expect(() => update.validate(appeal, config)).rejects.toThrow(
+          'Invalid Date or string not ISO format',
+        );
+      });
+
+      it('should throw an error when not given a value', async () => {
+        delete appeal.createdAt;
+
+        await expect(() => update.validate(appeal, config)).rejects.toThrow(
+          'createdAt is a required field',
+        );
+      });
+    });
+
+    describe('updatedAt', () => {
+      it('should throw an error when given a value which is in an incorrect format', async () => {
+        appeal.updatedAt = '03/07/2021';
+
+        await expect(() => update.validate(appeal, config)).rejects.toThrow(
+          'Invalid Date or string not ISO format',
+        );
+      });
+
+      it('should throw an error when not given a value', async () => {
+        delete appeal.updatedAt;
+
+        await expect(() => update.validate(appeal, config)).rejects.toThrow(
+          'updatedAt is a required field',
+        );
+      });
+    });
+
     describe('state', () => {
       it('should throw an error when given an invalid value', async () => {
         appeal.state = 'PENDING';

--- a/packages/business-rules/src/schemas/householder-appeal/insert.js
+++ b/packages/business-rules/src/schemas/householder-appeal/insert.js
@@ -16,6 +16,8 @@ const insert = pinsYup
     horizonId: pinsYup.string().trim().max(20).nullable(),
     lpaCode: pinsYup.string().trim().max(20).nullable(),
     decisionDate: pinsYup.date().transform(parseDateString).nullable(),
+    createdAt: pinsYup.date().transform(parseDateString).required(),
+    updatedAt: pinsYup.date().transform(parseDateString).required(),
     submissionDate: pinsYup.date().transform(parseDateString).nullable(),
     state: pinsYup.string().oneOf(Object.values(APPEAL_STATE)).default(APPEAL_STATE.DRAFT),
     appealType: pinsYup.lazy((appealType) => {

--- a/packages/business-rules/src/schemas/householder-appeal/insert.test.js
+++ b/packages/business-rules/src/schemas/householder-appeal/insert.test.js
@@ -130,6 +130,42 @@ describe('schemas/householder-appeal/insert', () => {
       });
     });
 
+    describe('createdAt', () => {
+      it('should throw an error when given a value which is in an incorrect format', async () => {
+        appeal.createdAt = '03/07/2021';
+
+        await expect(() => insert.validate(appeal, config)).rejects.toThrow(
+          'Invalid Date or string not ISO format',
+        );
+      });
+
+      it('should throw an error when not given a value', async () => {
+        delete appeal.createdAt;
+
+        await expect(() => insert.validate(appeal, config)).rejects.toThrow(
+          'createdAt is a required field',
+        );
+      });
+    });
+
+    describe('updatedAt', () => {
+      it('should throw an error when given a value which is in an incorrect format', async () => {
+        appeal.updatedAt = '03/07/2021';
+
+        await expect(() => insert.validate(appeal, config)).rejects.toThrow(
+          'Invalid Date or string not ISO format',
+        );
+      });
+
+      it('should throw an error when not given a value', async () => {
+        delete appeal.updatedAt;
+
+        await expect(() => insert.validate(appeal, config)).rejects.toThrow(
+          'updatedAt is a required field',
+        );
+      });
+    });
+
     describe('submissionDate', () => {
       it('should throw an error when given a value which is in an incorrect format', async () => {
         appeal.submissionDate = '03/07/2021';

--- a/packages/business-rules/src/schemas/householder-appeal/update.js
+++ b/packages/business-rules/src/schemas/householder-appeal/update.js
@@ -35,6 +35,8 @@ const update = pinsYup
         .transform(parseDateString)
         .required();
     }),
+    createdAt: pinsYup.date().transform(parseDateString).required(),
+    updatedAt: pinsYup.date().transform(parseDateString).required(),
     submissionDate: pinsYup.date().transform(parseDateString).nullable(),
     state: pinsYup.string().oneOf(Object.values(APPEAL_STATE)).required(),
     eligibility: pinsYup

--- a/packages/business-rules/src/schemas/householder-appeal/update.test.js
+++ b/packages/business-rules/src/schemas/householder-appeal/update.test.js
@@ -175,6 +175,42 @@ describe('schemas/householder-appeal/update', () => {
       });
     });
 
+    describe('createdAt', () => {
+      it('should throw an error when given a value which is in an incorrect format', async () => {
+        appeal.createdAt = '03/07/2021';
+
+        await expect(() => update.validate(appeal, config)).rejects.toThrow(
+          'Invalid Date or string not ISO format',
+        );
+      });
+
+      it('should throw an error when not given a value', async () => {
+        delete appeal.createdAt;
+
+        await expect(() => update.validate(appeal, config)).rejects.toThrow(
+          'createdAt is a required field',
+        );
+      });
+    });
+
+    describe('updatedAt', () => {
+      it('should throw an error when given a value which is in an incorrect format', async () => {
+        appeal.updatedAt = '03/07/2021';
+
+        await expect(() => update.validate(appeal, config)).rejects.toThrow(
+          'Invalid Date or string not ISO format',
+        );
+      });
+
+      it('should throw an error when not given a value', async () => {
+        delete appeal.updatedAt;
+
+        await expect(() => update.validate(appeal, config)).rejects.toThrow(
+          'updatedAt is a required field',
+        );
+      });
+    });
+
     describe('submissionDate', () => {
       it('should not throw an error when not given a value', async () => {
         delete appeal.submissionDate;

--- a/packages/business-rules/test/data/full-appeal.js
+++ b/packages/business-rules/test/data/full-appeal.js
@@ -5,6 +5,8 @@ const appeal = {
   horizonId: 'HORIZON123',
   lpaCode: 'E69999999',
   decisionDate: new Date(),
+  createdAt: new Date(),
+  updatedAt: new Date(),
   state: 'SUBMITTED',
   appealType: '1005',
   typeOfPlanningApplication: 'full-appeal',

--- a/packages/business-rules/test/data/householder-appeal.js
+++ b/packages/business-rules/test/data/householder-appeal.js
@@ -3,6 +3,8 @@ const appeal = {
   horizonId: 'HORIZON123',
   lpaCode: 'E69999999',
   decisionDate: new Date(),
+  createdAt: new Date(),
+  updatedAt: new Date(),
   submissionDate: new Date(),
   state: 'DRAFT',
   appealType: '1001',


### PR DESCRIPTION
## Ticket Number
https://pins-ds.atlassian.net/browse/AS-4540

## Description of change
Add `createdAt` and `updatedAt` dates to both schemas for both Full Appeal and Householder to ensure that these dates are saved and in the correct format and at the top level

## Checklist
<!-- Put an `x` in all the boxes that apply: -->
- [ ] Requires infrastructure changes
- [ ] If adding or remove environment variables (e.g. in `docker-compose.yaml`) then I have updated the appropriate Helm chart
- [ ] I have updated the documentation accordingly
- [ ] My commit history in this PR is linear
- [ ] New features have tests
- [ ] Breaking change (team conversation required)

## Important

Please do not merge from `master` (please only [rebase](https://github.com/foundry4/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
