### PR TITLE
fix(aapd-20): on removal of cookies force removal of ga cookie (prod …

### DIFF
--- a/packages/forms-web-app/__tests__/unit/lib/remove-unwanted-cookies.test.js
+++ b/packages/forms-web-app/__tests__/unit/lib/remove-unwanted-cookies.test.js
@@ -41,6 +41,14 @@ describe('lib/remove-unwanted-cookies', () => {
 				domain: `.${fakeDomain}`,
 				secure: false
 			});
+			expect(res.clearCookie).toHaveBeenCalledWith(cookieName, {
+				domain: `.${req.hostname}`,
+				secure: true
+			});
+			expect(res.clearCookie).toHaveBeenCalledWith(cookieName, {
+				domain: `.${req.hostname}`,
+				secure: false
+			});
 		};
 
 		[
@@ -84,7 +92,7 @@ describe('lib/remove-unwanted-cookies', () => {
 					keepTheseCookies: []
 				},
 				expected: (req, res) => {
-					expect(res.clearCookie).toHaveBeenCalledTimes(3);
+					expect(res.clearCookie).toHaveBeenCalledTimes(5);
 					expectedRemovalCalls(req, res, 'connect.sid');
 				}
 			},
@@ -119,7 +127,7 @@ describe('lib/remove-unwanted-cookies', () => {
 					keepTheseCookies: []
 				},
 				expected: (req, res) => {
-					expect(res.clearCookie).toHaveBeenCalledTimes(3);
+					expect(res.clearCookie).toHaveBeenCalledTimes(5);
 					expectedRemovalCalls(req, res, cookieConfig.COOKIE_POLICY_KEY);
 				}
 			},
@@ -138,7 +146,7 @@ describe('lib/remove-unwanted-cookies', () => {
 					keepTheseCookies: undefined
 				},
 				expected: (req, res) => {
-					expect(res.clearCookie).toHaveBeenCalledTimes(3);
+					expect(res.clearCookie).toHaveBeenCalledTimes(5);
 					expectedRemovalCalls(req, res, 'some-unwanted-cookie');
 				}
 			},
@@ -157,7 +165,7 @@ describe('lib/remove-unwanted-cookies', () => {
 					keepTheseCookies: ['some-unwanted-cookie']
 				},
 				expected: (req, res) => {
-					expect(res.clearCookie).toHaveBeenCalledTimes(6);
+					expect(res.clearCookie).toHaveBeenCalledTimes(10);
 					expectedRemovalCalls(req, res, 'connect.sid');
 					expectedRemovalCalls(req, res, cookieConfig.COOKIE_POLICY_KEY);
 				}
@@ -184,7 +192,7 @@ describe('lib/remove-unwanted-cookies', () => {
 					keepTheseCookies: undefined
 				},
 				expected: (req, res) => {
-					expect(res.clearCookie).toHaveBeenCalledTimes(6);
+					expect(res.clearCookie).toHaveBeenCalledTimes(10);
 					expectedRemovalCalls(req, res, '_ga_TZBWMVPTHV');
 					expectedRemovalCalls(req, res, '_ga');
 				}

--- a/packages/forms-web-app/src/lib/remove-unwanted-cookies.js
+++ b/packages/forms-web-app/src/lib/remove-unwanted-cookies.js
@@ -24,8 +24,12 @@ const removeUnwantedCookies = (req, res, keepTheseCookies = defaultKeepMeCookies
 		.filter((cookieName) => keepTheseCookies.includes(cookieName) === false)
 		.forEach((cookieName) => {
 			res.clearCookie(cookieName);
+			// in dev/test google analytics sets on root domain
 			res.clearCookie(cookieName, { domain: `.${domain}`, secure: true });
 			res.clearCookie(cookieName, { domain: `.${domain}`, secure: false });
+			// in prod google analytics appears to set cookies on hostname with a preceding .
+			res.clearCookie(cookieName, { domain: `.${req.hostname}`, secure: true });
+			res.clearCookie(cookieName, { domain: `.${req.hostname}`, secure: false });
 		});
 };
 


### PR DESCRIPTION
…variation)

## Ticket Number

<!-- Add the number from the Jira board -->

https://pins-ds.atlassian.net/browse/AAPD-20

## Description of change

GA is setting cookies differently between prod/test, fairly sure this will handle both environments although willing to accept a better solution outside of this brute forcing method

## Checklist

<!-- Put an `x` in all the boxes that apply: -->

- [ ] Requires infrastructure changes
- [ ] If adding or remove environment variables (e.g. in `docker-compose.yaml`) then I have updated the appropriate Helm chart
- [ ] I have updated the documentation accordingly
- [x] My commit history in this PR is linear
- [ ] New features have tests
- [ ] Breaking change (team conversation required)

## Important

Please do not merge from `main` (please only [rebase](https://github.com/foundry4/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
