### PR TITLE
fix(aapd-177): appeals details page handles null document metadata

### DIFF
--- a/packages/appeals-service-api/__tests__/developer/appeals-document-meta-data.test.js
+++ b/packages/appeals-service-api/__tests__/developer/appeals-document-meta-data.test.js
@@ -87,18 +87,30 @@ describe('document-meta-data', () => {
 		expect(response.status).toEqual(200);
 		expect(response.body).toEqual(fakeDocument);
 	});
+	it('should retrieve a supporting document', async () => {
+		const fakeDocument = fakeDocuments.filter(
+			(fakeDocument) => fakeDocument.documentType === DOCUMENT_TYPES.SUPPORTING_DOCUMENTS
+		)[getRandomInt(99)];
+		const url = `/api/v1/document-meta-data/${encodeURIComponent(
+			fakeDocument.caseRef
+		)}?documenttype=${encodeURIComponent(DOCUMENT_TYPES.SUPPORTING_DOCUMENTS)}`;
+		const response = await appealsApi.get(url);
+		expect(response.status).toEqual(200);
+		expect(response.body).toEqual(fakeDocument);
+	});
+
+	it('should handle no documents', async () => {
+		const fakeDocument = fakeDocuments.filter(
+			(fakeDocument) => fakeDocument.documentType === DOCUMENT_TYPES.SUPPORTING_DOCUMENTS
+		)[getRandomInt(99)];
+		const url = `/api/v1/document-meta-data/${encodeURIComponent(
+			fakeDocument.caseRef
+		)}?documenttype=nope`;
+		const response = await appealsApi.get(url);
+		expect(response.status).toEqual(404);
+	});
 });
-it('should retrieve a supporting document', async () => {
-	const fakeDocument = fakeDocuments.filter(
-		(fakeDocument) => fakeDocument.documentType === DOCUMENT_TYPES.SUPPORTING_DOCUMENTS
-	)[getRandomInt(99)];
-	const url = `/api/v1/document-meta-data/${encodeURIComponent(
-		fakeDocument.caseRef
-	)}?documenttype=${encodeURIComponent(DOCUMENT_TYPES.SUPPORTING_DOCUMENTS)}`;
-	const response = await appealsApi.get(url);
-	expect(response.status).toEqual(200);
-	expect(response.body).toEqual(fakeDocument);
-});
+
 const _seedDatabase = async () => {
 	const collection = await databaseConnection.db(collectionName).collection(collectionName);
 	await collection.insertMany(fakeDocuments);

--- a/packages/appeals-service-api/src/errors/apiError.js
+++ b/packages/appeals-service-api/src/errors/apiError.js
@@ -93,8 +93,14 @@ class ApiError {
 		return new ApiError(400, { errors: [`Can't match this user to the lpa`] });
 	}
 
+	// appeals case data
 	static appealsCaseDataNotFound() {
 		return new ApiError(404, { errors: [`The appeals case data was not found`] });
+	}
+
+	// document metadata
+	static documentMetadataNotFound(caseRef) {
+		return new ApiError(404, { errors: [`The document metadata ${caseRef} was not found`] });
 	}
 }
 

--- a/packages/appeals-service-api/src/routes/documentMetadata.js
+++ b/packages/appeals-service-api/src/routes/documentMetadata.js
@@ -7,7 +7,7 @@ router.get('/:caseref', async (req, res) => {
 	const caseRef = req.params.caseref;
 	const documentType = req.query.documenttype;
 	const returnMultipleDocuments = req.query.returnMultipleDocuments;
-	let body = '';
+	let body = {};
 
 	try {
 		body = await getDocumentMetadata(caseRef, documentType, returnMultipleDocuments);

--- a/packages/appeals-service-api/src/services/document-metadata.service.js
+++ b/packages/appeals-service-api/src/services/document-metadata.service.js
@@ -1,4 +1,6 @@
+const logger = require('../lib/logger');
 const { DocumentMetadataRepository } = require('../repositories/document-metadata-repository');
+const ApiError = require('../errors/apiError');
 
 const documentMetadataRepository = new DocumentMetadataRepository();
 
@@ -8,6 +10,12 @@ const getDocumentMetadata = async (caseRef, documentType, returnMultipleDocument
 		documentType,
 		returnMultipleDocuments
 	);
+
+	if (document === null) {
+		logger.info(`document meta data for ${caseRef} not found`);
+		throw ApiError.documentMetadataNotFound(caseRef);
+	}
+
 	return document;
 };
 

--- a/packages/forms-web-app/__tests__/unit/controllers/lpa-dashboard/appeal-details.test.js
+++ b/packages/forms-web-app/__tests__/unit/controllers/lpa-dashboard/appeal-details.test.js
@@ -84,11 +84,12 @@ describe('controllers/lpa-dashboard/your-appeals', () => {
 			getAppealDocumentMetaData.mockResolvedValueOnce(mockDocuments.appealStatement);
 			getAppealDocumentMetaData.mockResolvedValueOnce(mockDocuments.supportingDocuments);
 			isFeatureActive.mockResolvedValueOnce(false);
-
 			getAppealByLPACodeAndId.mockResolvedValue(mockAppeal);
+
 			req.session.lpaUser = {
 				lpaCode: 'E9999'
 			};
+
 			await getAppealDetails(req, res);
 
 			expect(res.render).toHaveBeenCalledWith(VIEW.LPA_DASHBOARD.APPEAL_DETAILS, {
@@ -102,7 +103,7 @@ describe('controllers/lpa-dashboard/your-appeals', () => {
 			});
 		});
 
-		it('should render the view with a link to add-remove', async () => {
+		it('should render the view and show questionnaire', async () => {
 			getAppealDocumentMetaData.mockResolvedValueOnce(mockDocuments.applicationForm);
 			getAppealDocumentMetaData.mockResolvedValueOnce(mockDocuments.decisionLetter);
 			getAppealDocumentMetaData.mockResolvedValueOnce(mockDocuments.appealStatement);
@@ -120,6 +121,36 @@ describe('controllers/lpa-dashboard/your-appeals', () => {
 				backOverride,
 				appeal: mockAppeal,
 				documents: mockDocuments,
+				dueInDays: -3,
+				appealQuestionnaireLink: `/${VIEW.LPA_QUESTIONNAIRE.QUESTIONNAIRE}`,
+				questionnaireDueDate: 'Friday, 7 July 2023',
+				showQuestionnaire: true
+			});
+		});
+
+		it('should handle no document data', async () => {
+			getAppealDocumentMetaData.mockRejectedValueOnce(new Error('Async error'));
+			getAppealDocumentMetaData.mockRejectedValueOnce(new Error('Async error'));
+			getAppealDocumentMetaData.mockResolvedValueOnce(mockDocuments.appealStatement);
+			getAppealDocumentMetaData.mockResolvedValueOnce(mockDocuments.supportingDocuments);
+			isFeatureActive.mockResolvedValueOnce(true);
+			getAppealByLPACodeAndId.mockResolvedValue(mockAppeal);
+
+			req.session.lpaUser = {
+				lpaCode: 'E9999'
+			};
+
+			await getAppealDetails(req, res);
+
+			expect(res.render).toHaveBeenCalledWith(VIEW.LPA_DASHBOARD.APPEAL_DETAILS, {
+				backOverride,
+				appeal: mockAppeal,
+				documents: {
+					applicationForm: null,
+					decisionLetter: null,
+					appealStatement: mockDocuments.appealStatement,
+					supportingDocuments: mockDocuments.supportingDocuments
+				},
 				dueInDays: -3,
 				appealQuestionnaireLink: `/${VIEW.LPA_QUESTIONNAIRE.QUESTIONNAIRE}`,
 				questionnaireDueDate: 'Friday, 7 July 2023',

--- a/packages/forms-web-app/src/lib/appeals-api-wrapper.js
+++ b/packages/forms-web-app/src/lib/appeals-api-wrapper.js
@@ -186,6 +186,19 @@ exports.getAppealByLPACodeAndId = async (lpaCode, id) => {
 	return handler(`/api/v1/appeals-case-data/${lpaCode}/${id}`, 'GET');
 };
 
+/**
+ * @typedef documentMetaData The metadata associated with a document.
+ * @property {string} documentMetaData.filename - The name of the document file.
+ * @property {string} documentMetaData.documentURI - The URI (Uniform Resource Identifier) of the document.
+ */
+
+/**
+ * @async
+ * @param {string} caseRef
+ * @param {string} documentType
+ * @param {string | boolean} returnMultipleDocuments
+ * @returns { Promise<documentMetaData | Array<documentMetaData>> }
+ */
 exports.getAppealDocumentMetaData = async (caseRef, documentType, returnMultipleDocuments = '') => {
 	return handler(
 		`/api/v1/document-meta-data/${caseRef}?documenttype=${documentType}&returnMultipleDocuments=${returnMultipleDocuments}`,


### PR DESCRIPTION
## Ticket Number

<!-- Add the number from the Jira board -->

https://pins-ds.atlassian.net/browse/aapd-177

## Description of change

<!-- Please describe the change -->

## Checklist

<!-- Put an `x` in all the boxes that apply: -->

- [ ] Requires infrastructure changes
- [ ] If adding or remove environment variables (e.g. in `docker-compose.yaml`) then I have updated the appropriate Helm chart
- [ ] I have updated the documentation accordingly
- [x] My commit history in this PR is linear
- [x] New features have tests
- [ ] Breaking change (team conversation required)

## Important

Please do not merge from `main` (please only [rebase](https://github.com/foundry4/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
