### PR TITLE
fix(as-5031): `flatMap` can not be used to prepare docs for submissio…

### DIFF
--- a/packages/forms-web-app/src/lib/appeals-api-wrapper.js
+++ b/packages/forms-web-app/src/lib/appeals-api-wrapper.js
@@ -90,8 +90,8 @@ exports.submitAppeal = async (appeal) => {
 
 exports.submitAppealDocumentsToBackOffice = async (appeal) => {
 	const uploadedFiles = [
-		...jp.query(appeal, '$..uploadedFile').flatMap(Infinity),
-	 	...jp.query(appeal, '$..uploadedFiles').flatMap(Infinity)
+		...jp.query(appeal, '$..uploadedFile').flat(Infinity),
+	 	...jp.query(appeal, '$..uploadedFiles').flat(Infinity)
 	];
 
 	const responses = []


### PR DESCRIPTION
…n to BE; use `flat` instead

## Ticket Number

<!-- Add the number from the Jira board -->

https://pins-ds.atlassian.net/browse/AS-

## Description of change

<!-- Please describe the change -->

## Checklist

<!-- Put an `x` in all the boxes that apply: -->

- [ ] Requires infrastructure changes
- [ ] If adding or remove environment variables (e.g. in `docker-compose.yaml`) then I have updated the appropriate Helm chart
- [ ] I have updated the documentation accordingly
- [ ] My commit history in this PR is linear
- [ ] New features have tests
- [ ] Breaking change (team conversation required)

## Important

Please do not merge from `main` (please only [rebase](https://github.com/foundry4/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
