### PR TITLE
[AS-5774] Refactor app insights bootstrap logic to enforce startup before mongo db connection initialisation

### DIFF
--- a/packages/document-service-api/src/main.js
+++ b/packages/document-service-api/src/main.js
@@ -9,21 +9,18 @@ const main = require('./lib/mongooseBootstrap');
 const logger = require('./lib/logger');
 const server = require('./server');
 
+try {
+	appInsights.setup().setAutoDependencyCorrelation(true).setSendLiveMetrics(true);
+	appInsights.defaultClient.context.tags[appInsights.defaultClient.context.keys.cloudRole] =
+		'document-service-api';
+	appInsights.start();
+} catch (err) {
+	logger.warn({ err }, 'Application insights failed to start: ');
+}
+
 main()
-	.then(() => initInsights())
 	.then(() => server())
 	.catch((err) => {
 		logger.fatal({ err }, 'Unable to start application');
 		process.exit(1);
 	});
-
-function initInsights() {
-	try {
-		appInsights.setup().setAutoDependencyCorrelation(true).setSendLiveMetrics(true);
-		appInsights.defaultClient.context.tags[appInsights.defaultClient.context.keys.cloudRole] =
-			'document-service-api';
-		appInsights.start();
-	} catch (err) {
-		logger.warn({ err }, 'Application insights failed to start: ');
-	}
-}


### PR DESCRIPTION
## Ticket Number

AS-5774

https://pins-ds.atlassian.net/browse/AS-5774

## Description of change

Additional refactor of the app insights bootstrap logic to ensure initialisation before mongo db connection initialisation.

## Checklist

- [ ] Requires infrastructure changes
- [ ] If adding or remove environment variables (e.g. in `docker-compose.yaml`) then I have updated the appropriate Helm chart
- [ ] I have updated the documentation accordingly
- [x] My commit history in this PR is linear
- [ ] New features have tests
- [ ] Breaking change (team conversation required)

## Important

Please do not merge from `main` (please only [rebase](https://github.com/foundry4/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
