### PR TITLE
Feature/as 4767 remove planning application number on appeal a planning decision

### DIFF
--- a/packages/appeals-service-api/src/models/appeal.js
+++ b/packages/appeals-service-api/src/models/appeal.js
@@ -110,7 +110,6 @@ exports.appealDocument = {
     isOriginalApplicant: null,
   },
   planningApplicationDocumentsSection: {
-    applicationNumber: null,
     descriptionDevelopmentCorrect: null,
     isDesignAccessStatementSubmitted: null,
     originalApplication: {

--- a/packages/business-rules/src/schemas/full-appeal/insert.js
+++ b/packages/business-rules/src/schemas/full-appeal/insert.js
@@ -218,7 +218,6 @@ const insert = pinsYup
     planningApplicationDocumentsSection: pinsYup
       .object()
       .shape({
-        applicationNumber: pinsYup.string().max(30).nullable(),
         ownershipCertificate: pinsYup
           .object()
           .shape({
@@ -568,10 +567,6 @@ const insert = pinsYup
         planningApplicationDocumentsSection: pinsYup
           .object()
           .shape({
-            applicationNumber: pinsYup
-              .string()
-              .oneOf(Object.values(SECTION_STATE))
-              .default('NOT STARTED'),
             ownershipCertificate: pinsYup
               .string()
               .oneOf(Object.values(SECTION_STATE))

--- a/packages/business-rules/src/schemas/full-appeal/insert.test.js
+++ b/packages/business-rules/src/schemas/full-appeal/insert.test.js
@@ -2124,22 +2124,6 @@ describe('schemas/full-appeal/insert', () => {
           'planningApplicationDocumentsSection must be a `object` type, but the final value was: `null`',
         );
       });
-
-      describe('planningApplicationDocumentsSection.applicationNumber', () => {
-        it('should throw an error when given a value with more than 30 characters', async () => {
-          appeal.planningApplicationDocumentsSection.applicationNumber = 'a'.repeat(31);
-
-          await expect(() => insert.validate(appeal, config)).rejects.toThrow(
-            'planningApplicationDocumentsSection.applicationNumber must be at most 30 characters',
-          );
-        });
-
-        it('should not throw an error when not given a value', async () => {
-          delete appeal.planningApplicationDocumentsSection.applicationNumber;
-
-          const result = await insert.validate(appeal, config);
-          expect(result).toEqual(appeal);
-        });
       });
 
       describe('planningApplicationDocumentsSection.plansDrawingsSupportingDocuments', () => {
@@ -3118,7 +3102,6 @@ describe('schemas/full-appeal/insert', () => {
 
         [
           'originalApplication',
-          'applicationNumber',
           'plansDrawingsSupportingDocuments',
           'designAccessStatementSubmitted',
           'decisionLetter',

--- a/packages/business-rules/src/schemas/full-appeal/update.js
+++ b/packages/business-rules/src/schemas/full-appeal/update.js
@@ -199,7 +199,6 @@ const update = pinsYup
     planningApplicationDocumentsSection: pinsYup
       .object()
       .shape({
-        applicationNumber: pinsYup.string().max(30).required(),
         ownershipCertificate: pinsYup
           .object()
           .shape({
@@ -501,7 +500,6 @@ const update = pinsYup
         planningApplicationDocumentsSection: pinsYup
           .object()
           .shape({
-            applicationNumber: pinsYup.string().oneOf(Object.values(SECTION_STATE)).required(),
             ownershipCertificate: pinsYup.string().oneOf(Object.values(SECTION_STATE)).required(),
             descriptionDevelopmentCorrect: pinsYup
               .string()

--- a/packages/business-rules/src/schemas/full-appeal/update.test.js
+++ b/packages/business-rules/src/schemas/full-appeal/update.test.js
@@ -2162,32 +2162,6 @@ describe('schemas/full-appeal/update', () => {
         );
       });
 
-      describe('planningApplicationDocumentsSection.applicationNumber', () => {
-        it('should throw an error when given a value with more than 30 characters', async () => {
-          appeal.planningApplicationDocumentsSection.applicationNumber = 'a'.repeat(31);
-
-          await expect(() => update.validate(appeal, config)).rejects.toThrow(
-            'planningApplicationDocumentsSection.applicationNumber must be at most 30 characters',
-          );
-        });
-
-        it('should throw an error when given a null value', async () => {
-          appeal.planningApplicationDocumentsSection.applicationNumber = null;
-
-          await expect(() => update.validate(appeal, config)).rejects.toThrow(
-            'planningApplicationDocumentsSection.applicationNumber must be a `string` type, but the final value was: `null`',
-          );
-        });
-
-        it('should throw an error when not given a value', async () => {
-          delete appeal.planningApplicationDocumentsSection.applicationNumber;
-
-          await expect(() => update.validate(appeal, config)).rejects.toThrow(
-            'planningApplicationDocumentsSection.applicationNumber is a required field',
-          );
-        });
-      });
-
       describe('planningApplicationDocumentsSection.plansDrawingsSupportingDocuments', () => {
         it('should remove unknown fields', async () => {
           appeal2.planningApplicationDocumentsSection.plansDrawingsSupportingDocuments.unknownField =
@@ -3254,7 +3228,6 @@ describe('schemas/full-appeal/update', () => {
 
         [
           'originalApplication',
-          'applicationNumber',
           'plansDrawingsSupportingDocuments',
           'designAccessStatementSubmitted',
           'decisionLetter',

--- a/packages/business-rules/test/data/full-appeal.js
+++ b/packages/business-rules/test/data/full-appeal.js
@@ -86,7 +86,6 @@ const appeal = {
     },
   },
   planningApplicationDocumentsSection: {
-    applicationNumber: 'ABCDE12345',
     ownershipCertificate: {
       submittedSeparateCertificate: true,
       uploadedFile: {
@@ -319,7 +318,6 @@ const appeal = {
     },
     planningApplicationDocumentsSection: {
       originalApplication: 'NOT STARTED',
-      applicationNumber: 'NOT STARTED',
       ownershipCertificate: 'NOT STARTED',
       descriptionDevelopmentCorrect: 'NOT STARTED',
       plansDrawingsSupportingDocuments: 'NOT STARTED',

--- a/packages/e2e-tests/cypress/fixtures/completedAppeal.json
+++ b/packages/e2e-tests/cypress/fixtures/completedAppeal.json
@@ -18,7 +18,6 @@
     }
   },
   "requiredDocumentsSection": {
-    "applicationNumber": "ValidNumber/12345",
     "originalApplication": {
       "uploadedFile": {
         "name": "appeal-statement-valid.doc",

--- a/packages/e2e-tests/cypress/fixtures/completedDeterministicFullAppeal.json
+++ b/packages/e2e-tests/cypress/fixtures/completedDeterministicFullAppeal.json
@@ -25,7 +25,6 @@
     }
   },
   "requiredDocumentsSection": {
-    "applicationNumber": "ValidNumber/12345",
     "originalApplication": {
       "uploadedFile": {
         "name": "original-application-valid.doc",

--- a/packages/e2e-tests/cypress/fixtures/completedNonDeterministicFullAppeal.json
+++ b/packages/e2e-tests/cypress/fixtures/completedNonDeterministicFullAppeal.json
@@ -25,7 +25,6 @@
     }
   },
   "requiredDocumentsSection": {
-    "applicationNumber": "ValidNumber/12345",
     "originalApplication": {
       "uploadedFile": {
         "name": "original-application-valid.doc",
@@ -107,7 +106,6 @@
     "companyName": ""
   },
   "planningApplicationDocumentsSection": {
-    "applicationNumber": "12345",
     "isDesignAccessStatementSubmitted": false,
     "originalApplication": {
       "uploadedFile": {
@@ -133,7 +131,6 @@
       "yourDetails": "COMPLETED"
     },
     "requiredDocumentsSection": {
-      "applicationNumber": "COMPLETED",
       "originalApplication": "COMPLETED",
       "decisionLetter": "COMPLETED"
     },

--- a/packages/forms-web-app/__tests__/mockData/full-appeal.js
+++ b/packages/forms-web-app/__tests__/mockData/full-appeal.js
@@ -82,7 +82,6 @@ const appeal = {
     },
   },
   planningApplicationDocumentsSection: {
-    applicationNumber: 'ABCDE12345',
     ownershipCertificate: {
       submittedSeparateCertificate: true,
       uploadedFile: {
@@ -263,7 +262,6 @@ const appeal = {
     },
     planningApplicationDocumentsSection: {
       originalApplication: 'NOT STARTED',
-      applicationNumber: 'NOT STARTED',
       plansDrawingsSupportingDocuments: 'NOT STARTED',
       designAccessStatementSubmitted: 'NOT STARTED',
       designAccessStatement: 'NOT STARTED',

--- a/packages/forms-web-app/__tests__/unit/controllers/appellant-submission/task-list.test.js
+++ b/packages/forms-web-app/__tests__/unit/controllers/appellant-submission/task-list.test.js
@@ -13,8 +13,8 @@ describe('controllers/appellant-submission/task-list', () => {
       expect(res.render).toHaveBeenCalledWith(VIEW.APPELLANT_SUBMISSION.TASK_LIST, {
         applicationStatus: 'Application incomplete',
         sectionInfo: {
-          nbTasks: 11,
-          nbCompleted: 10,
+          nbTasks: 10,
+          nbCompleted: 9,
           sections: {
             count: 5,
             completed: 4,
@@ -42,15 +42,6 @@ describe('controllers/appellant-submission/task-list', () => {
               text: 'About the original planning application',
             },
             items: [
-              {
-                text: 'Planning application number',
-                href: `/${VIEW.APPELLANT_SUBMISSION.APPLICATION_NUMBER}`,
-                status: 'COMPLETED',
-                attributes: {
-                  'applicationNumber-status': 'COMPLETED',
-                  name: 'applicationNumber',
-                },
-              },
               {
                 text: 'Upload the original planning application form',
                 href: `/${VIEW.APPELLANT_SUBMISSION.UPLOAD_APPLICATION}`,
@@ -179,7 +170,6 @@ describe('controllers/appellant-submission/task-list', () => {
           },
         },
         requiredDocumentsSection: {
-          applicationNumber: '123',
           originalApplication: {
             uploadedFile: {
               id: '123',
@@ -222,8 +212,8 @@ describe('controllers/appellant-submission/task-list', () => {
       expect(res.render).toHaveBeenCalledWith(VIEW.APPELLANT_SUBMISSION.TASK_LIST, {
         applicationStatus: 'Application incomplete',
         sectionInfo: {
-          nbTasks: 11,
-          nbCompleted: 8,
+          nbTasks: 10,
+          nbCompleted: 7,
           sections: {
             count: 5,
             completed: 2,
@@ -251,15 +241,6 @@ describe('controllers/appellant-submission/task-list', () => {
               text: 'About the original planning application',
             },
             items: [
-              {
-                text: 'Planning application number',
-                href: `/${VIEW.APPELLANT_SUBMISSION.APPLICATION_NUMBER}`,
-                status: 'COMPLETED',
-                attributes: {
-                  'applicationNumber-status': 'COMPLETED',
-                  name: 'applicationNumber',
-                },
-              },
               {
                 text: 'Upload the original planning application form',
                 href: `/${VIEW.APPELLANT_SUBMISSION.UPLOAD_APPLICATION}`,
@@ -397,7 +378,6 @@ describe('controllers/appellant-submission/task-list', () => {
           },
         },
         requiredDocumentsSection: {
-          applicationNumber: '123',
           originalApplication: {
             uploadedFile: {
               id: '123',
@@ -431,8 +411,8 @@ describe('controllers/appellant-submission/task-list', () => {
       expect(res.render).toHaveBeenCalledWith(VIEW.APPELLANT_SUBMISSION.TASK_LIST, {
         applicationStatus: 'Application incomplete',
         sectionInfo: {
-          nbTasks: 11,
-          nbCompleted: 9,
+          nbTasks: 10,
+          nbCompleted: 8,
           sections: {
             count: 5,
             completed: 3,
@@ -460,15 +440,6 @@ describe('controllers/appellant-submission/task-list', () => {
               text: 'About the original planning application',
             },
             items: [
-              {
-                text: 'Planning application number',
-                href: `/${VIEW.APPELLANT_SUBMISSION.APPLICATION_NUMBER}`,
-                status: 'COMPLETED',
-                attributes: {
-                  'applicationNumber-status': 'COMPLETED',
-                  name: 'applicationNumber',
-                },
-              },
               {
                 text: 'Upload the original planning application form',
                 href: `/${VIEW.APPELLANT_SUBMISSION.UPLOAD_APPLICATION}`,

--- a/packages/forms-web-app/__tests__/unit/controllers/full-appeal/submit-appeal/application-certificates-included.test.js
+++ b/packages/forms-web-app/__tests__/unit/controllers/full-appeal/submit-appeal/application-certificates-included.test.js
@@ -120,7 +120,7 @@ describe('controllers/full-appeal/submit-appeal/application-certificates-include
       };
       await postApplicationCertificatesIncluded(req, res);
       expect(res.render).not.toHaveBeenCalled();
-      expect(res.redirect).toHaveBeenCalledWith(`/${VIEW.FULL_APPEAL.APPLICATION_NUMBER}`);
+      expect(res.redirect).toHaveBeenCalledWith(`/${VIEW.FULL_APPEAL.PROPOSED_DEVELOPMENT_CHANGED}`);
     });
   });
 });

--- a/packages/forms-web-app/__tests__/unit/controllers/full-appeal/submit-appeal/certificates.test.js
+++ b/packages/forms-web-app/__tests__/unit/controllers/full-appeal/submit-appeal/certificates.test.js
@@ -117,7 +117,7 @@ describe('controllers/full-appeal/submit-appeal/certificates', () => {
         taskName
       );
       expect(createOrUpdateAppeal).toHaveBeenCalledWith(appeal);
-      expect(res.redirect).toHaveBeenCalledWith(`/${VIEW.FULL_APPEAL.APPLICATION_NUMBER}`);
+      expect(res.redirect).toHaveBeenCalledWith(`/${VIEW.FULL_APPEAL.PROPOSED_DEVELOPMENT_CHANGED}`);
       expect(req.session.appeal).toEqual(submittedAppeal);
     });
 
@@ -135,7 +135,7 @@ describe('controllers/full-appeal/submit-appeal/certificates', () => {
 
       expect(createDocument).not.toHaveBeenCalled();
       expect(createOrUpdateAppeal).toHaveBeenCalledWith(appeal);
-      expect(res.redirect).toHaveBeenCalledWith(`/${VIEW.FULL_APPEAL.APPLICATION_NUMBER}`);
+      expect(res.redirect).toHaveBeenCalledWith(`/${VIEW.FULL_APPEAL.PROPOSED_DEVELOPMENT_CHANGED}`);
       expect(req.session.appeal).toEqual(submittedAppeal);
     });
   });

--- a/packages/forms-web-app/__tests__/unit/controllers/full-appeal/submit-appeal/declaration.test.js
+++ b/packages/forms-web-app/__tests__/unit/controllers/full-appeal/submit-appeal/declaration.test.js
@@ -18,7 +18,7 @@ describe('controllers/full-appeal/submit-appeal/declaration', () => {
     location: 'here',
     size: '123',
   };
-  const fileName = `planning-appeal-for-planning-application-${appeal.planningApplicationDocumentsSection.applicationNumber.replace(
+  const fileName = `planning-appeal-for-planning-application-${appeal.planningApplicationNumber.replace(
     /\//g,
     '-'
   )}`;

--- a/packages/forms-web-app/__tests__/unit/lib/full-appeal/views.test.js
+++ b/packages/forms-web-app/__tests__/unit/lib/full-appeal/views.test.js
@@ -11,7 +11,6 @@ describe('/lib/full-appeal/views', () => {
         APPLICATION_CERTIFICATES_INCLUDED:
           'full-appeal/submit-appeal/application-certificates-included',
         CERTIFICATES: 'full-appeal/submit-appeal/certificates',
-        APPLICATION_NUMBER: 'full-appeal/submit-appeal/application-number',
         DESIGN_ACCESS_STATEMENT: 'full-appeal/submit-appeal/design-access-statement',
         DESIGN_ACCESS_STATEMENT_SUBMITTED:
           'full-appeal/submit-appeal/design-access-statement-submitted',

--- a/packages/forms-web-app/__tests__/unit/services/task.service.test.js
+++ b/packages/forms-web-app/__tests__/unit/services/task.service.test.js
@@ -20,7 +20,6 @@ beforeEach(() => {
 
 const completedAppeal = {
   requiredDocumentsSection: {
-    applicationNumber: '2323',
     originalApplication: {
       uploadedFile: {
         id: 'asdsad',
@@ -239,10 +238,12 @@ describe('services/task.service', () => {
     it('should return "CANNOT START YET" from statusCheckYourAnswer if not all sections have been COMPLETED and the appeal is not submitted ', () => {
       const incompletedAppeal = {
         ...completedAppeal,
-        requiredDocumentsSection: {
-          ...completedAppeal.requiredDocumentsSection,
-          applicationNumber: undefined,
-        },
+        aboutYouSection: {
+          yourDetails: {
+            isOriginalApplicant: true,
+            name: undefined,
+          },
+        }
       };
       expect(SECTIONS.submitYourAppealSection.checkYourAnswers.rule(incompletedAppeal)).toEqual(
         CANNOT_START_YET
@@ -340,7 +341,6 @@ describe('services/task.service', () => {
             yourDetails: IN_PROGRESS,
           },
           requiredDocumentsSection: {
-            applicationNumber: NOT_STARTED,
             originalApplication: NOT_STARTED,
             decisionLetter: NOT_STARTED,
           },
@@ -348,12 +348,12 @@ describe('services/task.service', () => {
       };
       const currentTask = {
         sectionName: 'requiredDocumentsSection',
-        taskName: 'applicationNumber',
+        taskName: 'originalApplication',
       };
       expect(getNextTask(appeal, currentTask)).toEqual({
-        href: '/appellant-submission/upload-application',
+        href: '/appellant-submission/upload-decision',
         status: COMPLETED,
-        taskName: 'originalApplication',
+        taskName: 'decisionLetter',
       });
     });
   });

--- a/packages/forms-web-app/src/controllers/appellant-submission/task-list.js
+++ b/packages/forms-web-app/src/controllers/appellant-submission/task-list.js
@@ -6,7 +6,6 @@ const HEADERS = {
   aboutYouSection: 'About you',
   yourDetails: 'Your details',
   requiredDocumentsSection: 'About the original planning application',
-  applicationNumber: 'Planning application number',
   originalApplication: 'Upload the original planning application form',
   decisionLetter: 'Upload the decision letter',
   dateApplied: 'Date you applied for planning permission',

--- a/packages/forms-web-app/src/controllers/full-appeal/submit-appeal/application-certificates-included.js
+++ b/packages/forms-web-app/src/controllers/full-appeal/submit-appeal/application-certificates-included.js
@@ -48,7 +48,7 @@ const postApplicationCertificatesIncluded = async (req, res) => {
 
   return submittedSeparateCertificate
     ? res.redirect(`/${VIEW.FULL_APPEAL.CERTIFICATES}`)
-    : res.redirect(`/${VIEW.FULL_APPEAL.APPLICATION_NUMBER}`);
+    : res.redirect(`/${VIEW.FULL_APPEAL.PROPOSED_DEVELOPMENT_CHANGED}`);
 };
 
 module.exports = { getApplicationCertificatesIncluded, postApplicationCertificatesIncluded };

--- a/packages/forms-web-app/src/controllers/full-appeal/submit-appeal/certificates.js
+++ b/packages/forms-web-app/src/controllers/full-appeal/submit-appeal/certificates.js
@@ -72,7 +72,7 @@ const postCertificates = async (req, res) => {
     });
   }
 
-  return res.redirect(`/${VIEW.FULL_APPEAL.APPLICATION_NUMBER}`);
+  return res.redirect(`/${VIEW.FULL_APPEAL.PROPOSED_DEVELOPMENT_CHANGED}`);
 };
 
 module.exports = { getCertificates, postCertificates };

--- a/packages/forms-web-app/src/controllers/full-appeal/submit-appeal/declaration.js
+++ b/packages/forms-web-app/src/controllers/full-appeal/submit-appeal/declaration.js
@@ -16,10 +16,7 @@ const postDeclaration = async (req, res) => {
   const { body } = req;
   const { errors = {} } = body;
   const {
-    appeal,
-    appeal: {
-      planningApplicationDocumentsSection: { applicationNumber },
-    },
+    appeal
   } = req.session;
 
   const log = logger.child({ appealId: appeal.id, uuid: uuid.v4() });
@@ -33,7 +30,7 @@ const postDeclaration = async (req, res) => {
   try {
     const { id, name, location, size } = await storePdfAppeal(
       appeal,
-      `planning-appeal-for-planning-application-${applicationNumber.replace(/\//g, '-')}`
+      `planning-appeal-for-planning-application-${appeal.planningApplicationNumber.replace(/\//g, '-')}`
     );
 
     appeal.state = 'SUBMITTED';

--- a/packages/forms-web-app/src/lib/full-appeal/views.js
+++ b/packages/forms-web-app/src/lib/full-appeal/views.js
@@ -8,7 +8,6 @@ const VIEW = {
     APPLICATION_CERTIFICATES_INCLUDED:
       'full-appeal/submit-appeal/application-certificates-included',
     CERTIFICATES: 'full-appeal/submit-appeal/certificates',
-    APPLICATION_NUMBER: 'full-appeal/submit-appeal/application-number',
     PROPOSED_DEVELOPMENT_CHANGED: 'full-appeal/submit-appeal/proposed-development-changed',
     DESIGN_ACCESS_STATEMENT: 'full-appeal/submit-appeal/design-access-statement',
     LETTER_CONFIRMING_APPLICATION: 'full-appeal/submit-appeal/letter-confirming-application',

--- a/packages/forms-web-app/src/services/task.service.js
+++ b/packages/forms-web-app/src/services/task.service.js
@@ -62,7 +62,6 @@ function statusSiteAccess(appeal) {
 
 const houseHolderTasksRules = [
   statusYourDetails,
-  statusApplicationNumber,
   statusOriginalApplication,
   statusDecisionLetter,
   statusAppealStatement,

--- a/packages/forms-web-app/src/services/task.service.js
+++ b/packages/forms-web-app/src/services/task.service.js
@@ -41,11 +41,6 @@ function statusDecisionLetter(appeal) {
   return task.uploadedFile.id ? TASK_STATUS.COMPLETED : TASK_STATUS.NOT_STARTED;
 }
 
-function statusApplicationNumber(appeal) {
-  const task = appeal.requiredDocumentsSection;
-  return task.applicationNumber ? TASK_STATUS.COMPLETED : TASK_STATUS.NOT_STARTED;
-}
-
 function statusHealthAndSafety(appeal) {
   return appeal.appealSiteSection.healthAndSafety &&
     appeal.appealSiteSection.healthAndSafety.hasIssues !== null

--- a/packages/forms-web-app/src/services/task.service.js
+++ b/packages/forms-web-app/src/services/task.service.js
@@ -97,10 +97,6 @@ const SECTIONS = {
     },
   },
   requiredDocumentsSection: {
-    applicationNumber: {
-      href: `/${VIEW.APPELLANT_SUBMISSION.APPLICATION_NUMBER}`,
-      rule: statusApplicationNumber,
-    },
     originalApplication: {
       href: `/${VIEW.APPELLANT_SUBMISSION.UPLOAD_APPLICATION}`,
       rule: statusOriginalApplication,

--- a/packages/forms-web-app/src/views/full-appeal/check-your-answers.njk
+++ b/packages/forms-web-app/src/views/full-appeal/check-your-answers.njk
@@ -700,29 +700,6 @@
       ) },
       actions: ownershipCertificateRowActions if isPdf !== true
     } %}
-    {% set applicationNumberRowActions = {
-      items: [
-        {
-          href: "/full-appeal/submit-appeal/application-number",
-          text: "Change",
-          visuallyHiddenText: "the planning application number",
-          attributes: {
-            "data-cy": "change-application-number"
-          }
-        }
-      ]
-    } %}
-    {% set applicationNumberRow = {
-      key: { text: summaryField(
-        "Planning application number",
-        { "data-cy": "application-number-label" }
-      ) },
-      value: { text: summaryField(
-        appeal.planningApplicationNumber,
-        { "data-cy": "application-number" }
-      ) },
-      actions: applicationNumberRowActions if isPdf !== true
-    } %}
     {% set isDescriptionOfDevelopmentCorrectRowActions = {
       items: [
         {

--- a/packages/forms-web-app/src/views/full-appeal/submit-appeal/proposed-development-changed.njk
+++ b/packages/forms-web-app/src/views/full-appeal/submit-appeal/proposed-development-changed.njk
@@ -5,7 +5,6 @@
 {% from "govuk/components/textarea/macro.njk" import govukTextarea %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
 
-{% set backLink = '/full-appeal/submit-appeal/application-number' %}
 {% set title = "Is the description of development on  your application form still correct? - Appeal a planning decision - GOV.UK" %}
 {% block pageTitle %}{{ "Error: " + title if errors else title }}{% endblock %}
 
@@ -22,16 +21,6 @@
     }
   }) }}
 {% endset %}
-
-{% block backButton %}
-  {{ govukBackLink({
-    text: 'Back',
-    href: backLink,
-    attributes: {
-      'data-cy': 'back'
-    }
-  }) }}
-{% endblock %}
 
 {% block content %}
   <div class="govuk-grid-row">


### PR DESCRIPTION
## Ticket Number
<!-- Add the number from the Jira board -->
https://pins-ds.atlassian.net/browse/AS-4767

## Description of change
<!-- Please describe the change -->
Application number page is no longer used in full-appeal.
## Checklist
<!-- Put an `x` in all the boxes that apply: -->
- [ ] Requires infrastructure changes
- [ ] If adding or remove environment variables (e.g. in `docker-compose.yaml`) then I have updated the appropriate Helm chart
- [ ] I have updated the documentation accordingly
- [ ] My commit history in this PR is linear
- [ ] New features have tests
- [ ] Breaking change (team conversation required)

## Important

Please do not merge from `main` (please only [rebase](https://github.com/foundry4/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
