### PR TITLE
refactor(pipelines): update pipelines to use latest version

### DIFF
--- a/azure-pipelines-commit-lint.yml
+++ b/azure-pipelines-commit-lint.yml
@@ -11,7 +11,7 @@ resources:
       type: github
       endpoint: Planning-Inspectorate
       name: Planning-Inspectorate/common-pipeline-templates
-      ref: refs/tags/release/1.2.2
+      ref: refs/tags/release/2.0.0
 
 pool:
   name: pins-odt-agent-pool

--- a/azure-pipelines-variables.yml
+++ b/azure-pipelines-variables.yml
@@ -1,4 +1,3 @@
 variables:
   azurecrName: pinscrsharedtoolinguks
-  azurecrServiceConnection: appeal-planning-decision-tooling
-  projectName: appeal-planning-decision
+  resourceGroup: pins-rg-appeals-service-$(ENVIRONMENT)-$(REGION_SHORT)-001

--- a/packages/appeal-reply-service-api/pipelines/azure-pipelines-build.yml
+++ b/packages/appeal-reply-service-api/pipelines/azure-pipelines-build.yml
@@ -21,17 +21,14 @@ resources:
       type: github
       endpoint: Planning-Inspectorate
       name: Planning-Inspectorate/common-pipeline-templates
-      ref: refs/tags/release/1.2.2
+      ref: refs/tags/release/2.0.0
 
 extends:
   template: stages/wrapper_ci.yml@templates
   parameters:
-    azurecrName: $(azurecrName)
-    authType: acr
     globalVariables:
       - template: azure-pipelines-variables.yml@self
       - template: packages/appeal-reply-service-api/pipelines/azure-pipelines-variables.yml@self
-    projectName: $(projectName)
     validateName: Build Test and Push
     validationSteps:
       - script: |
@@ -46,5 +43,4 @@ extends:
           repository: $(repository)
           runTests: true
           testRunTitle: Appeal Reply Service API Jest Tests
-          versionNumber: $(versionNumber)
           workingDirectory: $(Build.Repository.LocalPath)

--- a/packages/appeal-reply-service-api/pipelines/azure-pipelines-release.yml
+++ b/packages/appeal-reply-service-api/pipelines/azure-pipelines-release.yml
@@ -21,7 +21,7 @@ resources:
       type: github
       endpoint: Planning-Inspectorate
       name: Planning-Inspectorate/common-pipeline-templates
-      ref: refs/tags/release/1.2.2
+      ref: refs/tags/release/2.0.0
   pipelines:
     - pipeline: appeal-reply-service-api-ci
       source: appeal-reply-service-api CI
@@ -31,19 +31,17 @@ resources:
             - main
 
 extends:
-  template: stages/wrapper_web_app_cd.yml@templates
+  template: stages/wrapper_cd.yml@templates
   parameters:
-    appName: $(webAppNamePrefix)-$(ENVIRONMENT)-$(REGION_SHORT)-001
-    artifactSourcePipeline: appeals-service-api CI
-    azurecrName: $(azurecrName)
-    azurecrServiceConnection: $(azurecrServiceConnection)
-    deploymentTag: ${{ parameters.deploymentTag }}
+    deploymentStages:
+      - name: Deploy
+        deploymentSteps:
+          - template: ../steps/azure_web_app_deploy.yml
+            parameters:
+              appName: $(webAppName)
+              appResourceGroup: $(resourceGroup)
+              azurecrName: $(azurecrName)
+              repository: $(repository)
     globalVariables:
       - template: azure-pipelines-variables.yml@self
       - template: packages/appeal-reply-service-api/pipelines/azure-pipelines-variables.yml@self
-    projectName: $(projectName) 
-    releaseVersion: $(version.MajorMinor)
-    repository: $(repository)
-    ${{ if in(variables['Build.Reason'], 'IndividualCI', 'BatchedCI', 'ResourceTrigger') }}:
-      environments:
-        - name: Dev

--- a/packages/appeal-reply-service-api/pipelines/azure-pipelines-variables.yml
+++ b/packages/appeal-reply-service-api/pipelines/azure-pipelines-variables.yml
@@ -7,4 +7,4 @@ variables:
 
   dockerFilePath: $(Build.SourcesDirectory)/packages/appeals-service-api/Dockerfile
   repository: appeal-planning-decision/appeals-service-api
-  webAppNamePrefix: pins-app-appeals-service-appeal-reply-api
+  webAppName: pins-app-appeals-service-appeal-reply-api-$(ENVIRONMENT)-$(REGION_SHORT)-001

--- a/packages/appeals-service-api/pipelines/azure-pipelines-build.yml
+++ b/packages/appeals-service-api/pipelines/azure-pipelines-build.yml
@@ -21,17 +21,14 @@ resources:
       type: github
       endpoint: Planning-Inspectorate
       name: Planning-Inspectorate/common-pipeline-templates
-      ref: refs/tags/release/1.2.2
+      ref: refs/tags/release/2.0.0
 
 extends:
   template: stages/wrapper_ci.yml@templates
   parameters:
-    azurecrName: $(azurecrName)
-    authType: acr
     globalVariables:
       - template: azure-pipelines-variables.yml@self
       - template: packages/appeals-service-api/pipelines/azure-pipelines-variables.yml@self
-    projectName: $(projectName)
     validateName: Build Test and Push
     validationSteps:
       - script: |
@@ -46,5 +43,4 @@ extends:
           repository: $(repository)
           runTests: true
           testRunTitle: Appeals Service API Jest Tests
-          versionNumber: $(versionNumber)
           workingDirectory: $(Build.Repository.LocalPath)

--- a/packages/appeals-service-api/pipelines/azure-pipelines-release.yml
+++ b/packages/appeals-service-api/pipelines/azure-pipelines-release.yml
@@ -1,8 +1,4 @@
 parameters:
-  - name: deploymentTag
-    displayName: Deployment Tag
-    type: string
-    default: none
   - name: region
     displayName: Region
     type: string
@@ -21,7 +17,7 @@ resources:
       type: github
       endpoint: Planning-Inspectorate
       name: Planning-Inspectorate/common-pipeline-templates
-      ref: refs/tags/release/1.2.2
+      ref: refs/tags/release/2.0.0
   pipelines:
     - pipeline: appeals-service-api-ci
       source: appeals-service-api CI
@@ -31,19 +27,17 @@ resources:
             - main
 
 extends:
-  template: stages/wrapper_web_app_cd.yml@templates
+  template: stages/wrapper_cd.yml@templates
   parameters:
-    appName: $(webAppNamePrefix)-$(ENVIRONMENT)-$(REGION_SHORT)-001
-    artifactSourcePipeline: appeals-service-api CI
-    azurecrName: $(azurecrName)
-    azurecrServiceConnection: $(azurecrServiceConnection)
-    deploymentTag: ${{ parameters.deploymentTag }}
+    deploymentStages:
+      - name: Deploy
+        deploymentSteps:
+          - template: ../steps/azure_web_app_deploy.yml
+            parameters:
+              appName: $(webAppName)
+              appResourceGroup: $(resourceGroup)
+              azurecrName: $(azurecrName)
+              repository: $(repository)
     globalVariables:
       - template: azure-pipelines-variables.yml@self
       - template: packages/appeals-service-api/pipelines/azure-pipelines-variables.yml@self
-    projectName: $(projectName) 
-    releaseVersion: $(version.MajorMinor)
-    repository: $(repository)
-    ${{ if in(variables['Build.Reason'], 'IndividualCI', 'BatchedCI', 'ResourceTrigger') }}:
-      environments:
-        - name: Dev

--- a/packages/appeals-service-api/pipelines/azure-pipelines-variables.yml
+++ b/packages/appeals-service-api/pipelines/azure-pipelines-variables.yml
@@ -7,4 +7,4 @@ variables:
 
   dockerFilePath: $(Build.SourcesDirectory)/packages/appeals-service-api/Dockerfile
   repository: appeal-planning-decision/appeals-service-api
-  webAppNamePrefix: pins-app-appeals-service-appeals-api
+  webAppName: pins-app-appeals-service-appeals-api-$(ENVIRONMENT)-$(REGION_SHORT)-001

--- a/packages/business-rules/pipelines/azure-pipelines-build.yml
+++ b/packages/business-rules/pipelines/azure-pipelines-build.yml
@@ -17,18 +17,15 @@ resources:
       type: github
       endpoint: Planning-Inspectorate
       name: Planning-Inspectorate/common-pipeline-templates
-      ref: refs/tags/release/1.2.2
+      ref: refs/tags/release/2.0.0
 
 extends:
   template: stages/wrapper_ci.yml@templates
   parameters:
-    azurecrName: $(azurecrName)
-    authType: acr
     globalVariables:
-      - template: packages/business-rules/pipelines/azure-pipelines-variables.yml@self
       - template: azure-pipelines-variables.yml@self
-    projectName: $(projectName)
-    validateName: Build and Push
+      - template: packages/business-rules/pipelines/azure-pipelines-variables.yml@self
+    validateName: Build Test and Push
     validationSteps:
       - script: |
           buildName=$(versionNumber)_$(Build.BuildId)
@@ -42,5 +39,4 @@ extends:
           repository: $(repository)
           runTests: true
           testRunTitle: Appeals Service Business Rules Jest Tests
-          versionNumber: $(versionNumber)
           workingDirectory: $(Build.Repository.LocalPath)

--- a/packages/clamav-rest-server/pipelines/azure-pipelines-build.yml
+++ b/packages/clamav-rest-server/pipelines/azure-pipelines-build.yml
@@ -19,17 +19,14 @@ resources:
       type: github
       endpoint: Planning-Inspectorate
       name: Planning-Inspectorate/common-pipeline-templates
-      ref: refs/tags/release/1.2.2
+      ref: refs/tags/release/2.0.0
 
 extends:
   template: stages/wrapper_ci.yml@templates
   parameters:
-    azurecrName: $(azurecrName)
-    authType: acr
     globalVariables:
       - template: azure-pipelines-variables.yml@self
-      - template: packages/clamav-rest-server/pipelines/azure-pipelines-variables.yml@self
-    projectName: $(projectName)
+      - template: packages/clamav-rest-server//pipelines/azure-pipelines-variables.yml@self
     validateName: Build Test and Push
     validationSteps:
       - script: |
@@ -44,5 +41,4 @@ extends:
           repository: $(repository)
           runTests: true
           testRunTitle: Clamav API Jest Tests
-          versionNumber: $(versionNumber)
           workingDirectory: $(Build.Repository.LocalPath)

--- a/packages/clamav-rest-server/pipelines/azure-pipelines-release.yml
+++ b/packages/clamav-rest-server/pipelines/azure-pipelines-release.yml
@@ -21,7 +21,7 @@ resources:
       type: github
       endpoint: Planning-Inspectorate
       name: Planning-Inspectorate/common-pipeline-templates
-      ref: refs/tags/release/1.2.2
+      ref: refs/tags/release/2.0.0
   pipelines:
     - pipeline: clamav-rest-server-ci
       source: clamav-rest-server CI
@@ -31,19 +31,17 @@ resources:
             - main
 
 extends:
-  template: stages/wrapper_web_app_cd.yml@templates
+  template: stages/wrapper_cd.yml@templates
   parameters:
-    appName: $(webAppNamePrefix)-$(ENVIRONMENT)-$(REGION_SHORT)-001
-    artifactSourcePipeline: clamav-rest-server CI
-    azurecrName: $(azurecrName)
-    azurecrServiceConnection: $(azurecrServiceConnection)
-    deploymentTag: ${{ parameters.deploymentTag }}
+    deploymentStages:
+      - name: Deploy
+        deploymentSteps:
+          - template: ../steps/azure_web_app_deploy.yml
+            parameters:
+              appName: $(webAppName)
+              appResourceGroup: $(resourceGroup)
+              azurecrName: $(azurecrName)
+              repository: $(repository)
     globalVariables:
       - template: azure-pipelines-variables.yml@self
       - template: packages/clamav-rest-server/pipelines/azure-pipelines-variables.yml@self
-    projectName: $(projectName) 
-    releaseVersion: $(version.MajorMinor)
-    repository: $(repository)
-    ${{ if in(variables['Build.Reason'], 'IndividualCI', 'BatchedCI', 'ResourceTrigger') }}:
-      environments:
-        - name: Dev

--- a/packages/clamav-rest-server/pipelines/azure-pipelines-variables.yml
+++ b/packages/clamav-rest-server/pipelines/azure-pipelines-variables.yml
@@ -7,4 +7,4 @@ variables:
 
   dockerFilePath: $(Build.SourcesDirectory)/packages/clamav-rest-server/Dockerfile
   repository: appeal-planning-decision/clamav-api
-  webAppNamePrefix: pins-app-appeals-service-clamav-api
+  webAppName: pins-app-appeals-service-clamav-api-$(ENVIRONMENT)-$(REGION_SHORT)-001

--- a/packages/common/pipelines/azure-pipelines-build.yml
+++ b/packages/common/pipelines/azure-pipelines-build.yml
@@ -17,18 +17,15 @@ resources:
       type: github
       endpoint: Planning-Inspectorate
       name: Planning-Inspectorate/common-pipeline-templates
-      ref: refs/tags/release/1.2.2
+      ref: refs/tags/release/2.0.0
 
 extends:
   template: stages/wrapper_ci.yml@templates
   parameters:
-    azurecrName: $(azurecrName)
-    authType: acr
     globalVariables:
-      - template: packages/common/pipelines/azure-pipelines-variables.yml@self
       - template: azure-pipelines-variables.yml@self
-    projectName: $(projectName)
-    validateName: Build and Push
+      - template: packages/common/pipelines/azure-pipelines-variables.yml@self
+    validateName: Build Test and Push
     validationSteps:
       - script: |
           buildName=$(versionNumber)_$(Build.BuildId)
@@ -42,5 +39,4 @@ extends:
           repository: $(repository)
           runTests: true
           testRunTitle: Appeals Service Common Jest Tests
-          versionNumber: $(versionNumber)
           workingDirectory: $(Build.Repository.LocalPath)

--- a/packages/document-service-api/pipelines/azure-pipelines-build.yml
+++ b/packages/document-service-api/pipelines/azure-pipelines-build.yml
@@ -19,17 +19,14 @@ resources:
       type: github
       endpoint: Planning-Inspectorate
       name: Planning-Inspectorate/common-pipeline-templates
-      ref: refs/tags/release/1.2.2
+      ref: refs/tags/release/2.0.0
 
 extends:
   template: stages/wrapper_ci.yml@templates
   parameters:
-    azurecrName: $(azurecrName)
-    authType: acr
     globalVariables:
       - template: azure-pipelines-variables.yml@self
       - template: packages/document-service-api/pipelines/azure-pipelines-variables.yml@self
-    projectName: $(projectName)
     validateName: Build Test and Push
     validationSteps:
       - script: |
@@ -44,5 +41,4 @@ extends:
           repository: $(repository)
           runTests: true
           testRunTitle: Document Service API Jest Tests
-          versionNumber: $(versionNumber)
           workingDirectory: $(Build.Repository.LocalPath)

--- a/packages/document-service-api/pipelines/azure-pipelines-release.yml
+++ b/packages/document-service-api/pipelines/azure-pipelines-release.yml
@@ -21,7 +21,7 @@ resources:
       type: github
       endpoint: Planning-Inspectorate
       name: Planning-Inspectorate/common-pipeline-templates
-      ref: refs/tags/release/1.2.2
+      ref: refs/tags/release/2.0.0
   pipelines:
     - pipeline: document-service-api-ci
       source: document-service-api CI
@@ -31,19 +31,17 @@ resources:
             - main
 
 extends:
-  template: stages/wrapper_web_app_cd.yml@templates
+  template: stages/wrapper_cd.yml@templates
   parameters:
-    appName: $(webAppNamePrefix)-$(ENVIRONMENT)-$(REGION_SHORT)-001
-    artifactSourcePipeline: document-service-api CI
-    azurecrName: $(azurecrName)
-    azurecrServiceConnection: $(azurecrServiceConnection)
-    deploymentTag: ${{ parameters.deploymentTag }}
+    deploymentStages:
+      - name: Deploy
+        deploymentSteps:
+          - template: ../steps/azure_web_app_deploy.yml
+            parameters:
+              appName: $(webAppName)
+              appResourceGroup: $(resourceGroup)
+              azurecrName: $(azurecrName)
+              repository: $(repository)
     globalVariables:
       - template: azure-pipelines-variables.yml@self
       - template: packages/document-service-api/pipelines/azure-pipelines-variables.yml@self
-    projectName: $(projectName) 
-    releaseVersion: $(version.MajorMinor)
-    repository: $(repository)
-    ${{ if in(variables['Build.Reason'], 'IndividualCI', 'BatchedCI', 'ResourceTrigger') }}:
-      environments:
-        - name: Dev

--- a/packages/document-service-api/pipelines/azure-pipelines-variables.yml
+++ b/packages/document-service-api/pipelines/azure-pipelines-variables.yml
@@ -7,4 +7,4 @@ variables:
 
   dockerFilePath: $(Build.SourcesDirectory)/packages/document-service-api/Dockerfile
   repository: appeal-planning-decision/documents-api
-  webAppNamePrefix: pins-app-appeals-service-documents-api
+  webAppName: pins-app-appeals-service-documents-api-$(ENVIRONMENT)-$(REGION_SHORT)-001

--- a/packages/e2e-tests/pipelines/azure-pipelines-cypress-e2e.yml
+++ b/packages/e2e-tests/pipelines/azure-pipelines-cypress-e2e.yml
@@ -14,7 +14,7 @@ resources:
       type: github
       endpoint: Planning-Inspectorate
       name: Planning-Inspectorate/common-pipeline-templates
-      ref: refs/tags/release/1.2.2
+      ref: refs/tags/release/2.0.0
 
 variables:
   - group: pipeline_secrets

--- a/packages/forms-web-app/pipelines/azure-pipelines-build.yml
+++ b/packages/forms-web-app/pipelines/azure-pipelines-build.yml
@@ -21,17 +21,14 @@ resources:
       type: github
       endpoint: Planning-Inspectorate
       name: Planning-Inspectorate/common-pipeline-templates
-      ref: refs/tags/release/1.2.2
+      ref: refs/tags/release/2.0.0
 
 extends:
   template: stages/wrapper_ci.yml@templates
   parameters:
-    azurecrName: $(azurecrName)
-    authType: acr
     globalVariables:
       - template: azure-pipelines-variables.yml@self
       - template: packages/forms-web-app/pipelines/azure-pipelines-variables.yml@self
-    projectName: $(projectName)
     validateName: Build Test and Push
     validationSteps:
       - script: |
@@ -46,5 +43,4 @@ extends:
           repository: $(repository)
           runTests: true
           testRunTitle: Appeals Forms Web App Jest Tests
-          versionNumber: $(versionNumber)
           workingDirectory: $(Build.Repository.LocalPath)

--- a/packages/forms-web-app/pipelines/azure-pipelines-release.yml
+++ b/packages/forms-web-app/pipelines/azure-pipelines-release.yml
@@ -21,7 +21,7 @@ resources:
       type: github
       endpoint: Planning-Inspectorate
       name: Planning-Inspectorate/common-pipeline-templates
-      ref: refs/tags/release/1.2.2
+      ref: refs/tags/release/2.0.0
   pipelines:
     - pipeline: forms-web-app-ci
       source: forms-web-app CI
@@ -31,19 +31,17 @@ resources:
             - main
 
 extends:
-  template: stages/wrapper_web_app_cd.yml@templates
+  template: stages/wrapper_cd.yml@templates
   parameters:
-    appName: $(webAppNamePrefix)-$(ENVIRONMENT)-$(REGION_SHORT)-001
-    artifactSourcePipeline: forms-web-app CI
-    azurecrName: $(azurecrName)
-    azurecrServiceConnection: $(azurecrServiceConnection)
-    deploymentTag: ${{ parameters.deploymentTag }}
+    deploymentStages:
+      - name: Deploy
+        deploymentSteps:
+          - template: ../steps/azure_web_app_deploy.yml
+            parameters:
+              appName: $(webAppName)
+              appResourceGroup: $(resourceGroup)
+              azurecrName: $(azurecrName)
+              repository: $(repository)
     globalVariables:
       - template: azure-pipelines-variables.yml@self
       - template: packages/forms-web-app/pipelines/azure-pipelines-variables.yml@self
-    projectName: $(projectName) 
-    releaseVersion: $(version.MajorMinor)
-    repository: $(repository)
-    ${{ if in(variables['Build.Reason'], 'IndividualCI', 'BatchedCI', 'ResourceTrigger') }}:
-      environments:
-        - name: Dev

--- a/packages/forms-web-app/pipelines/azure-pipelines-variables.yml
+++ b/packages/forms-web-app/pipelines/azure-pipelines-variables.yml
@@ -7,4 +7,4 @@ variables:
 
   dockerFilePath: $(Build.SourcesDirectory)/packages/forms-web-app/Dockerfile
   repository: appeal-planning-decision/forms-web-app
-  webAppNamePrefix: pins-app-appeals-service-appeals-wfe
+  webAppName: pins-app-appeals-service-appeals-wfe-$(ENVIRONMENT)-$(REGION_SHORT)-001

--- a/packages/horizon-functions/pipelines/azure-pipelines-build.yml
+++ b/packages/horizon-functions/pipelines/azure-pipelines-build.yml
@@ -17,7 +17,7 @@ resources:
       type: github
       endpoint: Planning-Inspectorate
       name: Planning-Inspectorate/common-pipeline-templates
-      ref: refs/tags/release/1.2.2
+      ref: refs/tags/release/2.0.0
 
 extends:
   template: stages/wrapper_ci.yml@templates
@@ -25,20 +25,16 @@ extends:
     globalVariables:
       - template: azure-pipelines-variables.yml@self
       - template: packages/horizon-functions/pipelines/azure-pipelines-variables.yml@self
-    pool:
-      vmImage: ubuntu-latest
-    projectName: $(projectName)
     validateName: Build
     validationSteps:
       - script: |
           buildName=$(versionNumber)_$(Build.BuildId)
           echo "Setting the name of the build to '$buildName'."
           echo "##vso[build.updatebuildnumber]$buildName"
-        displayName: Set Build Number
-      - script: |
           echo "Setting build tag to '$(Build.SourceBranchName)'."
           echo "##vso[build.addbuildtag]$(Build.SourceBranchName)"
-        displayName: Add Branch Tag
+        displayName: Set Build Number and Add Branch Tag
       - template: steps/function_app_validate.yml@templates
         parameters:
+          nodeVersion: 14
           workingDirectory: $(Build.Repository.LocalPath)/packages/horizon-functions

--- a/packages/horizon-functions/pipelines/azure-pipelines-release.yml
+++ b/packages/horizon-functions/pipelines/azure-pipelines-release.yml
@@ -3,9 +3,9 @@ parameters:
     displayName: Region
     type: string
     values:
-      - uks
-      - ukw
-    default: ukw
+      - UK West
+      - UK South
+    default: UK West
 
 trigger: none
 
@@ -17,7 +17,7 @@ resources:
       type: github
       endpoint: Planning-Inspectorate
       name: Planning-Inspectorate/common-pipeline-templates
-      ref: refs/tags/release/1.2.2
+      ref: refs/tags/release/2.0.0
   pipelines:
     - pipeline: horizon-functions-ci
       source: horizon-functions CI
@@ -27,9 +27,18 @@ resources:
             - main
 
 extends:
-  template: stages/wrapper_function_app_cd.yml@templates
+  template: stages/wrapper_cd.yml@templates
   parameters:
-    appName: pins-func-appeals-service-horizon-$(ENVIRONMENT)-${{ parameters.region }}-001
-    artifactSourcePipeline: horizon-functions CI
-    project: appeal-planning-decision
-    resourceGroup: pins-rg-appeals-service-$(ENVIRONMENT)-${{ parameters.region }}-001
+    artifact: azure-functions
+    deploymentStages:
+      - name: Deploy
+        deploymentSteps:
+          - template: ../steps/function_app_deploy.yml
+            parameters:
+              appName: $(functionAppName)
+              resourceGroup: $(resourceGroup)
+    downloadArtifact: true
+    globalVariables:
+      - template: azure-pipelines-variables.yml@self
+      - template: packages/horizon-functions/pipelines/azure-pipelines-variables.yml@self
+    sourcePipeline: horizon-functions CI

--- a/packages/horizon-functions/pipelines/azure-pipelines-variables.yml
+++ b/packages/horizon-functions/pipelines/azure-pipelines-variables.yml
@@ -4,3 +4,5 @@ variables:
   version.Revision: $[counter(variables['version.MajorMinor'], 0)]
   versionNumber: $(version.MajorMinor).$(version.Revision)
   # -----------------------------------------------------------------------
+
+  functionAppName: pins-func-appeals-service-horizon-$(ENVIRONMENT)-$(REGION_SHORT)-001

--- a/packages/pdf-service-api/pipelines/azure-pipelines-build.yml
+++ b/packages/pdf-service-api/pipelines/azure-pipelines-build.yml
@@ -17,17 +17,14 @@ resources:
       type: github
       endpoint: Planning-Inspectorate
       name: Planning-Inspectorate/common-pipeline-templates
-      ref: refs/tags/release/1.2.2
+      ref: refs/tags/release/2.0.0
 
 extends:
   template: stages/wrapper_ci.yml@templates
   parameters:
-    azurecrName: $(azurecrName)
-    authType: acr
     globalVariables:
       - template: azure-pipelines-variables.yml@self
       - template: packages/pdf-service-api/pipelines/azure-pipelines-variables.yml@self
-    projectName: $(projectName)
     validateName: Build Test and Push
     validationSteps:
       - script: |
@@ -42,6 +39,4 @@ extends:
           repository: $(repository)
           runTests: true
           testRunTitle: PDF Service API Jest Tests
-          versionNumber: $(versionNumber)
           workingDirectory: $(Build.Repository.LocalPath)
-

--- a/packages/pdf-service-api/pipelines/azure-pipelines-release.yml
+++ b/packages/pdf-service-api/pipelines/azure-pipelines-release.yml
@@ -21,7 +21,7 @@ resources:
       type: github
       endpoint: Planning-Inspectorate
       name: Planning-Inspectorate/common-pipeline-templates
-      ref: refs/tags/release/1.2.2
+      ref: refs/tags/release/2.0.0
   pipelines:
     - pipeline: pdf-service-api-ci
       source: pdf-service-api CI
@@ -31,19 +31,17 @@ resources:
             - main
 
 extends:
-  template: stages/wrapper_web_app_cd.yml@templates
+  template: stages/wrapper_cd.yml@templates
   parameters:
-    appName: $(webAppNamePrefix)-$(ENVIRONMENT)-$(REGION_SHORT)-001
-    artifactSourcePipeline: pdf-service-api CI
-    azurecrName: $(azurecrName)
-    azurecrServiceConnection: $(azurecrServiceConnection)
-    deploymentTag: ${{ parameters.deploymentTag }}
+    deploymentStages:
+      - name: Deploy
+        deploymentSteps:
+          - template: ../steps/azure_web_app_deploy.yml
+            parameters:
+              appName: $(webAppName)
+              appResourceGroup: $(resourceGroup)
+              azurecrName: $(azurecrName)
+              repository: $(repository)
     globalVariables:
       - template: azure-pipelines-variables.yml@self
       - template: packages/pdf-service-api/pipelines/azure-pipelines-variables.yml@self
-    projectName: $(projectName) 
-    releaseVersion: $(version.MajorMinor)
-    repository: $(repository)
-    ${{ if in(variables['Build.Reason'], 'IndividualCI', 'BatchedCI', 'ResourceTrigger') }}:
-      environments:
-        - name: Dev

--- a/packages/pdf-service-api/pipelines/azure-pipelines-variables.yml
+++ b/packages/pdf-service-api/pipelines/azure-pipelines-variables.yml
@@ -7,4 +7,4 @@ variables:
 
   dockerFilePath: $(Build.SourcesDirectory)/packages/pdf-service-api/Dockerfile
   repository: appeal-planning-decision/pdf-service-api
-  webAppNamePrefix: pins-app-appeals-service-pdf-api
+  webAppName: pins-app-appeals-service-pdf-api-$(ENVIRONMENT)-$(REGION_SHORT)-001

--- a/packages/ping/pipelines/azure-pipelines-build.yml
+++ b/packages/ping/pipelines/azure-pipelines-build.yml
@@ -17,18 +17,15 @@ resources:
       type: github
       endpoint: Planning-Inspectorate
       name: Planning-Inspectorate/common-pipeline-templates
-      ref: refs/tags/release/1.2.2
+      ref: refs/tags/release/2.0.0
 
 extends:
   template: stages/wrapper_ci.yml@templates
   parameters:
-    azurecrName: $(azurecrName)
-    authType: acr
     globalVariables:
-      - template: packages/ping/pipelines/azure-pipelines-variables.yml@self
       - template: azure-pipelines-variables.yml@self
-    projectName: $(projectName)
-    validateName: Build and Push
+      - template: packages/ping/pipelines/azure-pipelines-variables.yml@self
+    validateName: Build Test and Push
     validationSteps:
       - script: |
           buildName=$(versionNumber)_$(Build.BuildId)
@@ -41,5 +38,4 @@ extends:
           dockerfilePath: $(dockerFilePath)
           repository: $(repository)
           runTests: false
-          versionNumber: $(versionNumber)
           workingDirectory: $(Build.Repository.LocalPath)

--- a/packages/queue-retry/pipelines/azure-pipelines-build.yml
+++ b/packages/queue-retry/pipelines/azure-pipelines-build.yml
@@ -17,18 +17,15 @@ resources:
       type: github
       endpoint: Planning-Inspectorate
       name: Planning-Inspectorate/common-pipeline-templates
-      ref: refs/tags/release/1.2.2
+      ref: refs/tags/release/2.0.0
 
 extends:
   template: stages/wrapper_ci.yml@templates
   parameters:
-    azurecrName: $(azurecrName)
-    authType: acr
     globalVariables:
-      - template: packages/queue-retry/pipelines/azure-pipelines-variables.yml@self
       - template: azure-pipelines-variables.yml@self
-    projectName: $(projectName)
-    validateName: Build and Push
+      - template: packages/queue-retry/pipelines/azure-pipelines-variables.yml@self
+    validateName: Build Test and Push
     validationSteps:
       - script: |
           buildName=$(versionNumber)_$(Build.BuildId)
@@ -41,5 +38,4 @@ extends:
           dockerfilePath: $(dockerFilePath)
           repository: $(repository)
           runTests: false
-          versionNumber: $(versionNumber)
           workingDirectory: $(Build.Repository.LocalPath)


### PR DESCRIPTION
Updated pipelines to use the latest version of the templates. This version requires less parameters
to be passed into the wrapper templates. It also makes a specific wrapper template for web and
functions apps redundant and we can now use the generic wrapper_cd.yml template.

https://pins-ds.atlassian.net/browse/DBO-38
