### PR TITLE
fix(document-types.js): revert doc type change for other docs, fix to…

### DIFF
--- a/packages/common/src/document-types.js
+++ b/packages/common/src/document-types.js
@@ -35,7 +35,7 @@ const documentTypes = {
 		multiple: true,
 		displayName: 'Supporting Documents',
 		involvement: 'Appellant',
-		horizonDocumentType: 'Appellant Initial Documents',
+		horizonDocumentType: 'Other Evidence from Appellant/Agent',
 		horizonDocumentGroupType: 'Initial Documents'
 	},
 	designAccessStatement: {


### PR DESCRIPTION
… be made in horizon instead

## Ticket Number

<!-- Add the number from the Jira board -->

https://pins-ds.atlassian.net/browse/AS-5822

## Description of change

Reverting previous commit, destination folder was correct but document type label needs to remain the same in horizon.

This fix needs to be made in Horizon instead (in mapping table)

## Checklist

<!-- Put an `x` in all the boxes that apply: -->

- [ ] Requires infrastructure changes
- [ ] If adding or remove environment variables (e.g. in `docker-compose.yaml`) then I have updated the appropriate Helm chart
- [ ] I have updated the documentation accordingly
- [x] My commit history in this PR is linear
- [ ] New features have tests
- [ ] Breaking change (team conversation required)

## Important

Please do not merge from `main` (please only [rebase](https://github.com/foundry4/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
