### PR TITLE
fix(pipelines): fix ref for templates repo in e2e tests pipeline

### DIFF
--- a/packages/e2e-tests/pipelines/azure-pipelines-cypress-e2e.yml
+++ b/packages/e2e-tests/pipelines/azure-pipelines-cypress-e2e.yml
@@ -14,7 +14,7 @@ resources:
       type: github
       endpoint: Planning-Inspectorate
       name: Planning-Inspectorate/common-pipeline-templates
-      ref: fix/cypress-artifact-publish
+      ref: refs/tags/release/1.2.2
 
 variables:
   - group: pipeline_secrets


### PR DESCRIPTION
## Description of change
- Incorrect ref used for pipeline templates in e2e tests pipeline

## Checklist
<!-- Put an `x` in all the boxes that apply: -->
- [ ] Requires infrastructure changes
- [ ] If adding or remove environment variables (e.g. in `docker-compose.yaml`) then I have updated the appropriate Helm chart
- [ ] I have updated the documentation accordingly
- [ ] My commit history in this PR is linear
- [ ] New features have tests
- [ ] Breaking change (team conversation required)

## Important

Please do not merge from `main` (please only [rebase](https://github.com/foundry4/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
