### PR TITLE
fix(as-5922): handle errors without response in horizon requests

### DIFF
--- a/packages/appeals-service-api/src/gateway/horizon-gateway.js
+++ b/packages/appeals-service-api/src/gateway/horizon-gateway.js
@@ -200,13 +200,22 @@ class HorizonGateway {
 			if (error.response) {
 				logger.error(
 					error.response.data,
-					`Horizon returned a ${error.response.status} status code when attempting to ${descriptionOfRequest}. Response is below`
+					`Horizon returned a ${error.response?.status} status code when attempting to ${descriptionOfRequest}. Response is below`
 				);
 
 				return new HorizonResponseValue(
-					error.response.data.Envelope.Body.Fault.faultstring.value,
+					error.response?.data?.Envelope?.Body?.Fault?.faultstring?.value,
 					true
 				);
+			}
+
+			let errMsg = `Call to Horizon returned an undefined error when attempting to ${descriptionOfRequest}.`;
+			logger.error(error, errMsg);
+
+			if (error.message) {
+				return new HorizonResponseValue(error.message, true);
+			} else {
+				return new HorizonResponseValue(errMsg, true);
 			}
 		}
 	}


### PR DESCRIPTION
## Ticket Number

https://pins-ds.atlassian.net/browse/AS-5922

## Description of change

Updated the error handling of makeRequestAndHandleAnyErrors that makes requests to horizon wrapper

Previously only handled scenarios that conformed to a specific SOAP format.

It should now log an error of any failure helping to avoid duplicates.

Separate work to improve process to be handled in AS-5923

## Checklist

<!-- Put an `x` in all the boxes that apply: -->

- [ ] Requires infrastructure changes
- [ ] If adding or remove environment variables (e.g. in `docker-compose.yaml`) then I have updated the appropriate Helm chart
- [ ] I have updated the documentation accordingly
- [x] My commit history in this PR is linear
- [ ] New features have tests
- [ ] Breaking change (team conversation required)

## Important

Please do not merge from `main` (please only [rebase](https://github.com/foundry4/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
