### PR TITLE
fix(as-4524): update householder schema to make hasPriorApprovalForExistingHome field nullable

### DIFF
--- a/packages/business-rules/src/schemas/householder-appeal/update.js
+++ b/packages/business-rules/src/schemas/householder-appeal/update.js
@@ -69,7 +69,7 @@ const update = pinsYup
         householderPlanningPermission: pinsYup.bool().nullable(),
         isClaimingCosts: pinsYup.bool().required(),
         isListedBuilding: pinsYup.bool().required(),
-        hasPriorApprovalForExistingHome: pinsYup.bool().required(),
+        hasPriorApprovalForExistingHome: pinsYup.bool().nullable(),
       })
       .noUnknown(true),
     aboutYouSection: pinsYup

--- a/packages/business-rules/src/schemas/householder-appeal/update.test.js
+++ b/packages/business-rules/src/schemas/householder-appeal/update.test.js
@@ -316,7 +316,7 @@ describe('schemas/householder-appeal/update', () => {
         delete appeal.eligibility;
 
         await expect(() => update.validate(appeal, config)).rejects.toThrow(
-          'eligibility.hasPriorApprovalForExistingHome is a required field',
+          'eligibility.isListedBuilding is a required field',
         );
       });
     });
@@ -380,20 +380,11 @@ describe('schemas/householder-appeal/update', () => {
         );
       });
 
-      it('should throw an error when given a null value', async () => {
+      it('should not throw an error when given a null value', async () => {
         appeal.eligibility.hasPriorApprovalForExistingHome = null;
 
-        await expect(() => update.validate(appeal, config)).rejects.toThrow(
-          'eligibility.hasPriorApprovalForExistingHome must be a `boolean` type, but the final value was: `null`',
-        );
-      });
-
-      it('should throw an error when not given a value', async () => {
-        delete appeal.eligibility.hasPriorApprovalForExistingHome;
-
-        await expect(() => update.validate(appeal, config)).rejects.toThrow(
-          'eligibility.hasPriorApprovalForExistingHome is a required field',
-        );
+        const result = await update.validate(appeal, config);
+        expect(result).toEqual(appeal);
       });
     });
 


### PR DESCRIPTION
## Ticket Number
https://pins-ds.atlassian.net/browse/AS-4524

## Description of change
Update `hasPriorApprovalForExistingHome` field in the Householder schema nullable as it's not a required field

## Checklist
<!-- Put an `x` in all the boxes that apply: -->
- [ ] Requires infrastructure changes
- [ ] If adding or remove environment variables (e.g. in `docker-compose.yaml`) then I have updated the appropriate Helm chart
- [ ] I have updated the documentation accordingly
- [ ] My commit history in this PR is linear
- [ ] New features have tests
- [ ] Breaking change (team conversation required)

## Important

Please do not merge from `master` (please only [rebase](https://github.com/foundry4/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
