### PR TITLE
ci: stop skipping build steps on automatic runs on main branch

### DIFF
--- a/azure-pipelines-build.yml
+++ b/azure-pipelines-build.yml
@@ -81,6 +81,7 @@ extends:
               and(
                 ne(variables['Build.Reason'], 'Manual'),
                 or(
+                  eq(variables['Build.SourceBranchName'], 'main'),
                   eq(dependencies.run_linting_and_tests.outputs['check_files.appeals-api'], 'true'),
                   eq(dependencies.run_linting_and_tests.outputs['check_files.business-rules'], 'true'),
                   eq(dependencies.run_linting_and_tests.outputs['check_files.common'], 'true')
@@ -108,6 +109,7 @@ extends:
               and(
                 ne(variables['Build.Reason'], 'Manual'),
                 or(
+                 eq(variables['Build.SourceBranchName'], 'main'),
                   eq(dependencies.run_linting_and_tests.outputs['check_files.clamav'], 'true'),
                   eq(dependencies.run_linting_and_tests.outputs['check_files.common'], 'true')
                 )
@@ -134,6 +136,7 @@ extends:
               and(
                 ne(variables['Build.Reason'], 'Manual'),
                 or(
+                  eq(variables['Build.SourceBranchName'], 'main'),
                   eq(dependencies.run_linting_and_tests.outputs['check_files.documents-api'], 'true'),
                   eq(dependencies.run_linting_and_tests.outputs['check_files.common'], 'true')
                 )
@@ -159,7 +162,10 @@ extends:
               ),
               and(
                 ne(variables['Build.Reason'], 'Manual'),
-                eq(dependencies.run_linting_and_tests.outputs['check_files.horizon-functions'], 'true')
+                or(
+                  eq(variables['Build.SourceBranchName'], 'main'),
+                  eq(dependencies.run_linting_and_tests.outputs['check_files.horizon-functions'], 'true')
+                )
               )
             )
           )
@@ -181,7 +187,10 @@ extends:
               ),
               and(
                 ne(variables['Build.Reason'], 'Manual'),
-                eq(dependencies.run_linting_and_tests.outputs['check_files.pdf-api'], 'true')
+                or(
+                  eq(variables['Build.SourceBranchName'], 'main'),
+                  eq(dependencies.run_linting_and_tests.outputs['check_files.pdf-api'], 'true')
+                )
               )
             )
           )
@@ -205,6 +214,7 @@ extends:
               and(
                 ne(variables['Build.Reason'], 'Manual'),  
                 or(
+                  eq(variables['Build.SourceBranchName'], 'main'),
                   eq(dependencies.run_linting_and_tests.outputs['check_files.business-rules'], 'true'),
                   eq(dependencies.run_linting_and_tests.outputs['check_files.common'], 'true'),
                   eq(dependencies.run_linting_and_tests.outputs['check_files.web'], 'true')


### PR DESCRIPTION
## Description of change
<!-- Please describe the change -->

Fixes build steps being skipped when `main` branch pipelines were running.

## Checklist
<!-- Put an `x` in all the boxes that apply: -->
- [ ] Requires infrastructure changes
- [ ] If adding or remove environment variables (e.g. in `docker-compose.yaml`) then I have updated the appropriate Helm chart
- [ ] I have updated the documentation accordingly
- [ ] My commit history in this PR is linear
- [ ] New features have tests
- [ ] Breaking change (team conversation required)

## Important

Please do not merge from `main` (please only [rebase](https://github.com/foundry4/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
