### PR TITLE
ci: bump templates version and re-enable git tagging on main branch

### DIFF
--- a/azure-pipelines-build.yml
+++ b/azure-pipelines-build.yml
@@ -30,7 +30,7 @@ resources:
       type: github
       endpoint: Planning-Inspectorate
       name: Planning-Inspectorate/common-pipeline-templates
-      ref: refs/tags/release/3.0.3
+      ref: refs/tags/release/3.1.1
 
 extends:
   template: stages/wrapper_ci.yml@templates

--- a/azure-pipelines-deploy.yml
+++ b/azure-pipelines-deploy.yml
@@ -40,7 +40,7 @@ resources:
       type: github
       endpoint: Planning-Inspectorate
       name: Planning-Inspectorate/common-pipeline-templates
-      ref: refs/tags/release/3.0.3
+      ref: refs/tags/release/3.1.1
   pipelines:
     - pipeline: build
       source: Appeals Service Build

--- a/azure-pipelines-e2e-tests.yml
+++ b/azure-pipelines-e2e-tests.yml
@@ -14,7 +14,7 @@ resources:
       type: github
       endpoint: Planning-Inspectorate
       name: Planning-Inspectorate/common-pipeline-templates
-      ref: refs/tags/release/3.1.0
+      ref: refs/tags/release/3.1.1
 variables:
   - group: pipeline_secrets
 

--- a/azure-pipelines-release.yml
+++ b/azure-pipelines-release.yml
@@ -16,7 +16,7 @@ resources:
       type: github
       endpoint: Planning-Inspectorate
       name: Planning-Inspectorate/common-pipeline-templates
-      ref: refs/tags/release/3.0.3
+      ref: refs/tags/release/3.1.1
 
 extends:
   template: stages/wrapper_cd.yml@templates

--- a/azure-pipelines-variables.yml
+++ b/azure-pipelines-variables.yml
@@ -1,3 +1,4 @@
 variables:
   azurecrName: pinscrsharedtoolinguks
   resourceGroup: pins-rg-appeals-service-$(ENVIRONMENT)-$(REGION_SHORT)-001
+  tagPrefix: appeal-planning-decision


### PR DESCRIPTION
## Description of change

- Bump templates to enable git tagging on main branch

## Checklist

<!-- Put an `x` in all the boxes that apply: -->

- [ ] Requires infrastructure changes
- [ ] If adding or remove environment variables (e.g. in `docker-compose.yaml`) then I have updated the appropriate Helm chart
- [ ] I have updated the documentation accordingly
- [ ] My commit history in this PR is linear
- [ ] New features have tests
- [ ] Breaking change (team conversation required)

## Important

Please do not merge from `main` (please only [rebase](https://github.com/foundry4/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
