### PR TITLE
feat(as-5798): middleware to restrict access to final comments, debug…

### DIFF
--- a/packages/appeals-service-api/src/services/final-comments.service.js
+++ b/packages/appeals-service-api/src/services/final-comments.service.js
@@ -103,6 +103,7 @@ class FinalCommentsService {
 
 		const finalCommentData = {
 			horizonId: caseReference,
+			lpaCode: localAppealData.lpaCode,
 			state: 'DRAFT',
 			finalCommentExpiryDate: new Date(Date.parse(finalCommentsDueDate)),
 			email: appellantEmail,

--- a/packages/forms-web-app/__tests__/unit/controllers/debug.test.js
+++ b/packages/forms-web-app/__tests__/unit/controllers/debug.test.js
@@ -1,0 +1,50 @@
+const { mockReq, mockRes } = require('../mocks');
+const debug = require('../../../src/controllers/debug');
+
+describe('controllers/debug', () => {
+	let req;
+	let res;
+
+	beforeEach(() => {
+		jest.resetAllMocks();
+
+		req = {
+			...mockReq(),
+			session: {},
+			query: {}
+		};
+		res = mockRes();
+	});
+
+	describe('set-comment-deadline', () => {
+		it('should 404 if given no deadline', () => {
+			req.query.deadline = undefined;
+			req.session.finalCommentOverrideExpiryDate = '123';
+
+			debug.setCommentDeadline(req, res);
+
+			expect(res.sendStatus).toHaveBeenCalledWith(400);
+			expect(req.session.finalCommentOverrideExpiryDate).toEqual(undefined);
+		});
+
+		it('should 404 with bad deadline', () => {
+			req.query.deadline = 'abc';
+			req.session.finalCommentOverrideExpiryDate = '123';
+
+			debug.setCommentDeadline(req, res);
+
+			expect(res.sendStatus).toHaveBeenCalledWith(400);
+			expect(req.session.finalCommentOverrideExpiryDate).toEqual(undefined);
+		});
+
+		it('should 200 if given deadline', () => {
+			const mockDate = '2023-06-01T00:00:00Z';
+			req.query.deadline = mockDate;
+
+			debug.setCommentDeadline(req, res);
+
+			expect(res.sendStatus).toHaveBeenCalledWith(200);
+			expect(req.session.finalCommentOverrideExpiryDate).toEqual(new Date(mockDate));
+		});
+	});
+});

--- a/packages/forms-web-app/__tests__/unit/middleware/check-debug-allowed.test.js
+++ b/packages/forms-web-app/__tests__/unit/middleware/check-debug-allowed.test.js
@@ -1,0 +1,33 @@
+const checkDebugAllowed = require('../../../src/middleware/check-debug-allowed');
+const config = require('../../../src/config');
+const { mockReq, mockRes } = require('../mocks');
+
+describe('middleware/check-debug-allowed', () => {
+	let req;
+	const res = mockRes();
+	const next = jest.fn();
+
+	beforeEach(() => {
+		req = {
+			...mockReq
+		};
+	});
+
+	it('should call next() when allowTestingOverrides is true', () => {
+		config.server.allowTestingOverrides = true;
+
+		checkDebugAllowed(req, res, next);
+
+		expect(next).toHaveBeenCalled();
+	});
+
+	it('should return 404 and render error/not-found when allowTestingOverrides is false', () => {
+		config.server.allowTestingOverrides = false;
+
+		checkDebugAllowed(req, res, next);
+
+		expect(next).not.toHaveBeenCalled();
+		expect(res.status).toHaveBeenCalledWith(404);
+		expect(res.render).toHaveBeenCalledWith('error/not-found');
+	});
+});

--- a/packages/forms-web-app/__tests__/unit/middleware/check-final-comment-deadline.test.js
+++ b/packages/forms-web-app/__tests__/unit/middleware/check-final-comment-deadline.test.js
@@ -1,0 +1,153 @@
+const { mockReq, mockRes } = require('../mocks');
+const checkFinalCommentDeadline = require('../../../src/middleware/final-comment/check-final-comment-deadline');
+const { utils } = require('@pins/common');
+const config = require('../../../src/config');
+
+const {
+	VIEW: {
+		FINAL_COMMENT: { APPEAL_CLOSED_FOR_COMMENT }
+	}
+} = require('../../../src/lib/views');
+
+jest.mock('../../../src/lib/logger', () => ({
+	info: jest.fn()
+}));
+
+describe('middleware/final-comment/check-final-comment-deadline', () => {
+	let req;
+	let res;
+	let next;
+
+	beforeEach(() => {
+		// mockReq by default sets an appeal field and places appeal object in session
+		// so pass null and clear req.session to use for final comments
+		res = mockRes();
+		next = jest.fn();
+		jest.resetAllMocks();
+		jest.useFakeTimers('modern');
+	});
+
+	afterEach(() => {
+		jest.useRealTimers();
+	});
+
+	it('should render error page when final comment is not found in session', () => {
+		req = {
+			...mockReq(null),
+			session: {}
+		};
+
+		checkFinalCommentDeadline(req, res);
+
+		expect(res.status).toHaveBeenCalledWith(404);
+		expect(res.render).toHaveBeenCalledWith('error/not-found');
+	});
+
+	it('should render error page when final comment secureCodeEnteredCorrectly is not true', () => {
+		const possibleSecureCodes = [false, 'true', 1, '', undefined, null];
+
+		possibleSecureCodes.forEach((secureCodeEnteredCorrectly) => {
+			const req = {
+				...mockReq(null),
+				session: {
+					finalComment: {
+						finalCommentExpiryDate: '2023-06-01T23:59:59.999Z',
+						lpaCode: 'abc',
+						secureCodeEnteredCorrectly
+					}
+				}
+			};
+
+			jest.setSystemTime(new Date('2023-06-01T12:00:00.000Z'));
+
+			checkFinalCommentDeadline(req, res, jest.fn());
+
+			expect(res.status).toHaveBeenCalledWith(404);
+			expect(res.render).toHaveBeenCalledWith('error/not-found');
+		});
+	});
+
+	it('should call the next middleware when within the deadline date', () => {
+		req = {
+			...mockReq(null),
+			session: {
+				finalComment: {
+					finalCommentExpiryDate: '2023-06-01T23:59:59.999Z',
+					lpaCode: 'abc',
+					secureCodeEnteredCorrectly: true
+				}
+			}
+		};
+
+		jest.setSystemTime(new Date('2023-06-01T12:00:00.000Z'));
+
+		checkFinalCommentDeadline(req, res, next);
+
+		expect(res.redirect).not.toHaveBeenCalled();
+		expect(next).toHaveBeenCalled();
+	});
+
+	it('should allow past middleware check when testing override is enabled and override within debug date', () => {
+		req = {
+			...mockReq(null),
+			session: {
+				finalComment: {
+					finalCommentExpiryDate: '2023-05-31T23:59:59.999Z',
+					lpaCode: utils.testLPACode,
+					secureCodeEnteredCorrectly: true
+				},
+				finalCommentOverrideExpiryDate: '2023-06-02T23:59:59.999Z'
+			}
+		};
+		config.server.allowTestingOverrides = true;
+
+		jest.setSystemTime(new Date('2023-06-01T00:00:00.000Z'));
+
+		checkFinalCommentDeadline(req, res, next);
+
+		expect(res.redirect).not.toHaveBeenCalled();
+		expect(next).toHaveBeenCalled();
+	});
+
+	it('should redirect to APPEAL_CLOSED_FOR_COMMENT if override is set but override not within debug date', () => {
+		req = {
+			...mockReq(null),
+			session: {
+				finalComment: {
+					finalCommentExpiryDate: '2023-05-31T23:59:59.999Z',
+					lpaCode: utils.testLPACode,
+					secureCodeEnteredCorrectly: true
+				},
+				finalCommentOverrideExpiryDate: '2023-05-02T23:59:59.999Z'
+			}
+		};
+		config.server.allowTestingOverrides = true;
+
+		jest.setSystemTime(new Date('2023-06-01T00:00:00.000Z'));
+
+		checkFinalCommentDeadline(req, res, next);
+
+		expect(res.redirect).toHaveBeenCalledWith('/' + APPEAL_CLOSED_FOR_COMMENT);
+	});
+
+	it('should redirect to APPEAL_CLOSED_FOR_COMMENT if override is set but and not in test', () => {
+		req = {
+			...mockReq(null),
+			session: {
+				finalComment: {
+					finalCommentExpiryDate: '2023-05-31T23:59:59.999Z',
+					lpaCode: utils.testLPACode,
+					secureCodeEnteredCorrectly: true
+				},
+				finalCommentOverrideExpiryDate: '2023-06-02T23:59:59.999Z'
+			}
+		};
+		config.server.allowTestingOverrides = false;
+
+		jest.setSystemTime(new Date('2023-06-01T00:00:00.000Z'));
+
+		checkFinalCommentDeadline(req, res, next);
+
+		expect(res.redirect).toHaveBeenCalledWith('/' + APPEAL_CLOSED_FOR_COMMENT);
+	});
+});

--- a/packages/forms-web-app/__tests__/unit/routes/debug.test.js
+++ b/packages/forms-web-app/__tests__/unit/routes/debug.test.js
@@ -1,0 +1,17 @@
+const { get } = require('./router-mock');
+const { setCommentDeadline } = require('../../../src/controllers/debug');
+
+describe('routes/debug', () => {
+	beforeEach(() => {
+		// eslint-disable-next-line global-require
+		require('../../../src/routes/debug');
+	});
+
+	afterEach(() => {
+		jest.resetAllMocks();
+	});
+
+	it('should define the expected routes', () => {
+		expect(get).toHaveBeenCalledWith('/set-comment-deadline', setCommentDeadline);
+	});
+});

--- a/packages/forms-web-app/src/controllers/debug.js
+++ b/packages/forms-web-app/src/controllers/debug.js
@@ -1,0 +1,21 @@
+const isValidDate = (dateString) => {
+	const timestamp = Date.parse(dateString);
+	return !isNaN(timestamp);
+};
+
+const setCommentDeadline = async (req, res) => {
+	const { deadline } = req.query;
+
+	if (!isValidDate(deadline)) {
+		delete req.session.finalCommentOverrideExpiryDate;
+		return res.sendStatus(400);
+	}
+
+	const date = new Date(deadline);
+	req.session.finalCommentOverrideExpiryDate = date;
+	return res.sendStatus(200);
+};
+
+module.exports = {
+	setCommentDeadline
+};

--- a/packages/forms-web-app/src/middleware/check-debug-allowed.js
+++ b/packages/forms-web-app/src/middleware/check-debug-allowed.js
@@ -1,0 +1,12 @@
+const config = require('../config');
+
+const checkDebugAllowed = (req, res, next) => {
+	if (config.server.allowTestingOverrides) {
+		return next();
+	}
+
+	res.status(404);
+	return res.render('error/not-found');
+};
+
+module.exports = checkDebugAllowed;

--- a/packages/forms-web-app/src/middleware/final-comment/check-final-comment-deadline.js
+++ b/packages/forms-web-app/src/middleware/final-comment/check-final-comment-deadline.js
@@ -1,0 +1,43 @@
+const { utils } = require('@pins/common');
+const config = require('../../config');
+const logger = require('../../lib/logger');
+
+const {
+	VIEW: {
+		FINAL_COMMENT: { APPEAL_CLOSED_FOR_COMMENT }
+	}
+} = require('../../lib/views');
+
+const checkFinalCommentDeadline = (req, res, next) => {
+	// get final comment from session
+	let {
+		session: { finalComment }
+	} = req;
+
+	if (!finalComment || finalComment.secureCodeEnteredCorrectly !== true) {
+		res.status(404);
+		logger.info('checkFinalCommentDeadline: No final comment in session - 404');
+		return res.render('error/not-found');
+	}
+
+	let overrideDate = null;
+
+	// is test LPA + Test environment + has debug date
+	// then allow past middleware check
+	if (config.server.allowTestingOverrides && utils.isTestLPA(req.session.finalComment?.lpaCode)) {
+		overrideDate = req.session.finalCommentOverrideExpiryDate;
+	}
+
+	const dateToCheck = overrideDate ? overrideDate : finalComment.finalCommentExpiryDate;
+
+	// if past deadline date
+	let now = new Date(new Date().toISOString());
+	let expiry = new Date(dateToCheck);
+	if (expiry < now) {
+		return res.redirect(`/${APPEAL_CLOSED_FOR_COMMENT}`);
+	}
+
+	return next();
+};
+
+module.exports = checkFinalCommentDeadline;

--- a/packages/forms-web-app/src/routes/debug.js
+++ b/packages/forms-web-app/src/routes/debug.js
@@ -1,0 +1,8 @@
+const express = require('express');
+const { setCommentDeadline } = require('../controllers/debug');
+
+const router = express.Router();
+
+router.get('/set-comment-deadline', setCommentDeadline);
+
+module.exports = router;

--- a/packages/forms-web-app/src/routes/full-appeal/submit-final-comment/index.js
+++ b/packages/forms-web-app/src/routes/full-appeal/submit-final-comment/index.js
@@ -1,5 +1,7 @@
 const express = require('express');
 const featureFlagMiddleware = require('../../../middleware/feature-flag');
+const checkFinalCommentDeadline = require('../../../middleware/final-comment/check-final-comment-deadline');
+const { skipMiddlewareForPaths } = require('../../../middleware/skip-middleware-for-paths');
 
 const router = express.Router();
 
@@ -14,6 +16,13 @@ const uploadDocumentsRouter = require('../../final-comment/upload-documents');
 const checkYourAnswersRouter = require('../../final-comment/check-your-answers');
 
 router.use(featureFlagMiddleware('final-comments', 'enableForAllLPAs'));
+router.use(
+	skipMiddlewareForPaths(checkFinalCommentDeadline, [
+		'input-code',
+		'need-new-code',
+		'appeal-closed-for-comment'
+	])
+);
 router.use(finalCommentRouter);
 router.use(finalCommentSubmittedRouter);
 router.use(appealClosedForCommentRouter);

--- a/packages/forms-web-app/src/routes/index.js
+++ b/packages/forms-web-app/src/routes/index.js
@@ -19,9 +19,11 @@ const saveAndReturnHasRouter = require('./appeal-householder-decision/save');
 const appealHouseholderdecision = require('./appeal-householder-decision');
 const checkDecisionDateDeadline = require('../middleware/check-decision-date-deadline');
 const checkPathAllowed = require('../middleware/check-path-allowed');
+const checkDebugAllowed = require('../middleware/check-debug-allowed');
 const { skipMiddlewareForPaths } = require('../middleware/skip-middleware-for-paths');
 const accessibilityStatementRouter = require('./accessibility-statement/accessibility-statement');
 const errorPageRouter = require('./error');
+const debugRouter = require('./debug');
 
 router.use('/', homeRouter);
 router.use(guidancePagesRouter);
@@ -79,5 +81,7 @@ router.use(
 	checkDecisionDateDeadline,
 	appealHouseholderdecision
 );
+
+router.use('/debug', checkDebugAllowed, debugRouter);
 
 module.exports = router;


### PR DESCRIPTION
…debug page to override deadline

## Ticket Number

<!-- Add the number from the Jira board -->

https://pins-ds.atlassian.net/browse/as-5798
https://pins-ds.atlassian.net/browse/as-5842

## Description of change

A middleware function that only allows access to final comments routes if the deadline has not passed and code has been entered

A debug route that sets a value in session that will allow testers to bypass the deadline check.
Submitting would still fail as the API validates the deadline on submission, and the original date will not be updated by the debug route

## Checklist

<!-- Put an `x` in all the boxes that apply: -->

- [ ] Requires infrastructure changes
- [ ] If adding or remove environment variables (e.g. in `docker-compose.yaml`) then I have updated the appropriate Helm chart
- [ ] I have updated the documentation accordingly
- [x] My commit history in this PR is linear
- [x] New features have tests
- [ ] Breaking change (team conversation required)

## Important

Please do not merge from `main` (please only [rebase](https://github.com/foundry4/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
