### PR TITLE
fix(aapd-148): set colour on task list status tags

### DIFF
--- a/packages/forms-web-app/src/dynamic-forms/dynamic-components/task-list/index.njk
+++ b/packages/forms-web-app/src/dynamic-forms/dynamic-components/task-list/index.njk
@@ -1,5 +1,6 @@
 {% extends layoutTemplate %}
 {% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
+{% from "govuk/components/tag/macro.njk" import govukTag %}
 
 {% block pageTitle %}
   {{ title }}
@@ -38,9 +39,24 @@
         <div class="app-task-list__section">
             <h2 class="govuk-heading-m">
               <span class="app-task-list__section-number">{{loop.index}}. </span> {{section.heading}}
-              <strong class="govuk-tag govuk-tag--grey moj-task-list__task-completed">
-                {{section.status}}
-              </strong>
+              {%- if section.status %}
+                {%- if section.status == 'Completed' %}
+                  {{ govukTag({
+                    text: section.status,
+                    classes: 'moj-task-list__task-completed'
+                  }) }}
+                {%- elif section.status == 'In progress' %}
+                  {{ govukTag({
+                    text: section.status,
+                    classes: 'govuk-tag--blue moj-task-list__task-completed'
+                  }) }}
+                {% else %}
+                  {{ govukTag({
+                    text: section.status,
+                    classes: 'govuk-tag--grey moj-task-list__task-completed'
+                  }) }}
+                {% endif -%}
+              {% endif -%}
             </h2>
         </div>
         


### PR DESCRIPTION
## Ticket Number

<!-- Add the number from the Jira board -->

https://pins-ds.atlassian.net/browse/aapd-148

## Description of change

Used macros for status tags and used correct colours

## Checklist

<!-- Put an `x` in all the boxes that apply: -->

- [ ] Requires infrastructure changes
- [ ] If adding or remove environment variables (e.g. in `docker-compose.yaml`) then I have updated the appropriate Helm chart
- [ ] I have updated the documentation accordingly
- [x] My commit history in this PR is linear
- [ ] New features have tests
- [ ] Breaking change (team conversation required)

## Important

Please do not merge from `main` (please only [rebase](https://github.com/foundry4/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
