### PR TITLE
feat(as-4951): remove s&r post page from navigation history

### DIFF
--- a/packages/forms-web-app/__tests__/unit/controllers/save-and-return.test.js
+++ b/packages/forms-web-app/__tests__/unit/controllers/save-and-return.test.js
@@ -11,14 +11,23 @@ describe('controllers/save-and-return', () => {
 
   beforeEach(() => {
     appeal = 'data';
-    req = mockReq(appeal);
+    req = mockReq();
     res = mockRes();
     jest.resetAllMocks();
   });
   describe('postSaveAndReturn', () => {
     it('should redirect to the expected route if valid', async () => {
+      req = {
+        ...req,
+        session: {
+          appeal: appeal,
+          navigationHistory: ['nav/p1', 'nav/p2'],
+        },
+      };
       await saveAndReturnController.postSaveAndReturn(req, res);
       expect(saveAppeal).toHaveBeenCalledWith(appeal);
+      expect(req.session.navigationHistory).toHaveLength(1);
+      expect(req.session.navigationHistory).toEqual(['nav/p2']);
       expect(res.redirect).toHaveBeenCalledWith(`/${VIEW.SUBMIT_APPEAL.APPLICATION_SAVED}`);
     });
   });

--- a/packages/forms-web-app/src/controllers/save-and-return.js
+++ b/packages/forms-web-app/src/controllers/save-and-return.js
@@ -2,6 +2,7 @@ const { saveAppeal } = require('../lib/appeals-api-wrapper');
 const { VIEW } = require('../lib/submit-appeal/views');
 
 exports.postSaveAndReturn = async (req, res) => {
+  req.session.navigationHistory.shift();
   await saveAppeal(req.session.appeal);
   res.redirect(`/${VIEW.SUBMIT_APPEAL.APPLICATION_SAVED}`);
-};
+};;


### PR DESCRIPTION
## Ticket Number
<!-- Add the number from the Jira board -->
https://pins-ds.atlassian.net/browse/AS-4951

## Description of change
<!-- Please describe the change -->
* remove the `/save-and-return` POST page from the navigation history, so that back functionality from 'your appeal has been saved page' will work as intended

## Checklist
<!-- Put an `x` in all the boxes that apply: -->
- [ ] Requires infrastructure changes
- [ ] If adding or remove environment variables (e.g. in `docker-compose.yaml`) then I have updated the appropriate Helm chart
- [ ] I have updated the documentation accordingly
- [ ] My commit history in this PR is linear
- [ ] New features have tests
- [ ] Breaking change (team conversation required)

## Important

Please do not merge from `main` (please only [rebase](https://github.com/foundry4/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
