### PR TITLE
ci: fix dependency reference in release pipeline

### DIFF
--- a/azure-pipelines-release.yml
+++ b/azure-pipelines-release.yml
@@ -26,7 +26,7 @@ extends:
         condition: eq(dependencies.semantic_release.outputs['run_semantic_release.versions.release'], 'true')
         deploymentJobs:
           - name: Stage Appeals API
-            condition: eq(dependencies.semantic_release.outputs['run_semantic_release.versions.appealsApiRelease'], 'true')
+            condition: eq(stageDependencies.semantic_release.run_semantic_release.outputs['versions.appealsApiRelease'], 'true')
             steps:
               - template: ../steps/azure_web_app_docker_tag.yml
                 parameters:
@@ -45,7 +45,7 @@ extends:
               - name: appealsApiVersion
                 value: $[ stageDependencies.semantic_release.run_semantic_release.outputs['versions.appealsApiVersion'] ]
           - name: Stage ClamAV API
-            condition: eq(dependencies.semantic_release.outputs['run_semantic_release.versions.clamAvApiRelease'], 'true')
+            condition: eq(stageDependencies.semantic_release.run_semantic_release.outputs['versions.clamAvApiVersion'], 'true')
             steps:
               - template: ../steps/azure_web_app_docker_tag.yml
                 parameters:
@@ -64,7 +64,7 @@ extends:
               - name: clamAvApiVersion
                 value: $[ stageDependencies.semantic_release.run_semantic_release.outputs['versions.clamAvApiVersion'] ]
           - name: Stage Documents API
-            condition: eq(dependencies.semantic_release.outputs['run_semantic_release.versions.documentsApiRelease'], 'true')
+            condition: eq(stageDependencies.semantic_release.run_semantic_release.outputs['versions.documentsApiVersion'], 'true')
             steps:
               - template: ../steps/azure_web_app_docker_tag.yml
                 parameters:
@@ -83,7 +83,7 @@ extends:
               - name: documentsApiVersion
                 value: $[ stageDependencies.semantic_release.run_semantic_release.outputs['versions.documentsApiVersion'] ]
           - name: Stage PDF API
-            condition: eq(dependencies.semantic_release.outputs['run_semantic_release.versions.pdfApiRelease'], 'true')
+            condition: eq(stageDependencies.semantic_release.run_semantic_release.outputs['versions.pdfApiVersion'], 'true')
             steps:
               - template: ../steps/azure_web_app_docker_tag.yml
                 parameters:
@@ -102,7 +102,7 @@ extends:
               - name: pdfApiVersion
                 value: $[ stageDependencies.semantic_release.run_semantic_release.outputs['versions.pdfApiVersion'] ]
           - name: Stage Web
-            condition: eq(dependencies.semantic_release.outputs['run_semantic_release.versions.webRelease'], 'true')
+            condition: eq(stageDependencies.semantic_release.run_semantic_release.outputs['versions.webVersion'], 'true')
             steps:
               - template: ../steps/azure_web_app_docker_tag.yml
                 parameters:


### PR DESCRIPTION
## Description of change

- Stop release pipeline skipping deployments as the dependency reference for each job was in the wrong format

## Checklist

<!-- Put an `x` in all the boxes that apply: -->

- [ ] Requires infrastructure changes
- [ ] If adding or remove environment variables (e.g. in `docker-compose.yaml`) then I have updated the appropriate Helm chart
- [ ] I have updated the documentation accordingly
- [ ] My commit history in this PR is linear
- [ ] New features have tests
- [ ] Breaking change (team conversation required)

## Important

Please do not merge from `main` (please only [rebase](https://github.com/foundry4/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
