### PR TITLE
fix: require consent js fixed to use env vars from server side using …

### DIFF
--- a/packages/forms-web-app/__tests__/unit/lib/client-side/javascript-requiring-consent.test.js
+++ b/packages/forms-web-app/__tests__/unit/lib/client-side/javascript-requiring-consent.test.js
@@ -1,3 +1,6 @@
+/**
+ * @jest-environment jsdom
+ */
 const {
 	initialiseOptionalJavaScripts
 } = require('../../../../src/lib/client-side/javascript-requiring-consent');
@@ -12,6 +15,10 @@ jest.mock('../../../../src/lib/client-side/google-tag-manager');
 
 describe('lib/client-side/javascript-requiring-consent', () => {
 	describe('initialiseOptionalJavaScripts', () => {
+		beforeEach(() => {
+			window.wfeconfig = {};
+		});
+
 		test('return early if cookie is null', () => {
 			jest.spyOn(console, 'log').mockImplementation();
 
@@ -38,20 +45,14 @@ describe('lib/client-side/javascript-requiring-consent', () => {
 		});
 
 		describe('tagmanager active', () => {
-			const OLD_ENV = process.env;
-
 			beforeEach(() => {
-				jest.resetModules();
-				jest.resetAllMocks();
-				process.env = { ...OLD_ENV, googleTagManager: true };
-			});
-
-			afterEach(() => {
-				process.env = OLD_ENV;
+				window.wfeconfig = {
+					googleTagManager: true
+				};
 			});
 
 			test('disables consent if `usage=false`', () => {
-				process.env.googleTagManagerId = '123';
+				window.wfeconfig.googleTagManagerId = '123';
 
 				jest.spyOn(console, 'log').mockImplementation();
 
@@ -64,7 +65,7 @@ describe('lib/client-side/javascript-requiring-consent', () => {
 			});
 
 			test('enables consent if `usage=true`', () => {
-				process.env.googleTagManagerId = '123';
+				window.wfeconfig.googleTagManagerId = '123';
 
 				readCookie.mockImplementation(() => JSON.stringify({ usage: true }));
 
@@ -75,6 +76,8 @@ describe('lib/client-side/javascript-requiring-consent', () => {
 			});
 
 			test('does not enable consent if no tag manager id present', () => {
+				window.wfeconfig.googleTagManagerId = undefined;
+
 				readCookie.mockImplementation(() => JSON.stringify({ usage: true }));
 
 				initialiseOptionalJavaScripts();
@@ -85,16 +88,10 @@ describe('lib/client-side/javascript-requiring-consent', () => {
 		});
 
 		describe('tagmanager inactive', () => {
-			const OLD_ENV = process.env;
-
 			beforeEach(() => {
-				jest.resetModules();
-				jest.resetAllMocks();
-				process.env = { ...OLD_ENV, googleTagManager: false };
-			});
-
-			afterEach(() => {
-				process.env = OLD_ENV;
+				window.wfeconfig = {
+					googleTagManager: false
+				};
 			});
 
 			test('return early if `usage=false`', () => {

--- a/packages/forms-web-app/__tests__/unit/views/includes/__snapshots__/head.njk.test.js.snap
+++ b/packages/forms-web-app/__tests__/unit/views/includes/__snapshots__/head.njk.test.js.snap
@@ -6,6 +6,9 @@ exports[`views/includes/head should not render if googleAnalyticsId is not set b
   <!--[if lte IE 8]><link href=\\"/public/stylesheets/main-ie8.css\\" rel=\\"stylesheet\\" type=\\"text/css\\" /><![endif]-->
   <!--[if gt IE 8]><!--><link href=\\"/public/stylesheets/main.css\\" media=\\"all\\" rel=\\"stylesheet\\" type=\\"text/css\\" /><!--<![endif]-->
 
+  <script>
+      window.wfeconfig = window.wfeconfig || {};
+  </script>
   
     <script id=\\"gaId\\" type='text/plain'></script>
 
@@ -24,6 +27,9 @@ exports[`views/includes/head should not render if googleAnalyticsId is set but c
   <!--[if lte IE 8]><link href=\\"/public/stylesheets/main-ie8.css\\" rel=\\"stylesheet\\" type=\\"text/css\\" /><![endif]-->
   <!--[if gt IE 8]><!--><link href=\\"/public/stylesheets/main.css\\" media=\\"all\\" rel=\\"stylesheet\\" type=\\"text/css\\" /><!--<![endif]-->
 
+  <script>
+      window.wfeconfig = window.wfeconfig || {};
+  </script>
   
     <script id=\\"gaId\\" type='text/plain'>123</script>
 
@@ -42,7 +48,13 @@ exports[`views/includes/head should not render if googleTagManager and GA are se
   <!--[if lte IE 8]><link href=\\"/public/stylesheets/main-ie8.css\\" rel=\\"stylesheet\\" type=\\"text/css\\" /><![endif]-->
   <!--[if gt IE 8]><!--><link href=\\"/public/stylesheets/main.css\\" media=\\"all\\" rel=\\"stylesheet\\" type=\\"text/css\\" /><!--<![endif]-->
 
+  <script>
+      window.wfeconfig = window.wfeconfig || {};
+  </script>
   
+    <script>
+      window.wfeconfig.googleTagManager = true;
+    </script>
     
   
 
@@ -58,6 +70,9 @@ exports[`views/includes/head should not render if no ids set 1`] = `
   <!--[if lte IE 8]><link href=\\"/public/stylesheets/main-ie8.css\\" rel=\\"stylesheet\\" type=\\"text/css\\" /><![endif]-->
   <!--[if gt IE 8]><!--><link href=\\"/public/stylesheets/main.css\\" media=\\"all\\" rel=\\"stylesheet\\" type=\\"text/css\\" /><!--<![endif]-->
 
+  <script>
+      window.wfeconfig = window.wfeconfig || {};
+  </script>
   
     <script id=\\"gaId\\" type='text/plain'></script>
 
@@ -76,7 +91,13 @@ exports[`views/includes/head should not render if only tagmanager set 1`] = `
   <!--[if lte IE 8]><link href=\\"/public/stylesheets/main-ie8.css\\" rel=\\"stylesheet\\" type=\\"text/css\\" /><![endif]-->
   <!--[if gt IE 8]><!--><link href=\\"/public/stylesheets/main.css\\" media=\\"all\\" rel=\\"stylesheet\\" type=\\"text/css\\" /><!--<![endif]-->
 
+  <script>
+      window.wfeconfig = window.wfeconfig || {};
+  </script>
   
+    <script>
+      window.wfeconfig.googleTagManager = true;
+    </script>
     
   
 
@@ -92,6 +113,9 @@ exports[`views/includes/head should render if googleAnalyticsId and cookies.cook
   <!--[if lte IE 8]><link href=\\"/public/stylesheets/main-ie8.css\\" rel=\\"stylesheet\\" type=\\"text/css\\" /><![endif]-->
   <!--[if gt IE 8]><!--><link href=\\"/public/stylesheets/main.css\\" media=\\"all\\" rel=\\"stylesheet\\" type=\\"text/css\\" /><!--<![endif]-->
 
+  <script>
+      window.wfeconfig = window.wfeconfig || {};
+  </script>
   
     <script id=\\"gaId\\" type='text/plain'>123</script>
 
@@ -120,9 +144,16 @@ exports[`views/includes/head should render tagmanager if all are set 1`] = `
   <!--[if lte IE 8]><link href=\\"/public/stylesheets/main-ie8.css\\" rel=\\"stylesheet\\" type=\\"text/css\\" /><![endif]-->
   <!--[if gt IE 8]><!--><link href=\\"/public/stylesheets/main.css\\" media=\\"all\\" rel=\\"stylesheet\\" type=\\"text/css\\" /><!--<![endif]-->
 
+  <script>
+      window.wfeconfig = window.wfeconfig || {};
+  </script>
   
+    <script>
+      window.wfeconfig.googleTagManager = true;
+    </script>
     
       <script>
+        window.wfeconfig.googleTagManagerId = '123';
         // default deined for tag manager
         window.dataLayer = window.dataLayer || [];
         function gtag(){dataLayer.push(arguments);}
@@ -152,9 +183,16 @@ exports[`views/includes/head should render tagmanager if tagmanager and id are s
   <!--[if lte IE 8]><link href=\\"/public/stylesheets/main-ie8.css\\" rel=\\"stylesheet\\" type=\\"text/css\\" /><![endif]-->
   <!--[if gt IE 8]><!--><link href=\\"/public/stylesheets/main.css\\" media=\\"all\\" rel=\\"stylesheet\\" type=\\"text/css\\" /><!--<![endif]-->
 
+  <script>
+      window.wfeconfig = window.wfeconfig || {};
+  </script>
   
+    <script>
+      window.wfeconfig.googleTagManager = true;
+    </script>
     
       <script>
+        window.wfeconfig.googleTagManagerId = '123';
         // default deined for tag manager
         window.dataLayer = window.dataLayer || [];
         function gtag(){dataLayer.push(arguments);}

--- a/packages/forms-web-app/package.json
+++ b/packages/forms-web-app/package.json
@@ -22,6 +22,7 @@
 		"lint:fix": "eslint ./ --fix",
 		"postinstall": "patch-package",
 		"test": "jest",
+		"test:update": "jest --updateSnapshot",
 		"test:cov": "jest --coverage --verbose",
 		"test:watch": "jest --watchAll --runInBand"
 	},

--- a/packages/forms-web-app/src/lib/client-side/javascript-requiring-consent.js
+++ b/packages/forms-web-app/src/lib/client-side/javascript-requiring-consent.js
@@ -7,7 +7,7 @@ const { initialiseGoogleAnalytics } = require('./google-analytics');
 const googleTagManager = require('./google-tag-manager');
 
 function initialiseTagManager(consent) {
-	if (!process.env.googleTagManagerId) {
+	if (!window.wfeconfig.googleTagManagerId) {
 		return;
 	}
 
@@ -40,7 +40,7 @@ const initialiseOptionalJavaScripts = (document) => {
 		}
 
 		// using tag manager
-		if (process.env.googleTagManager) {
+		if (window.wfeconfig.googleTagManager) {
 			initialiseTagManager(parsed.usage);
 			return;
 		}

--- a/packages/forms-web-app/src/views/includes/head.njk
+++ b/packages/forms-web-app/src/views/includes/head.njk
@@ -3,9 +3,16 @@
   <!--[if lte IE 8]><link href="/public/stylesheets/main-ie8.css" rel="stylesheet" type="text/css" /><![endif]-->
   <!--[if gt IE 8]><!--><link href="/public/stylesheets/main.css" media="all" rel="stylesheet" type="text/css" /><!--<![endif]-->
 
+  <script>
+      window.wfeconfig = window.wfeconfig || {};
+  </script>
   {% if featureFlag.googleTagManager %}
+    <script>
+      window.wfeconfig.googleTagManager = true;
+    </script>
     {% if googleTagManagerId %}
       <script>
+        window.wfeconfig.googleTagManagerId = '{{ googleTagManagerId | safe }}';
         // default deined for tag manager
         window.dataLayer = window.dataLayer || [];
         function gtag(){dataLayer.push(arguments);}

--- a/packages/forms-web-app/webpack.common.js
+++ b/packages/forms-web-app/webpack.common.js
@@ -10,11 +10,5 @@ module.exports = {
 		filename: '[name].bundle.js',
 		path: path.resolve(__dirname, 'src', 'public', 'javascripts')
 	},
-	plugins: [
-		new webpack.DefinePlugin({
-			'process.env.googleAnalyticsId': JSON.stringify(process.env.GOOGLE_ANALYTICS_ID),
-			'process.env.googleTagManager': process.env.FEATURE_FLAG_GOOGLE_TAG_MANAGER === 'true',
-			'process.env.googleTagManagerId': JSON.stringify(process.env.GOOGLE_TAG_MANAGER_ID)
-		})
-	]
+	plugins: []
 };


### PR DESCRIPTION
…window object

## Ticket Number

<!-- Add the number from the Jira board -->

https://pins-ds.atlassian.net/browse/AS-5870

The use of webpack for env variables wasn't working when deployed as the build wouldn't have the current values from the server, only what was on the machine at the time it was built.
Instead populating from server side on window in order to always have the latest values

<!-- Please describe the change -->

## Checklist

<!-- Put an `x` in all the boxes that apply: -->

- [ ] Requires infrastructure changes
- [ ] If adding or remove environment variables (e.g. in `docker-compose.yaml`) then I have updated the appropriate Helm chart
- [ ] I have updated the documentation accordingly
- [X] My commit history in this PR is linear
- [ ] New features have tests
- [ ] Breaking change (team conversation required)

## Important

Please do not merge from `main` (please only [rebase](https://github.com/foundry4/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
