### PR TITLE
feat(as-4583): add full appeal pre-validation

### DIFF
--- a/packages/appeals-service-api/__tests__/unit/validators/validate-full-appeal.test.js
+++ b/packages/appeals-service-api/__tests__/unit/validators/validate-full-appeal.test.js
@@ -1,0 +1,189 @@
+const fullAppeal = require('@pins/business-rules/test/data/full-appeal');
+const {
+  constants: { APPEAL_STATE, KNOW_THE_OWNERS, PROCEDURE_TYPE },
+} = require('@pins/business-rules');
+const v8 = require('v8');
+const validateFullAppeal = require('../../../src/validators/validate-full-appeal');
+
+describe('validators/validate-full-appeal', () => {
+  let appeal;
+
+  beforeEach(() => {
+    appeal = v8.deserialize(v8.serialize(fullAppeal));
+  });
+
+  it('should return no errors when given valid data', () => {
+    const errors = validateFullAppeal(appeal);
+    expect(errors).toEqual([]);
+  });
+
+  it('should return no errors when the appeal has not been submitted', () => {
+    appeal.state = APPEAL_STATE.DRAFT;
+    appeal.contactDetailsSection.isOriginalApplicant = false;
+    appeal.contactDetailsSection.appealingOnBehalfOf.name = null;
+    const errors = validateFullAppeal(appeal);
+    expect(errors).toEqual([]);
+  });
+
+  it('should return an error if the isOriginalApplicant = false and appealingOnBehalfOf.name = null', () => {
+    appeal.contactDetailsSection.isOriginalApplicant = false;
+    appeal.contactDetailsSection.appealingOnBehalfOf.name = null;
+    const errors = validateFullAppeal(appeal);
+    expect(errors).toEqual([
+      "If you are appealing on behalf of the applicant then the applicant's name is required",
+    ]);
+  });
+
+  it('should return an error if ownsAllTheLand = false and ownsSomeOfTheLand = null', () => {
+    appeal.appealSiteSection.siteOwnership.ownsAllTheLand = false;
+    appeal.appealSiteSection.siteOwnership.ownsSomeOfTheLand = null;
+    const errors = validateFullAppeal(appeal);
+    expect(errors).toEqual([
+      "If you don't own all the land then you must specify if you own some of the land",
+    ]);
+  });
+
+  it('should return an error if ownsAllTheLand = false and knowsTheOwners = null', () => {
+    appeal.appealSiteSection.siteOwnership.ownsAllTheLand = false;
+    appeal.appealSiteSection.siteOwnership.knowsTheOwners = null;
+    const errors = validateFullAppeal(appeal);
+    expect(errors).toEqual([
+      "If you don't own all the land then you must specify if you know who owns the land",
+    ]);
+  });
+
+  it('should return an error if knowsTheOwners = yes and tellingTheLandowners = null', () => {
+    appeal.appealSiteSection.siteOwnership.knowsTheOwners = KNOW_THE_OWNERS.YES;
+    appeal.appealSiteSection.siteOwnership.tellingTheLandowners = null;
+    const errors = validateFullAppeal(appeal);
+    expect(errors).toEqual([
+      'If you know who owns all of the land then you must confirm that you have told the other landowners',
+    ]);
+  });
+
+  it('should return an error if knowsTheOwners = some and hasIdentifiedTheOwners = null', () => {
+    appeal.appealSiteSection.siteOwnership.knowsTheOwners = KNOW_THE_OWNERS.SOME;
+    appeal.appealSiteSection.siteOwnership.hasIdentifiedTheOwners = null;
+    const errors = validateFullAppeal(appeal);
+    expect(errors).toEqual([
+      'If you know who owns some of the land then you must confirm that you have identified the other landowners',
+    ]);
+  });
+
+  it('should return an error if knowsTheOwners = some and advertisingYourAppeal = null', () => {
+    appeal.appealSiteSection.siteOwnership.knowsTheOwners = KNOW_THE_OWNERS.SOME;
+    appeal.appealSiteSection.siteOwnership.advertisingYourAppeal = null;
+    const errors = validateFullAppeal(appeal);
+    expect(errors).toEqual([
+      'If you know who owns some of the land then you must confirm that you have advertised your appeal',
+    ]);
+  });
+
+  it('should return an error if knowsTheOwners = no and hasIdentifiedTheOwners = null', () => {
+    appeal.appealSiteSection.siteOwnership.knowsTheOwners = KNOW_THE_OWNERS.NO;
+    appeal.appealSiteSection.siteOwnership.hasIdentifiedTheOwners = null;
+    const errors = validateFullAppeal(appeal);
+    expect(errors).toEqual([
+      "If you don't know who owns the land then you must confirm that you have identified the other landowners",
+    ]);
+  });
+
+  it('should return an error if knowsTheOwners = no and advertisingYourAppeal = null', () => {
+    appeal.appealSiteSection.siteOwnership.knowsTheOwners = KNOW_THE_OWNERS.NO;
+    appeal.appealSiteSection.siteOwnership.advertisingYourAppeal = null;
+    const errors = validateFullAppeal(appeal);
+    expect(errors).toEqual([
+      "If you don't know who owns the land then you must confirm that you have advertised your appeal",
+    ]);
+  });
+
+  it('should return an error if isAgriculturalHolding = true and isTenant = null', () => {
+    appeal.appealSiteSection.agriculturalHolding.isTenant = null;
+    const errors = validateFullAppeal(appeal);
+    expect(errors).toEqual([
+      'If the appeal site is part of an agricultural holding then you must confirm if you are a tenant',
+    ]);
+  });
+
+  it('should return an error if isTenant = true and hasOtherTenants = null', () => {
+    appeal.appealSiteSection.agriculturalHolding.isTenant = true;
+    appeal.appealSiteSection.agriculturalHolding.hasOtherTenants = null;
+    const errors = validateFullAppeal(appeal);
+    expect(errors).toEqual([
+      'If you are a tenant of the agricultural holding then you must confirm if there are any other tenants',
+    ]);
+  });
+
+  it('should return an error if isAgriculturalHolding = true and tellingTheTenants = null', () => {
+    appeal.appealSiteSection.agriculturalHolding.tellingTheTenants = null;
+    const errors = validateFullAppeal(appeal);
+    expect(errors).toEqual([
+      'If the appeal site is part of an agricultural holding then you must confirm that you have told the other tenants',
+    ]);
+  });
+
+  it('should return an error if procedureType = hearing and hearing.reason = null', () => {
+    appeal.appealDecisionSection.procedureType = PROCEDURE_TYPE.HEARING;
+    appeal.appealDecisionSection.hearing.reason = null;
+    const errors = validateFullAppeal(appeal);
+    expect(errors).toEqual([
+      'If you would prefer your appeal to be decided by hearing then you must give a reason',
+    ]);
+  });
+
+  it('should return an error if procedureType = hearing and draftStatementOfCommonGround.uploadedFile = {}', () => {
+    appeal.appealDecisionSection.procedureType = PROCEDURE_TYPE.HEARING;
+    appeal.appealDecisionSection.draftStatementOfCommonGround.uploadedFile = {};
+    const errors = validateFullAppeal(appeal);
+    expect(errors).toEqual([
+      'If you would prefer your appeal to be decided by hearing then you must upload your draft statement of common ground',
+    ]);
+  });
+
+  it('should return an error if procedureType = inquiry and inquiry.reason = null', () => {
+    appeal.appealDecisionSection.procedureType = PROCEDURE_TYPE.INQUIRY;
+    appeal.appealDecisionSection.inquiry.reason = null;
+    const errors = validateFullAppeal(appeal);
+    expect(errors).toEqual([
+      'If you would prefer your appeal to be decided by inquiry then you must give a reason',
+    ]);
+  });
+
+  it('should return an error if procedureType = inquiry and inquiry.expectedDays = null', () => {
+    appeal.appealDecisionSection.procedureType = PROCEDURE_TYPE.INQUIRY;
+    appeal.appealDecisionSection.inquiry.expectedDays = null;
+    const errors = validateFullAppeal(appeal);
+    expect(errors).toEqual([
+      'If you would prefer your appeal to be decided by inquiry then you must enter the number of days you expect the inquriy to last',
+    ]);
+  });
+
+  it('should return an error if procedureType = inquiry and draftStatementOfCommonGround.uploadedFile = {}', () => {
+    appeal.appealDecisionSection.procedureType = PROCEDURE_TYPE.INQUIRY;
+    appeal.appealDecisionSection.draftStatementOfCommonGround.uploadedFile = {};
+    const errors = validateFullAppeal(appeal);
+    expect(errors).toEqual([
+      'If you would prefer your appeal to be decided by inquiry then you must upload your draft statement of common ground',
+    ]);
+  });
+
+  it('should return an error if designAccessStatement.isSubmitted = true and designAccessStatement.uploadedFile = {}', () => {
+    appeal.planningApplicationDocumentsSection.designAccessStatement.uploadedFile = {};
+    const errors = validateFullAppeal(appeal);
+    expect(errors).toEqual([
+      'Your design and access statement must be uploaded if you submitted one with your application',
+    ]);
+  });
+
+  it('should return an error if plansDrawings.hasPlansDrawings = true and plansDrawings.uploadedFiles = []', () => {
+    appeal.appealDocumentsSection.plansDrawings.uploadedFiles = [];
+    const errors = validateFullAppeal(appeal);
+    expect(errors).toEqual(['Your new plans and drawings must be uploaded']);
+  });
+
+  it('should return an error if supportingDocuments.hasSupportingDocuments = true and supportingDocuments.uploadedFiles = []', () => {
+    appeal.appealDocumentsSection.supportingDocuments.uploadedFiles = [];
+    const errors = validateFullAppeal(appeal);
+    expect(errors).toEqual(['Your other new supporting documents must be uploaded']);
+  });
+});

--- a/packages/appeals-service-api/src/validators/validate-full-appeal.js
+++ b/packages/appeals-service-api/src/validators/validate-full-appeal.js
@@ -1,0 +1,141 @@
+const {
+  constants: { APPEAL_STATE, KNOW_THE_OWNERS, PROCEDURE_TYPE },
+} = require('@pins/business-rules');
+
+const validateFullAppeal = (appeal) => {
+  const {
+    state,
+    contactDetailsSection: { appealingOnBehalfOf, isOriginalApplicant },
+    appealSiteSection: {
+      siteOwnership: {
+        advertisingYourAppeal,
+        hasIdentifiedTheOwners,
+        knowsTheOwners,
+        ownsAllTheLand,
+        ownsSomeOfTheLand,
+        tellingTheLandowners,
+      },
+      agriculturalHolding: { hasOtherTenants, isAgriculturalHolding, isTenant, tellingTheTenants },
+    },
+    appealDecisionSection: { draftStatementOfCommonGround, hearing, inquiry, procedureType },
+    planningApplicationDocumentsSection: { designAccessStatement },
+    appealDocumentsSection: { plansDrawings, supportingDocuments },
+  } = appeal;
+  const errors = [];
+
+  if (state !== APPEAL_STATE.SUBMITTED) {
+    return errors;
+  }
+
+  if (isOriginalApplicant === false && !appealingOnBehalfOf.name) {
+    errors.push(
+      "If you are appealing on behalf of the applicant then the applicant's name is required"
+    );
+  }
+
+  if (ownsAllTheLand === false && [null, ''].includes(ownsSomeOfTheLand)) {
+    errors.push("If you don't own all the land then you must specify if you own some of the land");
+  }
+
+  if (ownsAllTheLand === false && [null, ''].includes(knowsTheOwners)) {
+    errors.push(
+      "If you don't own all the land then you must specify if you know who owns the land"
+    );
+  }
+
+  if (knowsTheOwners === KNOW_THE_OWNERS.YES && !tellingTheLandowners) {
+    errors.push(
+      'If you know who owns all of the land then you must confirm that you have told the other landowners'
+    );
+  }
+
+  if (knowsTheOwners === KNOW_THE_OWNERS.SOME && [null, ''].includes(hasIdentifiedTheOwners)) {
+    errors.push(
+      'If you know who owns some of the land then you must confirm that you have identified the other landowners'
+    );
+  }
+
+  if (knowsTheOwners === KNOW_THE_OWNERS.SOME && !advertisingYourAppeal) {
+    errors.push(
+      'If you know who owns some of the land then you must confirm that you have advertised your appeal'
+    );
+  }
+
+  if (knowsTheOwners === KNOW_THE_OWNERS.NO && [null, ''].includes(hasIdentifiedTheOwners)) {
+    errors.push(
+      "If you don't know who owns the land then you must confirm that you have identified the other landowners"
+    );
+  }
+
+  if (knowsTheOwners === KNOW_THE_OWNERS.NO && !advertisingYourAppeal) {
+    errors.push(
+      "If you don't know who owns the land then you must confirm that you have advertised your appeal"
+    );
+  }
+
+  if (isAgriculturalHolding && [null, ''].includes(isTenant)) {
+    errors.push(
+      'If the appeal site is part of an agricultural holding then you must confirm if you are a tenant'
+    );
+  }
+
+  if (isTenant && [null, ''].includes(hasOtherTenants)) {
+    errors.push(
+      'If you are a tenant of the agricultural holding then you must confirm if there are any other tenants'
+    );
+  }
+
+  if (isAgriculturalHolding && !tellingTheTenants) {
+    errors.push(
+      'If the appeal site is part of an agricultural holding then you must confirm that you have told the other tenants'
+    );
+  }
+
+  if (procedureType === PROCEDURE_TYPE.HEARING && !hearing.reason) {
+    errors.push(
+      'If you would prefer your appeal to be decided by hearing then you must give a reason'
+    );
+  }
+
+  if (procedureType === PROCEDURE_TYPE.HEARING && !draftStatementOfCommonGround.uploadedFile.id) {
+    errors.push(
+      'If you would prefer your appeal to be decided by hearing then you must upload your draft statement of common ground'
+    );
+  }
+
+  if (procedureType === PROCEDURE_TYPE.INQUIRY && !inquiry.reason) {
+    errors.push(
+      'If you would prefer your appeal to be decided by inquiry then you must give a reason'
+    );
+  }
+
+  if (procedureType === PROCEDURE_TYPE.INQUIRY && !inquiry.expectedDays) {
+    errors.push(
+      'If you would prefer your appeal to be decided by inquiry then you must enter the number of days you expect the inquriy to last'
+    );
+  }
+
+  if (procedureType === PROCEDURE_TYPE.INQUIRY && !draftStatementOfCommonGround.uploadedFile.id) {
+    errors.push(
+      'If you would prefer your appeal to be decided by inquiry then you must upload your draft statement of common ground'
+    );
+  }
+
+  if (designAccessStatement.isSubmitted && !designAccessStatement.uploadedFile.id) {
+    errors.push(
+      'Your design and access statement must be uploaded if you submitted one with your application'
+    );
+  }
+
+  if (plansDrawings.hasPlansDrawings && !plansDrawings.uploadedFiles.length) {
+    errors.push('Your new plans and drawings must be uploaded');
+  }
+
+  if (supportingDocuments.hasSupportingDocuments && !supportingDocuments.uploadedFiles.length) {
+    errors.push('Your other new supporting documents must be uploaded');
+  }
+
+  return errors;
+};
+
+module.exports = validateFullAppeal;


### PR DESCRIPTION
## Ticket Number
https://pins-ds.atlassian.net/browse/AS-4583

## Description of change
Add Full Appeal pre-validation. This validation happens after the user has submitted their application and before the schema validation to ensure that certain pages have been completed based on what has been selected on  previous page.

For example if the appellant selects that they are appealing on behalf of the applicant then the applicant's name needs to be entered.

## Checklist
<!-- Put an `x` in all the boxes that apply: -->
- [ ] Requires infrastructure changes
- [ ] If adding or remove environment variables (e.g. in `docker-compose.yaml`) then I have updated the appropriate Helm chart
- [ ] I have updated the documentation accordingly
- [ ] My commit history in this PR is linear
- [ ] New features have tests
- [ ] Breaking change (team conversation required)

## Important

Please do not merge from `master` (please only [rebase](https://github.com/foundry4/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
