### PR TITLE
fix(as-4504): update change link hidden text on full appeal check your answers page

### DIFF
--- a/packages/forms-web-app/src/views/full-appeal/submit-appeal/check-your-answers.njk
+++ b/packages/forms-web-app/src/views/full-appeal/submit-appeal/check-your-answers.njk
@@ -28,7 +28,7 @@
           {
             href: "/full-appeal/submit-appeal/original-applicant",
             text: "Change",
-            visuallyHiddenText: "Change if the planning application was made in your name",
+            visuallyHiddenText: "if the planning application was made in your name",
             attributes: {
               "data-cy": "change-is-original-applicant"
             }
@@ -55,7 +55,7 @@
           {
             href: "/full-appeal/submit-appeal/applicant-name",
             text: "Change",
-            visuallyHiddenText: "Change the applicant's name",
+            visuallyHiddenText: "the applicant's name",
             attributes: {
               "data-cy": "change-appealing-on-behalf-of"
             }
@@ -75,7 +75,7 @@
           {
             href: "/full-appeal/submit-appeal/contact-details",
             text: "Change",
-            visuallyHiddenText: "Change your contact details",
+            visuallyHiddenText: "your contact details",
             attributes: {
               "data-cy": "change-contact-details"
             }
@@ -106,7 +106,7 @@
           {
             href: "/full-appeal/submit-appeal/appeal-site-address",
             text: "Change",
-            visuallyHiddenText: "Change the appeal site address",
+            visuallyHiddenText: "the appeal site address",
             attributes: {
               "data-cy": "change-site-address"
             }
@@ -139,7 +139,7 @@
           {
             href: "/full-appeal/submit-appeal/own-all-the-land",
             text: "Change",
-            visuallyHiddenText: "Change if you own all the land involved in the appeal",
+            visuallyHiddenText: "if you own all the land involved in the appeal",
             attributes: {
               "data-cy": "change-owns-all-the-land"
             }
@@ -175,7 +175,7 @@
           {
             href: "/full-appeal/submit-appeal/telling-the-landowners",
             text: "Change",
-            visuallyHiddenText: "Change if you've told the other landowners",
+            visuallyHiddenText: "if you've told the other landowners",
             attributes: {
               "data-cy": "change-telling-other-landowners"
             }
@@ -199,7 +199,7 @@
           {
             href: "/full-appeal/submit-appeal/know-the-owners",
             text: "Change",
-            visuallyHiddenText: "Change if you know who owns the rest of the land involved in the appeal",
+            visuallyHiddenText: "if you know who owns the rest of the land involved in the appeal",
             attributes: {
               "data-cy": "change-know-the-owners"
             }
@@ -227,7 +227,7 @@
           {
             href: "/full-appeal/submit-appeal/identifying-the-owners",
             text: "Change",
-            visuallyHiddenText: "Change if you have attempted to identify the landowners",
+            visuallyHiddenText: "if you have attempted to identify the landowners",
             attributes: {
               "data-cy": "change-identifying-the-landowners"
             }
@@ -266,7 +266,7 @@
           {
             href: "/full-appeal/submit-appeal/advertising-your-appeal",
             text: "Change",
-            visuallyHiddenText: "Change if you have advertised your appeal",
+            visuallyHiddenText: "if you have advertised your appeal",
             attributes: {
               "data-cy": "change-advertising-your-appeal"
             }
@@ -286,7 +286,7 @@
           {
             href: "/full-appeal/submit-appeal/agricultural-holding",
             text: "Change",
-            visuallyHiddenText: "Change if the appeal site is part of an agricultural holding",
+            visuallyHiddenText: "if the appeal site is part of an agricultural holding",
             attributes: {
               "data-cy": "change-is-agricultural-holding"
             }
@@ -309,7 +309,7 @@
           {
             href: "/full-appeal/submit-appeal/are-you-a-tenant",
             text: "Change",
-            visuallyHiddenText: "Change if you are a tenant of the agricultural holding",
+            visuallyHiddenText: "if you are a tenant of the agricultural holding",
             attributes: {
               "data-cy": "change-is-agricultural-holding-tenant"
             }
@@ -332,7 +332,7 @@
           {
             href: "/full-appeal/submit-appeal/other-tenants",
             text: "Change",
-            visuallyHiddenText: "Change if there are any other tenants",
+            visuallyHiddenText: "if there are any other tenants",
             attributes: {
               "data-cy": "change-has-other-tenants"
             }
@@ -375,7 +375,7 @@
           {
             href: "/full-appeal/submit-appeal/telling-the-tenants",
             text: "Change",
-            visuallyHiddenText: "Change if you know who owns the rest of the land involved in the appeal",
+            visuallyHiddenText: "if you know who owns the rest of the land involved in the appeal",
             attributes: {
               "data-cy": "change-telling-the-tenants"
             }
@@ -400,7 +400,7 @@
           {
             href: "/full-appeal/submit-appeal/visible-from-road",
             text: "Change",
-            visuallyHiddenText: "Change if the site is visible from a public road",
+            visuallyHiddenText: "if the site is visible from a public road",
             attributes: {
               "data-cy": "change-is-visible-from-road"
             }
@@ -428,7 +428,7 @@
           {
             href: "/full-appeal/submit-appeal/health-safety-issues",
             text: "Change",
-            visuallyHiddenText: "Change if there are any health and safety issues on the appeal site",
+            visuallyHiddenText: "if there are any health and safety issues on the appeal site",
             attributes: {
               "data-cy": "change-has-health-safety-issues"
             }
@@ -478,7 +478,7 @@
           {
             href: "/full-appeal/submit-appeal/how-decide-appeal",
             text: "Change",
-            visuallyHiddenText: "Change how you would prefer us to decide your appeal",
+            visuallyHiddenText: "how you would prefer us to decide your appeal",
             attributes: {
               "data-cy": "change-procedure-type"
             }
@@ -501,7 +501,7 @@
           {
             href: "/full-appeal/submit-appeal/why-hearing",
             text: "Change",
-            visuallyHiddenText: "Change why you would prefer a hearing",
+            visuallyHiddenText: "why you would prefer a hearing",
             attributes: {
               "data-cy": "change-hearing-reason"
             }
@@ -523,7 +523,7 @@
           {
             href: "/full-appeal/submit-appeal/expect-inquiry-last",
             text: "Change",
-            visuallyHiddenText: "Change how many days you would expect the inquiry to last",
+            visuallyHiddenText: "how many days you would expect the inquiry to last",
             attributes: {
               "data-cy": "change-inquiry-expected-days"
             }
@@ -546,7 +546,7 @@
           {
             href: "/full-appeal/submit-appeal/why-inquiry",
             text: "Change",
-            visuallyHiddenText: "Change why you would prefer a inquiry",
+            visuallyHiddenText: "why you would prefer a inquiry",
             attributes: {
               "data-cy": "change-inquiry-reason"
             }
@@ -568,7 +568,7 @@
           {
             href: "/full-appeal/submit-appeal/draft-statement-common-ground",
             text: "Change",
-            visuallyHiddenText: "Change the draft statement of common ground",
+            visuallyHiddenText: "the draft statement of common ground",
             attributes: {
               "data-cy": "change-draft-statement-of-common-ground"
             }
@@ -604,7 +604,7 @@
           {
             href: "/full-appeal/submit-appeal/application-number",
             text: "Change",
-            visuallyHiddenText: "Change the planning application-number",
+            visuallyHiddenText: "the planning application number",
             attributes: {
               "data-cy": "change-application-number"
             }
@@ -627,7 +627,7 @@
           {
             href: "/full-appeal/submit-appeal/application-form",
             text: "Change",
-            visuallyHiddenText: "Change the planning application form",
+            visuallyHiddenText: "the planning application form",
             attributes: {
               "data-cy": "change-application-form"
             }
@@ -651,7 +651,7 @@
           {
             href: "/full-appeal/submit-appeal/design-access-statement-submitted",
             text: "Change",
-            visuallyHiddenText: "Change if you submitted a design and access statement with your application",
+            visuallyHiddenText: "if you submitted a design and access statement with your application",
             attributes: {
               "data-cy": "change-design-access-statement"
             }
@@ -674,7 +674,7 @@
           {
             href: "/full-appeal/submit-appeal/design-access-statement",
             text: "Change",
-            visuallyHiddenText: "Change the design and access statement",
+            visuallyHiddenText: "the design and access statement",
             attributes: {
               "data-cy": "change-design-access-statement"
             }
@@ -698,7 +698,7 @@
           {
             href: "/full-appeal/submit-appeal/decision-letter",
             text: "Change",
-            visuallyHiddenText: "Change the decision letter",
+            visuallyHiddenText: "the decision letter",
             attributes: {
               "data-cy": "change-decision-letter"
             }
@@ -733,7 +733,7 @@
           {
             href: "/full-appeal/submit-appeal/appeal-statement",
             text: "Change",
-            visuallyHiddenText: "Change the appeal statement",
+            visuallyHiddenText: "the appeal statement",
             attributes: {
               "data-cy": "change-appeal-statement"
             }
@@ -757,7 +757,7 @@
           {
             href: "/full-appeal/submit-appeal/plans-drawings",
             text: "Change",
-            visuallyHiddenText: "Change if you have any new plans or drawings that support your appeal",
+            visuallyHiddenText: "if you have any new plans or drawings that support your appeal",
             attributes: {
               "data-cy": "change-has-plans-drawings"
             }
@@ -787,7 +787,7 @@
           {
             href: "/full-appeal/submit-appeal/new-plans-drawings",
             text: "Change",
-            visuallyHiddenText: "Change if you have any new plans or drawings that support your appeal",
+            visuallyHiddenText: "if you have any new plans or drawings that support your appeal",
             attributes: {
               "data-cy": "change-plans-drawings"
             }
@@ -807,7 +807,7 @@
           {
             href: "/full-appeal/submit-appeal/supporting-documents",
             text: "Change",
-            visuallyHiddenText: "Change if you want to submit any new supporting documents with your appeal",
+            visuallyHiddenText: "if you want to submit any new supporting documents with your appeal",
             attributes: {
               "data-cy": "change-has-supporting-documents"
             }
@@ -837,7 +837,7 @@
           {
             href: "/full-appeal/submit-appeal/new-supporting-documents",
             text: "Change",
-            visuallyHiddenText: "Change if you have any new plans or drawings that support your appeal",
+            visuallyHiddenText: "if you have any new plans or drawings that support your appeal",
             attributes: {
               "data-cy": "change-supporting-documents"
             }


### PR DESCRIPTION
## Ticket Number
https://pins-ds.atlassian.net/browse/AS-4504

## Description of change
Update the Change link hidden text on the Full Appeal Check Your Answers page to remove the 'Change' word to prevent it being duplicated as it is already part of the link text.

## Checklist
<!-- Put an `x` in all the boxes that apply: -->
- [ ] Requires infrastructure changes
- [ ] If adding or remove environment variables (e.g. in `docker-compose.yaml`) then I have updated the appropriate Helm chart
- [ ] I have updated the documentation accordingly
- [ ] My commit history in this PR is linear
- [ ] New features have tests
- [ ] Breaking change (team conversation required)

## Important

Please do not merge from `master` (please only [rebase](https://github.com/foundry4/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
