### PR TITLE
fix(allow test flow on test env): fixes regression where testing coul…

### DIFF
--- a/packages/forms-web-app/src/controllers/common/enter-code.js
+++ b/packages/forms-web-app/src/controllers/common/enter-code.js
@@ -158,8 +158,19 @@ const postEnterCode = (views) => {
 			});
 		}
 
+		let tokenValidResult = async () => {
+			if (isTestEnvironment() && isTestLPACheckTokenAndSession(token, req.session)) {
+				return {
+					valid: true,
+					action: enterCodeConfig.actions.confirmEmail
+				};
+			} else {
+				return await isTokenValid(id, token, req.session);
+			}
+		};
+
 		// check token
-		let tokenValid = await isTokenValid(id, token, req.session);
+		let tokenValid = await tokenValidResult(id, token, req.session);
 
 		if (tokenValid.tooManyAttempts) {
 			return res.redirect(`/${views.NEED_NEW_CODE}`);


### PR DESCRIPTION
…d not pass auth code

Fixes a regression where by we no longer supported the test lpa and test code

AS-5985

## Ticket Number

AS-5985

https://pins-ds.atlassian.net/browse/AS-5985

## Description of change

Allow test code and lpa through the post code screen

## Checklist

<!-- Put an `x` in all the boxes that apply: -->

- [ ] Requires infrastructure changes
- [ ] If adding or remove environment variables (e.g. in `docker-compose.yaml`) then I have updated the appropriate Helm chart
- [ ] I have updated the documentation accordingly
- [x] My commit history in this PR is linear
- [x] New features have tests
- [ ] Breaking change (team conversation required)

## Important

Please do not merge from `main` (please only [rebase](https://github.com/foundry4/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
