### PR TITLE
fix(as-5905): show multifile for planning obligation on cya page

### DIFF
--- a/packages/forms-web-app/src/views/full-appeal/check-your-answers.njk
+++ b/packages/forms-web-app/src/views/full-appeal/check-your-answers.njk
@@ -1056,13 +1056,11 @@
         "Planning obligation",
         { "data-cy": "planning-obligation-label" }
       ) },
-      value: { text: uploadedFileLink(
+      value: { text: uploadedFileList(
+        appeal.appealDocumentsSection.planningObligations.uploadedFiles,
         appeal.id,
-        appeal.appealDocumentsSection.planningObligations.uploadedFiles[0],
-        { "data-cy": "planning-obligation" }
-      ) if isPdf !== true else summaryField(
-        appeal.appealDocumentsSection.planningObligations.uploadedFiles[0].name,
-        { "data-cy": "planning-obligation" }
+        'planning-obligation',
+        isPdf !== true
       ) },
       actions: planningObligationRowActions if isPdf !== true
     } %}
@@ -1083,13 +1081,11 @@
         "Planning obligation",
         { "data-cy": "draft-planning-obligation-label" }
       ) },
-      value: { text: uploadedFileLink(
+      value: { html: uploadedFileList(
+        appeal.appealDocumentsSection.draftPlanningObligations.uploadedFiles,
         appeal.id,
-        appeal.appealDocumentsSection.draftPlanningObligations.uploadedFiles[0],
-        { "data-cy": "draft-planning-obligation" }
-      ) if isPdf !== true else summaryField(
-        appeal.appealDocumentsSection.draftPlanningObligations.uploadedFiles[0].name,
-        { "data-cy": "draft-planning-obligation" }
+        'draft-planning-obligation',
+        isPdf !== true
       ) },
       actions: draftPlanningObligationRowActions if isPdf !== true
     } %}


### PR DESCRIPTION
## Ticket Number

<!-- Add the number from the Jira board -->

https://pins-ds.atlassian.net/browse/AS-5905

## Description of change

<!-- Please describe the change -->

## Checklist

<!-- Put an `x` in all the boxes that apply: -->

- [ ] Requires infrastructure changes
- [ ] If adding or remove environment variables (e.g. in `docker-compose.yaml`) then I have updated the appropriate Helm chart
- [ ] I have updated the documentation accordingly
- [ ] My commit history in this PR is linear
- [ ] New features have tests
- [ ] Breaking change (team conversation required)

## Important

Please do not merge from `main` (please only [rebase](https://github.com/foundry4/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
