### PR TITLE
ci(removed cypress tests from npm ci): npm ci will no longer trigger the cypress tests

### DIFF
--- a/azure-pipelines-e2e-tests.yml
+++ b/azure-pipelines-e2e-tests.yml
@@ -31,10 +31,10 @@ extends:
             environmentVariables:
               CYPRESS_INSTALL_BINARY: 0
           nodeVersion: 14
-          script: make install
+          script: npm run test-cypress:e2e
     postTestRunSteps:
       - template: steps/node_script.yml@templates
         parameters:
           nodeVersion: 14
-          script: npm run test:e2e:postprocess
+          script: npm run test-cypress:e2e:postprocess
     workingDirectory: packages/e2e-tests

--- a/packages/e2e-tests/package.json
+++ b/packages/e2e-tests/package.json
@@ -3,12 +3,12 @@
 	"version": "1.0.0",
 	"description": "E2E tests for appeals and lpa questionnaire",
 	"scripts": {
-		"test:e2e": "cypress run -e TAGS='not @wip'",
-		"test:e2e:demo": "cypress run --headed -b chrome -e TAGS='not @wip',demoDelay=1000",
-		"test:e2e:postprocess": "node ./reporter.js",
-		"test:e2e:files": "./create-large-test-files.sh",
-		"test:e2e:smoke": "cypress run -e",
-		"test:e2e:horizon:script": "cypress run --headed -b chrome --env QUEUE_VALIDATION_ENABLED=false --spec='**/*horizon*.feature'"
+		"test-cypress:e2e": "cypress run -e TAGS='not @wip'",
+		"test-cypress:e2e:demo": "cypress run --headed -b chrome -e TAGS='not @wip',demoDelay=1000",
+		"test-cypress:e2e:postprocess": "node ./reporter.js",
+		"test-cypress:e2e:files": "./create-large-test-files.sh",
+		"test-cypress:e2e:smoke": "cypress run -e",
+		"test-cypress:e2e:horizon:script": "cypress run --headed -b chrome --env QUEUE_VALIDATION_ENABLED=false --spec='**/*horizon*.feature'"
 	},
 	"author": "",
 	"license": "ISC",


### PR DESCRIPTION
Cypress tests have their own pipeline, currently disabled and will no longer run as part of the main build process as their output was being ignored

## Description of change

If we want to trigger the cypress tests we can still do so via azure-pipelines-e2e-tests.yml however this will stop them running as part of the `npm ci` job

## Checklist

<!-- Put an `x` in all the boxes that apply: -->

- [ ] Requires infrastructure changes
- [ ] If adding or remove environment variables (e.g. in `docker-compose.yaml`) then I have updated the appropriate Helm chart
- [ ] I have updated the documentation accordingly
- [ ] My commit history in this PR is linear
- [ ] New features have tests
- [ ] Breaking change (team conversation required)

## Important

Please do not merge from `main` (please only [rebase](https://github.com/foundry4/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
