### PR TITLE
 chore(pipelines): bump templates version and remove unused params

### DIFF
--- a/azure-pipelines-commit-lint.yml
+++ b/azure-pipelines-commit-lint.yml
@@ -11,7 +11,7 @@ resources:
       type: github
       endpoint: Planning-Inspectorate
       name: Planning-Inspectorate/common-pipeline-templates
-      ref: refs/tags/release/2.0.2
+      ref: refs/tags/release/2.1.1
 
 pool:
   name: pins-odt-agent-pool

--- a/packages/appeal-reply-service-api/pipelines/azure-pipelines-build.yml
+++ b/packages/appeal-reply-service-api/pipelines/azure-pipelines-build.yml
@@ -21,7 +21,7 @@ resources:
       type: github
       endpoint: Planning-Inspectorate
       name: Planning-Inspectorate/common-pipeline-templates
-      ref: refs/tags/release/2.0.2
+      ref: refs/tags/release/2.1.1
 
 extends:
   template: stages/wrapper_ci.yml@templates

--- a/packages/appeal-reply-service-api/pipelines/azure-pipelines-release.yml
+++ b/packages/appeal-reply-service-api/pipelines/azure-pipelines-release.yml
@@ -1,8 +1,4 @@
 parameters:
-  - name: deploymentTag
-    displayName: Deployment Tag
-    type: string
-    default: none
   - name: region
     displayName: Region
     type: string
@@ -21,7 +17,7 @@ resources:
       type: github
       endpoint: Planning-Inspectorate
       name: Planning-Inspectorate/common-pipeline-templates
-      ref: refs/tags/release/2.0.2
+      ref: refs/tags/release/2.1.1
   pipelines:
     - pipeline: appeal-reply-service-api-ci
       source: appeal-reply-service-api CI

--- a/packages/appeals-service-api/pipelines/azure-pipelines-build.yml
+++ b/packages/appeals-service-api/pipelines/azure-pipelines-build.yml
@@ -21,7 +21,7 @@ resources:
       type: github
       endpoint: Planning-Inspectorate
       name: Planning-Inspectorate/common-pipeline-templates
-      ref: refs/tags/release/2.0.2
+      ref: refs/tags/release/2.1.1
 
 extends:
   template: stages/wrapper_ci.yml@templates

--- a/packages/appeals-service-api/pipelines/azure-pipelines-release.yml
+++ b/packages/appeals-service-api/pipelines/azure-pipelines-release.yml
@@ -17,7 +17,7 @@ resources:
       type: github
       endpoint: Planning-Inspectorate
       name: Planning-Inspectorate/common-pipeline-templates
-      ref: refs/tags/release/2.0.2
+      ref: refs/tags/release/2.1.1
   pipelines:
     - pipeline: appeals-service-api-ci
       source: appeals-service-api CI

--- a/packages/business-rules/pipelines/azure-pipelines-build.yml
+++ b/packages/business-rules/pipelines/azure-pipelines-build.yml
@@ -17,7 +17,7 @@ resources:
       type: github
       endpoint: Planning-Inspectorate
       name: Planning-Inspectorate/common-pipeline-templates
-      ref: refs/tags/release/2.0.2
+      ref: refs/tags/release/2.1.1
 
 extends:
   template: stages/wrapper_ci.yml@templates

--- a/packages/clamav-rest-server/pipelines/azure-pipelines-build.yml
+++ b/packages/clamav-rest-server/pipelines/azure-pipelines-build.yml
@@ -19,7 +19,7 @@ resources:
       type: github
       endpoint: Planning-Inspectorate
       name: Planning-Inspectorate/common-pipeline-templates
-      ref: refs/tags/release/2.0.2
+      ref: refs/tags/release/2.1.1
 
 extends:
   template: stages/wrapper_ci.yml@templates

--- a/packages/clamav-rest-server/pipelines/azure-pipelines-release.yml
+++ b/packages/clamav-rest-server/pipelines/azure-pipelines-release.yml
@@ -1,8 +1,4 @@
 parameters:
-  - name: deploymentTag
-    displayName: Deployment Tag
-    type: string
-    default: none
   - name: region
     displayName: Region
     type: string
@@ -21,7 +17,7 @@ resources:
       type: github
       endpoint: Planning-Inspectorate
       name: Planning-Inspectorate/common-pipeline-templates
-      ref: refs/tags/release/2.0.2
+      ref: refs/tags/release/2.1.1
   pipelines:
     - pipeline: clamav-rest-server-ci
       source: clamav-rest-server CI

--- a/packages/common/pipelines/azure-pipelines-build.yml
+++ b/packages/common/pipelines/azure-pipelines-build.yml
@@ -17,7 +17,7 @@ resources:
       type: github
       endpoint: Planning-Inspectorate
       name: Planning-Inspectorate/common-pipeline-templates
-      ref: refs/tags/release/2.0.2
+      ref: refs/tags/release/2.1.1
 
 extends:
   template: stages/wrapper_ci.yml@templates

--- a/packages/document-service-api/pipelines/azure-pipelines-build.yml
+++ b/packages/document-service-api/pipelines/azure-pipelines-build.yml
@@ -19,7 +19,7 @@ resources:
       type: github
       endpoint: Planning-Inspectorate
       name: Planning-Inspectorate/common-pipeline-templates
-      ref: refs/tags/release/2.0.2
+      ref: refs/tags/release/2.1.1
 
 extends:
   template: stages/wrapper_ci.yml@templates

--- a/packages/document-service-api/pipelines/azure-pipelines-release.yml
+++ b/packages/document-service-api/pipelines/azure-pipelines-release.yml
@@ -1,8 +1,4 @@
 parameters:
-  - name: deploymentTag
-    displayName: Deployment Tag
-    type: string
-    default: none
   - name: region
     displayName: Region
     type: string
@@ -21,7 +17,7 @@ resources:
       type: github
       endpoint: Planning-Inspectorate
       name: Planning-Inspectorate/common-pipeline-templates
-      ref: refs/tags/release/2.0.2
+      ref: refs/tags/release/2.1.1
   pipelines:
     - pipeline: document-service-api-ci
       source: document-service-api CI

--- a/packages/e2e-tests/pipelines/azure-pipelines-cypress-e2e.yml
+++ b/packages/e2e-tests/pipelines/azure-pipelines-cypress-e2e.yml
@@ -14,7 +14,7 @@ resources:
       type: github
       endpoint: Planning-Inspectorate
       name: Planning-Inspectorate/common-pipeline-templates
-      ref: refs/tags/release/2.0.2
+      ref: refs/tags/release/2.1.1
 
 variables:
   - group: pipeline_secrets

--- a/packages/forms-web-app/pipelines/azure-pipelines-build.yml
+++ b/packages/forms-web-app/pipelines/azure-pipelines-build.yml
@@ -21,7 +21,7 @@ resources:
       type: github
       endpoint: Planning-Inspectorate
       name: Planning-Inspectorate/common-pipeline-templates
-      ref: refs/tags/release/2.0.2
+      ref: refs/tags/release/2.1.1
 
 extends:
   template: stages/wrapper_ci.yml@templates

--- a/packages/forms-web-app/pipelines/azure-pipelines-release.yml
+++ b/packages/forms-web-app/pipelines/azure-pipelines-release.yml
@@ -1,8 +1,4 @@
 parameters:
-  - name: deploymentTag
-    displayName: Deployment Tag
-    type: string
-    default: none
   - name: region
     displayName: Region
     type: string
@@ -21,7 +17,7 @@ resources:
       type: github
       endpoint: Planning-Inspectorate
       name: Planning-Inspectorate/common-pipeline-templates
-      ref: refs/tags/release/2.0.2
+      ref: refs/tags/release/2.1.1
   pipelines:
     - pipeline: forms-web-app-ci
       source: forms-web-app CI

--- a/packages/horizon-functions/pipelines/azure-pipelines-build.yml
+++ b/packages/horizon-functions/pipelines/azure-pipelines-build.yml
@@ -17,7 +17,7 @@ resources:
       type: github
       endpoint: Planning-Inspectorate
       name: Planning-Inspectorate/common-pipeline-templates
-      ref: refs/tags/release/2.0.2
+      ref: refs/tags/release/2.1.1
 
 extends:
   template: stages/wrapper_ci.yml@templates

--- a/packages/horizon-functions/pipelines/azure-pipelines-release.yml
+++ b/packages/horizon-functions/pipelines/azure-pipelines-release.yml
@@ -17,7 +17,7 @@ resources:
       type: github
       endpoint: Planning-Inspectorate
       name: Planning-Inspectorate/common-pipeline-templates
-      ref: refs/tags/release/2.0.2
+      ref: refs/tags/release/2.1.1
   pipelines:
     - pipeline: horizon-functions-ci
       source: horizon-functions CI

--- a/packages/pdf-service-api/pipelines/azure-pipelines-build.yml
+++ b/packages/pdf-service-api/pipelines/azure-pipelines-build.yml
@@ -17,7 +17,7 @@ resources:
       type: github
       endpoint: Planning-Inspectorate
       name: Planning-Inspectorate/common-pipeline-templates
-      ref: refs/tags/release/2.0.2
+      ref: refs/tags/release/2.1.1
 
 extends:
   template: stages/wrapper_ci.yml@templates

--- a/packages/pdf-service-api/pipelines/azure-pipelines-release.yml
+++ b/packages/pdf-service-api/pipelines/azure-pipelines-release.yml
@@ -1,8 +1,4 @@
 parameters:
-  - name: deploymentTag
-    displayName: Deployment Tag
-    type: string
-    default: none
   - name: region
     displayName: Region
     type: string
@@ -21,7 +17,7 @@ resources:
       type: github
       endpoint: Planning-Inspectorate
       name: Planning-Inspectorate/common-pipeline-templates
-      ref: refs/tags/release/2.0.2
+      ref: refs/tags/release/2.1.1
   pipelines:
     - pipeline: pdf-service-api-ci
       source: pdf-service-api CI

--- a/packages/ping/pipelines/azure-pipelines-build.yml
+++ b/packages/ping/pipelines/azure-pipelines-build.yml
@@ -17,7 +17,7 @@ resources:
       type: github
       endpoint: Planning-Inspectorate
       name: Planning-Inspectorate/common-pipeline-templates
-      ref: refs/tags/release/2.0.2
+      ref: refs/tags/release/2.1.1
 
 extends:
   template: stages/wrapper_ci.yml@templates

--- a/packages/queue-retry/pipelines/azure-pipelines-build.yml
+++ b/packages/queue-retry/pipelines/azure-pipelines-build.yml
@@ -17,7 +17,7 @@ resources:
       type: github
       endpoint: Planning-Inspectorate
       name: Planning-Inspectorate/common-pipeline-templates
-      ref: refs/tags/release/2.0.2
+      ref: refs/tags/release/2.1.1
 
 extends:
   template: stages/wrapper_ci.yml@templates


### PR DESCRIPTION
## Ticket Number
N/A

## Description of change
Remove unused "deploymentTag" param from release pipelines and bump templates version.

## Checklist
<!-- Put an `x` in all the boxes that apply: -->
- [ ] Requires infrastructure changes
- [ ] If adding or remove environment variables (e.g. in `docker-compose.yaml`) then I have updated the appropriate Helm chart
- [ ] I have updated the documentation accordingly
- [ ] My commit history in this PR is linear
- [ ] New features have tests
- [ ] Breaking change (team conversation required)

## Important

Please do not merge from `main` (please only [rebase](https://github.com/foundry4/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
