### PR TITLE
Fix/as 4689 hha any other documents

### DIFF
--- a/packages/forms-web-app/__tests__/unit/controllers/appellant-submission/supporting-documents.test.js
+++ b/packages/forms-web-app/__tests__/unit/controllers/appellant-submission/supporting-documents.test.js
@@ -5,7 +5,11 @@ const { mockReq, mockRes } = require('../../mocks');
 const logger = require('../../../../src/lib/logger');
 const { createOrUpdateAppeal } = require('../../../../src/lib/appeals-api-wrapper');
 const { createDocument } = require('../../../../src/lib/documents-api-wrapper');
-const { getNextTask, getTaskStatus } = require('../../../../src/services/task.service');
+const {
+  getNextTask,
+  getTaskStatus,
+  setTaskStatusComplete,
+} = require('../../../../src/services/task.service');
 const { VIEW } = require('../../../../src/lib/views');
 
 jest.mock('../../../../src/lib/appeals-api-wrapper');
@@ -90,7 +94,7 @@ describe('controllers/appellant-submission/supporting-documents', () => {
       };
       await supportingDocumentsController.postSupportingDocuments(mockRequest, res);
 
-      expect(getTaskStatus).toHaveBeenCalledWith(appeal, sectionName, taskName);
+      expect(setTaskStatusComplete).toHaveBeenCalled();
 
       expect(res.redirect).not.toHaveBeenCalled();
 
@@ -179,7 +183,7 @@ describe('controllers/appellant-submission/supporting-documents', () => {
         },
       ].forEach(({ nextStep, request, expectedNextUrl }) => {
         it(`should redirect - ${nextStep} - if valid - single file`, async () => {
-          getTaskStatus.mockImplementation(() => fakeTaskStatus);
+          setTaskStatusComplete.mockImplementation(() => fakeTaskStatus);
 
           createDocument.mockImplementation(() => ({ id: fakeFile1Id }));
           getNextTask.mockReturnValue({
@@ -272,7 +276,7 @@ describe('controllers/appellant-submission/supporting-documents', () => {
         },
       ].forEach(({ nextStep, request, expectedNextUrl }) => {
         it(`should redirect - ${nextStep} if valid - multiple file`, async () => {
-          getTaskStatus.mockImplementation(() => fakeTaskStatus);
+          setTaskStatusComplete.mockImplementation(() => fakeTaskStatus);
 
           createDocument
             .mockImplementationOnce(() => ({ id: fakeFile1Id }))

--- a/packages/forms-web-app/__tests__/unit/controllers/appellant-submission/supporting-documents.test.js
+++ b/packages/forms-web-app/__tests__/unit/controllers/appellant-submission/supporting-documents.test.js
@@ -9,6 +9,7 @@ const {
   getNextTask,
   getTaskStatus,
   setTaskStatusComplete,
+  setTaskStatusNotStarted,
 } = require('../../../../src/services/task.service');
 const { VIEW } = require('../../../../src/lib/views');
 
@@ -94,7 +95,7 @@ describe('controllers/appellant-submission/supporting-documents', () => {
       };
       await supportingDocumentsController.postSupportingDocuments(mockRequest, res);
 
-      expect(setTaskStatusComplete).toHaveBeenCalled();
+      expect(setTaskStatusNotStarted).toHaveBeenCalled();
 
       expect(res.redirect).not.toHaveBeenCalled();
 

--- a/packages/forms-web-app/__tests__/unit/controllers/appellant-submission/task-list.test.js
+++ b/packages/forms-web-app/__tests__/unit/controllers/appellant-submission/task-list.test.js
@@ -371,6 +371,11 @@ describe('controllers/appellant-submission/task-list', () => {
 
     it('All the mandatory tasks should be completed and check your answer can be started', () => {
       const req = mockReq({
+        sectionStates: {
+          yourAppealSection: {
+            otherDocuments: 'NOT STARTED',
+          },
+        },
         aboutYouSection: {
           yourDetails: { isOriginalApplicant: true, name: 'Joe', email: 'joe@email.com' },
         },

--- a/packages/forms-web-app/__tests__/unit/services/task.service.test.js
+++ b/packages/forms-web-app/__tests__/unit/services/task.service.test.js
@@ -6,7 +6,13 @@ const {
   IN_PROGRESS,
   NOT_STARTED,
 } = require('../../../src/services/task-status/task-statuses');
-const { SECTIONS, getNextTask, getTaskStatus } = require('../../../src/services/task.service');
+const {
+  SECTIONS,
+  getNextTask,
+  getTaskStatus,
+  setTaskStatusComplete,
+  setTaskStatusNotStarted,
+} = require('../../../src/services/task.service');
 
 beforeEach(() => {
   jest.resetAllMocks();
@@ -148,7 +154,6 @@ describe('services/task.service', () => {
         })
       ).toEqual(COMPLETED);
     });
-
 
     it('should return NOT_STARTED from statusAppealStatement if id is empty', () => {
       expect(
@@ -385,6 +390,18 @@ describe('services/task.service', () => {
       });
       expect(ruleUnderSection).toBeCalledTimes(1);
       expect(taskStatus).toBeUndefined();
+    });
+  });
+
+  describe('setTaskStatusComplete', () => {
+    it('should return completed task status', () => {
+      expect(setTaskStatusComplete()).toBe(COMPLETED);
+    });
+  });
+
+  describe('setTaskStatusNotStarted', () => {
+    it('should return not started task status', () => {
+      expect(setTaskStatusNotStarted()).toBe(NOT_STARTED);
     });
   });
 });

--- a/packages/forms-web-app/__tests__/unit/services/task.service.test.js
+++ b/packages/forms-web-app/__tests__/unit/services/task.service.test.js
@@ -118,6 +118,11 @@ describe('services/task.service', () => {
     it('should return COMPLETED from statusSupportingDocuments if the appeal has other documents', () => {
       expect(
         SECTIONS.yourAppealSection.otherDocuments.rule({
+          sectionStates: {
+            yourAppealSection: {
+              otherDocuments: 'NOT_STARTED',
+            },
+          },
           yourAppealSection: {
             otherDocuments: {
               uploadedFiles: [{}],
@@ -126,6 +131,25 @@ describe('services/task.service', () => {
         })
       ).toEqual(COMPLETED);
     });
+
+    it('should return COMPLETED from statusSupportingDocuments if appeal has no documents but sectionState is complete', () => {
+      expect(
+        SECTIONS.yourAppealSection.otherDocuments.rule({
+          sectionStates: {
+            yourAppealSection: {
+              otherDocuments: 'COMPLETED',
+            },
+          },
+          yourAppealSection: {
+            otherDocuments: {
+              uploadedFiles: [],
+            },
+          },
+        })
+      ).toEqual(COMPLETED);
+    });
+
+
     it('should return NOT_STARTED from statusAppealStatement if id is empty', () => {
       expect(
         SECTIONS.yourAppealSection.appealStatement.rule({
@@ -137,9 +161,14 @@ describe('services/task.service', () => {
         })
       ).toEqual(NOT_STARTED);
     });
-    it('should return NOT_STARTED from statusSupportingDocuments if uploadedFiles empty', () => {
+    it('should return NOT_STARTED from statusSupportingDocuments if uploadedFiles empty and sectionState is not complete', () => {
       expect(
         SECTIONS.yourAppealSection.otherDocuments.rule({
+          sectionStates: {
+            yourAppealSection: {
+              otherDocuments: 'NOT_STARTED',
+            },
+          },
           yourAppealSection: {
             otherDocuments: {
               uploadedFiles: [],

--- a/packages/forms-web-app/src/controllers/appellant-submission/supporting-documents.js
+++ b/packages/forms-web-app/src/controllers/appellant-submission/supporting-documents.js
@@ -3,8 +3,7 @@ const { VIEW } = require('../../lib/views');
 const { createOrUpdateAppeal } = require('../../lib/appeals-api-wrapper');
 const logger = require('../../lib/logger');
 const { createDocument } = require('../../lib/documents-api-wrapper');
-const { getNextTask } = require('../../services/task.service');
-const { getTaskStatus } = require('../../services/task.service');
+const { getNextTask, setTaskStatusComplete } = require('../../services/task.service');
 
 const sectionName = 'yourAppealSection';
 const taskName = 'otherDocuments';
@@ -63,7 +62,7 @@ exports.postSupportingDocuments = async (req, res) => {
       }
     }
 
-    appeal.sectionStates[sectionName][taskName] = getTaskStatus(appeal, sectionName, taskName);
+    appeal.sectionStates[sectionName][taskName] = setTaskStatusComplete();
     req.session.appeal = await createOrUpdateAppeal(appeal);
   } catch (e) {
     logger.error(e);

--- a/packages/forms-web-app/src/controllers/appellant-submission/supporting-documents.js
+++ b/packages/forms-web-app/src/controllers/appellant-submission/supporting-documents.js
@@ -3,7 +3,11 @@ const { VIEW } = require('../../lib/views');
 const { createOrUpdateAppeal } = require('../../lib/appeals-api-wrapper');
 const logger = require('../../lib/logger');
 const { createDocument } = require('../../lib/documents-api-wrapper');
-const { getNextTask, setTaskStatusComplete } = require('../../services/task.service');
+const {
+  getNextTask,
+  setTaskStatusComplete,
+  setTaskStatusNotStarted,
+} = require('../../services/task.service');
 
 const sectionName = 'yourAppealSection';
 const taskName = 'otherDocuments';
@@ -66,6 +70,7 @@ exports.postSupportingDocuments = async (req, res) => {
     req.session.appeal = await createOrUpdateAppeal(appeal);
   } catch (e) {
     logger.error(e);
+    appeal.sectionStates[sectionName][taskName] = setTaskStatusNotStarted();
     res.render(VIEW.APPELLANT_SUBMISSION.SUPPORTING_DOCUMENTS, {
       appeal,
       errors,

--- a/packages/forms-web-app/src/services/task.service.js
+++ b/packages/forms-web-app/src/services/task.service.js
@@ -182,6 +182,10 @@ const setTaskStatusComplete = () => {
   return TASK_STATUS.COMPLETED;
 };
 
+const setTaskStatusNotStarted = () => {
+  return TASK_STATUS.NOT_STARTED;
+};
+
 const getTaskStatus = (appeal, sectionName, taskName, sections = SECTIONS, required = true) => {
   try {
     const { rule } = taskName ? sections[sectionName][taskName] : sections[sectionName];
@@ -230,4 +234,5 @@ module.exports = {
   getTaskStatus,
   getNextTask,
   setTaskStatusComplete,
+  setTaskStatusNotStarted,
 };

--- a/packages/forms-web-app/src/services/task.service.js
+++ b/packages/forms-web-app/src/services/task.service.js
@@ -25,7 +25,10 @@ function statusAppealStatement(appeal) {
 
 function statusSupportingDocuments(appeal) {
   const task = appeal.yourAppealSection.otherDocuments;
-  return task.uploadedFiles.length > 0 ? TASK_STATUS.COMPLETED : TASK_STATUS.NOT_STARTED;
+  return task.uploadedFiles.length > 0 ||
+    appeal.sectionStates.yourAppealSection.otherDocuments === 'COMPLETED'
+    ? TASK_STATUS.COMPLETED
+    : TASK_STATUS.NOT_STARTED;
 }
 
 function statusOriginalApplication(appeal) {
@@ -175,7 +178,11 @@ const FULL_APPEAL_SECTIONS = {
   },
 };
 
-const getTaskStatus = (appeal, sectionName, taskName, sections = SECTIONS) => {
+const setTaskStatusComplete = () => {
+  return TASK_STATUS.COMPLETED;
+};
+
+const getTaskStatus = (appeal, sectionName, taskName, sections = SECTIONS, required = true) => {
   try {
     const { rule } = taskName ? sections[sectionName][taskName] : sections[sectionName];
     return rule(appeal);
@@ -222,4 +229,5 @@ module.exports = {
   FULL_APPEAL_SECTIONS,
   getTaskStatus,
   getNextTask,
+  setTaskStatusComplete,
 };


### PR DESCRIPTION
## Ticket Number
<!-- Add the number from the Jira board -->
https://pins-ds.atlassian.net/browse/AS-4689

## Description of change
Updated logic so that a user on Householder Planning route can click continue on the 'Any other documents to support your appeal' page (part of the 'Appeal a householder planning decision' task list).

## Checklist
<!-- Put an `x` in all the boxes that apply: -->
- [ ] Requires infrastructure changes
- [ ] If adding or remove environment variables (e.g. in `docker-compose.yaml`) then I have updated the appropriate Helm chart
- [ ] I have updated the documentation accordingly
- [ ] My commit history in this PR is linear
- [ ] New features have tests
- [ ] Breaking change (team conversation required)

## Important

Please do not merge from `master` (please only [rebase](https://github.com/foundry4/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
