### PR TITLE
feat(aapd-105): add basic folder and routing structure for dynamic forms

### DIFF
--- a/packages/appeals-service-api/__tests__/developer/developer.test.js
+++ b/packages/appeals-service-api/__tests__/developer/developer.test.js
@@ -231,29 +231,6 @@ describe('Appeals', () => {
 		expectedNotifyInteractions = [];
 	});
 
-	it('should return the relevant appeal by lpacode and appeal_id when requested after the appeal has been saved', async () => {
-		// Given: an appeal is created
-		const savedAppeal = await _createAppeal();
-
-		// When: we try to request that appeal
-		const requestedAppeal = await appealsApi.get(
-			`/api/v1/appeals/${savedAppeal.body.lpaCode}/${savedAppeal.body.id}`
-		);
-
-		// Then: we should get a 200 status
-		expect(requestedAppeal.status).toEqual(200);
-
-		// And: the correct appeal should be returned
-		expect(requestedAppeal.body.id).toEqual(savedAppeal.body.id);
-
-		// And: there should be no data on the message queue
-		expectedMessages = [];
-
-		// And: external systems should be interacted with in the following ways
-		expectedHorizonInteractions = [];
-		expectedNotifyInteractions = [];
-	});
-
 	it(`should return an error if an appeal is requested that doesn't exist`, async () => {
 		// When: we try to access a non-existent appeal
 		const getAppealResponse = await appealsApi.get(`/api/v1/appeals/${uuid.v4()}`);

--- a/packages/appeals-service-api/src/repositories/appeals-case-data-repository.js
+++ b/packages/appeals-service-api/src/repositories/appeals-case-data-repository.js
@@ -45,7 +45,7 @@ class AppealsCaseDataRepository extends MongoRepository {
 		return result;
 	}
 	async getAppealByLpaCodeAndCaseRef(lpaCode, caseRef) {
-		return await this.findOneByQuery({
+		const result = await this.findOneByQuery({
 			LPACode: lpaCode,
 			caseReference: caseRef,
 			appealType: HAS,
@@ -53,6 +53,10 @@ class AppealsCaseDataRepository extends MongoRepository {
 			questionnaireDueDate: { $type: 'date' },
 			questionnaireReceived: { $not: { $type: 'date' } }
 		});
+
+		result.caseReferenceSlug = encodeUrlSlug(result.caseReference);
+
+		return result;
 	}
 }
 

--- a/packages/appeals-service-api/src/services/appeals-case-data.service.js
+++ b/packages/appeals-service-api/src/services/appeals-case-data.service.js
@@ -27,11 +27,7 @@ const getAppealByLpaCodeAndCaseRef = async (lpaCode, caseRef) => {
 	}
 
 	try {
-		const appealsCaseData = await appealsCaseDataRepository.getAppealByLpaCodeAndCaseRef(
-			lpaCode,
-			caseRef
-		);
-		return appealsCaseData;
+		return await appealsCaseDataRepository.getAppealByLpaCodeAndCaseRef(lpaCode, caseRef);
 	} catch (err) {
 		console.log(err);
 		logger.error(err);

--- a/packages/forms-web-app/__tests__/unit/controllers/lpa-dashboard/appeal-details.test.js
+++ b/packages/forms-web-app/__tests__/unit/controllers/lpa-dashboard/appeal-details.test.js
@@ -88,6 +88,7 @@ describe('controllers/lpa-dashboard/your-appeals', () => {
 				appeal,
 				documents,
 				dueInDays: -3,
+				appealQuestionnaireLink: `/${VIEW.LPA_QUESTIONNAIRE.QUESTIONNAIRE}`,
 				questionnaireDueDate: 'Friday, 7 July 2023'
 			});
 		});

--- a/packages/forms-web-app/src/app.js
+++ b/packages/forms-web-app/src/app.js
@@ -54,7 +54,8 @@ const viewPaths = [
 	path.join(__dirname, '..', 'node_modules', 'govuk-frontend'),
 	path.join(__dirname, '..', 'node_modules', '@ministryofjustice', 'frontend'),
 	path.join(__dirname, '..', 'node_modules', '@pins', 'common', 'src', 'frontend'),
-	path.join(__dirname, 'views')
+	path.join(__dirname, 'views'),
+	path.join(__dirname, 'dynamic-forms')
 ];
 
 const env = nunjucks.configure(viewPaths, nunjucksConfig);

--- a/packages/forms-web-app/src/controllers/lpa-dashboard/appeal-details.js
+++ b/packages/forms-web-app/src/controllers/lpa-dashboard/appeal-details.js
@@ -4,7 +4,8 @@ const {
 } = require('../../lib/appeals-api-wrapper');
 const {
 	VIEW: {
-		LPA_DASHBOARD: { DASHBOARD, APPEAL_DETAILS }
+		LPA_DASHBOARD: { DASHBOARD, APPEAL_DETAILS },
+		LPA_QUESTIONNAIRE: { QUESTIONNAIRE }
 	}
 } = require('../../lib/views');
 const dateFns = require('date-fns');
@@ -59,6 +60,7 @@ const getAppealDetails = async (req, res) => {
 		appeal,
 		documents,
 		dueInDays: calculateDueInDays(appeal.questionnaireDueDate),
+		appealQuestionnaireLink: `/${QUESTIONNAIRE}`,
 		questionnaireDueDate: (() => {
 			return new Intl.DateTimeFormat('en-GB', {
 				dateStyle: 'full',

--- a/packages/forms-web-app/src/dynamic-forms/controller.js
+++ b/packages/forms-web-app/src/dynamic-forms/controller.js
@@ -1,0 +1,23 @@
+// common controllers for dynamic forms
+const { getAppealByLPACodeAndId } = require('../lib/appeals-api-wrapper');
+const { getLPAUserFromSession } = require('../services/lpa-user.service');
+
+const {
+	VIEW: { TASK_LIST }
+} = require('./dynamic-components/views');
+
+async function renderTaskList(req, res) {
+	const { caseRef } = req.params;
+
+	const user = getLPAUserFromSession(req);
+	const caseReference = encodeURIComponent(caseRef);
+	const appeal = await getAppealByLPACodeAndId(user.lpaCode, caseReference);
+
+	return res.render(TASK_LIST, {
+		appeal
+	});
+}
+
+module.exports = {
+	renderTaskList
+};

--- a/packages/forms-web-app/src/dynamic-forms/controller.test.js
+++ b/packages/forms-web-app/src/dynamic-forms/controller.test.js
@@ -1,0 +1,40 @@
+const { renderTaskList } = require('./controller');
+const { getAppealByLPACodeAndId } = require('../lib/appeals-api-wrapper');
+const { getLPAUserFromSession } = require('../services/lpa-user.service');
+const {
+	VIEW: { TASK_LIST }
+} = require('./dynamic-components/views');
+
+const { mockReq, mockRes } = require('../../__tests__/unit/mocks');
+
+const req = {
+	...mockReq(null)
+};
+const res = mockRes();
+
+jest.mock('../lib/appeals-api-wrapper');
+jest.mock('../services/lpa-user.service');
+
+describe('dynamic-form/controller', () => {
+	beforeEach(() => {
+		jest.resetAllMocks();
+	});
+
+	describe('getAppealDetails', () => {
+		it('should render the view', async () => {
+			const appeal = { a: 1 };
+			const lpaUser = {
+				lpaCode: 'E9999'
+			};
+
+			getAppealByLPACodeAndId.mockResolvedValue(appeal);
+			getLPAUserFromSession.mockReturnValue(lpaUser);
+
+			await renderTaskList(req, res);
+
+			expect(res.render).toHaveBeenCalledWith(TASK_LIST, {
+				appeal
+			});
+		});
+	});
+});

--- a/packages/forms-web-app/src/dynamic-forms/dynamic-components/boolean/index.njk
+++ b/packages/forms-web-app/src/dynamic-forms/dynamic-components/boolean/index.njk
@@ -1,0 +1,1 @@
+{# view for a boolean question component #}

--- a/packages/forms-web-app/src/dynamic-forms/dynamic-components/boolean/question.js
+++ b/packages/forms-web-app/src/dynamic-forms/dynamic-components/boolean/question.js
@@ -1,0 +1,1 @@
+// question class

--- a/packages/forms-web-app/src/dynamic-forms/dynamic-components/boolean/validation.js
+++ b/packages/forms-web-app/src/dynamic-forms/dynamic-components/boolean/validation.js
@@ -1,0 +1,1 @@
+// validation for a question component

--- a/packages/forms-web-app/src/dynamic-forms/dynamic-components/task-list/index.njk
+++ b/packages/forms-web-app/src/dynamic-forms/dynamic-components/task-list/index.njk
@@ -1,0 +1,19 @@
+{% extends "../../../views/layouts/lpa-dashboard/main.njk" %}
+{% set title="Appeal questionnaire - Manage appeals - GOV.UK" %}
+
+{% block pageTitle %}
+  {{ title }}
+{% endblock %}
+
+{% block content %}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-full">
+        <div class="govuk-grid-column-full govuk-!-margin-bottom-3">
+            <span class="govuk-caption-l">Appeal {{appeal.caseReference}}</span>
+            <h1 class="govuk-heading-l">
+                Appeal questionnaire
+            </h1>
+        </div>
+    </div>
+  </div>
+{% endblock %}

--- a/packages/forms-web-app/src/dynamic-forms/dynamic-components/views.js
+++ b/packages/forms-web-app/src/dynamic-forms/dynamic-components/views.js
@@ -1,0 +1,7 @@
+const VIEW = {
+	TASK_LIST: 'dynamic-components/task-list/index'
+};
+
+module.exports = {
+	VIEW
+};

--- a/packages/forms-web-app/src/dynamic-forms/has-questionnaire/journey.js
+++ b/packages/forms-web-app/src/dynamic-forms/has-questionnaire/journey.js
@@ -1,0 +1,1 @@
+// definition of the HAS journey, extends base journey class

--- a/packages/forms-web-app/src/dynamic-forms/has-questionnaire/route.js
+++ b/packages/forms-web-app/src/dynamic-forms/has-questionnaire/route.js
@@ -1,0 +1,8 @@
+const express = require('express');
+const { renderTaskList } = require('../controller');
+
+const router = express.Router();
+
+router.get('/questionnaire/:caseRef', renderTaskList);
+
+module.exports = router;

--- a/packages/forms-web-app/src/dynamic-forms/journey.js
+++ b/packages/forms-web-app/src/dynamic-forms/journey.js
@@ -1,0 +1,1 @@
+// base journey class

--- a/packages/forms-web-app/src/dynamic-forms/question.js
+++ b/packages/forms-web-app/src/dynamic-forms/question.js
@@ -1,0 +1,1 @@
+// base question class

--- a/packages/forms-web-app/src/dynamic-forms/section.js
+++ b/packages/forms-web-app/src/dynamic-forms/section.js
@@ -1,0 +1,1 @@
+// base section class

--- a/packages/forms-web-app/src/lib/views.js
+++ b/packages/forms-web-app/src/lib/views.js
@@ -209,7 +209,7 @@ const VIEW = {
 	},
 
 	LPA_QUESTIONNAIRE: {
-		QUESTIONNAIRE: 'manage/questionnaire'
+		QUESTIONNAIRE: 'manage-appeals/questionnaire'
 	},
 
 	MESSAGES: {

--- a/packages/forms-web-app/src/routes/lpa-dashboard/index.js
+++ b/packages/forms-web-app/src/routes/lpa-dashboard/index.js
@@ -17,16 +17,20 @@ router.use(
 	])
 );
 
+// login
 router.use(require('./service-invite'));
 router.use(require('./enter-code'));
 router.use(require('./request-new-code'));
 router.use(require('./need-new-code'));
 router.use(require('./code-expired'));
 router.use(require('./your-email-address'));
-router.use(require('./appeal-details'));
 
+// appeals
 router.use(require('./your-appeals'));
+router.use(require('./appeal-details'));
+router.use(require('../../dynamic-forms/has-questionnaire/route'));
 
+// manage users
 router.use(require('./add-remove-users'));
 router.use(require('./email-address'));
 router.use(require('./confirm-add-user'));

--- a/packages/forms-web-app/src/views/manage-appeals/appeal-details.njk
+++ b/packages/forms-web-app/src/views/manage-appeals/appeal-details.njk
@@ -31,13 +31,13 @@
           {% if dueInDays < 0 %}
             This appeal was due {{questionnaireDueDate | date('D MMMM YYYY') }}
             <p class="govuk-body">
-              <a class="govuk-notification-banner__link" href="/manage/questionnaire">Submit questionnaire</a>
+              <a class="govuk-notification-banner__link" href="{{appealQuestionnaireLink}}/{{appeal.caseReferenceSlug}}">Submit questionnaire</a>
             </p>
           {% else %}
             You have until 11:59 on {{questionnaireDueDate}} to:
             <ul class="govuk-list govuk-list--bullet">
               <li>
-                <a class="govuk-notification-banner__link" href="/manage/questionnaire">Submit questionnaire</a>
+                <a class="govuk-notification-banner__link" href="{{appealQuestionnaireLink}}/{{appeal.caseReferenceSlug}}">Submit questionnaire</a>
               </li>
             </ul>
           {% endif %}

--- a/packages/forms-web-app/src/views/manage-appeals/your-appeals.njk
+++ b/packages/forms-web-app/src/views/manage-appeals/your-appeals.njk
@@ -54,7 +54,7 @@
                   {% endif %} 
                 </td>
                 <td class="govuk-table__cell govuk-table__cell--numeric">
-                  <a href="{{appealQuestionnaireLink}}" class="govuk-link">Questionnaire</a>
+                  <a href="{{appealQuestionnaireLink}}/{{item.caseReferenceSlug}}" class="govuk-link">Questionnaire</a>
                 </td>
               </tr>
             {% endfor %}


### PR DESCRIPTION
## Ticket Number

<!-- Add the number from the Jira board -->

https://pins-ds.atlassian.net/browse/aapd-105

## Description of change

Have added a folder structure for the dynamic questionnaire + the initial page
Have kept views alongside the component, which I think means we need to be careful to avoid folder-name clashes so have put in a folder called dynamic-components instead of just components - any smarter way to avoid that?

## Checklist

<!-- Put an `x` in all the boxes that apply: -->

- [ ] Requires infrastructure changes
- [ ] If adding or remove environment variables (e.g. in `docker-compose.yaml`) then I have updated the appropriate Helm chart
- [ ] I have updated the documentation accordingly
- [x] My commit history in this PR is linear
- [x] New features have tests
- [ ] Breaking change (team conversation required)

## Important

Please do not merge from `main` (please only [rebase](https://github.com/foundry4/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
