### PR TITLE
chore(seed-data): add dates from seed data as date objects in mongo

### DIFF
--- a/data/init.js
+++ b/data/init.js
@@ -7,6 +7,7 @@
 
 /* Node modules */
 const path = require('path');
+const { parseISO, isValid } = require('date-fns');
 
 /* Third-party modules */
 const { sync: glob } = require('glob');
@@ -92,15 +93,26 @@ module.exports = async function main(log = true) {
 				}
 
 				const parsedData = data.map((item) => {
-					const now = new Date();
-					if (!item.createdAt && meta.created !== false) {
-						// eslint-disable-next-line no-param-reassign
-						item.createdAt = now;
+					if (name === 'appeals') {
+						const now = new Date();
+						if (!item.createdAt && meta.created !== false) {
+							// eslint-disable-next-line no-param-reassign
+							item.createdAt = now;
+						}
+						if (!item.updatedAt && meta.updated !== false) {
+							// eslint-disable-next-line no-param-reassign
+							item.updatedAt = now;
+						}
 					}
-					if (!item.updatedAt && meta.updated !== false) {
-						// eslint-disable-next-line no-param-reassign
-						item.updatedAt = now;
-					}
+
+					Object.keys(item).forEach(function (key) {
+						if (typeof item[key] === 'string') {
+							const parsedDate = parseISO(item[key]);
+							if (isValid(parsedDate)) {
+								item[key] = parsedDate;
+							}
+						}
+					});
 
 					return item;
 				});

--- a/data/package-lock.json
+++ b/data/package-lock.json
@@ -9,10 +9,22 @@
 			"version": "0.0.0",
 			"license": "MIT",
 			"dependencies": {
+				"date-fns": "^2.30.0",
 				"glob": "^7.1.6",
 				"luxon": "^1.24.0",
 				"mongodb": "^3.6.2",
 				"nodemon": "^2.0.15"
+			}
+		},
+		"node_modules/@babel/runtime": {
+			"version": "7.22.6",
+			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.22.6.tgz",
+			"integrity": "sha512-wDb5pWm4WDdF6LFUde3Jl8WzPA+3ZbxYqkC6xAXuD3irdEHN1k0NfTRrJD8ZD378SJ61miMLCqIOXYhd8x+AJQ==",
+			"dependencies": {
+				"regenerator-runtime": "^0.13.11"
+			},
+			"engines": {
+				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@sindresorhus/is": {
@@ -334,6 +346,21 @@
 			"integrity": "sha512-v1plID3y9r/lPhviJ1wrXpLeyUIGAZ2SHNYTEapm7/8A9nLPoyvVp3RK/EPFqn5kEznyWgYZNsRtYYIWbuG8KA==",
 			"engines": {
 				"node": ">=8"
+			}
+		},
+		"node_modules/date-fns": {
+			"version": "2.30.0",
+			"resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.30.0.tgz",
+			"integrity": "sha512-fnULvOpxnC5/Vg3NCiWelDsLiUc9bRwAPs/+LfTLNvetFCtCTN+yQz15C/fs4AwX1R9K5GLtLfn8QW+dWisaAw==",
+			"dependencies": {
+				"@babel/runtime": "^7.21.0"
+			},
+			"engines": {
+				"node": ">=0.11"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/date-fns"
 			}
 		},
 		"node_modules/debug": {
@@ -1029,6 +1056,11 @@
 				"node": ">=8.10.0"
 			}
 		},
+		"node_modules/regenerator-runtime": {
+			"version": "0.13.11",
+			"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
+			"integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg=="
+		},
 		"node_modules/registry-auth-token": {
 			"version": "4.2.1",
 			"resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-4.2.1.tgz",
@@ -1384,6 +1416,14 @@
 		}
 	},
 	"dependencies": {
+		"@babel/runtime": {
+			"version": "7.22.6",
+			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.22.6.tgz",
+			"integrity": "sha512-wDb5pWm4WDdF6LFUde3Jl8WzPA+3ZbxYqkC6xAXuD3irdEHN1k0NfTRrJD8ZD378SJ61miMLCqIOXYhd8x+AJQ==",
+			"requires": {
+				"regenerator-runtime": "^0.13.11"
+			}
+		},
 		"@sindresorhus/is": {
 			"version": "0.14.0",
 			"resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-0.14.0.tgz",
@@ -1619,6 +1659,14 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-2.0.0.tgz",
 			"integrity": "sha512-v1plID3y9r/lPhviJ1wrXpLeyUIGAZ2SHNYTEapm7/8A9nLPoyvVp3RK/EPFqn5kEznyWgYZNsRtYYIWbuG8KA=="
+		},
+		"date-fns": {
+			"version": "2.30.0",
+			"resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.30.0.tgz",
+			"integrity": "sha512-fnULvOpxnC5/Vg3NCiWelDsLiUc9bRwAPs/+LfTLNvetFCtCTN+yQz15C/fs4AwX1R9K5GLtLfn8QW+dWisaAw==",
+			"requires": {
+				"@babel/runtime": "^7.21.0"
+			}
 		},
 		"debug": {
 			"version": "3.2.7",
@@ -2138,6 +2186,11 @@
 			"requires": {
 				"picomatch": "^2.2.1"
 			}
+		},
+		"regenerator-runtime": {
+			"version": "0.13.11",
+			"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
+			"integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg=="
 		},
 		"registry-auth-token": {
 			"version": "4.2.1",

--- a/data/package.json
+++ b/data/package.json
@@ -11,6 +11,7 @@
 	"author": "",
 	"license": "MIT",
 	"dependencies": {
+		"date-fns": "^2.30.0",
 		"glob": "^7.1.6",
 		"luxon": "^1.24.0",
 		"mongodb": "^3.6.2",


### PR DESCRIPTION
## Ticket Number

<!-- Add the number from the Jira board -->

https://pins-ds.atlassian.net/browse/AS-

## Description of change

Any string in seed data that gets parsed by the date-fns parseIso function will be added as a date object rather than a string

## Checklist

<!-- Put an `x` in all the boxes that apply: -->

- [ ] Requires infrastructure changes
- [ ] If adding or remove environment variables (e.g. in `docker-compose.yaml`) then I have updated the appropriate Helm chart
- [ ] I have updated the documentation accordingly
- [x] My commit history in this PR is linear
- [ ] New features have tests
- [ ] Breaking change (team conversation required)

## Important

Please do not merge from `main` (please only [rebase](https://github.com/foundry4/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
