### PR TITLE
fix(as-5721): escape xml characters in document filenames

### DIFF
--- a/packages/appeals-service-api/__tests__/developer/developer.test.js
+++ b/packages/appeals-service-api/__tests__/developer/developer.test.js
@@ -1118,9 +1118,9 @@ describe('Back Office', () => {
 			const createAppealResponse = await _createAppeal(appeal);
 			let createdAppeal = createAppealResponse.body;
 
-			// And: the documents API is mocked and the filename contains an ampersand
+			// And: the documents API is mocked and the filename contains forbidden xml characters
 			const document = jp.query(appeal, '$..uploadedFile')[0];
-			document.name = 'test&pdf.pdf';
+			document.name = `'<>test&"pdf.pdf`;
 			await mockedExternalApis.mockDocumentsApiResponse(200, createdAppeal.id, document, true);
 
 			// And: Horizon's upload documents endpoint is mocked
@@ -1134,8 +1134,8 @@ describe('Back Office', () => {
 			// Then: the status code for the submission request should be 200
 			expect(submittedToBackOfficeResponse.status).toBe(200);
 
-			// And: Horizon has been interacted with as expected, including a sanitised ampersand
-			document.name = 'test&amp;pdf.pdf';
+			// And: Horizon has been interacted with as expected, including xml escape characters
+			document.name = '&apos;&lt;&gt;test&amp;&quot;pdf.pdf';
 			expectedHorizonInteractions = [
 				HorizonInteraction.getCreateDocumentInteraction(appeal.horizonId, document, true)
 			];

--- a/packages/appeals-service-api/src/mappers/horizon-mapper.js
+++ b/packages/appeals-service-api/src/mappers/horizon-mapper.js
@@ -195,8 +195,7 @@ class HorizonMapper {
 			delete document['horizon_document_group_type'];
 		}
 
-		//the special character ampersand (&) is causing issues with documents not arriving in Horizon.
-		let sanitisedDocumentName = document.name.replace('&', '&amp;');
+		let sanitisedDocumentName = this.#escapeXml(document.name);
 
 		return {
 			AddDocuments: {
@@ -519,6 +518,23 @@ class HorizonMapper {
 				'a:Value': `${cleanValue}` // Ensure value a string
 			}
 		};
+	}
+
+	#escapeXml(unsafeString) {
+		return unsafeString.replace(/[<>&'"]/g, (c) => {
+			switch (c) {
+				case '<':
+					return '&lt;';
+				case '>':
+					return '&gt;';
+				case '&':
+					return '&amp;';
+				case "'":
+					return '&apos;';
+				case '"':
+					return '&quot;';
+			}
+		});
 	}
 }
 


### PR DESCRIPTION
## Ticket Number

<!-- Add the number from the Jira board -->

https://pins-ds.atlassian.net/browse/AS-5721

## Description of change

<!-- Please describe the change -->

## Checklist

<!-- Put an `x` in all the boxes that apply: -->

- [ ] Requires infrastructure changes
- [ ] If adding or remove environment variables (e.g. in `docker-compose.yaml`) then I have updated the appropriate Helm chart
- [ ] I have updated the documentation accordingly
- [ ] My commit history in this PR is linear
- [ ] New features have tests
- [ ] Breaking change (team conversation required)

## Important

Please do not merge from `main` (please only [rebase](https://github.com/foundry4/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
