### PR TITLE
fix(pipelines): update pipeline version and change references to deault branch to 'main'

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -16,4 +16,4 @@ https://pins-ds.atlassian.net/browse/AS-
 
 ## Important
 
-Please do not merge from `master` (please only [rebase](https://github.com/foundry4/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
+Please do not merge from `main` (please only [rebase](https://github.com/foundry4/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.

--- a/.releaserc
+++ b/.releaserc
@@ -4,7 +4,7 @@
   ],
   "branches": [
     "+([0-9])?(.{+([0-9]),x}).x",
-    "master",
+    "main",
     {
       "name": "develop",
       "prerelease": "rc"

--- a/README.md
+++ b/README.md
@@ -126,9 +126,9 @@ appealsServiceApi:
     tag: 1.15.3
 ````
 
-Once this change to the HelmRelease chart has been pushed to master, it will be detected by Flux and deployed to the cluster.
+Once this change to the HelmRelease chart has been pushed to main, it will be detected by Flux and deployed to the cluster.
 
-Note that, as Flux automation has been disabled, Flux will never automatically commit to master. This will remove the potential for race conditions and semantic-release errors when the version of master checked out by a Github Workflow is rendered out of date by Flux commits.
+Note that, as Flux automation has been disabled, Flux will never automatically commit to main. This will remove the potential for race conditions and semantic-release errors when the version of main checked out by a Github Workflow is rendered out of date by Flux commits.
 
 ## Commit Message Format
 
@@ -138,7 +138,7 @@ done using the [correct format](https://www.conventionalcommits.org/en/v1.0.0/#s
 
 Commits to the `develop` branch will create release candidates. These are a release
 of software that may or may not be made public. Under normal circumstance, releases
-should be made directly to the `master` branch.
+should be made directly to the `main` branch.
 
 ## Commit Message Rules
 
@@ -162,10 +162,10 @@ Without the `feat`, it would create no new release.
    called `Next version` which will tell you the version number that this should create
    if successful.
 2. Check a [new release was made](https://github.com/foundry4/appeal-planning-decision/releases).
-   Dependent upon whether it was made from the `develop` or `master` branch, you will be
+   Dependent upon whether it was made from the `develop` or `main` branch, you will be
    looking for either a pre-release version or a release. If no release has been made,
    ensure that your commit message was formatted correctly and begins with `feat` or `fix`.
-3. Check the [/releases](https://github.com/Planning-Inspectorate/appeal-planning-decision/tree/master/releases)
+3. Check the [/releases](https://github.com/Planning-Inspectorate/appeal-planning-decision/tree/main/releases)
    folder against the cluster you are expecting to see it deployed on. If the `app.yml` file does
    not contain the tag you are expecting then the deployment may have failed. It takes up to
    5 minutes for a new release to be detected.

--- a/azure-pipelines-commit-lint.yml
+++ b/azure-pipelines-commit-lint.yml
@@ -3,7 +3,7 @@ trigger: none
 pr:
   branches:
     include:
-      - master
+      - main
 
 resources:
   repositories:
@@ -11,7 +11,7 @@ resources:
       type: github
       endpoint: Planning-Inspectorate
       name: Planning-Inspectorate/common-pipeline-templates
-      ref: refs/tags/release/1.2.1
+      ref: refs/tags/release/1.2.2
 
 pool:
   name: pins-odt-agent-pool

--- a/packages/appeal-reply-service-api/pipelines/azure-pipelines-build.yml
+++ b/packages/appeal-reply-service-api/pipelines/azure-pipelines-build.yml
@@ -8,7 +8,7 @@ trigger:
 pr:
   branches:
     include:
-      - master
+      - main
   paths:
     include:
       - packages/appeal-reply-service-api
@@ -21,7 +21,7 @@ resources:
       type: github
       endpoint: Planning-Inspectorate
       name: Planning-Inspectorate/common-pipeline-templates
-      ref: refs/tags/release/1.2.1
+      ref: refs/tags/release/1.2.2
 
 extends:
   template: stages/wrapper_ci.yml@templates

--- a/packages/appeal-reply-service-api/pipelines/azure-pipelines-release.yml
+++ b/packages/appeal-reply-service-api/pipelines/azure-pipelines-release.yml
@@ -21,14 +21,14 @@ resources:
       type: github
       endpoint: Planning-Inspectorate
       name: Planning-Inspectorate/common-pipeline-templates
-      ref: refs/tags/release/1.2.1
+      ref: refs/tags/release/1.2.2
   pipelines:
     - pipeline: appeal-reply-service-api-ci
       source: appeal-reply-service-api CI
       trigger: 
         branches:
           include: 
-            - master
+            - main
 
 extends:
   template: stages/wrapper_web_app_cd.yml@templates

--- a/packages/appeals-service-api/pipelines/azure-pipelines-build.yml
+++ b/packages/appeals-service-api/pipelines/azure-pipelines-build.yml
@@ -8,7 +8,7 @@ trigger:
 pr:
   branches:
     include:
-      - master
+      - main
   paths:
     include:
       - packages/appeal-reply-service-api
@@ -21,7 +21,7 @@ resources:
       type: github
       endpoint: Planning-Inspectorate
       name: Planning-Inspectorate/common-pipeline-templates
-      ref: refs/tags/release/1.2.1
+      ref: refs/tags/release/1.2.2
 
 extends:
   template: stages/wrapper_ci.yml@templates

--- a/packages/appeals-service-api/pipelines/azure-pipelines-release.yml
+++ b/packages/appeals-service-api/pipelines/azure-pipelines-release.yml
@@ -21,14 +21,14 @@ resources:
       type: github
       endpoint: Planning-Inspectorate
       name: Planning-Inspectorate/common-pipeline-templates
-      ref: refs/tags/release/1.2.1
+      ref: refs/tags/release/1.2.2
   pipelines:
     - pipeline: appeals-service-api-ci
       source: appeals-service-api CI
       trigger: 
         branches:
           include: 
-            - master
+            - main
 
 extends:
   template: stages/wrapper_web_app_cd.yml@templates

--- a/packages/business-rules/pipelines/azure-pipelines-build.yml
+++ b/packages/business-rules/pipelines/azure-pipelines-build.yml
@@ -6,7 +6,7 @@ trigger:
 pr:
   branches:
     include:
-      - master
+      - main
   paths:
     include:
       - packages/business-rules
@@ -17,7 +17,7 @@ resources:
       type: github
       endpoint: Planning-Inspectorate
       name: Planning-Inspectorate/common-pipeline-templates
-      ref: refs/tags/release/1.2.1
+      ref: refs/tags/release/1.2.2
 
 extends:
   template: stages/wrapper_ci.yml@templates

--- a/packages/clamav-rest-server/pipelines/azure-pipelines-build.yml
+++ b/packages/clamav-rest-server/pipelines/azure-pipelines-build.yml
@@ -7,7 +7,7 @@ trigger:
 pr:
   branches:
     include:
-      - master
+      - main
   paths:
     include:
       - packages/clamav-rest-server
@@ -19,7 +19,7 @@ resources:
       type: github
       endpoint: Planning-Inspectorate
       name: Planning-Inspectorate/common-pipeline-templates
-      ref: refs/tags/release/1.2.1
+      ref: refs/tags/release/1.2.2
 
 extends:
   template: stages/wrapper_ci.yml@templates

--- a/packages/clamav-rest-server/pipelines/azure-pipelines-release.yml
+++ b/packages/clamav-rest-server/pipelines/azure-pipelines-release.yml
@@ -21,14 +21,14 @@ resources:
       type: github
       endpoint: Planning-Inspectorate
       name: Planning-Inspectorate/common-pipeline-templates
-      ref: refs/tags/release/1.2.1
+      ref: refs/tags/release/1.2.2
   pipelines:
     - pipeline: clamav-rest-server-ci
       source: clamav-rest-server CI
       trigger: 
         branches:
           include: 
-            - master
+            - main
 
 extends:
   template: stages/wrapper_web_app_cd.yml@templates

--- a/packages/common/pipelines/azure-pipelines-build.yml
+++ b/packages/common/pipelines/azure-pipelines-build.yml
@@ -6,7 +6,7 @@ trigger:
 pr:
   branches:
     include:
-      - master
+      - main
   paths:
     include:
       - packages/common
@@ -17,7 +17,7 @@ resources:
       type: github
       endpoint: Planning-Inspectorate
       name: Planning-Inspectorate/common-pipeline-templates
-      ref: refs/tags/release/1.2.1
+      ref: refs/tags/release/1.2.2
 
 extends:
   template: stages/wrapper_ci.yml@templates

--- a/packages/document-service-api/README.md
+++ b/packages/document-service-api/README.md
@@ -37,7 +37,7 @@ variables required are declared as environment variables.
 
 The document service has a local container that mimics the same functionality the Azure blob storage provides, to browse the storage you need to [download Azure Storage browser](https://azure.microsoft.com/en-gb/features/storage-explorer/).
 
-First you'll need to [configure and run the development stack](https://github.com/Planning-Inspectorate/appeal-planning-decision/blob/master/README.md) and then find the BLOB_STORAGE_CONNECTION_STRING from the [docker-compose.yml](https://github.com/Planning-Inspectorate/appeal-planning-decision/blob/master/docker-compose.yml) file in the project root.
+First you'll need to [configure and run the development stack](https://github.com/Planning-Inspectorate/appeal-planning-decision/blob/main/README.md) and then find the BLOB_STORAGE_CONNECTION_STRING from the [docker-compose.yml](https://github.com/Planning-Inspectorate/appeal-planning-decision/blob/main/docker-compose.yml) file in the project root.
 
 Go into Azure Storage Browser, select the connection icon from the bar on the left, select `Local storage emulator` and enter the following:
 
@@ -67,7 +67,7 @@ Document metadata is now being stored as attributes of the document in Blob Stor
 
 The tool gets the metadata records from Cosmos DB, formats them and saves them to the corresponding document in Blob Storage. This way the metadata for the documents in Blob Storage is overwritten each time the tool is run so it can be run multiple times without duplicating any metadata and any documents that already have metadata in Blob Storage and don't have an associated Cosmos DB record will be ignored.
 
-To use, [configure and run the development stack](https://github.com/Planning-Inspectorate/appeal-planning-decision/blob/master/README.md) and go to http://localhost:3001/api/v1/migrate-metadata.
+To use, [configure and run the development stack](https://github.com/Planning-Inspectorate/appeal-planning-decision/blob/main/README.md) and go to http://localhost:3001/api/v1/migrate-metadata.
 
 The output will include the following:
 

--- a/packages/document-service-api/pipelines/azure-pipelines-build.yml
+++ b/packages/document-service-api/pipelines/azure-pipelines-build.yml
@@ -7,7 +7,7 @@ trigger:
 pr:
   branches:
     include:
-      - master
+      - main
   paths:
     include:
       - packages/document-service-api
@@ -19,7 +19,7 @@ resources:
       type: github
       endpoint: Planning-Inspectorate
       name: Planning-Inspectorate/common-pipeline-templates
-      ref: refs/tags/release/1.2.1
+      ref: refs/tags/release/1.2.2
 
 extends:
   template: stages/wrapper_ci.yml@templates

--- a/packages/document-service-api/pipelines/azure-pipelines-release.yml
+++ b/packages/document-service-api/pipelines/azure-pipelines-release.yml
@@ -21,14 +21,14 @@ resources:
       type: github
       endpoint: Planning-Inspectorate
       name: Planning-Inspectorate/common-pipeline-templates
-      ref: refs/tags/release/1.2.1
+      ref: refs/tags/release/1.2.2
   pipelines:
     - pipeline: document-service-api-ci
       source: document-service-api CI
       trigger: 
         branches:
           include: 
-            - master
+            - main
 
 extends:
   template: stages/wrapper_web_app_cd.yml@templates

--- a/packages/e2e-tests/pipelines/azure-pipelines-cypress-e2e.yml
+++ b/packages/e2e-tests/pipelines/azure-pipelines-cypress-e2e.yml
@@ -3,7 +3,7 @@ trigger: none
 pr:
   branches:
     include:
-      - master
+      - main
   paths:
     include:
       - packages
@@ -14,7 +14,7 @@ resources:
       type: github
       endpoint: Planning-Inspectorate
       name: Planning-Inspectorate/common-pipeline-templates
-      ref: refs/tags/release/1.2.1
+      ref: fix/cypress-artifact-publish
 
 variables:
   - group: pipeline_secrets

--- a/packages/forms-web-app/pipelines/azure-pipelines-build.yml
+++ b/packages/forms-web-app/pipelines/azure-pipelines-build.yml
@@ -8,7 +8,7 @@ trigger:
 pr:
   branches:
     include:
-      - master
+      - main
   paths:
     include:
       - packages/forms-web-app
@@ -21,7 +21,7 @@ resources:
       type: github
       endpoint: Planning-Inspectorate
       name: Planning-Inspectorate/common-pipeline-templates
-      ref: refs/tags/release/1.2.1
+      ref: refs/tags/release/1.2.2
 
 extends:
   template: stages/wrapper_ci.yml@templates

--- a/packages/forms-web-app/pipelines/azure-pipelines-release.yml
+++ b/packages/forms-web-app/pipelines/azure-pipelines-release.yml
@@ -21,14 +21,14 @@ resources:
       type: github
       endpoint: Planning-Inspectorate
       name: Planning-Inspectorate/common-pipeline-templates
-      ref: refs/tags/release/1.2.1
+      ref: refs/tags/release/1.2.2
   pipelines:
     - pipeline: forms-web-app-ci
       source: forms-web-app CI
       trigger: 
         branches:
           include: 
-            - master
+            - main
 
 extends:
   template: stages/wrapper_web_app_cd.yml@templates

--- a/packages/horizon-functions/pipelines/azure-pipelines-build.yml
+++ b/packages/horizon-functions/pipelines/azure-pipelines-build.yml
@@ -6,7 +6,7 @@ trigger:
 pr:
   branches:
     include:
-      - master
+      - main
   paths:
     include:
       - packages/horizon-functions
@@ -17,7 +17,7 @@ resources:
       type: github
       endpoint: Planning-Inspectorate
       name: Planning-Inspectorate/common-pipeline-templates
-      ref: refs/tags/release/1.2.1
+      ref: refs/tags/release/1.2.2
 
 extends:
   template: stages/wrapper_ci.yml@templates

--- a/packages/horizon-functions/pipelines/azure-pipelines-release.yml
+++ b/packages/horizon-functions/pipelines/azure-pipelines-release.yml
@@ -17,14 +17,14 @@ resources:
       type: github
       endpoint: Planning-Inspectorate
       name: Planning-Inspectorate/common-pipeline-templates
-      ref: refs/tags/release/1.2.1
+      ref: refs/tags/release/1.2.2
   pipelines:
     - pipeline: horizon-functions-ci
       source: horizon-functions CI
       trigger: 
         branches:
           include: 
-            - master
+            - main
 
 extends:
   template: stages/wrapper_function_app_cd.yml@templates

--- a/packages/pdf-service-api/pipelines/azure-pipelines-build.yml
+++ b/packages/pdf-service-api/pipelines/azure-pipelines-build.yml
@@ -6,7 +6,7 @@ trigger:
 pr:
   branches:
     include:
-      - master
+      - main
   paths:
     include:
       - packages/pdf-service-api
@@ -17,7 +17,7 @@ resources:
       type: github
       endpoint: Planning-Inspectorate
       name: Planning-Inspectorate/common-pipeline-templates
-      ref: refs/tags/release/1.2.1
+      ref: refs/tags/release/1.2.2
 
 extends:
   template: stages/wrapper_ci.yml@templates

--- a/packages/pdf-service-api/pipelines/azure-pipelines-release.yml
+++ b/packages/pdf-service-api/pipelines/azure-pipelines-release.yml
@@ -21,14 +21,14 @@ resources:
       type: github
       endpoint: Planning-Inspectorate
       name: Planning-Inspectorate/common-pipeline-templates
-      ref: refs/tags/release/1.2.1
+      ref: refs/tags/release/1.2.2
   pipelines:
     - pipeline: pdf-service-api-ci
       source: pdf-service-api CI
       trigger: 
         branches:
           include: 
-            - master
+            - main
 
 extends:
   template: stages/wrapper_web_app_cd.yml@templates

--- a/packages/ping/pipelines/azure-pipelines-build.yml
+++ b/packages/ping/pipelines/azure-pipelines-build.yml
@@ -6,7 +6,7 @@ trigger:
 pr:
   branches:
     include:
-      - master
+      - main
   paths:
     include:
       - packages/ping
@@ -17,7 +17,7 @@ resources:
       type: github
       endpoint: Planning-Inspectorate
       name: Planning-Inspectorate/common-pipeline-templates
-      ref: refs/tags/release/1.2.1
+      ref: refs/tags/release/1.2.2
 
 extends:
   template: stages/wrapper_ci.yml@templates

--- a/packages/queue-retry/pipelines/azure-pipelines-build.yml
+++ b/packages/queue-retry/pipelines/azure-pipelines-build.yml
@@ -6,7 +6,7 @@ trigger:
 pr:
   branches:
     include:
-      - master
+      - main
   paths:
     include:
       - packages/queue-retry
@@ -17,7 +17,7 @@ resources:
       type: github
       endpoint: Planning-Inspectorate
       name: Planning-Inspectorate/common-pipeline-templates
-      ref: refs/tags/release/1.2.1
+      ref: refs/tags/release/1.2.2
 
 extends:
   template: stages/wrapper_ci.yml@templates


### PR DESCRIPTION
## Description of change
- Default branch update to `main` and upgrade pipeline template version so Cypress E2E tests skip the publish artifact step if there is nothing to publish

## Checklist
<!-- Put an `x` in all the boxes that apply: -->
- [ ] Requires infrastructure changes
- [ ] If adding or remove environment variables (e.g. in `docker-compose.yaml`) then I have updated the appropriate Helm chart
- [ ] I have updated the documentation accordingly
- [ ] My commit history in this PR is linear
- [ ] New features have tests
- [ ] Breaking change (team conversation required)

## Important

Please do not merge from `master` (please only [rebase](https://github.com/foundry4/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
