### PR TITLE
fix: set google tag manager default consent setting

### DIFF
--- a/packages/forms-web-app/__tests__/unit/lib/client-side/javascript-requiring-consent.test.js
+++ b/packages/forms-web-app/__tests__/unit/lib/client-side/javascript-requiring-consent.test.js
@@ -4,9 +4,11 @@ const {
 
 const { readCookie } = require('../../../../src/lib/client-side/cookie/cookie-jar');
 const { initialiseGoogleAnalytics } = require('../../../../src/lib/client-side/google-analytics');
+const googleTagManager = require('../../../../src/lib/client-side/google-tag-manager');
 
 jest.mock('../../../../src/lib/client-side/cookie/cookie-jar');
 jest.mock('../../../../src/lib/client-side/google-analytics');
+jest.mock('../../../../src/lib/client-side/google-tag-manager');
 
 describe('lib/client-side/javascript-requiring-consent', () => {
 	describe('initialiseOptionalJavaScripts', () => {
@@ -21,6 +23,7 @@ describe('lib/client-side/javascript-requiring-consent', () => {
 			expect(console.log).toHaveBeenCalledWith('Consent not yet given for optional JavaScripts.');
 
 			expect(initialiseGoogleAnalytics).not.toHaveBeenCalled();
+			expect(googleTagManager.grantConsent).not.toHaveBeenCalled();
 		});
 
 		test('return early if `usage` is not defined', () => {
@@ -31,29 +34,90 @@ describe('lib/client-side/javascript-requiring-consent', () => {
 			initialiseOptionalJavaScripts();
 
 			expect(initialiseGoogleAnalytics).not.toHaveBeenCalled();
+			expect(googleTagManager.grantConsent).not.toHaveBeenCalled();
 		});
 
-		test('return early if `usage=false`', () => {
-			jest.spyOn(console, 'log').mockImplementation();
+		describe('tagmanager active', () => {
+			const OLD_ENV = process.env;
 
-			readCookie.mockImplementation(() => JSON.stringify({ usage: false }));
+			beforeEach(() => {
+				jest.resetModules();
+				jest.resetAllMocks();
+				process.env = OLD_ENV;
+				process.env = { ...OLD_ENV, googleTagManager: true };
+			});
 
-			initialiseOptionalJavaScripts();
+			afterEach(() => {
+				process.env = OLD_ENV;
+			});
 
-			// eslint-disable-next-line no-console
-			expect(console.log).toHaveBeenCalledWith(
-				'Declined consent. Third party cookies are not enabled.'
-			);
+			test('disables consent if `usage=false`', () => {
+				process.env.googleTagManagerId = '123';
 
-			expect(initialiseGoogleAnalytics).not.toHaveBeenCalled();
+				jest.spyOn(console, 'log').mockImplementation();
+
+				readCookie.mockImplementation(() => JSON.stringify({ usage: false }));
+
+				initialiseOptionalJavaScripts();
+
+				expect(googleTagManager.denyConsent).toHaveBeenCalled();
+				expect(initialiseGoogleAnalytics).not.toHaveBeenCalled();
+			});
+
+			test('enables consent if `usage=true`', () => {
+				process.env.googleTagManagerId = '123';
+
+				readCookie.mockImplementation(() => JSON.stringify({ usage: true }));
+
+				initialiseOptionalJavaScripts();
+
+				expect(googleTagManager.grantConsent).toHaveBeenCalled();
+				expect(initialiseGoogleAnalytics).not.toHaveBeenCalled();
+			});
+
+			test('does not enable consent if no tag manager id present', () => {
+				readCookie.mockImplementation(() => JSON.stringify({ usage: true }));
+
+				initialiseOptionalJavaScripts();
+
+				expect(googleTagManager.grantConsent).not.toHaveBeenCalled();
+				expect(initialiseGoogleAnalytics).not.toHaveBeenCalled();
+			});
 		});
 
-		test('calls through if `usage=true`', () => {
-			readCookie.mockImplementation(() => JSON.stringify({ usage: true }));
+		describe('tagmanager inactive', () => {
+			const OLD_ENV = process.env;
 
-			initialiseOptionalJavaScripts();
+			beforeEach(() => {
+				jest.resetModules();
+				jest.resetAllMocks();
+				process.env = OLD_ENV;
+				process.env = { ...OLD_ENV, googleTagManager: false };
+			});
 
-			expect(initialiseGoogleAnalytics).toHaveBeenCalled();
+			afterEach(() => {
+				process.env = OLD_ENV;
+			});
+
+			test('return early if `usage=false`', () => {
+				jest.spyOn(console, 'log').mockImplementation();
+
+				readCookie.mockImplementation(() => JSON.stringify({ usage: false }));
+
+				initialiseOptionalJavaScripts();
+
+				expect(googleTagManager.grantConsent).not.toHaveBeenCalled();
+				expect(initialiseGoogleAnalytics).not.toHaveBeenCalled();
+			});
+
+			test('calls through if `usage=true`', () => {
+				readCookie.mockImplementation(() => JSON.stringify({ usage: true }));
+
+				initialiseOptionalJavaScripts();
+
+				expect(googleTagManager.grantConsent).not.toHaveBeenCalled();
+				expect(initialiseGoogleAnalytics).toHaveBeenCalled();
+			});
 		});
 	});
 });

--- a/packages/forms-web-app/__tests__/unit/views/includes/__snapshots__/head.njk.test.js.snap
+++ b/packages/forms-web-app/__tests__/unit/views/includes/__snapshots__/head.njk.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`views/includes/head Google Analytics section should not render if googleAnalyticsId and cookies.cookie_policy.usage are not set 1`] = `
+exports[`views/includes/head should not render if googleAnalyticsId is not set but cookies.cookie_policy.usage is set 1`] = `
 "
 
   <!--[if lte IE 8]><link href=\\"/public/stylesheets/main-ie8.css\\" rel=\\"stylesheet\\" type=\\"text/css\\" /><![endif]-->
@@ -18,7 +18,41 @@ exports[`views/includes/head Google Analytics section should not render if googl
 "
 `;
 
-exports[`views/includes/head Google Analytics section should not render if googleAnalyticsId is not set but cookies.cookie_policy.usage is set 1`] = `
+exports[`views/includes/head should not render if googleAnalyticsId is set but cookies.cookie_policy.usage is not set 1`] = `
+"
+
+  <!--[if lte IE 8]><link href=\\"/public/stylesheets/main-ie8.css\\" rel=\\"stylesheet\\" type=\\"text/css\\" /><![endif]-->
+  <!--[if gt IE 8]><!--><link href=\\"/public/stylesheets/main.css\\" media=\\"all\\" rel=\\"stylesheet\\" type=\\"text/css\\" /><!--<![endif]-->
+
+  
+    <script id=\\"gaId\\" type='text/plain'>123</script>
+
+    
+  
+
+  <script src=\\"/public/javascripts/index.bundle.js\\" defer></script>
+
+
+"
+`;
+
+exports[`views/includes/head should not render if googleTagManager and GA are set 1`] = `
+"
+
+  <!--[if lte IE 8]><link href=\\"/public/stylesheets/main-ie8.css\\" rel=\\"stylesheet\\" type=\\"text/css\\" /><![endif]-->
+  <!--[if gt IE 8]><!--><link href=\\"/public/stylesheets/main.css\\" media=\\"all\\" rel=\\"stylesheet\\" type=\\"text/css\\" /><!--<![endif]-->
+
+  
+    
+  
+
+  <script src=\\"/public/javascripts/index.bundle.js\\" defer></script>
+
+
+"
+`;
+
+exports[`views/includes/head should not render if no ids set 1`] = `
 "
 
   <!--[if lte IE 8]><link href=\\"/public/stylesheets/main-ie8.css\\" rel=\\"stylesheet\\" type=\\"text/css\\" /><![endif]-->
@@ -36,15 +70,13 @@ exports[`views/includes/head Google Analytics section should not render if googl
 "
 `;
 
-exports[`views/includes/head Google Analytics section should not render if googleAnalyticsId is set but cookies.cookie_policy.usage is not set 1`] = `
+exports[`views/includes/head should not render if only tagmanager set 1`] = `
 "
 
   <!--[if lte IE 8]><link href=\\"/public/stylesheets/main-ie8.css\\" rel=\\"stylesheet\\" type=\\"text/css\\" /><![endif]-->
   <!--[if gt IE 8]><!--><link href=\\"/public/stylesheets/main.css\\" media=\\"all\\" rel=\\"stylesheet\\" type=\\"text/css\\" /><!--<![endif]-->
 
   
-    <script id=\\"gaId\\" type='text/plain'>123</script>
-
     
   
 
@@ -54,35 +86,7 @@ exports[`views/includes/head Google Analytics section should not render if googl
 "
 `;
 
-exports[`views/includes/head Google Analytics section should render if googleAnalyticsId and cookies.cookie_policy.usage are set 1`] = `
-"
-
-  <!--[if lte IE 8]><link href=\\"/public/stylesheets/main-ie8.css\\" rel=\\"stylesheet\\" type=\\"text/css\\" /><![endif]-->
-  <!--[if gt IE 8]><!--><link href=\\"/public/stylesheets/main.css\\" media=\\"all\\" rel=\\"stylesheet\\" type=\\"text/css\\" /><!--<![endif]-->
-
-  
-    <script id=\\"gaId\\" type='text/plain'>123</script>
-
-    
-      <!-- Global site tag (gtag.js) - Google Analytics -->
-      
-      <script>
-        window.dataLayer = window.dataLayer || [];
-        function gtag(){dataLayer.push(arguments);}
-        gtag('js', new Date());
-
-        gtag('config', '123');
-      </script>
-    
-  
-
-  <script src=\\"/public/javascripts/index.bundle.js\\" defer></script>
-
-
-"
-`;
-
-exports[`views/includes/head Google Tag Manager section should not render if featureFlag.googleTagManager and googleTagManagerId are not set 1`] = `
+exports[`views/includes/head should render if googleAnalyticsId and cookies.cookie_policy.usage are set 1`] = `
 "
 
   <!--[if lte IE 8]><link href=\\"/public/stylesheets/main-ie8.css\\" rel=\\"stylesheet\\" type=\\"text/css\\" /><![endif]-->
@@ -110,64 +114,60 @@ exports[`views/includes/head Google Tag Manager section should not render if fea
 "
 `;
 
-exports[`views/includes/head Google Tag Manager section should not render if featureFlag.googleTagManager is not set but googleTagManagerId is set 1`] = `
+exports[`views/includes/head should render tagmanager if all are set 1`] = `
 "
 
   <!--[if lte IE 8]><link href=\\"/public/stylesheets/main-ie8.css\\" rel=\\"stylesheet\\" type=\\"text/css\\" /><![endif]-->
   <!--[if gt IE 8]><!--><link href=\\"/public/stylesheets/main.css\\" media=\\"all\\" rel=\\"stylesheet\\" type=\\"text/css\\" /><!--<![endif]-->
 
   
-    <script id=\\"gaId\\" type='text/plain'>123</script>
-
     
-      <!-- Global site tag (gtag.js) - Google Analytics -->
-      
       <script>
+        // default deined for tag manager
         window.dataLayer = window.dataLayer || [];
         function gtag(){dataLayer.push(arguments);}
-        gtag('js', new Date());
-
-        gtag('config', '123');
+        gtag('consent', 'default', {
+          'analytics_storage': 'denied'
+        });
       </script>
-    
-  
-
-  <script src=\\"/public/javascripts/index.bundle.js\\" defer></script>
-
-
-"
-`;
-
-exports[`views/includes/head Google Tag Manager section should not render if featureFlag.googleTagManager is set but googleTagManagerId is not set 1`] = `
-"
-
-  <!--[if lte IE 8]><link href=\\"/public/stylesheets/main-ie8.css\\" rel=\\"stylesheet\\" type=\\"text/css\\" /><![endif]-->
-  <!--[if gt IE 8]><!--><link href=\\"/public/stylesheets/main.css\\" media=\\"all\\" rel=\\"stylesheet\\" type=\\"text/css\\" /><!--<![endif]-->
-
-  
-    
-  
-
-  <script src=\\"/public/javascripts/index.bundle.js\\" defer></script>
-
-
-"
-`;
-
-exports[`views/includes/head Google Tag Manager section should render if featureFlag.googleTagManager and googleTagManagerId are set 1`] = `
-"
-
-  <!--[if lte IE 8]><link href=\\"/public/stylesheets/main-ie8.css\\" rel=\\"stylesheet\\" type=\\"text/css\\" /><![endif]-->
-  <!--[if gt IE 8]><!--><link href=\\"/public/stylesheets/main.css\\" media=\\"all\\" rel=\\"stylesheet\\" type=\\"text/css\\" /><!--<![endif]-->
-
-  
-    
       <!-- Google Tag Manager -->
       <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
       new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
       j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
       'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-      })(window,document,'script','dataLayer','456');</script>
+      })(window,document,'script','dataLayer','123');</script>
+      <!-- End Google Tag Manager -->
+    
+  
+
+  <script src=\\"/public/javascripts/index.bundle.js\\" defer></script>
+
+
+"
+`;
+
+exports[`views/includes/head should render tagmanager if tagmanager and id are set 1`] = `
+"
+
+  <!--[if lte IE 8]><link href=\\"/public/stylesheets/main-ie8.css\\" rel=\\"stylesheet\\" type=\\"text/css\\" /><![endif]-->
+  <!--[if gt IE 8]><!--><link href=\\"/public/stylesheets/main.css\\" media=\\"all\\" rel=\\"stylesheet\\" type=\\"text/css\\" /><!--<![endif]-->
+
+  
+    
+      <script>
+        // default deined for tag manager
+        window.dataLayer = window.dataLayer || [];
+        function gtag(){dataLayer.push(arguments);}
+        gtag('consent', 'default', {
+          'analytics_storage': 'denied'
+        });
+      </script>
+      <!-- Google Tag Manager -->
+      <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+      new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+      j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+      'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+      })(window,document,'script','dataLayer','123');</script>
       <!-- End Google Tag Manager -->
     
   

--- a/packages/forms-web-app/__tests__/unit/views/includes/head.njk.test.js
+++ b/packages/forms-web-app/__tests__/unit/views/includes/head.njk.test.js
@@ -4,55 +4,54 @@ const { deleteGlobalVars, matchesSnapshot } = require('../nunjucks-helper-functi
 describe('views/includes/head', () => {
 	const includePath = '{% include "includes/head.njk" %}';
 
-	describe('Google Analytics section', () => {
-		beforeEach(() => {
-			deleteGlobalVars(['cookies', 'googleAnalyticsId']);
-		});
-
-		it(`should not render if googleAnalyticsId and cookies.cookie_policy.usage are not set`, () => {
-			matchesSnapshot(includePath);
-		});
-
-		it(`should not render if googleAnalyticsId is set but cookies.cookie_policy.usage is not set`, () => {
-			nunjucksTestRenderer.addGlobal('googleAnalyticsId', 123);
-			matchesSnapshot(includePath);
-		});
-
-		it(`should not render if googleAnalyticsId is not set but cookies.cookie_policy.usage is set`, () => {
-			nunjucksTestRenderer.addGlobal('cookies', { cookie_policy: { usage: true } });
-			matchesSnapshot(includePath);
-		});
-
-		it(`should render if googleAnalyticsId and cookies.cookie_policy.usage are set`, () => {
-			nunjucksTestRenderer.addGlobal('googleAnalyticsId', 123);
-			nunjucksTestRenderer.addGlobal('cookies', { cookie_policy: { usage: true } });
-			matchesSnapshot(includePath);
-		});
+	beforeEach(() => {
+		deleteGlobalVars(['cookies', 'featureFlag', 'googleAnalyticsId', 'googleTagManagerId']);
 	});
 
-	describe('Google Tag Manager section', () => {
-		beforeEach(() => {
-			deleteGlobalVars(['featureFlag', 'googleTagManagerId']);
-		});
+	it(`should not render if no ids set`, () => {
+		matchesSnapshot(includePath);
+	});
 
-		it(`should not render if featureFlag.googleTagManager and googleTagManagerId are not set`, () => {
-			matchesSnapshot(includePath);
-		});
+	it(`should not render if googleAnalyticsId is set but cookies.cookie_policy.usage is not set`, () => {
+		nunjucksTestRenderer.addGlobal('googleAnalyticsId', 123);
+		matchesSnapshot(includePath);
+	});
 
-		it(`should not render if featureFlag.googleTagManager is set but googleTagManagerId is not set`, () => {
-			nunjucksTestRenderer.addGlobal('featureFlag', { googleTagManager: true });
-			matchesSnapshot(includePath);
-		});
+	it(`should not render if googleAnalyticsId is not set but cookies.cookie_policy.usage is set`, () => {
+		nunjucksTestRenderer.addGlobal('cookies', { cookie_policy: { usage: true } });
+		matchesSnapshot(includePath);
+	});
 
-		it(`should not render if featureFlag.googleTagManager is not set but googleTagManagerId is set`, () => {
-			nunjucksTestRenderer.addGlobal('googleTagManagerId', 456);
-			matchesSnapshot(includePath);
-		});
+	it(`should render if googleAnalyticsId and cookies.cookie_policy.usage are set`, () => {
+		nunjucksTestRenderer.addGlobal('googleAnalyticsId', 123);
+		nunjucksTestRenderer.addGlobal('cookies', { cookie_policy: { usage: true } });
+		matchesSnapshot(includePath);
+	});
 
-		it(`should render if featureFlag.googleTagManager and googleTagManagerId are set`, () => {
-			nunjucksTestRenderer.addGlobal('googleTagManagerId', 456);
-			nunjucksTestRenderer.addGlobal('featureFlag', { googleTagManager: true });
-			matchesSnapshot(includePath);
-		});
+	it(`should not render if only tagmanager set`, () => {
+		nunjucksTestRenderer.addGlobal('featureFlag', { googleTagManager: true });
+		matchesSnapshot(includePath);
+	});
+
+	it(`should not render if googleTagManager and GA are set`, () => {
+		nunjucksTestRenderer.addGlobal('featureFlag', { googleTagManager: true });
+		nunjucksTestRenderer.addGlobal('googleAnalyticsId', 456);
+		nunjucksTestRenderer.addGlobal('cookies', { cookie_policy: { usage: true } });
+		matchesSnapshot(includePath);
+	});
+
+	it(`should render tagmanager if tagmanager and id are set`, () => {
+		nunjucksTestRenderer.addGlobal('featureFlag', { googleTagManager: true });
+		nunjucksTestRenderer.addGlobal('googleTagManagerId', 123);
+		matchesSnapshot(includePath);
+	});
+
+	it(`should render tagmanager if all are set`, () => {
+		nunjucksTestRenderer.addGlobal('featureFlag', { googleTagManager: true });
+		nunjucksTestRenderer.addGlobal('googleTagManagerId', 123);
+		nunjucksTestRenderer.addGlobal('googleAnalyticsId', 456);
+		nunjucksTestRenderer.addGlobal('cookies', { cookie_policy: { usage: true } });
+
+		matchesSnapshot(includePath);
 	});
 });

--- a/packages/forms-web-app/src/lib/client-side/javascript-requiring-consent.js
+++ b/packages/forms-web-app/src/lib/client-side/javascript-requiring-consent.js
@@ -6,6 +6,23 @@ const cookieConfig = require('./cookie/cookie-config');
 const { initialiseGoogleAnalytics } = require('./google-analytics');
 const googleTagManager = require('./google-tag-manager');
 
+function initialiseTagManager(consent) {
+	if (!process.env.googleTagManagerId) {
+		return;
+	}
+
+	if (consent === true) {
+		// eslint-disable-next-line no-console
+		console.log('Consent granted. Third party cookies are enabled.');
+		googleTagManager.grantConsent();
+		return;
+	}
+
+	// eslint-disable-next-line no-console
+	console.log('Declined consent. Third party cookies are not enabled.');
+	googleTagManager.denyConsent();
+}
+
 const initialiseOptionalJavaScripts = (document) => {
 	const cookie = readCookie(document, cookieConfig.COOKIE_POLICY_KEY);
 
@@ -22,19 +39,14 @@ const initialiseOptionalJavaScripts = (document) => {
 			return;
 		}
 
-		if (parsed.usage === false) {
-			// eslint-disable-next-line no-console
-			console.log('Declined consent. Third party cookies are not enabled.');
-
-			if (process.env.googleTagManager && process.env.googleTagManagerId) {
-				googleTagManager.denyConsent();
-			}
+		// using tag manager
+		if (process.env.googleTagManager) {
+			initialiseTagManager(parsed.usage);
 			return;
 		}
 
-		if (process.env.googleTagManager && process.env.googleTagManagerId) {
-			googleTagManager.grantConsent();
-		} else {
+		// not using tag manager
+		if (parsed.usage === true) {
 			initialiseGoogleAnalytics(document);
 		}
 	} catch (e) {

--- a/packages/forms-web-app/src/views/includes/head.njk
+++ b/packages/forms-web-app/src/views/includes/head.njk
@@ -5,6 +5,14 @@
 
   {% if featureFlag.googleTagManager %}
     {% if googleTagManagerId %}
+      <script>
+        // default deined for tag manager
+        window.dataLayer = window.dataLayer || [];
+        function gtag(){dataLayer.push(arguments);}
+        gtag('consent', 'default', {
+          'analytics_storage': 'denied'
+        });
+      </script>
       <!-- Google Tag Manager -->
       <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
       new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],

--- a/packages/forms-web-app/webpack.common.js
+++ b/packages/forms-web-app/webpack.common.js
@@ -13,7 +13,8 @@ module.exports = {
 	plugins: [
 		new webpack.DefinePlugin({
 			'process.env.googleAnalyticsId': JSON.stringify(process.env.GOOGLE_ANALYTICS_ID),
-			'process.env.googleTagManager': process.env.FEATURE_FLAG_GOOGLE_TAG_MANAGER === 'true'
+			'process.env.googleTagManager': process.env.FEATURE_FLAG_GOOGLE_TAG_MANAGER === 'true',
+			'process.env.googleTagManagerId': JSON.stringify(process.env.GOOGLE_TAG_MANAGER_ID)
 		})
 	]
 };


### PR DESCRIPTION
## Ticket Number

<!-- Add the number from the Jira board -->

https://pins-ds.atlassian.net/browse/AS-5870

## Description of change

Google tag manager needs a default cookie consent value set before the script is run, this has been added to head.njk

The js that sets consent then needs to have access to the gtm id so that has been passed through in compilation using webpack.

javascript-requiring-consent.js is refactored with the intention of having a clearer distinction of what occurs when the feature flag is toggled

## Checklist

<!-- Put an `x` in all the boxes that apply: -->

- [ ] Requires infrastructure changes
- [ ] If adding or remove environment variables (e.g. in `docker-compose.yaml`) then I have updated the appropriate Helm chart
- [ ] I have updated the documentation accordingly
- [x] My commit history in this PR is linear
- [ ] New features have tests
- [ ] Breaking change (team conversation required)

## Important

Please do not merge from `main` (please only [rebase](https://github.com/foundry4/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
