### PR TITLE
chore(AAPD-45): fix naming conventions on function config

### DIFF
--- a/packages/integration-functions/appeals-case-data-fo-integration/function.json
+++ b/packages/integration-functions/appeals-case-data-fo-integration/function.json
@@ -1,14 +1,12 @@
 {
 	"bindings": [
 		{
-			"connection": "APPEALS_SERVICE_BUS_CONNECTION",
+			"connection": "ServiceBusConnection",
 			"name": "appealsCaseMessage",
 			"type": "serviceBusTrigger",
 			"direction": "in",
 			"topicName": "appeal-bo-case",
-			"subscriptionName": "bo-appeals-case-subscription",
-			"autoComplete": true
+			"subscriptionName": "bo-appeals-case-subscription"
 		}
-	],
-	"disabled": false
+	]
 }


### PR DESCRIPTION
Fix proeprty names and values on function config for inbound appeals case data integration

AAPD-45

https://pins-ds.atlassian.net/browse/AAPD-45

## Description of change

Fix function json config for appeals case data ingestion

## Checklist

<!-- Put an `x` in all the boxes that apply: -->

- [ ] Requires infrastructure changes
- [ ] If adding or remove environment variables (e.g. in `docker-compose.yaml`) then I have updated the appropriate Helm chart
- [ ] I have updated the documentation accordingly
- [x] My commit history in this PR is linear
- [ ] New features have tests
- [ ] Breaking change (team conversation required)

## Important

Please do not merge from `main` (please only [rebase](https://github.com/foundry4/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
