### PR TITLE
fix(as-4582): add submission date to the full appeal schema

### DIFF
--- a/packages/business-rules/src/schemas/full-appeal/insert.js
+++ b/packages/business-rules/src/schemas/full-appeal/insert.js
@@ -22,6 +22,7 @@ const insert = pinsYup
     decisionDate: pinsYup.date().transform(parseDateString).nullable(),
     createdAt: pinsYup.date().transform(parseDateString).required(),
     updatedAt: pinsYup.date().transform(parseDateString).required(),
+    submissionDate: pinsYup.date().transform(parseDateString).nullable(),
     state: pinsYup.string().oneOf(Object.values(APPEAL_STATE)).default(APPEAL_STATE.DRAFT),
     appealType: pinsYup.lazy((appealType) => {
       if (appealType) {

--- a/packages/business-rules/src/schemas/full-appeal/insert.test.js
+++ b/packages/business-rules/src/schemas/full-appeal/insert.test.js
@@ -179,6 +179,23 @@ describe('schemas/full-appeal/insert', () => {
       });
     });
 
+    describe('submissionDate', () => {
+      it('should throw an error when given a value which is in an incorrect format', async () => {
+        appeal.submissionDate = '03/07/2021';
+
+        await expect(() => insert.validate(appeal, config)).rejects.toThrow(
+          'Invalid Date or string not ISO format',
+        );
+      });
+
+      it('should not throw an error when not given a value', async () => {
+        delete appeal.submissionDate;
+
+        const result = await insert.validate(appeal, config);
+        expect(result).toEqual(appeal);
+      });
+    });
+
     describe('state', () => {
       it('should throw an error when given an invalid value', async () => {
         appeal.state = 'PENDING';

--- a/packages/business-rules/src/schemas/full-appeal/update.js
+++ b/packages/business-rules/src/schemas/full-appeal/update.js
@@ -29,6 +29,7 @@ const update = pinsYup
     }),
     createdAt: pinsYup.date().transform(parseDateString).required(),
     updatedAt: pinsYup.date().transform(parseDateString).required(),
+    submissionDate: pinsYup.date().transform(parseDateString).nullable(),
     state: pinsYup.string().oneOf(Object.values(APPEAL_STATE)).required(),
     appealType: pinsYup.string().oneOf(Object.values(APPEAL_ID)).required(),
     typeOfPlanningApplication: pinsYup

--- a/packages/business-rules/src/schemas/full-appeal/update.test.js
+++ b/packages/business-rules/src/schemas/full-appeal/update.test.js
@@ -202,6 +202,23 @@ describe('schemas/full-appeal/update', () => {
       });
     });
 
+    describe('submissionDate', () => {
+      it('should throw an error when given a value which is in an incorrect format', async () => {
+        appeal.submissionDate = '03/07/2021';
+
+        await expect(() => update.validate(appeal, config)).rejects.toThrow(
+          'Invalid Date or string not ISO format',
+        );
+      });
+
+      it('should not throw an error when not given a value', async () => {
+        delete appeal.submissionDate;
+
+        const result = await update.validate(appeal, config);
+        expect(result).toEqual(appeal);
+      });
+    });
+
     describe('state', () => {
       it('should throw an error when given an invalid value', async () => {
         appeal.state = 'PENDING';

--- a/packages/business-rules/src/schemas/householder-appeal/update.test.js
+++ b/packages/business-rules/src/schemas/householder-appeal/update.test.js
@@ -212,6 +212,14 @@ describe('schemas/householder-appeal/update', () => {
     });
 
     describe('submissionDate', () => {
+      it('should throw an error when given a value which is in an incorrect format', async () => {
+        appeal.submissionDate = '03/07/2021';
+
+        await expect(() => update.validate(appeal, config)).rejects.toThrow(
+          'Invalid Date or string not ISO format',
+        );
+      });
+
       it('should not throw an error when not given a value', async () => {
         delete appeal.submissionDate;
 

--- a/packages/business-rules/test/data/full-appeal.js
+++ b/packages/business-rules/test/data/full-appeal.js
@@ -7,6 +7,7 @@ const appeal = {
   decisionDate: new Date(),
   createdAt: new Date(),
   updatedAt: new Date(),
+  submissionDate: new Date(),
   state: 'SUBMITTED',
   appealType: '1005',
   typeOfPlanningApplication: 'full-appeal',


### PR DESCRIPTION
## Ticket Number
https://pins-ds.atlassian.net/browse/AS-4582

## Description of change
Add `submissionDate` to the Full Appeal schema

## Checklist
<!-- Put an `x` in all the boxes that apply: -->
- [ ] Requires infrastructure changes
- [ ] If adding or remove environment variables (e.g. in `docker-compose.yaml`) then I have updated the appropriate Helm chart
- [ ] I have updated the documentation accordingly
- [ ] My commit history in this PR is linear
- [ ] New features have tests
- [ ] Breaking change (team conversation required)

## Important

Please do not merge from `master` (please only [rebase](https://github.com/foundry4/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
