### PR TITLE
feat/as 5693: Increase character limit for all free text fields to 1000 characters

### DIFF
--- a/packages/business-rules/src/schemas/full-appeal/appeal-schema/sections/appeal-site/appeal-site-validation.js
+++ b/packages/business-rules/src/schemas/full-appeal/appeal-schema/sections/appeal-site/appeal-site-validation.js
@@ -59,7 +59,8 @@ const appealSiteValidation = () => {
 							fieldName: 'details',
 							targetFieldName: 'isVisible',
 							emptyError: 'Tell us how visibility is restricted',
-							tooLongError: 'How visibility is restricted must be $maxLength characters or less'
+							tooLongError: 'How visibility is restricted must be $maxLength characters or less',
+							maxLength: 1000
 						});
 					})
 				})
@@ -75,7 +76,8 @@ const appealSiteValidation = () => {
 							targetFieldName: 'hasIssues',
 							targetFieldValue: true,
 							emptyError: 'Tell us about the health and safety issues',
-							tooLongError: 'Health and safety information must be $maxLength characters or less'
+							tooLongError: 'Health and safety information must be $maxLength characters or less',
+							maxLength: 1000
 						});
 					})
 				})

--- a/packages/business-rules/src/schemas/full-appeal/insert.test.js
+++ b/packages/business-rules/src/schemas/full-appeal/insert.test.js
@@ -1673,12 +1673,12 @@ describe('schemas/full-appeal/insert', () => {
 						);
 					});
 
-					it('should throw an error when given a value longer than 255 chars and appealSiteSection.visibleFromRoad.isVisible is false', async () => {
+					it('should throw an error when given a value longer than 1000 chars and appealSiteSection.visibleFromRoad.isVisible is false', async () => {
 						appeal.appealSiteSection.visibleFromRoad.isVisible = false;
-						appeal.appealSiteSection.visibleFromRoad.details = 'a'.repeat(256);
+						appeal.appealSiteSection.visibleFromRoad.details = 'a'.repeat(1001);
 
 						await expect(() => insert.validate(appeal, config)).rejects.toThrow(
-							'How visibility is restricted must be 255 characters or less'
+							'How visibility is restricted must be 1000 characters or less'
 						);
 					});
 
@@ -1742,12 +1742,12 @@ describe('schemas/full-appeal/insert', () => {
 						);
 					});
 
-					it('should throw an error when given a value longer than 255 chars and appealSiteSection.healthAndSafety.hasIssues is true', async () => {
+					it('should throw an error when given a value longer than 1000 chars and appealSiteSection.healthAndSafety.hasIssues is true', async () => {
 						appeal.appealSiteSection.healthAndSafety.hasIssues = true;
-						appeal.appealSiteSection.healthAndSafety.details = 'a'.repeat(256);
+						appeal.appealSiteSection.healthAndSafety.details = 'a'.repeat(1001);
 
 						await expect(() => insert.validate(appeal, config)).rejects.toThrow(
-							'Health and safety information must be 255 characters or less'
+							'Health and safety information must be 1000 characters or less'
 						);
 					});
 

--- a/packages/business-rules/src/schemas/full-appeal/update.js
+++ b/packages/business-rules/src/schemas/full-appeal/update.js
@@ -113,7 +113,8 @@ const update = pinsYup
 						fieldName: 'details',
 						targetFieldName: 'isVisible',
 						emptyError: 'Tell us how visibility is restricted',
-						tooLongError: 'How visibility is restricted must be $maxLength characters or less'
+						tooLongError: 'How visibility is restricted must be $maxLength characters or less',
+						maxLength: 1000
 					});
 				})
 			}),
@@ -126,7 +127,8 @@ const update = pinsYup
 						targetFieldName: 'hasIssues',
 						targetFieldValue: true,
 						emptyError: 'Tell us about the health and safety issues',
-						tooLongError: 'Health and safety information must be $maxLength characters or less'
+						tooLongError: 'Health and safety information must be $maxLength characters or less',
+						maxLength: 1000
 					});
 				})
 			})

--- a/packages/business-rules/src/schemas/full-appeal/update.test.js
+++ b/packages/business-rules/src/schemas/full-appeal/update.test.js
@@ -1610,12 +1610,12 @@ describe('schemas/full-appeal/update', () => {
 						);
 					});
 
-					it('should throw an error when given a value longer than 255 chars and appealSiteSection.visibleFromRoad.isVisible is false', async () => {
+					it('should throw an error when given a value longer than 1000 chars and appealSiteSection.visibleFromRoad.isVisible is false', async () => {
 						appeal.appealSiteSection.visibleFromRoad.isVisible = false;
-						appeal.appealSiteSection.visibleFromRoad.details = 'a'.repeat(256);
+						appeal.appealSiteSection.visibleFromRoad.details = 'a'.repeat(1001);
 
 						await expect(() => update.validate(appeal, config)).rejects.toThrow(
-							'How visibility is restricted must be 255 characters or less'
+							'How visibility is restricted must be 1000 characters or less'
 						);
 					});
 
@@ -1666,12 +1666,12 @@ describe('schemas/full-appeal/update', () => {
 						);
 					});
 
-					it('should throw an error when given a value longer than 255 chars and appealSiteSection.healthAndSafety.hasIssues is true', async () => {
+					it('should throw an error when given a value longer than 1000 chars and appealSiteSection.healthAndSafety.hasIssues is true', async () => {
 						appeal.appealSiteSection.healthAndSafety.hasIssues = true;
-						appeal.appealSiteSection.healthAndSafety.details = 'a'.repeat(256);
+						appeal.appealSiteSection.healthAndSafety.details = 'a'.repeat(1001);
 
 						await expect(() => update.validate(appeal, config)).rejects.toThrow(
-							'Health and safety information must be 255 characters or less'
+							'Health and safety information must be 1000 characters or less'
 						);
 					});
 

--- a/packages/business-rules/src/schemas/full-appeal/update.test.js
+++ b/packages/business-rules/src/schemas/full-appeal/update.test.js
@@ -1728,9 +1728,6 @@ describe('schemas/full-appeal/update', () => {
 					it('should throw an error when given a value with more than 1000 characters', async () => {
 						appeal.appealDecisionSection.hearing.reason = 'a'.repeat(1001);
 
-						console.log('appeal.appealDecisionSection.hearing.reason:');
-						console.log(appeal.appealDecisionSection.hearing.reason);
-
 						await expect(() => update.validate(appeal, config)).rejects.toThrow(
 							'appealDecisionSection.hearing.reason must be at most 1000 characters'
 						);

--- a/packages/business-rules/src/schemas/householder-appeal/appeal-schema/sections/appeal-site/health-and-safety/health-and-safety-validation.js
+++ b/packages/business-rules/src/schemas/householder-appeal/appeal-schema/sections/appeal-site/health-and-safety/health-and-safety-validation.js
@@ -6,7 +6,7 @@ const healthAndSafetyValidation = () => {
 		.object()
 		.shape({
 			hasIssues: booleanValidation(),
-			healthAndSafetyIssues: pinsYup.string().max(255).ensure()
+			healthAndSafetyIssues: pinsYup.string().max(1000).ensure()
 		})
 		.noUnknown(true);
 };

--- a/packages/business-rules/src/schemas/householder-appeal/appeal-schema/sections/appeal-site/site-access/site-access-validation.js
+++ b/packages/business-rules/src/schemas/householder-appeal/appeal-schema/sections/appeal-site/site-access/site-access-validation.js
@@ -6,7 +6,7 @@ const siteAccessValidation = () => {
 		.object()
 		.shape({
 			canInspectorSeeWholeSiteFromPublicRoad: booleanValidation(),
-			howIsSiteAccessRestricted: pinsYup.string().max(255).nullable()
+			howIsSiteAccessRestricted: pinsYup.string().max(1000).nullable()
 		})
 		.noUnknown(true);
 };

--- a/packages/business-rules/src/schemas/householder-appeal/insert.test.js
+++ b/packages/business-rules/src/schemas/householder-appeal/insert.test.js
@@ -869,11 +869,11 @@ describe('schemas/householder-appeal/insert', () => {
 		});
 
 		describe('appealSiteSection.siteAccess.howIsSiteAccessRestricted', () => {
-			it('should throw an error when given a value with more than 255 characters', async () => {
-				appeal.appealSiteSection.siteAccess.howIsSiteAccessRestricted = 'a'.repeat(256);
+			it('should throw an error when given a value with more than 1000 characters', async () => {
+				appeal.appealSiteSection.siteAccess.howIsSiteAccessRestricted = 'a'.repeat(1001);
 
 				await expect(() => insert.validate(appeal, config)).rejects.toThrow(
-					'appealSiteSection.siteAccess.howIsSiteAccessRestricted must be at most 255 characters'
+					'appealSiteSection.siteAccess.howIsSiteAccessRestricted must be at most 1000 characters'
 				);
 			});
 

--- a/packages/business-rules/src/schemas/householder-appeal/insert.test.js
+++ b/packages/business-rules/src/schemas/householder-appeal/insert.test.js
@@ -920,11 +920,11 @@ describe('schemas/householder-appeal/insert', () => {
 		});
 
 		describe('appealSiteSection.healthAndSafety.healthAndSafetyIssues', () => {
-			it('should throw an error when given a value with more than 255 characters', async () => {
-				appeal.appealSiteSection.healthAndSafety.healthAndSafetyIssues = 'a'.repeat(256);
+			it('should throw an error when given a value with more than 1000 characters', async () => {
+				appeal.appealSiteSection.healthAndSafety.healthAndSafetyIssues = 'a'.repeat(1001);
 
 				await expect(() => insert.validate(appeal, config)).rejects.toThrow(
-					'appealSiteSection.healthAndSafety.healthAndSafetyIssues must be at most 255 characters'
+					'appealSiteSection.healthAndSafety.healthAndSafetyIssues must be at most 1000 characters'
 				);
 			});
 

--- a/packages/business-rules/src/schemas/householder-appeal/update.js
+++ b/packages/business-rules/src/schemas/householder-appeal/update.js
@@ -215,7 +215,7 @@ const update = pinsYup
 				.object()
 				.shape({
 					hasIssues: pinsYup.bool().required(),
-					healthAndSafetyIssues: pinsYup.string().max(255).nullable()
+					healthAndSafetyIssues: pinsYup.string().max(1000).nullable()
 				})
 				.noUnknown(true)
 		}),

--- a/packages/business-rules/src/schemas/householder-appeal/update.js
+++ b/packages/business-rules/src/schemas/householder-appeal/update.js
@@ -208,7 +208,7 @@ const update = pinsYup
 				.object()
 				.shape({
 					canInspectorSeeWholeSiteFromPublicRoad: pinsYup.bool().required(),
-					howIsSiteAccessRestricted: pinsYup.string().max(255).nullable()
+					howIsSiteAccessRestricted: pinsYup.string().max(1000).nullable()
 				})
 				.noUnknown(true),
 			healthAndSafety: pinsYup

--- a/packages/business-rules/src/schemas/householder-appeal/update.test.js
+++ b/packages/business-rules/src/schemas/householder-appeal/update.test.js
@@ -1118,11 +1118,11 @@ describe('schemas/householder-appeal/update', () => {
 		});
 
 		describe('appealSiteSection.healthAndSafety.healthAndSafetyIssues', () => {
-			it('should throw an error when given a value with more than 255 characters', async () => {
-				appeal.appealSiteSection.healthAndSafety.healthAndSafetyIssues = 'a'.repeat(256);
+			it('should throw an error when given a value with more than 1000 characters', async () => {
+				appeal.appealSiteSection.healthAndSafety.healthAndSafetyIssues = 'a'.repeat(1001);
 
 				await expect(() => update.validate(appeal, config)).rejects.toThrow(
-					'appealSiteSection.healthAndSafety.healthAndSafetyIssues must be at most 255 characters'
+					'appealSiteSection.healthAndSafety.healthAndSafetyIssues must be at most 1000 characters'
 				);
 			});
 

--- a/packages/business-rules/src/schemas/householder-appeal/update.test.js
+++ b/packages/business-rules/src/schemas/householder-appeal/update.test.js
@@ -1050,11 +1050,11 @@ describe('schemas/householder-appeal/update', () => {
 		});
 
 		describe('appealSiteSection.siteAccess.howIsSiteAccessRestricted', () => {
-			it('should throw an error when given a value with more than 255 characters', async () => {
-				appeal.appealSiteSection.siteAccess.howIsSiteAccessRestricted = 'a'.repeat(256);
+			it('should throw an error when given a value with more than 1000 characters', async () => {
+				appeal.appealSiteSection.siteAccess.howIsSiteAccessRestricted = 'a'.repeat(1001);
 
 				await expect(() => update.validate(appeal, config)).rejects.toThrow(
-					'appealSiteSection.siteAccess.howIsSiteAccessRestricted must be at most 255 characters'
+					'appealSiteSection.siteAccess.howIsSiteAccessRestricted must be at most 1000 characters'
 				);
 			});
 

--- a/packages/forms-web-app/__tests__/unit/routes/full-appeal/submit-appeal/why-hearing.test.js
+++ b/packages/forms-web-app/__tests__/unit/routes/full-appeal/submit-appeal/why-hearing.test.js
@@ -35,8 +35,7 @@ describe('routes/full-appeal/submit-appeal/why-hearing', () => {
 		expect(textfieldValidationRules).toHaveBeenCalledWith({
 			fieldName: 'why-hearing',
 			emptyError: 'Enter why you would prefer a hearing',
-			tooLongError: 'Hearing information must be $maxLength characters or less',
-			maxLength: 1000
+			tooLongError: 'Hearing information must be $maxLength characters or less'
 		});
 	});
 });

--- a/packages/forms-web-app/__tests__/unit/routes/full-appeal/submit-appeal/why-inquiry.test.js
+++ b/packages/forms-web-app/__tests__/unit/routes/full-appeal/submit-appeal/why-inquiry.test.js
@@ -35,8 +35,7 @@ describe('routes/full-appeal/submit-appeal/why-inquiry', () => {
 		expect(textfieldValidationRules).toHaveBeenCalledWith({
 			fieldName: 'why-inquiry',
 			emptyError: 'Enter why you would prefer an inquiry',
-			tooLongError: 'Inquiry information must be $maxLength characters or less',
-			maxLength: 1000
+			tooLongError: 'Inquiry information must be $maxLength characters or less'
 		});
 	});
 });

--- a/packages/forms-web-app/__tests__/unit/validators/appellant-submission/site-access-safety.test.js
+++ b/packages/forms-web-app/__tests__/unit/validators/appellant-submission/site-access-safety.test.js
@@ -117,17 +117,17 @@ describe('validators/appellant-submission/site-access-safety', () => {
 				given: () => ({
 					body: {
 						'site-access-safety': 'yes',
-						'site-access-safety-concerns': 'x'.repeat(256)
+						'site-access-safety-concerns': 'x'.repeat(1001)
 					}
 				}),
 				expected: (result) => {
 					expect(result.errors).toHaveLength(1);
 					expect(result.errors[0].location).toEqual('body');
 					expect(result.errors[0].msg).toEqual(
-						'Health and safety information must be 255 characters or fewer'
+						'Health and safety information must be 1000 characters or fewer'
 					);
 					expect(result.errors[0].param).toEqual('site-access-safety-concerns');
-					expect(result.errors[0].value).toEqual('x'.repeat(256));
+					expect(result.errors[0].value).toEqual('x'.repeat(1001));
 				}
 			},
 			{

--- a/packages/forms-web-app/__tests__/unit/validators/appellant-submission/site-access.test.js
+++ b/packages/forms-web-app/__tests__/unit/validators/appellant-submission/site-access.test.js
@@ -129,7 +129,7 @@ describe('validators/appellant-submission/site-access', () => {
 				given: () => ({
 					body: {
 						'site-access': 'no',
-						'site-access-more-detail': 'x'.repeat(255)
+						'site-access-more-detail': 'x'.repeat(1000)
 					}
 				}),
 				expected: (result) => {
@@ -142,17 +142,17 @@ describe('validators/appellant-submission/site-access', () => {
 				given: () => ({
 					body: {
 						'site-access': 'no',
-						'site-access-more-detail': 'x'.repeat(256)
+						'site-access-more-detail': 'x'.repeat(1001)
 					}
 				}),
 				expected: (result) => {
 					expect(result.errors).toHaveLength(1);
 					expect(result.errors[0].location).toEqual('body');
 					expect(result.errors[0].msg).toEqual(
-						'How access is restricted must be 255 characters or less'
+						'How access is restricted must be 1000 characters or less'
 					);
 					expect(result.errors[0].param).toEqual('site-access-more-detail');
-					expect(result.errors[0].value).toEqual('x'.repeat(256));
+					expect(result.errors[0].value).toEqual('x'.repeat(1001));
 				}
 			}
 		].forEach(({ title, given, expected }) => {

--- a/packages/forms-web-app/__tests__/unit/validators/common/textfield.test.js
+++ b/packages/forms-web-app/__tests__/unit/validators/common/textfield.test.js
@@ -61,7 +61,7 @@ describe('validators/common/textfield', () => {
 		const req = {
 			body: {
 				'visible-from-road': 'yes',
-				'visible-from-road-details': 'a'.repeat(100)
+				'visible-from-road-details': 'a'.repeat(1000)
 			}
 		};
 
@@ -86,7 +86,7 @@ describe('validators/common/textfield', () => {
 		const req = {
 			body: {
 				'visible-from-road': 'yes',
-				'visible-from-road-details': 'a'.repeat(100)
+				'visible-from-road-details': 'a'.repeat(1000)
 			}
 		};
 
@@ -133,7 +133,7 @@ describe('validators/common/textfield', () => {
 	});
 
 	it('should return an error with the default max length and a value longer than the max length is given', async () => {
-		const fieldValue = 'a'.repeat(256);
+		const fieldValue = 'a'.repeat(1001);
 		const req = {
 			body: {
 				'visible-from-road': 'no',
@@ -156,7 +156,7 @@ describe('validators/common/textfield', () => {
 		expect(result.errors).toHaveLength(1);
 		expect(result.errors[0].location).toEqual('body');
 		expect(result.errors[0].msg).toEqual(
-			'How visibility is restricted must be 255 characters or less'
+			'How visibility is restricted must be 1000 characters or less'
 		);
 		expect(result.errors[0].param).toEqual(fieldName);
 		expect(result.errors[0].value).toEqual(fieldValue);

--- a/packages/forms-web-app/src/routes/full-appeal/submit-appeal/why-hearing.js
+++ b/packages/forms-web-app/src/routes/full-appeal/submit-appeal/why-hearing.js
@@ -8,7 +8,6 @@ const { validationErrorHandler } = require('../../../validators/validation-error
 const { rules: textfieldValidationRules } = require('../../../validators/common/textfield');
 
 const router = express.Router();
-const textFieldMaxCharacters = 1000;
 
 router.get('/submit-appeal/why-hearing', [fetchExistingAppealMiddleware], getWhyHearing);
 router.post(
@@ -16,8 +15,7 @@ router.post(
 	textfieldValidationRules({
 		fieldName: 'why-hearing',
 		emptyError: 'Enter why you would prefer a hearing',
-		tooLongError: `Hearing information must be $maxLength characters or less`,
-		maxLength: textFieldMaxCharacters
+		tooLongError: `Hearing information must be $maxLength characters or less`
 	}),
 	validationErrorHandler,
 	postWhyHearing

--- a/packages/forms-web-app/src/routes/full-appeal/submit-appeal/why-inquiry.js
+++ b/packages/forms-web-app/src/routes/full-appeal/submit-appeal/why-inquiry.js
@@ -8,7 +8,6 @@ const { validationErrorHandler } = require('../../../validators/validation-error
 const { rules: textfieldValidationRules } = require('../../../validators/common/textfield');
 
 const router = express.Router();
-const textFieldMaxCharacters = 1000;
 
 router.get('/submit-appeal/why-inquiry', [fetchExistingAppealMiddleware], getWhyInquiry);
 router.post(
@@ -16,8 +15,7 @@ router.post(
 	textfieldValidationRules({
 		fieldName: 'why-inquiry',
 		emptyError: 'Enter why you would prefer an inquiry',
-		tooLongError: 'Inquiry information must be $maxLength characters or less',
-		maxLength: textFieldMaxCharacters
+		tooLongError: 'Inquiry information must be $maxLength characters or less'
 	}),
 	validationErrorHandler,
 	postWhyInquiry

--- a/packages/forms-web-app/src/validators/appellant-submission/site-access-safety.js
+++ b/packages/forms-web-app/src/validators/appellant-submission/site-access-safety.js
@@ -15,8 +15,8 @@ const ruleSiteAccessSafetyConcerns = () =>
 		.notEmpty()
 		.withMessage('Tell us about the health and safety issues')
 		.bail()
-		.isLength({ min: 0, max: 255 })
-		.withMessage('Health and safety information must be 255 characters or fewer');
+		.isLength({ min: 0, max: 1000 })
+		.withMessage('Health and safety information must be 1000 characters or fewer');
 
 const rules = () => [ruleSiteAccessSafety(), ruleSiteAccessSafetyConcerns()];
 

--- a/packages/forms-web-app/src/validators/appellant-submission/site-access.js
+++ b/packages/forms-web-app/src/validators/appellant-submission/site-access.js
@@ -15,8 +15,8 @@ const ruleSiteAccessMoreDetail = () =>
 		.notEmpty()
 		.withMessage('Tell us how access is restricted')
 		.bail()
-		.isLength({ min: 1, max: 255 })
-		.withMessage('How access is restricted must be 255 characters or less');
+		.isLength({ min: 1, max: 1000 })
+		.withMessage('How access is restricted must be 1000 characters or less');
 
 const rules = () => [ruleSiteAccess(), ruleSiteAccessMoreDetail()];
 

--- a/packages/forms-web-app/src/validators/common/textfield.js
+++ b/packages/forms-web-app/src/validators/common/textfield.js
@@ -6,7 +6,7 @@ const rules = ({
 	emptyError,
 	tooLongError,
 	targetFieldValue = 'no',
-	maxLength = 255
+	maxLength = 1000
 }) => {
 	const rule = body(fieldName);
 


### PR DESCRIPTION
## Ticket Number

https://pins-ds.atlassian.net/browse/AS-5693

## Description of change

Increase character limit for all free text fields to 1000 characters

## Checklist

<!-- Put an `x` in all the boxes that apply: -->

- [ ] Requires infrastructure changes
- [ ] If adding or remove environment variables (e.g. in `docker-compose.yaml`) then I have updated the appropriate Helm chart
- [ ] I have updated the documentation accordingly
- [ ] My commit history in this PR is linear
- [ ] New features have tests
- [ ] Breaking change (team conversation required)

## Important

Please do not merge from `main` (please only [rebase](https://github.com/foundry4/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
