### PR TITLE
feat(aapd-262): change url for report-upload page and fix file upload

### DIFF
--- a/packages/forms-web-app/src/dynamic-forms/controller.js
+++ b/packages/forms-web-app/src/dynamic-forms/controller.js
@@ -214,31 +214,31 @@ exports.save = async (req, res, journeyId) => {
 	const { body } = req;
 	const { errors = {}, errorSummary = [] } = body;
 
-	// show errors
-	if (Object.keys(errors).length > 0) {
-		const answer = journeyResponse.answers[questionObj.fieldName] || '';
-
-		return questionObj.renderPage(
-			res,
-			{
-				layoutTemplate: journey.journeyTemplate,
-				pageCaption: sectionObj?.name,
-				backLink: journey.getNextQuestionUrl(section, question, true),
-				listLink: journey.baseUrl,
-				answers: journey.response.answers,
-				answer
-			},
-			{
-				errors,
-				errorSummary
-			}
-		);
-	}
-
 	try {
 		// use custom saveAction
 		if (questionObj.saveAction) {
 			return await questionObj.saveAction(req, res, journey, sectionObj, journeyResponse);
+		}
+
+		// show errors
+		if (Object.keys(errors).length > 0) {
+			const answer = journeyResponse.answers[questionObj.fieldName] || '';
+
+			return questionObj.renderPage(
+				res,
+				{
+					layoutTemplate: journey.journeyTemplate,
+					pageCaption: sectionObj?.name,
+					backLink: journey.getNextQuestionUrl(section, question, true),
+					listLink: journey.baseUrl,
+					answers: journey.response.answers,
+					answer
+				},
+				{
+					errors,
+					errorSummary
+				}
+			);
 		}
 
 		// set answer on response

--- a/packages/forms-web-app/src/dynamic-forms/controller.test.js
+++ b/packages/forms-web-app/src/dynamic-forms/controller.test.js
@@ -203,6 +203,44 @@ describe('dynamic-form/controller', () => {
 	});
 
 	describe('save', () => {
+		it('should use custom action if saveAction is defined on question', async () => {
+			const journeyId = 'has-questionnaire';
+			const sampleQuestionObjWithSaveAction = { ...sampleQuestionObj, saveAction: jest.fn() };
+
+			req.params = {
+				referenceId: mockRef,
+				section: mockJourney.sections[0].segment,
+				question: mockJourney.sections[0].questions[0].fieldName
+			};
+
+			res.locals.journeyResponse = {
+				answers: {}
+			};
+
+			req.body = {
+				sampleFieldName: true,
+				sampleFieldName_sub: 'send this',
+				notSampleFieldName: 'do not send this'
+			};
+
+			getJourney.mockReturnValue(mockJourney);
+
+			mockJourney.getQuestionBySectionAndName = jest.fn();
+			mockJourney.getQuestionBySectionAndName.mockReturnValueOnce(sampleQuestionObjWithSaveAction);
+
+			await save(req, res, journeyId);
+
+			expect(sampleQuestionObjWithSaveAction.saveAction).toHaveBeenCalledWith(
+				req,
+				res,
+				mockJourney,
+				mockJourney.sections[0],
+				res.locals.journeyResponse
+			);
+			expect(patchQuestionResponse).not.toHaveBeenCalled();
+			expect(res.redirect).not.toHaveBeenCalled();
+		});
+
 		it('should call API function to patch answer to question and redirect to next question if successful', async () => {
 			const journeyId = 'has-questionnaire';
 

--- a/packages/forms-web-app/src/dynamic-forms/dynamic-components/multi-file-upload/question.js
+++ b/packages/forms-web-app/src/dynamic-forms/dynamic-components/multi-file-upload/question.js
@@ -113,7 +113,6 @@ class MultiFileUploadQuestion extends Question {
 			// update journey based on response
 			const updatedJourney = new journey.constructor(journeyResponse);
 
-			// todo: validation after saving required?
 			if (Object.keys(errors).length > 0) {
 				const answer = journeyResponse.answers[this.fieldName];
 

--- a/packages/forms-web-app/src/dynamic-forms/has-questionnaire/journey.js
+++ b/packages/forms-web-app/src/dynamic-forms/has-questionnaire/journey.js
@@ -82,9 +82,10 @@ class HasJourney extends Journey {
 					response.answers &&
 						response.answers[questions.representationsFromOthers.fieldName] == 'yes'
 				),
-			new Section("Planning officer's report and supplementary documents", 'officer').addQuestion(
-				questions.planningOfficersReportUpload
-			),
+			new Section(
+				"Planning officer's report and supplementary documents",
+				'planning-officer-report'
+			).addQuestion(questions.planningOfficersReportUpload),
 			new Section('Site access', 'site-access')
 				.addQuestion(questions.accessForInspection)
 				.addQuestion(questions.neighbouringSite)

--- a/packages/forms-web-app/src/dynamic-forms/has-questionnaire/questions.js
+++ b/packages/forms-web-app/src/dynamic-forms/has-questionnaire/questions.js
@@ -166,8 +166,8 @@ exports.questions = {
 	planningOfficersReportUpload: new MultiFileUploadQuestion({
 		title: 'Upload planning officers report',
 		question: 'Upload the planning officer’s report',
-		fieldName: 'planning-officers-upload',
-		validators: [new RequiredValidator('You must add your documents')]
+		fieldName: 'upload-report',
+		validators: [new RequiredFileUploadValidator(), new MultifileUploadValidator()]
 	}),
 	accessForInspection: new BooleanQuestion({
 		title: 'Access for inspection',


### PR DESCRIPTION
## Ticket Number

<!-- Add the number from the Jira board -->

https://pins-ds.atlassian.net/browse/AS-

## Description of change

* update URL for report-upload page
* change multifile upload save action to handle situations where user is attempting to upload valid and invalid files (i.e. valid files will be uploaded and displayed on re-rendered file upload page, together with error message(s) about invalid file(s))
 
## Checklist

<!-- Put an `x` in all the boxes that apply: -->

- [ ] Requires infrastructure changes
- [ ] If adding or remove environment variables (e.g. in `docker-compose.yaml`) then I have updated the appropriate Helm chart
- [ ] I have updated the documentation accordingly
- [ ] My commit history in this PR is linear
- [ ] New features have tests
- [ ] Breaking change (team conversation required)

## Important

Please do not merge from `main` (please only [rebase](https://github.com/foundry4/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
