### PR TITLE
feat(aapd-148): calculate journey section states

### DIFF
--- a/packages/forms-web-app/src/dynamic-forms/controller.test.js
+++ b/packages/forms-web-app/src/dynamic-forms/controller.test.js
@@ -2,6 +2,7 @@ const { list, question } = require('./controller');
 const { getAppealByLPACodeAndId } = require('../lib/appeals-api-wrapper');
 const { getLPAUserFromSession } = require('../services/lpa-user.service');
 const { Journey } = require('./journey');
+const { SECTION_STATUS } = require('./section');
 const { getJourney, getJourneyResponseByType } = require('./journey-types');
 
 const {
@@ -23,6 +24,9 @@ class TestJourney extends Journey {
 			{
 				name: 'Section 1',
 				segment: 'segment-1',
+				getStatus: () => {
+					return SECTION_STATUS.COMPLETE;
+				},
 				questions: [
 					{
 						title: 'Title 1a',
@@ -41,6 +45,9 @@ class TestJourney extends Journey {
 			{
 				name: 'Section 2',
 				segment: 'segment-2',
+				getStatus: () => {
+					return SECTION_STATUS.IN_PROGRESS;
+				},
 				questions: [
 					{
 						title: 'Title 2a',
@@ -59,6 +66,9 @@ class TestJourney extends Journey {
 			{
 				name: 'Section 3',
 				segment: 'segment-3',
+				getStatus: () => {
+					return SECTION_STATUS.NOT_STARTED;
+				},
 				questions: [
 					{
 						title: 'Title 3a',
@@ -85,9 +95,11 @@ const mockResponse = {
 const mockJourney = new TestJourney(mockResponse);
 
 const mockSummaryListData = {
+	completedSectionCount: 1,
 	sections: [
 		{
 			heading: 'Section 1',
+			status: SECTION_STATUS.COMPLETE,
 			list: {
 				rows: [
 					{
@@ -108,6 +120,7 @@ const mockSummaryListData = {
 		},
 		{
 			heading: 'Section 2',
+			status: SECTION_STATUS.IN_PROGRESS,
 			list: {
 				rows: [
 					{
@@ -141,6 +154,7 @@ const mockSummaryListData = {
 		},
 		{
 			heading: 'Section 3',
+			status: SECTION_STATUS.NOT_STARTED,
 			list: {
 				rows: [
 					{

--- a/packages/forms-web-app/src/dynamic-forms/dynamic-components/task-list/index.njk
+++ b/packages/forms-web-app/src/dynamic-forms/dynamic-components/task-list/index.njk
@@ -39,7 +39,7 @@
             <h2 class="govuk-heading-m">
               <span class="app-task-list__section-number">{{loop.index}}. </span> {{section.heading}}
               <strong class="govuk-tag govuk-tag--grey moj-task-list__task-completed">
-              Not started
+                {{section.status}}
               </strong>
             </h2>
         </div>

--- a/packages/forms-web-app/src/dynamic-forms/dynamic-components/task-list/questionnaire.njk
+++ b/packages/forms-web-app/src/dynamic-forms/dynamic-components/task-list/questionnaire.njk
@@ -30,7 +30,7 @@
     <div class="govuk-grid-column-three-quarters-from-desktop">
       <hr class="govuk-section-break govuk-section-break--visible govuk-section-break--l">
       <h2 class="govuk-heading-s">Complete the questionnaire</h2>
-      <p class="govuk-!-margin-bottom-7">You have completed 0 of {{summaryListData.sections.length}} sections.</p>
+      <p class="govuk-!-margin-bottom-7">You have completed {{summaryListData.completedSectionCount}} of {{summaryListData.sections.length}} sections.</p>
     </div>
   </div>
 {% endblock %}

--- a/packages/forms-web-app/src/dynamic-forms/section.js
+++ b/packages/forms-web-app/src/dynamic-forms/section.js
@@ -1,5 +1,8 @@
+const RequiredValidator = require('./validator/required-validator');
+
 /**
- * @typedef {import('./question').Question} Question
+ * @typedef {import('./question')} Question
+ * @typedef {import('./journey-response').JourneyResponse} JourneyResponse
  */
 
 /**
@@ -54,9 +57,69 @@ class Section {
 		return this;
 	}
 
+	/**
+	 * checks answers on response to ensure that a answer is provded for each required question in the section
+	 * @param {JourneyResponse} journeyResponse
+	 * @returns {SectionStatus}
+	 */
+	getStatus(journeyResponse) {
+		let result = SECTION_STATUS.NOT_STARTED;
+		let requiredQuestionCount = 0;
+		let requiredAnswerCount = 0;
+		let answerCount = 0;
+
+		for (let question of this.questions) {
+			const isRequired = question.validators?.some((item) => item instanceof RequiredValidator);
+			const answer = journeyResponse?.answers[question.fieldName];
+
+			// increment count of required questions
+			if (isRequired) {
+				requiredQuestionCount++;
+			}
+
+			// move to next question if answer not provided for this question
+			if (!answer) {
+				continue;
+			}
+
+			answerCount++;
+
+			// increment count of required answers in this section
+			if (isRequired) {
+				requiredAnswerCount++;
+			}
+		}
+
+		// any answer given
+		if (answerCount > 0) {
+			result = SECTION_STATUS.IN_PROGRESS;
+		}
+
+		// all required questions complete
+		// if no required sections this will never be hit
+		if (requiredQuestionCount != 0 && requiredAnswerCount >= requiredQuestionCount) {
+			result = SECTION_STATUS.COMPLETE;
+		}
+
+		return result;
+	}
+
 	//todo: taskList withCondition - i.e. evaluate whether question should be
 	//included in taskList (summary list) or not. See also comment in Question class
 	//constructor - should only evaluate if on task list view
 }
 
-module.exports = { Section };
+/**
+ * @typedef {string} SectionStatus
+ */
+
+/**
+ * @enum {SectionStatus}
+ */
+const SECTION_STATUS = {
+	NOT_STARTED: 'Not started',
+	IN_PROGRESS: 'In progress',
+	COMPLETE: 'Completed'
+};
+
+module.exports = { Section, SECTION_STATUS };

--- a/packages/forms-web-app/src/dynamic-forms/section.test.js
+++ b/packages/forms-web-app/src/dynamic-forms/section.test.js
@@ -1,65 +1,97 @@
-const { Section } = require('./section');
+const { Section, SECTION_STATUS } = require('./section');
+const RequiredValidator = require('./validator/required-validator');
+
+const mockQuestion = {
+	fieldName: 'visitFrequently'
+};
+
 describe('./src/dynamic-forms/section.js', () => {
-	it('should create', () => {
-		const SECTION_NAME = 'Section1';
-		const SEGMENT = 'A SEGMENT';
-		const section = new Section(SECTION_NAME, SEGMENT);
-		expect(section.name).toEqual(SECTION_NAME);
-		expect(section.segment).toEqual(SEGMENT);
+	describe('constructor', () => {
+		it('should create', () => {
+			const SECTION_NAME = 'Section1';
+			const SEGMENT = 'A SEGMENT';
+			const section = new Section(SECTION_NAME, SEGMENT);
+			expect(section.name).toEqual(SECTION_NAME);
+			expect(section.segment).toEqual(SEGMENT);
+		});
 	});
-	it('should return self from addQuestion method as  a fluent api', () => {
-		const section = new Section();
-		const question = {
-			title: 'ice breaker',
-			question: 'Do you come here often?',
-			description: 'Chit chat',
-			type: 'Boolean',
-			fieldName: 'visitFrequently'
-		};
-		const result = section.addQuestion(question);
-		expect(result instanceof Section).toEqual(true);
-		expect(result).toEqual(section);
+
+	describe('addQuestion', () => {
+		it('should return self from addQuestion method as a fluent api', () => {
+			const section = new Section();
+			const result = section.addQuestion(mockQuestion);
+			expect(result instanceof Section).toEqual(true);
+			expect(result).toEqual(section);
+		});
+
+		it('should add a question', () => {
+			const section = new Section();
+			section.addQuestion(mockQuestion);
+			expect(section.questions.length).toEqual(1);
+			expect(section.questions[0]).toEqual(mockQuestion);
+		});
 	});
-	it('should return self from withCondition method as  a fluent api', () => {
-		const section = new Section();
-		const question = {
-			title: 'ice breaker',
-			question: 'Do you come here often?',
-			description: 'Chit chat',
-			type: 'Boolean',
-			fieldName: 'visitFrequently'
-		};
-		section.addQuestion(question);
-		const result = section.withCondition(false);
-		expect(result instanceof Section).toEqual(true);
-		expect(result).toEqual(section);
+
+	describe('withCondition', () => {
+		it('should return self from withCondition method as a fluent api', () => {
+			const section = new Section();
+			section.addQuestion(mockQuestion);
+			const result = section.withCondition(false);
+			expect(result instanceof Section).toEqual(true);
+			expect(result).toEqual(section);
+		});
+
+		it('should remove a question', () => {
+			const section = new Section();
+			section.addQuestion(mockQuestion);
+			section.withCondition(false);
+			expect(section.questions.length).toEqual(0);
+		});
 	});
-	it('should add a question', () => {
-		const section = new Section();
-		const question = {
-			title: 'ice breaker',
-			question: 'Do you come here often?',
-			description: 'Chit chat',
-			type: 'Boolean',
-			fieldName: 'visitFrequently'
-		};
-		section.addQuestion(question);
-		expect(section.questions.length).toEqual(1);
-		expect(section.questions[0]).toEqual(question);
+
+	describe('getStatus', () => {
+		it('should return NOT_STARTED when no answers are given', () => {
+			const mockJourneyResponse = {
+				answers: {}
+			};
+			const section = new Section();
+			section.addQuestion(mockQuestion);
+			const result = section.getStatus(mockJourneyResponse);
+			expect(result).toBe(SECTION_STATUS.NOT_STARTED);
+		});
+
+		it('should return IN_PROGRESS when at least one answer is given', () => {
+			const mockJourneyResponse = {
+				answers: {
+					visitFrequently: 'Answer 1'
+				}
+			};
+
+			const section = new Section();
+			section.addQuestion(mockQuestion);
+			const result = section.getStatus(mockJourneyResponse);
+			expect(result).toBe(SECTION_STATUS.IN_PROGRESS);
+		});
+
+		it('should return COMPLETE when all required answers are given', () => {
+			const mockJourneyResponse = {
+				answers: {
+					visitFrequently: 'Answer 1'
+				}
+			};
+
+			const requiredQuestion = {
+				fieldName: 'visitFrequently',
+				validators: [new RequiredValidator()]
+			};
+
+			const section = new Section();
+			section.addQuestion(requiredQuestion);
+			const result = section.getStatus(mockJourneyResponse);
+			expect(result).toBe(SECTION_STATUS.COMPLETE);
+		});
 	});
-	it('should remove a question', () => {
-		const section = new Section();
-		const question = {
-			title: 'ice breaker',
-			question: 'Do you come here often?',
-			description: 'Chit chat',
-			type: 'Boolean',
-			fieldName: 'visitFrequently'
-		};
-		section.addQuestion(question);
-		section.withCondition(false);
-		expect(section.questions.length).toEqual(0);
-	});
+
 	it('should do a noop', () => {
 		const section = new Section();
 		const question = {


### PR DESCRIPTION
## Ticket Number

<!-- Add the number from the Jira board -->

https://pins-ds.atlassian.net/browse/aapd-148

## Description of change

- Calculate section statuses and number of completed sections
- relies on each section having at least one required section

## Checklist

<!-- Put an `x` in all the boxes that apply: -->

- [ ] Requires infrastructure changes
- [ ] If adding or remove environment variables (e.g. in `docker-compose.yaml`) then I have updated the appropriate Helm chart
- [ ] I have updated the documentation accordingly
- [x] My commit history in this PR is linear
- [x] New features have tests
- [ ] Breaking change (team conversation required)

## Important

Please do not merge from `main` (please only [rebase](https://github.com/foundry4/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
