### PR TITLE
fix(aapd-185): fix param order for default journey response

### DIFF
--- a/packages/forms-web-app/src/dynamic-forms/journey-response.js
+++ b/packages/forms-web-app/src/dynamic-forms/journey-response.js
@@ -29,8 +29,8 @@ class JourneyResponse {
 	 * @param {Object | undefined} answers
 	 */
 	constructor(journeyId, referenceId, answers) {
-		this.referenceId = referenceId;
 		this.journeyId = journeyId;
+		this.referenceId = referenceId;
 		if (answers) {
 			this.answers = answers;
 		} else {

--- a/packages/forms-web-app/src/dynamic-forms/journey-types.js
+++ b/packages/forms-web-app/src/dynamic-forms/journey-types.js
@@ -44,12 +44,12 @@ function getJourneyResponseByType(req, journeyId, referenceId) {
 
 /**
  * returns a default response for a journey
- * @param {string} referenceId - unique ref used in journey url
  * @param {JourneyType} journeyId - the type of journey
+ * @param {string} referenceId - unique ref used in journey url
  * @returns {JourneyResponse}
  */
 function getDefaultResponse(journeyId, referenceId) {
-	return new JourneyResponse(referenceId, journeyId, null);
+	return new JourneyResponse(journeyId, referenceId, null);
 }
 
 /**

--- a/packages/forms-web-app/src/dynamic-forms/journey-types.test.js
+++ b/packages/forms-web-app/src/dynamic-forms/journey-types.test.js
@@ -50,6 +50,8 @@ describe('journey-types', () => {
 		it('should return default response if no session data', () => {
 			const response = getJourneyResponseByType(req, JOURNEY_TYPES.HAS_QUESTIONNAIRE, 'test');
 			expect(response instanceof JourneyResponse).toBe(true);
+			expect(response.journeyId).toBe(JOURNEY_TYPES.HAS_QUESTIONNAIRE);
+			expect(response.referenceId).toBe('test');
 		});
 
 		it('should error if an invalid journey type is used', () => {


### PR DESCRIPTION
## Ticket Number

<!-- Add the number from the Jira board -->

https://pins-ds.atlassian.net/browse/aapd-185

## Description of change

Missed a reordering of params in a refactor
Have added a test that would have caught this

## Checklist

<!-- Put an `x` in all the boxes that apply: -->

- [ ] Requires infrastructure changes
- [ ] If adding or remove environment variables (e.g. in `docker-compose.yaml`) then I have updated the appropriate Helm chart
- [ ] I have updated the documentation accordingly
- [x] My commit history in this PR is linear
- [ ] New features have tests
- [ ] Breaking change (team conversation required)

## Important

Please do not merge from `main` (please only [rebase](https://github.com/foundry4/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
