### PR TITLE
feat(as-5868): add submission of data to database api

### DIFF
--- a/packages/appeals-service-api/__tests__/developer/fixtures/finalComments.js
+++ b/packages/appeals-service-api/__tests__/developer/fixtures/finalComments.js
@@ -1,0 +1,32 @@
+module.exports = class FinalCommentFixtures {
+	static newFinalComment({
+		horizonId = '1234567',
+		state = 'DRAFT',
+		email = 'test@pins.com',
+		finalCommentExpiryDate = '2023-05-01T09:00:00',
+		typeOfUser = 'Appellant'
+	} = {}) {
+		return {
+			horizonId: horizonId,
+			state: state,
+			email: email,
+			finalCommentExpiryDate: finalCommentExpiryDate,
+			finalCommentSubmissionDate: null,
+			secureCodeEnteredCorrectly: null,
+			hasComment: false,
+			doesNotContainSensitiveInformation: true,
+			finalComment: 'Something interesting to say',
+			finalCommentAsDocument: {
+				uploadedFile: {
+					name: 'thefile.pdf',
+					id: null
+				}
+			},
+			hasSupportingDocuments: false,
+			typeOfUser: typeOfUser,
+			supportingDocuments: {
+				uploadedFiles: []
+			}
+		};
+	}
+};

--- a/packages/appeals-service-api/src/errors/apiError.js
+++ b/packages/appeals-service-api/src/errors/apiError.js
@@ -24,6 +24,18 @@ class ApiError {
 	static appealAlreadySubmitted() {
 		return new ApiError(409, { errors: ['Cannot update appeal that is already SUBMITTED'] });
 	}
+
+	static finalCommentAlreadySubmitted() {
+		return new ApiError(409, { errors: [`Cannot submit more than one final comment per email`] });
+	}
+
+	static finalCommentHasExpired() {
+		return new ApiError(409, { errors: ['Final comment submission window is closed'] });
+	}
+
+	static finalCommentsNotFound() {
+		return new ApiError(404, { errors: [`The final comments were not found`] });
+	}
 }
 
 module.exports = ApiError;

--- a/packages/appeals-service-api/src/repositories/final-comments-repository.js
+++ b/packages/appeals-service-api/src/repositories/final-comments-repository.js
@@ -4,7 +4,6 @@ const { FinalCommentsAggregate } = require('../models/aggregates/final-comments-
 const { MongoRepository } = require('./mongo-repository');
 
 class FinalCommentsRepository extends MongoRepository {
-
 	#finalCommentsMapper = new FinalCommentsMapper();
 
 	constructor() {
@@ -12,16 +11,27 @@ class FinalCommentsRepository extends MongoRepository {
 	}
 
 	/**
-	 * 
+	 *
 	 * @param {string} caseReference
 	 * @return {Promise<FinalCommentsAggregate | null>}
 	 */
 	async getByCaseReference(caseReference) {
 		const finalCommentFoundJson = await this.findOneByQuery({ caseReference: caseReference });
 		if (finalCommentFoundJson) {
-            return this.#finalCommentsMapper.fromJson(finalCommentFoundJson);
+			return this.#finalCommentsMapper.fromJson(finalCommentFoundJson);
+		}
+	}
+
+	async getAllFinalCommentsByCaseReference(horizonId) {
+		const finalCommentsFound = await this.getAllDocumentsThatMatchQuery({
+			'finalComment.horizonId': horizonId
+		});
+		if (finalCommentsFound) {
+			return finalCommentsFound;
+		} else {
+			return false;
 		}
 	}
 }
 
-module.exports = { FinalCommentsRepository}
+module.exports = { FinalCommentsRepository };

--- a/packages/appeals-service-api/src/repositories/mongo-repository.js
+++ b/packages/appeals-service-api/src/repositories/mongo-repository.js
@@ -38,6 +38,10 @@ class MongoRepository {
 		return await mongodb.get().collection(this.collectionName).find().toArray();
 	}
 
+	async getAllDocumentsThatMatchQuery(query) {
+		return await mongodb.get().collection(this.collectionName).find(query).toArray();
+	}
+
 	/**
 	 *
 	 * @param {any[]} updateOneOperations Mongo JSON structures that represent update operations. Their

--- a/packages/appeals-service-api/src/routes/index.js
+++ b/packages/appeals-service-api/src/routes/index.js
@@ -16,7 +16,6 @@ const localPlanningAuthoritiesRouter = require('./local-planning-authorities');
 const apiDocsRouter = require('./api-docs');
 const confirmEmailRouter = require('./confirm-email');
 const finalCommentsRouter = require('./final-comments');
-const { isFeatureActive } = require('../configuration/featureFlag');
 
 router.use('/api/v1/appeals', appealsRouter);
 router.use('/api/v1/back-office', backOfficeRouter);
@@ -26,18 +25,6 @@ router.use('/api-docs', apiDocsRouter);
 router.use('/api/v1/save', saveRouter);
 router.use('/api/v1/token', tokenRouter);
 router.use('/api/v1/confirm-email', confirmEmailRouter);
-router.use(
-	'/api/v1/final_comments',
-	(req, res, next) => {
-		if (isFeatureActive('as-5408-final-comments', req.headers['local-planning-authority-code'])) {
-			next();
-		} else {
-			res
-				.status(400)
-				.send({ error: 'This feature is not active for your local planning authority.' });
-		}
-	},
-	finalCommentsRouter
-);
+router.use('/api/v1/final-comments', finalCommentsRouter);
 
 module.exports = router;


### PR DESCRIPTION
this has been future proofed to allow not-only appellants to submit final comments but also any other usertype as required. The code does a scan of the database to check if any final comments exist for a certain horizonId (note this should possibly be renamed??), if one or more exists it checks if any of them have the same email as the one being submitted. If there is then it rejects submission with a 409 conflict, otherwise it submits the data to the appeals beta's database. This is is then ready for submission to horizon/the backend

#as-5788

## Ticket Number

<!-- Add the number from the Jira board -->

https://pins-ds.atlassian.net/browse/AS-5868

## Description of change

<!-- Please describe the change -->

## Checklist

<!-- Put an `x` in all the boxes that apply: -->

- [ ] Requires infrastructure changes
- [ ] If adding or remove environment variables (e.g. in `docker-compose.yaml`) then I have updated the appropriate Helm chart
- [ ] I have updated the documentation accordingly
- [ ] My commit history in this PR is linear
- [ ] New features have tests
- [ ] Breaking change (team conversation required)

## Important

Please do not merge from `main` (please only [rebase](https://github.com/foundry4/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
