### PR TITLE
fix(AAPD-69): fix syntax on mongo query

### DIFF
--- a/packages/appeals-service-api/src/repositories/document-metadata-repository.js
+++ b/packages/appeals-service-api/src/repositories/document-metadata-repository.js
@@ -15,26 +15,37 @@ class DocumentMetadataRepository extends MongoRepository {
 	 * @return {Promise<any>}
 	 */
 	async getDocumentMetadata(caseRef, documentType, returnMultipleDocuments) {
-		const query = {
-			caseRef: caseRef,
-			documentType: documentType,
-			virusCheckStatus: 'scanned',
-			redactedStatus: 'redacted',
-			publishedStatus: 'published'
-		};
-		const version = {
-			version: -1
-		};
-
 		if (returnMultipleDocuments) {
 			try {
-				return await this.getAllDocumentsThatMatchQuery(query, version);
+				return await this.getAllDocumentsThatMatchQuery(
+					{
+						caseRef: caseRef,
+						documentType: documentType,
+						virusCheckStatus: 'scanned',
+						redactedStatus: 'redacted',
+						publishedStatus: 'published'
+					},
+					{
+						version: -1
+					}
+				);
 			} catch (e) {
 				console.log(e);
 			}
 		} else {
 			try {
-				return await this.findOneByQuery(query, version);
+				return await this.findOneByQuery(
+					{
+						caseRef: caseRef,
+						documentType: documentType,
+						virusCheckStatus: 'scanned',
+						redactedStatus: 'redacted',
+						publishedStatus: 'published'
+					},
+					{
+						version: -1
+					}
+				);
 			} catch (e) {
 				console.log(e);
 			}


### PR DESCRIPTION
We tried to make the getDocumentMetadata query a bit more readable however this wasn't the right direction with the current mongo sdk. We could look to pass this in a string in the format of a mongo query but for now it's just easier to pass it in as an inline object in method parameter

AAPD-69

## Ticket Number

AAPD-69

https://pins-ds.atlassian.net/browse/AAPD-69


## Description of change

We tried to make the getDocumentMetadata query a bit more readable however this wasn't the right direction with the current mongo sdk. We could look to pass this in a string in the format of a mongo query but for now it's just easier to pass it in as an inline object in method parameter

## Checklist

<!-- Put an `x` in all the boxes that apply: -->

- [ ] Requires infrastructure changes
- [ ] If adding or remove environment variables (e.g. in `docker-compose.yaml`) then I have updated the appropriate Helm chart
- [ ] I have updated the documentation accordingly
- [ ] My commit history in this PR is linear
- [ ] New features have tests
- [ ] Breaking change (team conversation required)

## Important

Please do not merge from `main` (please only [rebase](https://github.com/foundry4/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
