### PR TITLE
fix(as-4636): update full appeal pdf to show the correct planning application type

### DIFF
--- a/packages/forms-web-app/src/views/full-appeal/submit-appeal/declaration-information.njk
+++ b/packages/forms-web-app/src/views/full-appeal/submit-appeal/declaration-information.njk
@@ -33,13 +33,27 @@
 {% block backButton %}
 {% endblock %}
 
-{% if appeal.eligibility.applicationDecision === 'granted' %}
-  {% set planningDecision = 'Granted' %}
-{% elif appeal.eligibility.applicationDecision === 'refused' %}
-  {% set planningDecision = 'Refused' %}
-{% else %}
-  {% set planningDecision = 'I have not received a decision' %}
-{% endif %}
+{% switch(appeal.eligibility.applicationDecision) %}
+  {% case 'granted' %}
+    {% set planningDecision = 'Granted' %}
+  {% case 'refused' %}
+    {% set planningDecision = 'Refused' %}
+  {% default %}
+    {% set planningDecision = 'I have not received a decision' %}
+{% endswitch %}
+
+{% switch(appeal.typeOfPlanningApplication) %}
+  {% case 'outline-planning' %}
+    {% set planningApplicationType = 'Outline planning' %}
+  {% case 'prior-approval' %}
+    {% set planningApplicationType = 'Prior approval' %}
+  {% case 'reserved-matters' %}
+    {% set planningApplicationType = 'Reserved matters' %}
+  {% case 'removal-or-variation-of-conditions' %}
+    {% set planningApplicationType = 'Removal or variation of conditions' %}
+  {% default %}
+    {% set planningApplicationType = 'Full planning' %}
+{% endswitch %}
 
 {% block content %}
   <div class="govuk-grid-row">
@@ -67,7 +81,7 @@
               text: "Planning application type"
             },
             value: {
-              text: summaryField("Full planning", { 'data-cy': "planning-appliction-type" })
+              text: summaryField(planningApplicationType, { 'data-cy': "planning-application-type" })
             }
           },
           {


### PR DESCRIPTION
## Ticket Number
https://pins-ds.atlassian.net/browse/AS-4636

## Description of change
Update the Full Appeal Declaration Information page so the application type is correctly displayed rather than being hard-coded to Full Appeal. This is required because appeal types other than Full Appeal go through the Full Appeal journey.

Also changed the setting of `planningDecision` to use a `switch` statement rather than an `if` statement.

## Checklist
<!-- Put an `x` in all the boxes that apply: -->
- [ ] Requires infrastructure changes
- [ ] If adding or remove environment variables (e.g. in `docker-compose.yaml`) then I have updated the appropriate Helm chart
- [ ] I have updated the documentation accordingly
- [ ] My commit history in this PR is linear
- [ ] New features have tests
- [ ] Breaking change (team conversation required)

## Important

Please do not merge from `master` (please only [rebase](https://github.com/foundry4/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
