### PR TITLE
feat(AS-5149): remove email and planning number from HAS cya

### DIFF
--- a/packages/forms-web-app/src/views/appellant-submission/check-answers.njk
+++ b/packages/forms-web-app/src/views/appellant-submission/check-answers.njk
@@ -94,24 +94,6 @@
                 }
               ]
             }
-          },
-          {
-            key: {
-              text: "Your email"
-            },
-            value: {
-              text: summaryField(appeal.aboutYouSection.yourDetails.email, { 'data-cy': "appellant-email" })
-            },
-            actions: {
-              items: [
-                {
-                  href: "/appellant-submission/your-details",
-                  text: "Change",
-                  visuallyHiddenText: "your email",
-                  attributes: { "data-cy": "yourDetailsEmail" }
-                }
-              ]
-            }
           }
         ]
       }) }}
@@ -121,24 +103,6 @@
       {{ govukSummaryList({
         classes: "govuk-summary-list govuk-!-margin-bottom-9",
         rows: [
-          {
-            key: {
-              text: "Planning application number"
-            },
-            value: {
-              text: summaryField(appeal.requiredDocumentsSection.applicationNumber, { 'data-cy': "application-number" })
-            },
-            actions: {
-              items: [
-                {
-                  href: "/appellant-submission/application-number",
-                  text: "Change",
-                  visuallyHiddenText: "Planning application number",
-                  attributes: { "data-cy":"applicationNumber"}
-                }
-              ]
-            }
-          },
           {
             key: {
               text: "Planning application form"


### PR DESCRIPTION
## Ticket Number

<!-- Add the number from the Jira board -->

https://pins-ds.atlassian.net/browse/AS-5149

## Description of change

removing the planning number and email address rows from the CYA page within HAS

## Checklist

<!-- Put an `x` in all the boxes that apply: -->

- [ ] Requires infrastructure changes
- [ ] If adding or remove environment variables (e.g. in `docker-compose.yaml`) then I have updated the appropriate Helm chart
- [ ] I have updated the documentation accordingly
- [ ] My commit history in this PR is linear
- [ ] New features have tests
- [ ] Breaking change (team conversation required)

## Important

Please do not merge from `main` (please only [rebase](https://github.com/foundry4/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
