### PR TITLE
fix(db-indexes): make failing caseref index not unique

### DIFF
--- a/packages/appeals-service-api/src/db/setup.js
+++ b/packages/appeals-service-api/src/db/setup.js
@@ -61,7 +61,7 @@ async function setupAppealCaseDataIndexes() {
 	try {
 		const caseDataCollection = mongodb.get().collection('appealsCaseData');
 
-		await caseDataCollection.createIndex({ caseReference: 1 }, { unique: true });
+		await caseDataCollection.createIndex({ caseReference: 1 }, { unique: false });
 		await caseDataCollection.createIndex({ LPAApplicationReference: 1 }, { unique: false });
 		await caseDataCollection.createIndex({ LPACode: 1 }, { unique: false });
 		await caseDataCollection.createIndex({ appealType: 1 }, { unique: false });


### PR DESCRIPTION
## Ticket Number

## Description of change

<!-- Please describe the change -->

## Checklist

<!-- Put an `x` in all the boxes that apply: -->

- [ ] Requires infrastructure changes
- [ ] If adding or remove environment variables (e.g. in `docker-compose.yaml`) then I have updated the appropriate Helm chart
- [ ] I have updated the documentation accordingly
- [ ] My commit history in this PR is linear
- [ ] New features have tests
- [ ] Breaking change (team conversation required)

## Important

Please do not merge from `main` (please only [rebase](https://github.com/foundry4/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
