### PR TITLE
Horizon functions CI agent pool

### DIFF
--- a/pipelines/horizon-functions/horizon-functions-cd.yml
+++ b/pipelines/horizon-functions/horizon-functions-cd.yml
@@ -24,9 +24,6 @@ resources:
         branches:
           include: 
             - master
-        paths:
-          include:
-            - packages/horizon-functions
 
 extends:
   template: stages/wrapper_function_app_cd.yml@templates

--- a/pipelines/horizon-functions/horizon-functions-cd.yml
+++ b/pipelines/horizon-functions/horizon-functions-cd.yml
@@ -28,7 +28,7 @@ resources:
 extends:
   template: stages/wrapper_function_app_cd.yml@templates
   parameters:
-    appName: pins-func-horizon-appeals-service-$(ENVIRONMENT)-${{ parameters.region }}-001
+    appName: pins-func-appeals-service-horizon-$(ENVIRONMENT)-${{ parameters.region }}-001
     artifactSourcePipeline: horizon-functions CI
     project: appeal-planning-decision
     resourceGroup: pins-rg-appeals-service-$(ENVIRONMENT)-${{ parameters.region }}-001

--- a/pipelines/horizon-functions/horizon-functions-cd.yml
+++ b/pipelines/horizon-functions/horizon-functions-cd.yml
@@ -18,8 +18,8 @@ resources:
       endpoint: Appeals Token
       name: Planning-Inspectorate/common-pipeline-templates
   pipelines:
-    - pipeline: azure-functions-ci
-      source: azure-functions CI
+    - pipeline: horizon-functions-ci
+      source: horizon-functions CI
       trigger: 
         branches:
           include: 

--- a/pipelines/horizon-functions/horizon-functions-ci.yml
+++ b/pipelines/horizon-functions/horizon-functions-ci.yml
@@ -16,6 +16,8 @@ extends:
     globalVariables:
       - template: pipelines/appeals-service-api/variables.yml@self
       - template: pipelines/variables.yml@self
+    pool:
+      vmImage: ubuntu-latest
     projectName: $(projectName)
     validateName: Build
     validationSteps:

--- a/pipelines/horizon-functions/horizon-functions-ci.yml
+++ b/pipelines/horizon-functions/horizon-functions-ci.yml
@@ -26,6 +26,10 @@ extends:
           echo "Setting the name of the build to '$buildName'."
           echo "##vso[build.updatebuildnumber]$buildName"
         displayName: Set Build Number
+      - script: |
+          echo "Setting build tag to '$(Build.SourceBranchName)'."
+          echo "##vso[build.addbuildtag]$(Build.SourceBranchName)"
+        displayName: Add Branch Tag
       - template: steps/function_app_validate.yml@templates
         parameters:
           workingDirectory: $(Build.Repository.LocalPath)/packages/horizon-functions


### PR DESCRIPTION
## Description of change
- Node isn't installed on the custom agent yet. So for the time being I'm just using the MS Hosted agents
- Updated name of CI pipeline (matches what's in Azure DevOps)
- Added a branch tag to the CI builds so the CD pipeline can deploy based on branch
- Fix name of function app