### PR TITLE
Task/as 4599

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,14 +19,17 @@ services:
       - 3003:3000
 
   clamav-server:
-    image: clamav/clamav
+    image: "clamav/clamav:stable"
     ports:
-      - 3310:3000
-
+      - 3310:3310
+    restart: unless-stopped  
+    
   clamav-rest-server:
     image: node:14-alpine
     ports:
       - 3100:3000
+    depends_on:
+      - clamav-server
     links:
       - clamav-server
     environment:

--- a/packages/clamav-rest-server/src/lib/clamd.js
+++ b/packages/clamav-rest-server/src/lib/clamd.js
@@ -1,3 +1,4 @@
+/* istanbul ignore file */
 const NodeClam = require('clamscan');
 const { Readable } = require('stream');
 const config = require('./config');

--- a/packages/clamav-rest-server/src/lib/clamd.js
+++ b/packages/clamav-rest-server/src/lib/clamd.js
@@ -8,17 +8,46 @@ const sendFile = async (file) => {
 		throw new Error('invalid or empty file');
 	}
 	logger.info('sending file');
-	const client = new NodeClam().init({
+	const ClamScan = new NodeClam().init({
 		removeInfected: true,
 		clamdscan: {
 			host: config.services.clamav.host || 'localhost',
 			port: config.services.clamav.port || 3310,
-			bypass_test: true
+			active: true,
+			bypassRest: false
 		},
 		preference: 'clamdscan'
 	});
-	const readableStream = Readable.from(file.toString());
-	return client.scanStream(readableStream);
+
+	// Get instance by resolving ClamScan promise object
+	ClamScan.then(async (client) => {
+		try {
+			// You can re-use the `clamscan` object as many times as you want
+			const version = await client.getVersion();
+			console.log(`ClamAV Version: ${version}`);
+
+			// const {isInfected, file, viruses} = await client.isInfected('/some/file.zip');
+			// if (isInfected) console.log(`${file} is infected with ${viruses}!`);
+
+			const fileStream = Readable();
+			fileStream.push(file.data);
+			fileStream.push(null);
+
+			return client.scanStream(fileStream);
+
+			// return client.scanStream(Readable.from(file.toString()));
+		} catch (err) {
+			// Handle any errors raised by the code in the try block
+			console.log(err);
+			logger.error(err, 'error calling clamav client');
+			throw err;
+		}
+	}).catch((err) => {
+		// Handle errors that may have occurred during initialization
+		console.log(err);
+		logger.error(err, 'error initializing clamav client');
+		throw err;
+	});
 };
 
 module.exports = {


### PR DESCRIPTION
## Enable CLAMAV for full planning file uploads

https://pins-ds.atlassian.net/browse/AS-4599

## Description of change

There were problems with ClamAV Rest API's docker-compose config and processing file in service code. All file scans are already being done by forms-web-app; I just enabled them to work correctly. I am able to see scans and result on logs.

## Checklist

<!-- Put an `x` in all the boxes that apply: -->

- [x] Requires infrastructure changes
- [ ] If adding or remove environment variables (e.g. in `docker-compose.yaml`) then I have updated the appropriate Helm chart
- [ ] I have updated the documentation accordingly
- [x] My commit history in this PR is linear
- [ ] New features have tests
- [ ] Breaking change (team conversation required)

## Important

Please do not merge from `main` (please only [rebase](https://github.com/foundry4/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
