### PR TITLE
feat(update shutter page): shutter page amend - application type not …

### DIFF
--- a/packages/e2e-tests/cypress/integration/eligibility/full-appeal/planning-application-type.feature
+++ b/packages/e2e-tests/cypress/integration/eligibility/full-appeal/planning-application-type.feature
@@ -42,7 +42,7 @@ Feature: Planning Application Type
     Given an appellant is on the select the type of planning application you made page
     When appellant selects '<invalid_planning_type>' planning application type
     And appellant clicks on the continue button
-    Then an appellants gets routed to shutter page which notifies them to use a different service
+    Then an appellants gets routed to shutter page which notifies them to use an existing service
     Examples:
     |invalid_planning_type|
     |Something else       |

--- a/packages/e2e-tests/cypress/integration/eligibility/full-appeal/planning-application-type/planning-application-type-steps.js
+++ b/packages/e2e-tests/cypress/integration/eligibility/full-appeal/planning-application-type/planning-application-type-steps.js
@@ -65,8 +65,8 @@ Then('any information they have inputted for planning type will not be saved',()
   getHouseHolderPlanningRadio().should('not.be.checked');
 });
 
-Then('an appellants gets routed to shutter page which notifies them to use a different service',()=>{
-  cy.url().should('contain', '/before-you-start/use-a-different-service');
+Then('an appellants gets routed to shutter page which notifies them to use an existing service',()=>{
+  cy.url().should('contain', '/before-you-start/use-existing-service-application-type');
 })
 
 Then('appellant is presented with the page Did you apply for prior approval to extend an existing home?',()=>{

--- a/packages/forms-web-app/__tests__/unit/controllers/full-appeal/type-of-planning-application.test.js
+++ b/packages/forms-web-app/__tests__/unit/controllers/full-appeal/type-of-planning-application.test.js
@@ -71,7 +71,7 @@ describe('controllers/full-appeal/type-of-planning-application', () => {
         ...updatedAppeal,
       });
 
-      expect(res.redirect).toBeCalledWith('/before-you-start/use-a-different-service');
+      expect(res.redirect).toBeCalledWith('/before-you-start/use-existing-service-application-type');
     });
 
     it('should redirect to the shutter page', async () => {
@@ -92,7 +92,7 @@ describe('controllers/full-appeal/type-of-planning-application', () => {
         ...updatedAppeal,
       });
 
-      expect(res.redirect).toBeCalledWith('/before-you-start/use-a-different-service');
+      expect(res.redirect).toBeCalledWith('/before-you-start/use-existing-service-application-type');
     });
 
     it('should redirect to the about appeal page', async () => {

--- a/packages/forms-web-app/__tests__/unit/controllers/full-appeal/use-existing-service-application-type.test.js
+++ b/packages/forms-web-app/__tests__/unit/controllers/full-appeal/use-existing-service-application-type.test.js
@@ -1,0 +1,17 @@
+const useExistingServiceApplicationType = require('../../../../src/controllers/full-appeal/use-existing-service-application-type');
+
+const { VIEW } = require('../../../../src/lib/views');
+const { mockReq, mockRes } = require('../../mocks');
+
+describe('controllers/full-appeal/use-existing-service-application-type', () => {
+  const req = mockReq();
+  const res = mockRes();
+
+  it('Test getUseExistingServiceApplicationType method calls the correct template', async () => {
+    await useExistingServiceApplicationType.getUseExistingServiceApplicationType(req, res);
+
+    expect(res.render).toBeCalledWith(VIEW.FULL_APPEAL.USE_EXISTING_SERVICE_APPLICATION_TYPE, {
+      acpLink: 'https://acp.planninginspectorate.gov.uk/',
+    });
+  });
+});

--- a/packages/forms-web-app/__tests__/unit/lib/views.test.js
+++ b/packages/forms-web-app/__tests__/unit/lib/views.test.js
@@ -65,6 +65,7 @@ describe('lib/views', () => {
         LOCAL_PLANNING_DEPARTMENT: 'full-appeal/local-planning-department',
         TYPE_OF_PLANNING_APPLICATION: 'full-appeal/type-of-planning-application',
         USE_A_DIFFERENT_SERVICE: 'full-appeal/use-a-different-service',
+        USE_EXISTING_SERVICE_APPLICATION_TYPE: "full-appeal/use-existing-service-application-type",
         YOU_CANNOT_APPEAL: 'full-appeal/you-cannot-appeal',
         PRIOR_APPROVAL_EXISTING_HOME: 'full-appeal/prior-approval-existing-home',
       },

--- a/packages/forms-web-app/__tests__/unit/routes/full-appeal/index.test.js
+++ b/packages/forms-web-app/__tests__/unit/routes/full-appeal/index.test.js
@@ -5,6 +5,7 @@ const grantedOrRefusedRouter = require('../../../../src/routes/full-appeal/grant
 const localPlanningDepartmentRouter = require('../../../../src/routes/full-appeal/local-planning-department');
 const typeOfPlanningRouter = require('../../../../src/routes/full-appeal/type-of-planning-application');
 const useADifferentServiceRouter = require('../../../../src/routes/full-appeal/use-a-different-service');
+const useExistingServiceApplicationType = require ('../../../../src/routes/full-appeal/use-existing-service-application-type');
 const outOfTimeRouter = require('../../../../src/routes/full-appeal/out-of-time');
 const enforcementNoticeRouter = require('../../../../src/routes/full-appeal/enforcement-notice');
 const dateDecisionDueRouter = require('../../../../src/routes/full-appeal/date-decision-due');
@@ -20,12 +21,13 @@ describe('routes/full-appeal/index', () => {
   });
 
   it('should define the expected routes', () => {
-    expect(use.mock.calls.length).toBe(10);
+    expect(use.mock.calls.length).toBe(11);
     expect(use).toHaveBeenCalledWith(localPlanningDepartmentRouter);
     expect(use).toHaveBeenCalledWith(typeOfPlanningRouter);
     expect(use).toHaveBeenCalledWith(anyOfFollowingRouter);
     expect(use).toHaveBeenCalledWith(grantedOrRefusedRouter);
     expect(use).toHaveBeenCalledWith(useADifferentServiceRouter);
+    expect(use).toHaveBeenCalledWith(useExistingServiceApplicationType);
     expect(use).toHaveBeenCalledWith(outOfTimeRouter);
     expect(use).toHaveBeenCalledWith(enforcementNoticeRouter);
     expect(use).toHaveBeenCalledWith(decisionDateRouter);

--- a/packages/forms-web-app/__tests__/unit/routes/full-appeal/use-existing-service-application-type.test.js
+++ b/packages/forms-web-app/__tests__/unit/routes/full-appeal/use-existing-service-application-type.test.js
@@ -1,0 +1,16 @@
+const { get } = require('../router-mock');
+const useExistingServiceApplicationType= require('../../../../src/controllers/full-appeal/use-existing-service-application-type');
+
+describe('routes/full-appeal/use-existing-service-application-type', () => {
+  beforeEach(() => {
+    // eslint-disable-next-line global-require
+    require('../../../../src/routes/full-appeal/use-existing-service-application-type');
+  });
+
+  it('should define the expected routes', () => {
+    expect(get).toHaveBeenCalledWith(
+      '/use-existing-service-application-type',
+      useExistingServiceApplicationType.getUseExistingServiceApplicationType
+    );
+  });
+});

--- a/packages/forms-web-app/src/controllers/full-appeal/type-of-planning-application.js
+++ b/packages/forms-web-app/src/controllers/full-appeal/type-of-planning-application.js
@@ -63,7 +63,7 @@ const postTypeOfPlanningApplication = async (req, res) => {
       return res.redirect('/before-you-start/conditions-householder-permission');
     case SOMETHING_ELSE:
     case I_HAVE_NOT_MADE_A_PLANNING_APPLICATION:
-      return res.redirect('/before-you-start/use-a-different-service');
+      return res.redirect('/before-you-start/use-existing-service-application-type');
     default:
       return res.redirect('/before-you-start/any-of-following');
   }

--- a/packages/forms-web-app/src/controllers/full-appeal/use-existing-service-application-type.js
+++ b/packages/forms-web-app/src/controllers/full-appeal/use-existing-service-application-type.js
@@ -1,0 +1,7 @@
+const { VIEW } = require('../../lib/views');
+
+exports.getUseExistingServiceApplicationType = async (_, res) => {
+  res.render(VIEW.FULL_APPEAL.USE_EXISTING_SERVICE_APPLICATION_TYPE, {
+    acpLink: 'https://acp.planninginspectorate.gov.uk/',
+  });
+};

--- a/packages/forms-web-app/src/lib/views.js
+++ b/packages/forms-web-app/src/lib/views.js
@@ -61,6 +61,7 @@ const VIEW = {
     LOCAL_PLANNING_DEPARTMENT: 'full-appeal/local-planning-department',
     TYPE_OF_PLANNING_APPLICATION: 'full-appeal/type-of-planning-application',
     USE_A_DIFFERENT_SERVICE: 'full-appeal/use-a-different-service',
+    USE_EXISTING_SERVICE_APPLICATION_TYPE: 'full-appeal/use-existing-service-application-type',
     YOU_CANNOT_APPEAL: 'full-appeal/you-cannot-appeal',
     PRIOR_APPROVAL_EXISTING_HOME: 'full-appeal/prior-approval-existing-home',
   },

--- a/packages/forms-web-app/src/middleware/check-appeal-type-exists.js
+++ b/packages/forms-web-app/src/middleware/check-appeal-type-exists.js
@@ -11,6 +11,7 @@ const checkAppealTypeExists = (req, res, next) => {
     '/before-you-start/local-planning-depart',
     '/before-you-start/type-of-planning-application',
     '/before-you-start/use-a-different-service',
+    '/before-you-start/use-existing-service-application-type',
     '/appellant-submission/submission-information',
     '/full-appeal/submit-appeal/declaration-information',
   ];

--- a/packages/forms-web-app/src/routes/full-appeal/index.js
+++ b/packages/forms-web-app/src/routes/full-appeal/index.js
@@ -4,6 +4,7 @@ const typeOfPlanningApplicationRouter = require('./type-of-planning-application'
 const anyOfFollowingRouter = require('./any-of-following');
 const grantedOrRefusedRouter = require('./granted-or-refused');
 const useADifferentServiceRouter = require('./use-a-different-service');
+const useExistingServiceApplicationType = require('./use-existing-service-application-type');
 const outOfTimeRouter = require('./out-of-time');
 const enforcementNoticeRouter = require('./enforcement-notice');
 const decisionDateRouter = require('./decision-date');
@@ -17,6 +18,7 @@ router.use(typeOfPlanningApplicationRouter);
 router.use(anyOfFollowingRouter);
 router.use(grantedOrRefusedRouter);
 router.use(useADifferentServiceRouter);
+router.use(useExistingServiceApplicationType);
 router.use(outOfTimeRouter);
 router.use(enforcementNoticeRouter);
 router.use(decisionDateRouter);

--- a/packages/forms-web-app/src/routes/full-appeal/use-existing-service-application-type.js
+++ b/packages/forms-web-app/src/routes/full-appeal/use-existing-service-application-type.js
@@ -1,0 +1,10 @@
+const express = require('express');
+const useExistingServiceApplicationType = require('../../controllers/full-appeal/use-existing-service-application-type');
+const router = express.Router();
+
+router.get(
+  '/use-existing-service-application-type',
+  useExistingServiceApplicationType.getUseExistingServiceApplicationType
+);
+
+module.exports = router;

--- a/packages/forms-web-app/src/views/full-appeal/use-existing-service-application-type.njk
+++ b/packages/forms-web-app/src/views/full-appeal/use-existing-service-application-type.njk
@@ -1,0 +1,31 @@
+{% extends "layouts/main.njk" %}
+
+{% from "govuk/components/button/macro.njk" import govukButton %}
+
+{% block pageTitle %}
+  You need to use the existing service - Appeal a planning decision - GOV.UK
+{% endblock %}
+
+{% block backButton %}
+{% endblock %}
+
+{% block content %}
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-l">You need to use the existing service</h1>
+    <p class="govuk-body">This new service is only for appeals about certain types of planning application.</p>
+
+    <p class="govuk-body">You need to submit your appeal using the existing service, the Appeals Casework Portal. </p>
+
+    <h2 class="govuk-heading-m">How to begin your appeal</h2>
+
+    <p class="govuk-body">To begin your appeal, log in or register on the Appeals Casework Portal.</p>
+    {{ govukButton({
+      text: "Continue to the Appeals Casework Portal",
+      href: acpLink
+    }) }}
+  </div>
+</div>
+
+{% endblock %}


### PR DESCRIPTION
…on new service

## Ticket Number
https://pins-ds.atlassian.net/browse/AS-4610

## Description of change
If user selects either 'Something else' or 'I have not made a planning application' on `/before-you-start/type-of-planning-application`, user will be redirected to `/before-you-start/use-existing-service-application-type` shutter page. Existing unit and E2E tests have been updated accordingly.

## Checklist
<!-- Put an `x` in all the boxes that apply: -->
- [ ] Requires infrastructure changes
- [ ] If adding or remove environment variables (e.g. in `docker-compose.yaml`) then I have updated the appropriate Helm chart
- [ ] I have updated the documentation accordingly
- [x] My commit history in this PR is linear
- [x] New features have tests
- [ ] Breaking change (team conversation required)

## Important

Please do not merge from `master` (please only [rebase](https://github.com/foundry4/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
