### PR TITLE
fix(aapd-24): only use encodeURIComponent for link to appeals detail …

### DIFF
--- a/packages/appeals-service-api/__tests__/developer/appeals-case-data.test.js
+++ b/packages/appeals-service-api/__tests__/developer/appeals-case-data.test.js
@@ -99,7 +99,7 @@ describe('appeals-case-data', () => {
 
 		expect(l2440response.status).toBe(200);
 		expect(l2440response.body.length).toEqual(2);
-		expect(l2440response.body[1].caseReferenceSlug).toBe('_%40_1');
+		expect(l2440response.body[1].caseReferenceSlug).toBe('%2F%40%2F1');
 	});
 
 	it('should 404 if no LPA code', async () => {

--- a/packages/appeals-service-api/__tests__/unit/lib/encode.test.js
+++ b/packages/appeals-service-api/__tests__/unit/lib/encode.test.js
@@ -1,4 +1,4 @@
-const { encodeUrlSlug, decodeUrlSlug } = require('../../../src/lib/encode');
+const { encodeUrlSlug } = require('../../../src/lib/encode');
 
 describe('lib/encode', () => {
 	describe('encodeUrlSlug', () => {
@@ -10,34 +10,10 @@ describe('lib/encode', () => {
 			});
 		});
 
-		it(`should replace all / chars`, () => {
-			const res = encodeUrlSlug('/a/a/');
-			expect(res).toEqual('_a_a_');
-		});
-
 		it(`should call encodeURIComponent`, () => {
 			jest.spyOn(global, 'encodeURIComponent');
 			encodeUrlSlug('@?');
 			expect(encodeURIComponent).toBeCalledWith('@?');
-		});
-	});
-
-	describe('decodeUrlSlug', () => {
-		it(`should decode url slug`, () => {
-			const input = '/a@a/';
-			const encoded = encodeUrlSlug(input);
-			const decoded = decodeUrlSlug(encoded);
-			expect(encoded).not.toEqual(decoded);
-			expect(decoded).toEqual(input);
-		});
-
-		it(`will fail if original ref contains _`, () => {
-			const input = '/_';
-			const encoded = encodeUrlSlug(input);
-			const decoded = decodeUrlSlug(encoded);
-			expect(encoded).not.toEqual(decoded);
-			expect(decoded).not.toEqual(input);
-			expect(decoded).toEqual('//');
 		});
 	});
 });

--- a/packages/appeals-service-api/__tests__/unit/services/appeals-case-data.service.test.js
+++ b/packages/appeals-service-api/__tests__/unit/services/appeals-case-data.service.test.js
@@ -107,7 +107,7 @@ describe('src/services/appeals-case-data.service.test', () => {
 
 		const result = await getAppeals(lpaCode);
 
-		expect(result[0].caseReferenceSlug).toEqual('_%40_1');
+		expect(result[0].caseReferenceSlug).toEqual('%2F%40%2F1');
 	});
 
 	it('should throw error if no lpaCode provided', async () => {

--- a/packages/appeals-service-api/src/lib/encode.js
+++ b/packages/appeals-service-api/src/lib/encode.js
@@ -1,28 +1,12 @@
 /**
- * Replaces /'s and encodes URI component unsafe chars for the string passed in
- * handles non string values as per encodeURIComponent
+ * encodes URI component unsafe chars for the string passed in
  * @param {string} ref
  * @returns {string} The url-friendly string
  */
 function encodeUrlSlug(ref) {
-	if (typeof ref === 'string') {
-		ref = ref.replace(/\//g, '_');
-	}
-
 	return encodeURIComponent(ref);
 }
 
-function decodeUrlSlug(ref) {
-	ref = decodeURIComponent(ref);
-
-	if (typeof ref === 'string') {
-		ref = ref.replace(/_/g, '/');
-	}
-
-	return ref;
-}
-
 module.exports = {
-	encodeUrlSlug,
-	decodeUrlSlug
+	encodeUrlSlug
 };


### PR DESCRIPTION
…page

## Ticket Number

<!-- Add the number from the Jira board -->

https://pins-ds.atlassian.net/browse/aapd-24

## Description of change

Resolved link to appeals details page

## Checklist

<!-- Put an `x` in all the boxes that apply: -->

- [ ] Requires infrastructure changes
- [ ] If adding or remove environment variables (e.g. in `docker-compose.yaml`) then I have updated the appropriate Helm chart
- [ ] I have updated the documentation accordingly
- [x] My commit history in this PR is linear
- [ ] New features have tests
- [ ] Breaking change (team conversation required)

## Important

Please do not merge from `main` (please only [rebase](https://github.com/foundry4/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
