### PR TITLE
fix(as-5914): send token to user on get of enter code page

### DIFF
--- a/packages/forms-web-app/__tests__/unit/controllers/common/need-new-code.test.js
+++ b/packages/forms-web-app/__tests__/unit/controllers/common/need-new-code.test.js
@@ -2,11 +2,7 @@ const {
 	getNeedNewCode,
 	postNeedNewCode
 } = require('../../../../src/controllers/common/need-new-code');
-const { enterCodeConfig } = require('@pins/common');
-
 const { mockRes, mockReq } = require('../../mocks');
-const { sendToken, getUserById } = require('../../../../src/lib/appeals-api-wrapper');
-jest.mock('../../../../src/lib/appeals-api-wrapper');
 
 describe('controllers/common/enter-code', () => {
 	let req;
@@ -36,32 +32,7 @@ describe('controllers/common/enter-code', () => {
 	});
 
 	describe('postRequestNewCode', () => {
-		const badUserResponseValues = [undefined, null, {}, { prop: 'test' }];
-
-		for (const badVal of badUserResponseValues) {
-			it(`should redirect to enter code page if user response is not valid`, async () => {
-				const {
-					VIEW: {
-						LPA_DASHBOARD: { NEED_NEW_CODE, ENTER_CODE }
-					}
-				} = require('../../../../src/lib/views');
-				const views = { NEED_NEW_CODE, ENTER_CODE };
-				const tokenId = '1552441a-1e56-4e83-8d85-de7b246d2594';
-
-				getUserById.mockResolvedValue(badVal);
-
-				const returnedFunction = postNeedNewCode(views);
-				req.params = {
-					id: tokenId
-				};
-				await returnedFunction(req, res);
-
-				expect(getUserById).toBeCalledWith(tokenId);
-				expect(res.redirect).toBeCalledWith(`/${ENTER_CODE}/${tokenId}`);
-			});
-		}
-
-		it(`should redirect to enter code page if user response returns an error`, async () => {
+		it(`should redirect to enter code page`, async () => {
 			const {
 				VIEW: {
 					LPA_DASHBOARD: { NEED_NEW_CODE, ENTER_CODE }
@@ -70,79 +41,12 @@ describe('controllers/common/enter-code', () => {
 			const views = { NEED_NEW_CODE, ENTER_CODE };
 			const tokenId = '1552441a-1e56-4e83-8d85-de7b246d2594';
 
-			getUserById.mockImplementation(() => {
-				throw new Error('Failed');
-			});
-
 			const returnedFunction = postNeedNewCode(views);
 			req.params = {
 				id: tokenId
 			};
 			await returnedFunction(req, res);
 
-			expect(getUserById).toBeCalledWith(tokenId);
-			expect(res.redirect).toBeCalledWith(`/${ENTER_CODE}/${tokenId}`);
-		});
-
-		it(`should redirect to enter code page if sendToken returns an error`, async () => {
-			const {
-				VIEW: {
-					LPA_DASHBOARD: { NEED_NEW_CODE, ENTER_CODE }
-				}
-			} = require('../../../../src/lib/views');
-			const views = { NEED_NEW_CODE, ENTER_CODE };
-			const tokenId = '1552441a-1e56-4e83-8d85-de7b246d2594';
-			const fakeUserResponse = {
-				email: 'test@example.com'
-			};
-
-			getUserById.mockResolvedValue(fakeUserResponse);
-
-			sendToken.mockImplementation(() => {
-				throw new Error('Failed');
-			});
-
-			const returnedFunction = postNeedNewCode(views);
-			req.params = {
-				id: tokenId
-			};
-			await returnedFunction(req, res);
-
-			expect(getUserById).toBeCalledWith(tokenId);
-			expect(sendToken).toBeCalledWith(
-				tokenId,
-				enterCodeConfig.actions.lpaDashboard,
-				fakeUserResponse.email
-			);
-			expect(res.redirect).toBeCalledWith(`/${ENTER_CODE}/${tokenId}`);
-		});
-
-		it(`should redirect to enter code page if sendToken works`, async () => {
-			const {
-				VIEW: {
-					LPA_DASHBOARD: { NEED_NEW_CODE, ENTER_CODE }
-				}
-			} = require('../../../../src/lib/views');
-			const views = { NEED_NEW_CODE, ENTER_CODE };
-			const tokenId = '1552441a-1e56-4e83-8d85-de7b246d2594';
-			const fakeUserResponse = {
-				email: 'test@example.com'
-			};
-
-			getUserById.mockResolvedValue(fakeUserResponse);
-
-			const returnedFunction = postNeedNewCode(views);
-			req.params = {
-				id: tokenId
-			};
-			await returnedFunction(req, res);
-
-			expect(getUserById).toBeCalledWith(tokenId);
-			expect(sendToken).toBeCalledWith(
-				tokenId,
-				enterCodeConfig.actions.lpaDashboard,
-				fakeUserResponse.email
-			);
 			expect(res.redirect).toBeCalledWith(`/${ENTER_CODE}/${tokenId}`);
 		});
 	});

--- a/packages/forms-web-app/src/controllers/common/need-new-code.js
+++ b/packages/forms-web-app/src/controllers/common/need-new-code.js
@@ -1,37 +1,14 @@
-const logger = require('../../lib/logger');
-const { sendToken, getUserById } = require('../../lib/appeals-api-wrapper');
-const { enterCodeConfig } = require('@pins/common');
-
 const getNeedNewCode = (views) => {
 	return async (req, res) => {
 		res.render(views.NEED_NEW_CODE);
 	};
 };
 
-/**
- * Sends a new token to the lpa user referenced by the id in the url params
- * @param {ExpressRequest} req
- * @returns {Promise}
- */
-async function resendTokenToLpaUser(req) {
-	const user = await getUserById(req.params.id);
-
-	if (user?.email) {
-		await sendToken(req.params.id, enterCodeConfig.actions.lpaDashboard, user.email);
-		req.session.enterCode = req.session.enterCode || {};
-		req.session.enterCode.newCode = true;
-	}
-}
-
 const postNeedNewCode = (views) => {
 	return async (req, res) => {
-		try {
-			await resendTokenToLpaUser(req);
-		} catch (err) {
-			logger.error(err);
-		}
+		req.session.enterCode = req.session.enterCode || {};
+		req.session.enterCode.newCode = true;
 
-		// even if we error, return to enter code page so as to not give anyway any user detail
 		const url = `/${views.ENTER_CODE}/${req.params.id}`;
 		res.redirect(url);
 	};


### PR DESCRIPTION
## Ticket Number

<!-- Add the number from the Jira board -->

https://pins-ds.atlassian.net/browse/AS-5914

## Description of change

Enter code page was not creating or sending a token so the need new code feature did not have a token to check against.

Enter code page now sends a token on the get request to be in line with confirm email and save/return

## Checklist

<!-- Put an `x` in all the boxes that apply: -->

- [ ] Requires infrastructure changes
- [ ] If adding or remove environment variables (e.g. in `docker-compose.yaml`) then I have updated the appropriate Helm chart
- [ ] I have updated the documentation accordingly
- [x] My commit history in this PR is linear
- [ ] New features have tests
- [ ] Breaking change (team conversation required)

## Important

Please do not merge from `main` (please only [rebase](https://github.com/foundry4/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
