### PR TITLE
feat(aapd-24): add appeal num to your appeals page

### DIFF
--- a/packages/appeals-service-api/__tests__/developer/appeals-case-data.test.js
+++ b/packages/appeals-service-api/__tests__/developer/appeals-case-data.test.js
@@ -70,6 +70,7 @@ describe('appeals-case-data', () => {
 				appealsCaseData[caseDataIndex].LPAApplicationReference
 			);
 			expect(result.caseReference).toEqual(appealsCaseData[caseDataIndex].caseReference);
+			expect(result.caseReferenceSlug).toEqual(appealsCaseData[caseDataIndex].caseReference);
 			expect(result.questionnaireDueDate).toEqual(
 				appealsCaseData[caseDataIndex].questionnaireDueDate.toISOString()
 			);
@@ -79,7 +80,7 @@ describe('appeals-case-data', () => {
 		});
 
 		expect(l2440response.status).toBe(200);
-		expect(l2440response.body.length).toBe(1);
+		expect(l2440response.body.length).toBe(2);
 		expect(l2440response.body[0]._id).toEqual(appealsCaseData[9]._id);
 		expect(l2440response.body[0].LPAApplicationReference).toEqual(
 			appealsCaseData[9].LPAApplicationReference
@@ -91,6 +92,14 @@ describe('appeals-case-data', () => {
 		expect(l2440response.body[0].LPACode).toBe(undefined);
 		expect(l2440response.body[0].validity).toBe(undefined);
 		expect(l2440response.body[0].questionnaireReceived).toBe(undefined);
+	});
+
+	it('should return a url friendly slug for appeal case ref', async () => {
+		const l2440response = await appealsApi.get(`/api/v1/appeals-case-data/L2440`);
+
+		expect(l2440response.status).toBe(200);
+		expect(l2440response.body.length).toEqual(2);
+		expect(l2440response.body[1].caseReferenceSlug).toBe('_%40_1');
 	});
 
 	it('should 404 if no LPA code', async () => {

--- a/packages/appeals-service-api/__tests__/developer/fixtures/appeals-case-data.js
+++ b/packages/appeals-service-api/__tests__/developer/fixtures/appeals-case-data.js
@@ -67,6 +67,15 @@ const fakeAppealsCaseData = () => {
 			new Date(Date.UTC(2023, 0, 28)),
 			undefined,
 			'Valid'
+		),
+		// url reserved chars in caseRef
+		_generateFakeAppeal(
+			'/@/1',
+			'1234567/tuv',
+			new Date(Date.UTC(2023, 1, 1)),
+			undefined,
+			'Valid',
+			'L2440'
 		)
 	];
 

--- a/packages/appeals-service-api/__tests__/unit/lib/encode.test.js
+++ b/packages/appeals-service-api/__tests__/unit/lib/encode.test.js
@@ -1,0 +1,43 @@
+const { encodeUrlSlug, decodeUrlSlug } = require('../../../src/lib/encode');
+
+describe('lib/encode', () => {
+	describe('encodeUrlSlug', () => {
+		it(`should handle bad values without throwing error`, () => {
+			const badVals = [null, undefined, 1, '12/12/2000', 'a', [1, 2]];
+
+			badVals.forEach((item) => {
+				expect(() => encodeUrlSlug(item)).not.toThrow();
+			});
+		});
+
+		it(`should replace all / chars`, () => {
+			const res = encodeUrlSlug('/a/a/');
+			expect(res).toEqual('_a_a_');
+		});
+
+		it(`should call encodeURIComponent`, () => {
+			jest.spyOn(global, 'encodeURIComponent');
+			encodeUrlSlug('@?');
+			expect(encodeURIComponent).toBeCalledWith('@?');
+		});
+	});
+
+	describe('decodeUrlSlug', () => {
+		it(`should decode url slug`, () => {
+			const input = '/a@a/';
+			const encoded = encodeUrlSlug(input);
+			const decoded = decodeUrlSlug(encoded);
+			expect(encoded).not.toEqual(decoded);
+			expect(decoded).toEqual(input);
+		});
+
+		it(`will fail if original ref contains _`, () => {
+			const input = '/_';
+			const encoded = encodeUrlSlug(input);
+			const decoded = decodeUrlSlug(encoded);
+			expect(encoded).not.toEqual(decoded);
+			expect(decoded).not.toEqual(input);
+			expect(decoded).toEqual('//');
+		});
+	});
+});

--- a/packages/appeals-service-api/__tests__/unit/services/appeals-case-data.service.test.js
+++ b/packages/appeals-service-api/__tests__/unit/services/appeals-case-data.service.test.js
@@ -89,6 +89,27 @@ describe('src/services/appeals-case-data.service.test', () => {
 		expect(result[2].caseReference).toEqual('3221288');
 	});
 
+	it('should return a url friendly slug for appeal case ref', async () => {
+		const lpaCode = 'Q9999';
+
+		const appealCaseData = {
+			_id: '89aa8504-773c-42be-bb68-029716ad9756',
+			caseReference: '/@/1',
+			LPAApplicationReference: '2323232/pla',
+			questionnaireDueDate: '2023-07-07T13:53:31.6003126+00:00'
+		};
+
+		collectionMock.find.mockResolvedValue({
+			toArray: jest.fn(() => {
+				return [appealCaseData];
+			})
+		});
+
+		const result = await getAppeals(lpaCode);
+
+		expect(result[0].caseReferenceSlug).toEqual('_%40_1');
+	});
+
 	it('should throw error if no lpaCode provided', async () => {
 		try {
 			await getAppeals();

--- a/packages/appeals-service-api/src/lib/encode.js
+++ b/packages/appeals-service-api/src/lib/encode.js
@@ -1,0 +1,28 @@
+/**
+ * Replaces /'s and encodes URI component unsafe chars for the string passed in
+ * handles non string values as per encodeURIComponent
+ * @param {string} ref
+ * @returns {string} The url-friendly string
+ */
+function encodeUrlSlug(ref) {
+	if (typeof ref === 'string') {
+		ref = ref.replace(/\//g, '_');
+	}
+
+	return encodeURIComponent(ref);
+}
+
+function decodeUrlSlug(ref) {
+	ref = decodeURIComponent(ref);
+
+	if (typeof ref === 'string') {
+		ref = ref.replace(/_/g, '/');
+	}
+
+	return ref;
+}
+
+module.exports = {
+	encodeUrlSlug,
+	decodeUrlSlug
+};

--- a/packages/appeals-service-api/src/services/appeals-case-data.service.js
+++ b/packages/appeals-service-api/src/services/appeals-case-data.service.js
@@ -1,6 +1,7 @@
 const logger = require('../lib/logger');
 const mongodb = require('../db/db');
 const ApiError = require('../errors/apiError');
+const { encodeUrlSlug } = require('../lib/encode');
 const {
 	APPEALS_CASE_DATA: {
 		APPEAL_TYPE: { HAS },
@@ -42,6 +43,10 @@ const getAppeals = async (lpaCode) => {
 		logger.error(err);
 		throw ApiError.appealsCaseDataNotFound();
 	}
+
+	result.forEach((item) => {
+		item.caseReferenceSlug = encodeUrlSlug(item.caseReference);
+	});
 
 	result.sort((a, b) => {
 		if (!a.questionnaireDueDate || !b.questionnaireDueDate) {

--- a/packages/forms-web-app/__tests__/unit/controllers/lpa-dashboard/your-appeals.test.js
+++ b/packages/forms-web-app/__tests__/unit/controllers/lpa-dashboard/your-appeals.test.js
@@ -19,6 +19,8 @@ const mockUser = {
 	lpaName: 'test-lpa'
 };
 
+const mockAppealData = [1, 2];
+
 describe('controllers/lpa-dashboard/your-appeals', () => {
 	beforeEach(() => {
 		jest.resetAllMocks();
@@ -27,13 +29,15 @@ describe('controllers/lpa-dashboard/your-appeals', () => {
 	describe('getYourAppeals', () => {
 		it('should render the view with a link to add-remove', async () => {
 			getLPAUserFromSession.mockReturnValue(mockUser);
-
+			getAppealsCaseData.mockResolvedValue(mockAppealData);
 			await getYourAppeals(req, res);
 
 			expect(getLPAUserFromSession).toHaveBeenCalledWith(req);
 			expect(res.render).toHaveBeenCalledWith(VIEW.LPA_DASHBOARD.DASHBOARD, {
 				lpaName: mockUser.lpaName,
-				addOrRemoveLink: `/${VIEW.LPA_DASHBOARD.ADD_REMOVE_USERS}`
+				addOrRemoveLink: `/${VIEW.LPA_DASHBOARD.ADD_REMOVE_USERS}`,
+				appealDetailsLink: `/${VIEW.LPA_DASHBOARD.APPEAL_DETAILS}`,
+				appealsCaseData: mockAppealData
 			});
 		});
 

--- a/packages/forms-web-app/src/controllers/lpa-dashboard/your-appeals.js
+++ b/packages/forms-web-app/src/controllers/lpa-dashboard/your-appeals.js
@@ -2,7 +2,7 @@ const { getLPAUserFromSession } = require('../../services/lpa-user.service');
 
 const {
 	VIEW: {
-		LPA_DASHBOARD: { DASHBOARD, ADD_REMOVE_USERS }
+		LPA_DASHBOARD: { DASHBOARD, ADD_REMOVE_USERS, APPEAL_DETAILS }
 	}
 } = require('../../lib/views');
 
@@ -18,7 +18,9 @@ const getYourAppeals = async (req, res) => {
 
 	return res.render(DASHBOARD, {
 		lpaName: user.lpaName,
-		addOrRemoveLink: `/${ADD_REMOVE_USERS}`
+		addOrRemoveLink: `/${ADD_REMOVE_USERS}`,
+		appealsCaseData: appealsCaseData,
+		appealDetailsLink: `/${APPEAL_DETAILS}`
 	});
 };
 

--- a/packages/forms-web-app/src/views/manage-appeals/your-appeals.njk
+++ b/packages/forms-web-app/src/views/manage-appeals/your-appeals.njk
@@ -34,13 +34,18 @@
           </tr>
         </thead>
         <tbody class="govuk-table__body">
-          {# <tr class="govuk-table__row">
-            <td class="govuk-table__cell"></td>
-            <td class="govuk-table__cell"></td>
-            <td class="govuk-table__cell"></td>
-            <td class="govuk-table__cell govuk-table__cell--numeric"></td>
-            <td class="govuk-table__cell govuk-table__cell--numeric"></td>
-          </tr> #}
+            {% for item in appealsCaseData %}
+              <tr class="govuk-table__row">
+                <td class="govuk-table__cell">
+                  <a href="{{appealDetailsLink}}/{{item.caseReferenceSlug}}" class="govuk-link">{{item.caseReference}}</a>
+                </td>
+                <td class="govuk-table__cell"></td>
+                <td class="govuk-table__cell"></td>
+                <td class="govuk-table__cell govuk-table__cell--numeric"></td>
+                <td class="govuk-table__cell govuk-table__cell--numeric"></td>
+              </tr>
+            {% endfor %}
+
         </tbody>
       </table>
    </div>


### PR DESCRIPTION
## Ticket Number

<!-- Add the number from the Jira board -->

https://pins-ds.atlassian.net/browse/AAPD-24

## Description of change

Encoded url slug at api level, with a function to decode if needed, slightly nervous around the suggestion to replace '/' with '\_' as it'll break if a ref already has an '\_'

## Checklist

<!-- Put an `x` in all the boxes that apply: -->

- [ ] Requires infrastructure changes
- [ ] If adding or remove environment variables (e.g. in `docker-compose.yaml`) then I have updated the appropriate Helm chart
- [ ] I have updated the documentation accordingly
- [x] My commit history in this PR is linear
- [x] New features have tests
- [ ] Breaking change (team conversation required)

## Important

Please do not merge from `main` (please only [rebase](https://github.com/foundry4/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
