### PR TITLE
Feature/as 4531 appeal type redirect test

### DIFF
--- a/packages/e2e-tests/cypress/integration/common/appeal-type-redirect.js
+++ b/packages/e2e-tests/cypress/integration/common/appeal-type-redirect.js
@@ -1,0 +1,28 @@
+import { Given, When, Then } from 'cypress-cucumber-preprocessor/steps';
+import { goToAppealsPage } from '../../support/common/go-to-page/goToAppealsPage';
+
+const localPlanningDepartmentUrl = 'before-you-start/local-planning-depart';
+
+Given('the user wants to start an appeal from a random page', () => {
+  return true;
+});
+
+Given('the user has started an appeal and not yet selected an appeal type', () => {
+  return true;
+});
+
+When('they manually go to the {string} page', (url) => {
+  goToAppealsPage(url);
+});
+
+When('they are taken to the {string} page', (url) => {
+  goToAppealsPage(url);
+});
+
+Then("they are redirected back to the first question", () => {
+  cy.url().should('contain', localPlanningDepartmentUrl);
+});
+
+Then('they are not redirected back to the first question and remain on the {string} page', (url) => {
+  cy.url().should('contain', url);
+});

--- a/packages/e2e-tests/cypress/integration/full-appeal/appeals-service/appeal-type-redirect.feature
+++ b/packages/e2e-tests/cypress/integration/full-appeal/appeals-service/appeal-type-redirect.feature
@@ -1,0 +1,64 @@
+Feature: As an Appellant/Agent
+  I want the application to redirect me back to the first question if the appeal type is not set
+  So that I can be sure I'm providing the correct information for the Full Appeal appeal type
+
+  Scenario Outline: <Test> - The user has not started an appeal and manually goes to the <URL> page
+    Given the user wants to start an appeal from a random page
+    When they manually go to the '<URL>' page
+    Then they are redirected back to the first question
+    Examples:
+      | Test | URL                                                         |
+      | 1    | before-you-start/any-of-following                           |
+      | 2    | before-you-start/granted-or-refused                         |
+      | 3    | before-you-start/decision-date                              |
+      | 4    | before-you-start/date-decision-due                          |
+      | 5    | before-you-start/enforcement-notice                         |
+      | 6    | before-you-start/prior-approval-existing-home               |
+      | 7    | before-you-start/you-cannot-appeal                          |
+      | 8    | full-appeal/submit-appeal/task-list                         |
+      | 9    | full-appeal/submit-appeal/original-applicant                |
+      | 10   | full-appeal/submit-appeal/contact-details                   |
+      | 11   | full-appeal/submit-appeal/applicant-name                    |
+      | 12   | full-appeal/submit-appeal/appeal-site-address               |
+      | 13   | full-appeal/submit-appeal/own-all-the-land                  |
+      | 14   | full-appeal/submit-appeal/own-some-of-the-land              |
+      | 15   | full-appeal/submit-appeal/know-the-owners                   |
+      | 16   | full-appeal/submit-appeal/telling-the-landowners            |
+      | 17   | full-appeal/submit-appeal/identifying-the-owners            |
+      | 18   | full-appeal/submit-appeal/advertising-your-appeal           |
+      | 19   | full-appeal/submit-appeal/agricultural-holding              |
+      | 20   | full-appeal/submit-appeal/are-you-a-tenant                  |
+      | 21   | full-appeal/submit-appeal/other-tenants                     |
+      | 22   | full-appeal/submit-appeal/telling-the-tenants               |
+      | 23   | full-appeal/submit-appeal/visible-from-road                 |
+      | 24   | full-appeal/submit-appeal/health-safety-issues              |
+      | 25   | full-appeal/submit-appeal/how-decide-appeal                 |
+      | 26   | full-appeal/submit-appeal/why-hearing                       |
+      | 27   | full-appeal/submit-appeal/draft-statement-common-ground     |
+      | 28   | full-appeal/submit-appeal/why-inquiry                       |
+      | 29   | full-appeal/submit-appeal/expect-inquiry-last               |
+      | 30   | full-appeal/submit-appeal/application-form                  |
+      | 31   | full-appeal/submit-appeal/application-number                |
+      | 32   | full-appeal/submit-appeal/plans-drawings-documents          |
+      | 33   | full-appeal/submit-appeal/design-access-statement-submitted |
+      | 34   | full-appeal/submit-appeal/design-access-statement           |
+      | 35   | full-appeal/submit-appeal/decision-letter                   |
+      | 36   | full-appeal/submit-appeal/appeal-statement                  |
+      | 37   | full-appeal/submit-appeal/plans-drawings                    |
+      | 38   | full-appeal/submit-appeal/new-plans-drawings                |
+      | 39   | full-appeal/submit-appeal/supporting-documents              |
+      | 40   | full-appeal/submit-appeal/new-supporting-documents          |
+      | 41   | full-appeal/submit-appeal/check-your-answers                |
+      | 42   | full-appeal/submit-appeal/declaration                       |
+      | 43   | full-appeal/submit-appeal/appeal-submitted                  |
+
+  Scenario Outline: <Test> - The user has started an appeal and is taken to the <URL> page
+    Given the user has started an appeal and not yet selected an appeal type
+    When they are taken to the '<URL>' page
+    Then they are not redirected back to the first question and remain on the '<URL>' page
+    Examples:
+      | Test | URL                                               |
+      | 44   | before-you-start/local-planning-depart            |
+      | 45   | before-you-start/type-of-planning-application     |
+      | 46   | before-you-start/use-a-different-service          |
+      | 47   | full-appeal/submit-appeal/declaration-information |

--- a/packages/e2e-tests/cypress/integration/householder-planning/appeals-service/appeal-type-redirect.feature
+++ b/packages/e2e-tests/cypress/integration/householder-planning/appeals-service/appeal-type-redirect.feature
@@ -30,7 +30,7 @@ Feature: As an Appellant/Agent
       | 20   | appellant-submission/site-access                |
       | 21   | appellant-submission/site-access-safety         |
       | 22   | appellant-submission/check-answers              |
-      | 23   | appellant-submission/submission?                |
+      | 23   | appellant-submission/submission                 |
 
   Scenario Outline: <Test> - The user has started an appeal and is taken to the <URL> page
     Given the user has started an appeal and not yet selected an appeal type

--- a/packages/e2e-tests/cypress/integration/householder-planning/appeals-service/appeal-type-redirect.feature
+++ b/packages/e2e-tests/cypress/integration/householder-planning/appeals-service/appeal-type-redirect.feature
@@ -1,0 +1,44 @@
+Feature: As an Appellant/Agent
+  I want the application to redirect me back to the first question if the appeal type is not set
+  So that I can be sure I'm providing the correct information for the Householder appeal type
+
+  Scenario Outline: <Test> - The user has not started an appeal and manually goes to the <URL> page
+    Given the user wants to start an appeal from a random page
+    When they manually go to the '<URL>' page
+    Then they are redirected back to the first question
+    Examples:
+      | Test | URL                                             |
+      | 1    | before-you-start/listed-building-householder    |
+      | 2    | before-you-start/granted-or-refused-householder |
+      | 3    | before-you-start/decision-date-householder      |
+      | 4    | before-you-start/enforcement-notice-householder |
+      | 5    | before-you-start/claiming-costs-householder     |
+      | 6    | before-you-start/prior-approval-existing-home   |
+      | 7    | before-you-start/you-cannot-appeal              |
+      | 8    | appellant-submission/task-list                  |
+      | 9    | appellant-submission/who-are-you                |
+      | 10   | appellant-submission/your-details               |
+      | 11   | appellant-submission/applicant-name             |
+      | 12   | appellant-submission/application-number         |
+      | 13   | appellant-submission/upload-application         |
+      | 14   | appellant-submission/upload-decision            |
+      | 15   | appellant-submission/appeal-statement           |
+      | 16   | appellant-submission/supporting-documents       |
+      | 17   | appellant-submission/site-location              |
+      | 18   | appellant-submission/site-ownership             |
+      | 19   | appellant-submission/site-ownership-certb       |
+      | 20   | appellant-submission/site-access                |
+      | 21   | appellant-submission/site-access-safety         |
+      | 22   | appellant-submission/check-answers              |
+      | 23   | appellant-submission/submission?                |
+
+  Scenario Outline: <Test> - The user has started an appeal and is taken to the <URL> page
+    Given the user has started an appeal and not yet selected an appeal type
+    When they are taken to the '<URL>' page
+    Then they are not redirected back to the first question and remain on the '<URL>' page
+    Examples:
+      | Test | URL                                           |
+      | 24   | before-you-start/local-planning-depart        |
+      | 25   | before-you-start/type-of-planning-application |
+      | 26   | before-you-start/use-a-different-service      |
+      | 27   | appellant-submission/submission-information   |

--- a/packages/forms-web-app/src/middleware/check-appeal-type-exists.js
+++ b/packages/forms-web-app/src/middleware/check-appeal-type-exists.js
@@ -12,7 +12,7 @@ const checkAppealTypeExists = (req, res, next) => {
     '/before-you-start/type-of-planning-application',
     '/before-you-start/use-a-different-service',
     '/appellant-submission/submission-information',
-    'full-appeal/submit-appeal/declaration-information',
+    '/full-appeal/submit-appeal/declaration-information',
   ];
 
   if (!featureFlag.newAppealJourney) {

--- a/packages/forms-web-app/src/views/appellant-submission/check-answers.njk
+++ b/packages/forms-web-app/src/views/appellant-submission/check-answers.njk
@@ -329,12 +329,7 @@
         ]
       }) }}
 
-      <form action="/appellant-submission/submission" method="get" novalidate>
-        {{ govukButton({
-          text: "Save and continue",
-          attributes: { "data-cy":"button-save-and-continue"}
-        }) }}
-      </form>
+      <a href="/appellant-submission/submission" class="govuk-button" role="button" data-cy="button-save-and-continue">Save and continue</a>
     </div>
   </div>
 {% endblock %}


### PR DESCRIPTION
## Ticket Number
https://pins-ds.atlassian.net/browse/AS-4531

## Description of change
Add E2E tests for each of the Full Appeal and Householder pages to check that they correctly either redirect to the first question or not.

Pages after the second question redirect back tot he first question and pages up to and including the second question don;t redirect.

Also changed the button on the Check Your Answers page to a link to prevent the ? appearing in the URL for the Declaration page.

## Checklist
<!-- Put an `x` in all the boxes that apply: -->
- [ ] Requires infrastructure changes
- [ ] If adding or remove environment variables (e.g. in `docker-compose.yaml`) then I have updated the appropriate Helm chart
- [ ] I have updated the documentation accordingly
- [ ] My commit history in this PR is linear
- [ ] New features have tests
- [ ] Breaking change (team conversation required)

## Important

Please do not merge from `master` (please only [rebase](https://github.com/foundry4/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
