### PR TITLE
(feat AS-5774) for usage of async hooks module for correlation

### DIFF
--- a/packages/appeals-service-api/src/main.js
+++ b/packages/appeals-service-api/src/main.js
@@ -10,7 +10,7 @@ const mongodb = require('./db/db');
 
 async function main() {
 	try {
-		appInsights.setup().setAutoDependencyCorrelation(true).setSendLiveMetrics(true);
+		appInsights.setup().setAutoDependencyCorrelation(true, true).setSendLiveMetrics(true);
 		appInsights.defaultClient.context.tags[appInsights.defaultClient.context.keys.cloudRole] =
 			'appeals-service-api';
 		appInsights.start();

--- a/packages/clamav-rest-server/src/main.js
+++ b/packages/clamav-rest-server/src/main.js
@@ -9,7 +9,7 @@ const server = require('./server');
 
 async function main() {
 	try {
-		appInsights.setup().setAutoDependencyCorrelation(true).setSendLiveMetrics(true);
+		appInsights.setup().setAutoDependencyCorrelation(true, true).setSendLiveMetrics(true);
 		appInsights.defaultClient.context.tags[appInsights.defaultClient.context.keys.cloudRole] =
 			'clamav-rest-server';
 		appInsights.start();

--- a/packages/document-service-api/src/main.js
+++ b/packages/document-service-api/src/main.js
@@ -10,7 +10,7 @@ const logger = require('./lib/logger');
 const server = require('./server');
 
 try {
-	appInsights.setup().setAutoDependencyCorrelation(true).setSendLiveMetrics(true);
+	appInsights.setup().setAutoDependencyCorrelation(true, true).setSendLiveMetrics(true);
 	appInsights.defaultClient.context.tags[appInsights.defaultClient.context.keys.cloudRole] =
 		'document-service-api';
 	appInsights.start();

--- a/packages/forms-web-app/src/server.js
+++ b/packages/forms-web-app/src/server.js
@@ -15,7 +15,7 @@ const healthChecks = require('./lib/healthchecks');
  * Initialise app insights
  */
 try {
-	appInsights.setup().setAutoDependencyCorrelation(true).setSendLiveMetrics(true);
+	appInsights.setup().setAutoDependencyCorrelation(true, true).setSendLiveMetrics(true);
 	appInsights.defaultClient.context.tags[appInsights.defaultClient.context.keys.cloudRole] =
 		'web-front-end';
 	appInsights.start();

--- a/packages/lpa-questionnaire-web-app/src/app.js
+++ b/packages/lpa-questionnaire-web-app/src/app.js
@@ -21,7 +21,7 @@ const routes = require('./routes');
 const { VIEW } = require('./lib/views');
 
 try {
-	appInsights.setup().setAutoDependencyCorrelation(true).setSendLiveMetrics(true).start();
+	appInsights.setup().setAutoDependencyCorrelation(true, true).setSendLiveMetrics(true).start();
 	appInsights.defaultClient.setAutoPopulateAzureProperties(true);
 } catch (err) {
 	logger.warn({ err }, 'Application insights failed to start: ');


### PR DESCRIPTION
AS-5774

## Ticket Number

https://pins-ds.atlassian.net/browse/AS-5774

## Description of change

Pass in true to force usage of the experimental async hooks module to provide correlation, otherwise it relies on patching to provide log correlation for async calls. See here for more info setAutoDependencyCorrelation

## Checklist

<!-- Put an `x` in all the boxes that apply: -->

- [ ] Requires infrastructure changes
- [ ] If adding or remove environment variables (e.g. in `docker-compose.yaml`) then I have updated the appropriate Helm chart
- [ ] I have updated the documentation accordingly
- [X] My commit history in this PR is linear
- [ ] New features have tests
- [ ] Breaking change (team conversation required)

## Important

Please do not merge from `main` (please only [rebase](https://github.com/foundry4/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
