### PR TITLE
feat(claim costs shutter page amend): new Shutter page for the /use-e…

### DIFF
--- a/packages/forms-web-app/__tests__/unit/controllers/householder-planning/eligibility/claiming-costs-householder.test.js
+++ b/packages/forms-web-app/__tests__/unit/controllers/householder-planning/eligibility/claiming-costs-householder.test.js
@@ -49,7 +49,7 @@ describe('controllers/householder-planning/claiming-costs-householder', () => {
       expect(appeal.eligibility.isClaimingCosts).toEqual(true);
       expect(createOrUpdateAppeal).toHaveBeenCalledWith({ ...appeal });
 
-      expect(res.redirect).toBeCalledWith(`/before-you-start/use-a-different-service`);
+      expect(res.redirect).toBeCalledWith(`/before-you-start/use-existing-service-costs`);
     });
 
     it('should redirect to the results-householder page', async () => {

--- a/packages/forms-web-app/__tests__/unit/controllers/householder-planning/use-existing-service-costs.test.js
+++ b/packages/forms-web-app/__tests__/unit/controllers/householder-planning/use-existing-service-costs.test.js
@@ -1,0 +1,24 @@
+const useExistingServiceCostsController = require('../../../../src/controllers/householder-planning/eligibility/use-existing-service-costs');
+
+const {
+  VIEW: {
+    HOUSEHOLDER_PLANNING: {
+      ELIGIBILITY: { USE_EXISTING_SERVICE_COSTS: useExistingServiceCosts },
+    },
+  },
+} = require('../../../../src/lib/householder-planning/views');
+
+const { mockReq, mockRes } = require('../../mocks');
+
+describe('controllers/householder-planning/eligibility/use-existing-service-costs', () => {
+  const req = mockReq();
+  const res = mockRes();
+
+  it('Test the postClaimingCostsHouseholder method calls the correct template', async () => {
+    await useExistingServiceCostsController.getUseExistingServiceCosts(req, res);
+
+    expect(res.render).toBeCalledWith(useExistingServiceCosts, {
+      acpLink: 'https://acp.planninginspectorate.gov.uk/',
+    });
+  });
+});

--- a/packages/forms-web-app/__tests__/unit/lib/householder-planning/views.test.js
+++ b/packages/forms-web-app/__tests__/unit/lib/householder-planning/views.test.js
@@ -6,6 +6,7 @@ describe('/lib/householder-planning/views', () => {
       HOUSEHOLDER_PLANNING: {
         ELIGIBILITY: {
           CLAIMING_COSTS: 'householder-planning/eligibility/claiming-costs-householder',
+          USE_EXISTING_SERVICE_COSTS: 'householder-planning/eligibility/use-existing-service-costs',
           ENFORCEMENT_NOTICE_HOUSEHOLDER:
             'householder-planning/eligibility/enforcement-notice-householder',
           DATE_DECISION_DUE_HOUSEHOLDER:

--- a/packages/forms-web-app/__tests__/unit/routes/householder-planning/eligibility/index.test.js
+++ b/packages/forms-web-app/__tests__/unit/routes/householder-planning/eligibility/index.test.js
@@ -7,6 +7,7 @@ const listedBuildingHouseholderRouter = require('../../../../../src/routes/house
 const dateDecisionDueHouseholderRouter = require('../../../../../src/routes/householder-planning/eligibility/date-decision-due-householder');
 const decisionDateHouseholderRouter = require('../../../../../src/routes/householder-planning/eligibility/decision-date-householder');
 const conditionsHouseholderPermissionRouter = require('../../../../../src/routes/householder-planning/eligibility/conditions-householder-permission');
+const useExistingServiceCostsRouter = require('../../../../../src/routes/householder-planning/eligibility/use-existing-service-costs');
 
 describe('routes/householder-planning/eligibility/index', () => {
   beforeEach(() => {
@@ -17,7 +18,7 @@ describe('routes/householder-planning/eligibility/index', () => {
   });
 
   it('should define the expected routes', () => {
-    expect(use.mock.calls.length).toBe(7);
+    expect(use.mock.calls.length).toBe(8);
     expect(use).toHaveBeenCalledWith(claimingCostsHouseholderRouter);
     expect(use).toHaveBeenCalledWith(enforcementNoticeHouseholderRouter);
     expect(use).toHaveBeenCalledWith(grantedOrRefusedHouseholderRouter);
@@ -25,5 +26,6 @@ describe('routes/householder-planning/eligibility/index', () => {
     expect(use).toHaveBeenCalledWith(dateDecisionDueHouseholderRouter);
     expect(use).toHaveBeenCalledWith(decisionDateHouseholderRouter);
     expect(use).toHaveBeenCalledWith(conditionsHouseholderPermissionRouter);
+    expect(use).toHaveBeenCalledWith(useExistingServiceCostsRouter);
   });
 });

--- a/packages/forms-web-app/__tests__/unit/routes/householder-planning/eligibility/use-existing-service-costs.test.js
+++ b/packages/forms-web-app/__tests__/unit/routes/householder-planning/eligibility/use-existing-service-costs.test.js
@@ -1,0 +1,17 @@
+const { get } = require('../../router-mock');
+
+const useExistingServiceCostsController = require('../../../../../src/controllers/householder-planning/eligibility/use-existing-service-costs');
+
+describe('routes/householder-planning/eligibility/use-existing-service-costs', () => {
+  beforeEach(() => {
+    // eslint-disable-next-line global-require
+    require('../../../../../src/routes/householder-planning/eligibility/use-existing-service-costs');
+  });
+
+  it('should define the expected routes', () => {
+    expect(get).toHaveBeenCalledWith(
+      '/use-existing-service-costs',
+      useExistingServiceCostsController.getUseExistingServiceCosts
+    );
+  });
+});

--- a/packages/forms-web-app/src/controllers/householder-planning/eligibility/claiming-costs-householder.js
+++ b/packages/forms-web-app/src/controllers/householder-planning/eligibility/claiming-costs-householder.js
@@ -23,7 +23,7 @@ exports.getClaimingCostsHouseholder = async (req, res) => {
 
 const redirect = (selection, res) => {
   if (selection === 'yes') {
-    res.redirect(`/before-you-start/use-a-different-service`);
+    res.redirect(`/before-you-start/use-existing-service-costs`);
     return;
   }
 

--- a/packages/forms-web-app/src/controllers/householder-planning/eligibility/use-existing-service-costs.js
+++ b/packages/forms-web-app/src/controllers/householder-planning/eligibility/use-existing-service-costs.js
@@ -1,0 +1,13 @@
+const {
+  VIEW: {
+    HOUSEHOLDER_PLANNING: {
+      ELIGIBILITY: { USE_EXISTING_SERVICE_COSTS: useExistingServiceCosts },
+    },
+  },
+} = require('../../../lib/householder-planning/views');
+
+exports.getUseExistingServiceCosts = async (_, res) => {
+  res.render(useExistingServiceCosts, {
+    acpLink: 'https://acp.planninginspectorate.gov.uk/',
+  });
+};

--- a/packages/forms-web-app/src/lib/householder-planning/views.js
+++ b/packages/forms-web-app/src/lib/householder-planning/views.js
@@ -2,6 +2,7 @@ const VIEW = {
   HOUSEHOLDER_PLANNING: {
     ELIGIBILITY: {
       CLAIMING_COSTS: 'householder-planning/eligibility/claiming-costs-householder',
+      USE_EXISTING_SERVICE_COSTS: 'householder-planning/eligibility/use-existing-service-costs',
       DATE_DECISION_DUE_HOUSEHOLDER:
         'householder-planning/eligibility/date-decision-due-householder',
       LISTED_BUILDING_HOUSEHOLDER: 'householder-planning/eligibility/listed-building-householder',

--- a/packages/forms-web-app/src/routes/householder-planning/eligibility/index.js
+++ b/packages/forms-web-app/src/routes/householder-planning/eligibility/index.js
@@ -9,6 +9,7 @@ const enforcementNoticeRouter = require('./enforcement-notice-householder');
 const grantedOrRefusedRouter = require('./granted-or-refused-householder');
 const decisionDateHouseholderRouter = require('./decision-date-householder');
 const conditionsHouseholderPermissionRouter = require('./conditions-householder-permission');
+const useExistingServiceCosts = require('./use-existing-service-costs');
 
 router.use(claimingCostsHouseholderRouter);
 router.use(enforcementNoticeRouter);
@@ -17,5 +18,6 @@ router.use(listedBuildingHouseholderRouter);
 router.use(dateDecisionDueHouseholderRouter);
 router.use(decisionDateHouseholderRouter);
 router.use(conditionsHouseholderPermissionRouter);
+router.use(useExistingServiceCosts);
 
 module.exports = router;

--- a/packages/forms-web-app/src/routes/householder-planning/eligibility/use-existing-service-costs.js
+++ b/packages/forms-web-app/src/routes/householder-planning/eligibility/use-existing-service-costs.js
@@ -1,0 +1,8 @@
+const express = require('express');
+const useExistingServiceCosts = require('../../../controllers/householder-planning/eligibility/use-existing-service-costs');
+
+const router = express.Router();
+
+router.get('/use-existing-service-costs', useExistingServiceCosts.getUseExistingServiceCosts);
+
+module.exports = router;

--- a/packages/forms-web-app/src/views/householder-planning/eligibility/use-existing-service-costs.njk
+++ b/packages/forms-web-app/src/views/householder-planning/eligibility/use-existing-service-costs.njk
@@ -1,0 +1,31 @@
+{% extends "layouts/main.njk" %}
+
+{% from "govuk/components/button/macro.njk" import govukButton %}
+
+{% block pageTitle %}
+  This service is not available if you are claiming costs - Eligibility - Appeal a planning decision - GOV.UK
+{% endblock %}
+
+{% block backButton %}
+{% endblock %}
+
+{% block content %}
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-l">You need to use the existing service</h1>
+    <p class="govuk-body">This new service is only for appeals that do not involve a claim for costs. </p>
+
+    <p class="govuk-body">You need to submit your appeal using the existing service, the Appeals Casework Portal. </p>
+
+    <h2 class="govuk-heading-m">How to begin your appeal</h2>
+
+    <p class="govuk-body">To begin your appeal, log in or register on the Appeals Casework Portal.</p>
+    {{ govukButton({
+      text: "Continue to the Appeals Casework Portal",
+      href: acpLink
+    }) }}
+  </div>
+</div>
+
+{% endblock %}


### PR DESCRIPTION
…xisting-service-costs route

For the Householder Planning Application type, when the user selects 'yes' on claiming costs, they
are being redirected to a new Shutter page with URL: /before-you-start/use-existing-service-costs.
The new page is based on the prototype:
https://pins-appeals.herokuapp.com/before-you-start/v10/shutter/claiming-costs.

## Ticket Number
<!-- Add the number from the Jira board -->
https://pins-ds.atlassian.net/browse/AS-

## Description of change
<!-- Please describe the change -->

## Checklist
<!-- Put an `x` in all the boxes that apply: -->
- [ ] Requires infrastructure changes
- [ ] If adding or remove environment variables (e.g. in `docker-compose.yaml`) then I have updated the appropriate Helm chart
- [ ] I have updated the documentation accordingly
- [ ] My commit history in this PR is linear
- [ ] New features have tests
- [ ] Breaking change (team conversation required)

## Important

Please do not merge from `master` (please only [rebase](https://github.com/foundry4/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
