### PR TITLE
feat(lpa-dashboard): allow test security code to be used for lpa login

### DIFF
--- a/packages/common/src/utils.js
+++ b/packages/common/src/utils.js
@@ -2,7 +2,8 @@
  * Utility methods
  */
 
-const testLPACode = 'E69999999';
+const testLPAONSCode = 'E69999999';
+const testLPACode = 'Q9999';
 
 module.exports = {
 	/**
@@ -49,7 +50,8 @@ module.exports = {
 	 * @return {boolean}
 	 */
 	isTestLPA(lpaCode) {
-		return lpaCode === testLPACode;
+		return lpaCode === testLPACode || lpaCode === testLPAONSCode;
 	},
-	testLPACode
+	testLPACode,
+	testLPAONSCode
 };

--- a/packages/common/src/utils.test.js
+++ b/packages/common/src/utils.test.js
@@ -32,4 +32,21 @@ describe('Utils test', () => {
 			await expect(util.promiseTimeout(timeout, promise())).rejects.toEqual(new Error('timeout'));
 		});
 	});
+
+	describe('isTestLPA', () => {
+		it('should return true if test ONS code', async () => {
+			const testONSCode = 'E69999999';
+			expect(util.isTestLPA(testONSCode)).toEqual(true);
+		});
+
+		it('should return true if test lpa code', async () => {
+			const testLpaCode = 'Q9999';
+			expect(util.isTestLPA(testLpaCode)).toEqual(true);
+		});
+
+		it('should return false if test lpa code', async () => {
+			const testLpaCode = 'Q0000';
+			expect(util.isTestLPA(testLpaCode)).toEqual(false);
+		});
+	});
 });

--- a/packages/forms-web-app/__tests__/unit/controllers/common/enter-code.test.js
+++ b/packages/forms-web-app/__tests__/unit/controllers/common/enter-code.test.js
@@ -17,11 +17,15 @@ const {
 	sendToken,
 	getUserById
 } = require('../../../../src/lib/appeals-api-wrapper');
-const { getLPAUserStatus, setLPAUserStatus } = require('../../../../src/services/lpa-user.service');
+const {
+	getLPAUserStatus,
+	setLPAUserStatus,
+	getLPAUser
+} = require('../../../../src/services/lpa-user.service');
 const {
 	isTokenValid,
 	isTestEnvironment,
-	isTestLPACheckTokenAndSession
+	isTestLpaAndToken
 } = require('../../../../src/lib/is-token-valid');
 const { enterCodeConfig } = require('@pins/common');
 const { utils } = require('@pins/common');
@@ -34,7 +38,8 @@ jest.mock('../../../../src/services/lpa-user.service', () => {
 	return {
 		getLPAUserStatus: jest.fn(),
 		createLPAUserSession: jest.fn(),
-		setLPAUserStatus: jest.fn()
+		setLPAUserStatus: jest.fn(),
+		getLPAUser: jest.fn()
 	};
 });
 
@@ -424,7 +429,7 @@ describe('controllers/full-appeal/submit-appeal/enter-code', () => {
 				createdAt: '2022-07-14T13:00:48.024Z'
 			});
 			isTestEnvironment.mockReturnValue(true);
-			isTestLPACheckTokenAndSession.mockReturnValue(true);
+			isTestLpaAndToken.mockReturnValue(true);
 			const returnedFunction = postEnterCode({ EMAIL_CONFIRMED });
 			await returnedFunction(req, res);
 			expect(isTokenValid).not.toBeCalled();
@@ -726,8 +731,8 @@ describe('controllers/full-appeal/submit-appeal/enter-code', () => {
 			const code = '12345';
 
 			isTestEnvironment.mockReturnValue(true);
-			isTestLPACheckTokenAndSession.mockReturnValue(true);
-			getUserById.mockReturnValue({
+			isTestLpaAndToken.mockReturnValue(true);
+			getLPAUser.mockResolvedValue({
 				_id: userId,
 				email: 'admin1@planninginspectorate.gov.uk',
 				isAdmin: true,

--- a/packages/forms-web-app/__tests__/unit/services/lpa-user.service.test.js
+++ b/packages/forms-web-app/__tests__/unit/services/lpa-user.service.test.js
@@ -3,12 +3,11 @@ const {
 	getLPAUserFromSession,
 	setLPAUserStatus
 } = require('../../../src/services/lpa-user.service');
-const { getUserById, getLPA, setUserStatus } = require('../../../src/lib/appeals-api-wrapper');
+const { getLPA, setUserStatus } = require('../../../src/lib/appeals-api-wrapper');
 const { STATUS_CONSTANTS } = require('@pins/common/src/constants');
 
 jest.mock('../../../src/lib/appeals-api-wrapper', () => {
 	return {
-		getUserById: jest.fn(),
 		setUserStatus: jest.fn(),
 		getLPA: jest.fn()
 	};
@@ -20,21 +19,18 @@ describe('services/lpa-user.service', () => {
 	});
 
 	describe('createLPAUserSession', () => {
-		it('should add user to session ', async () => {
+		it('should add user to session and combine with lpa details', async () => {
 			const mockUser = { test: 'test' };
 			const mockReq = {
 				session: {}
 			};
-			const mockId = 'a';
 			const mockLPA = { domain: 'example.com', name: 'Test LPA' };
 			const expectedResult = { ...mockUser, lpaName: mockLPA.name, lpaDomain: mockLPA.domain };
 
-			getUserById.mockResolvedValue(mockUser);
 			getLPA.mockResolvedValue(mockLPA);
 
-			await createLPAUserSession(mockReq, mockId);
+			await createLPAUserSession(mockReq, mockUser);
 
-			expect(getUserById).toHaveBeenCalledWith(mockId);
 			expect(mockReq.session.lpaUser).toEqual(expectedResult);
 		});
 	});

--- a/packages/forms-web-app/src/lib/is-token-valid.js
+++ b/packages/forms-web-app/src/lib/is-token-valid.js
@@ -7,10 +7,14 @@ const testConfirmEmailToken = '12345';
 
 const isTestEnvironment = () => config.server.allowTestingOverrides;
 
-// is test LPA + Test environment + test token
-// then allow through as a confirm email token
-const isTestLPACheckTokenAndSession = (token, session) => {
-	return utils.isTestLPA(session?.appeal?.lpaCode) && token === testConfirmEmailToken;
+/**
+ * Check if LPA is System Test Borough Council and token is test token
+ * @param {string} token
+ * @param {string} lpaCode
+ * @return {boolean}
+ */
+const isTestLpaAndToken = (token, lpaCode) => {
+	return utils.isTestLPA(lpaCode) && token === testConfirmEmailToken;
 };
 
 const getToken = async (id, token, session) => {
@@ -68,7 +72,7 @@ const isTokenValid = async (id, token, session) => {
 
 module.exports = {
 	isTokenValid,
-	isTestLPACheckTokenAndSession,
+	isTestLpaAndToken,
 	testConfirmEmailToken,
 	isTestEnvironment
 };

--- a/packages/forms-web-app/src/services/lpa-user.service.js
+++ b/packages/forms-web-app/src/services/lpa-user.service.js
@@ -18,10 +18,20 @@ const { STATUS_CONSTANTS } = require('@pins/common/src/constants');
  */
 
 /**
+ * An LPA user from the DB
+ * @typedef {Object} DBUser
+ * @property {UserId} _id - The id of the user.
+ * @property {string} email - The email of the user.
+ * @property {boolean} isAdmin - If the user is an admin user (cannot be deleted).
+ * @property {string} status - The status of a user (STATUS_CONSTANTS)
+ * @property {string} lpaCode - If code of the lpa the user belongs to.
+ */
+
+/**
  * Gets lpaUser by their id
  * @async
  * @param {UserId} userId
- * @returns {Promise<User>}
+ * @returns {Promise<DBUser>}
  */
 const getLPAUser = async (userId) => {
 	return await getUserById(userId);
@@ -31,11 +41,10 @@ const getLPAUser = async (userId) => {
  * Creates the user object within the session object of the request for the successfully logged in LPAUser
  * @async
  * @param {ExpressRequest} req
- * @param {UserId} userId
+ * @param {DBUser} user
  * @returns {Promise<void>}
  */
-const createLPAUserSession = async (req, userId) => {
-	let user = await getLPAUser(userId);
+const createLPAUserSession = async (req, user) => {
 	req.session.lpaUser = user;
 
 	let lpa = await getLPA(user.lpaCode);
@@ -76,5 +85,6 @@ module.exports = {
 	createLPAUserSession,
 	getLPAUserFromSession,
 	getLPAUserStatus,
-	setLPAUserStatus
+	setLPAUserStatus,
+	getLPAUser
 };


### PR DESCRIPTION
## Ticket Number

<!-- Add the number from the Jira board -->

## Description of change

Allows test code to be used to log into LPA dashboard if user belongs to test council

## Checklist

<!-- Put an `x` in all the boxes that apply: -->

- [ ] Requires infrastructure changes
- [ ] If adding or remove environment variables (e.g. in `docker-compose.yaml`) then I have updated the appropriate Helm chart
- [ ] I have updated the documentation accordingly
- [x] My commit history in this PR is linear
- [x] New features have tests
- [ ] Breaking change (team conversation required)

## Important

Please do not merge from `main` (please only [rebase](https://github.com/foundry4/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
