### PR TITLE
build(AAPD-45): downgrade got to support require

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5262,6 +5262,17 @@
 				"@types/node": "*"
 			}
 		},
+		"node_modules/@types/cacheable-request": {
+			"version": "6.0.3",
+			"resolved": "https://registry.npmjs.org/@types/cacheable-request/-/cacheable-request-6.0.3.tgz",
+			"integrity": "sha512-IQ3EbTzGxIigb1I3qPZc1rWJnH0BmSKv5QYTalEwweFvyBDLSAe24zP0le/hyi7ecGfZVlIVAg4BZqb8WBwKqw==",
+			"dependencies": {
+				"@types/http-cache-semantics": "*",
+				"@types/keyv": "^3.1.4",
+				"@types/node": "*",
+				"@types/responselike": "^1.0.0"
+			}
+		},
 		"node_modules/@types/docker-modem": {
 			"version": "3.0.2",
 			"resolved": "https://registry.npmjs.org/@types/docker-modem/-/docker-modem-3.0.2.tgz",
@@ -5432,6 +5443,14 @@
 			"integrity": "sha512-wOuvG1SN4Us4rez+tylwwwCV1psiNVOkJeM3AUWUNWg/jDQY2+HE/444y5gc+jBmRqASOm2Oeh5c1axHobwRKQ==",
 			"dev": true
 		},
+		"node_modules/@types/keyv": {
+			"version": "3.1.4",
+			"resolved": "https://registry.npmjs.org/@types/keyv/-/keyv-3.1.4.tgz",
+			"integrity": "sha512-BQ5aZNSCpj7D6K2ksrRCTmKRLEpnPvWDiLPfoGyhZ++8YtiK9d/3DBKPJgry359X/P1PfruyYwvnvwFjuEiEIg==",
+			"dependencies": {
+				"@types/node": "*"
+			}
+		},
 		"node_modules/@types/lodash": {
 			"version": "4.14.195",
 			"resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.195.tgz",
@@ -5514,6 +5533,14 @@
 			"resolved": "https://registry.npmjs.org/@types/readdir-glob/-/readdir-glob-1.1.1.tgz",
 			"integrity": "sha512-ImM6TmoF8bgOwvehGviEj3tRdRBbQujr1N+0ypaln/GWjaerOB26jb93vsRHmdMtvVQZQebOlqt2HROark87mQ==",
 			"dev": true,
+			"dependencies": {
+				"@types/node": "*"
+			}
+		},
+		"node_modules/@types/responselike": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/@types/responselike/-/responselike-1.0.0.tgz",
+			"integrity": "sha512-85Y2BjiufFzaMIlvJDvTTB8Fxl2xfLo4HgmHzVBz08w4wDePCTjYw66PdrolO0kzli3yam/YCgRufyo1DdQVTA==",
 			"dependencies": {
 				"@types/node": "*"
 			}
@@ -7779,6 +7806,25 @@
 			},
 			"engines": {
 				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/clone-response": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/clone-response/-/clone-response-1.0.3.tgz",
+			"integrity": "sha512-ROoL94jJH2dUVML2Y/5PEDNaSHgeOdSDicUyS7izcF63G6sTc/FTjLub4b8Il9S8S0beOfYt0TaA5qvFK+w0wA==",
+			"dependencies": {
+				"mimic-response": "^1.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/clone-response/node_modules/mimic-response": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.1.tgz",
+			"integrity": "sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ==",
+			"engines": {
+				"node": ">=4"
 			}
 		},
 		"node_modules/cls-hooked": {
@@ -16532,7 +16578,6 @@
 			"version": "6.1.0",
 			"resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-6.1.0.tgz",
 			"integrity": "sha512-DlL+XwOy3NxAQ8xuC0okPgK46iuVNAK01YN7RueYBqqFeGsBjV9XmCAzAdgt+667bCl5kPh9EqKKDwnaPG1I7A==",
-			"dev": true,
 			"engines": {
 				"node": ">=10"
 			},
@@ -35902,7 +35947,7 @@
 		"packages/integration-functions": {
 			"version": "1.0.0",
 			"dependencies": {
-				"got": "*"
+				"got": "11.8.3"
 			},
 			"devDependencies": {
 				"@azure/service-bus": "^7.9.0"
@@ -35910,6 +35955,141 @@
 			"engines": {
 				"node": ">=18.0.0 <19.0.0",
 				"npm": ">=9.0.0 <10.0.0"
+			}
+		},
+		"packages/integration-functions/node_modules/@sindresorhus/is": {
+			"version": "4.6.0",
+			"resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-4.6.0.tgz",
+			"integrity": "sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw==",
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sindresorhus/is?sponsor=1"
+			}
+		},
+		"packages/integration-functions/node_modules/@szmarczak/http-timer": {
+			"version": "4.0.6",
+			"resolved": "https://registry.npmjs.org/@szmarczak/http-timer/-/http-timer-4.0.6.tgz",
+			"integrity": "sha512-4BAffykYOgO+5nzBWYwE3W90sBgLJoUPRWWcL8wlyiM8IB8ipJz3UMJ9KXQd1RKQXpKp8Tutn80HZtWsu2u76w==",
+			"dependencies": {
+				"defer-to-connect": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"packages/integration-functions/node_modules/cacheable-lookup": {
+			"version": "5.0.4",
+			"resolved": "https://registry.npmjs.org/cacheable-lookup/-/cacheable-lookup-5.0.4.tgz",
+			"integrity": "sha512-2/kNscPhpcxrOigMZzbiWF7dz8ilhb/nIHU3EyZiXWXpeq/au8qJ8VhdftMkty3n7Gj6HIGalQG8oiBNB3AJgA==",
+			"engines": {
+				"node": ">=10.6.0"
+			}
+		},
+		"packages/integration-functions/node_modules/cacheable-request": {
+			"version": "7.0.4",
+			"resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-7.0.4.tgz",
+			"integrity": "sha512-v+p6ongsrp0yTGbJXjgxPow2+DL93DASP4kXCDKb8/bwRtt9OEF3whggkkDkGNzgcWy2XaF4a8nZglC7uElscg==",
+			"dependencies": {
+				"clone-response": "^1.0.2",
+				"get-stream": "^5.1.0",
+				"http-cache-semantics": "^4.0.0",
+				"keyv": "^4.0.0",
+				"lowercase-keys": "^2.0.0",
+				"normalize-url": "^6.0.1",
+				"responselike": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"packages/integration-functions/node_modules/get-stream": {
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
+			"integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
+			"dependencies": {
+				"pump": "^3.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"packages/integration-functions/node_modules/got": {
+			"version": "11.8.3",
+			"resolved": "https://registry.npmjs.org/got/-/got-11.8.3.tgz",
+			"integrity": "sha512-7gtQ5KiPh1RtGS9/Jbv1ofDpBFuq42gyfEib+ejaRBJuj/3tQFeR5+gw57e4ipaU8c/rCjvX6fkQz2lyDlGAOg==",
+			"dependencies": {
+				"@sindresorhus/is": "^4.0.0",
+				"@szmarczak/http-timer": "^4.0.5",
+				"@types/cacheable-request": "^6.0.1",
+				"@types/responselike": "^1.0.0",
+				"cacheable-lookup": "^5.0.3",
+				"cacheable-request": "^7.0.2",
+				"decompress-response": "^6.0.0",
+				"http2-wrapper": "^1.0.0-beta.5.2",
+				"lowercase-keys": "^2.0.0",
+				"p-cancelable": "^2.0.0",
+				"responselike": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=10.19.0"
+			},
+			"funding": {
+				"url": "https://github.com/sindresorhus/got?sponsor=1"
+			}
+		},
+		"packages/integration-functions/node_modules/http2-wrapper": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/http2-wrapper/-/http2-wrapper-1.0.3.tgz",
+			"integrity": "sha512-V+23sDMr12Wnz7iTcDeJr3O6AIxlnvT/bmaAAAP/Xda35C90p9599p0F1eHR/N1KILWSoWVAiOMFjBBXaXSMxg==",
+			"dependencies": {
+				"quick-lru": "^5.1.1",
+				"resolve-alpn": "^1.0.0"
+			},
+			"engines": {
+				"node": ">=10.19.0"
+			}
+		},
+		"packages/integration-functions/node_modules/lowercase-keys": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-2.0.0.tgz",
+			"integrity": "sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA==",
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"packages/integration-functions/node_modules/p-cancelable": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-2.1.1.tgz",
+			"integrity": "sha512-BZOr3nRQHOntUjTrH8+Lh54smKHoHyur8We1V8DSMVrl5A2malOOwuJRnKRDjSnkoeBh4at6BwEnb5I7Jl31wg==",
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"packages/integration-functions/node_modules/quick-lru": {
+			"version": "5.1.1",
+			"resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-5.1.1.tgz",
+			"integrity": "sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==",
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"packages/integration-functions/node_modules/responselike": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/responselike/-/responselike-2.0.1.tgz",
+			"integrity": "sha512-4gl03wn3hj1HP3yzgdI7d3lCkF95F21Pz4BPGvKHinyQzALR5CapwC8yIi0Rh58DEMQ/SguC03wFj2k0M/mHhw==",
+			"dependencies": {
+				"lowercase-keys": "^2.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"packages/pdf-service-api": {
@@ -43002,6 +43182,17 @@
 				"@types/node": "*"
 			}
 		},
+		"@types/cacheable-request": {
+			"version": "6.0.3",
+			"resolved": "https://registry.npmjs.org/@types/cacheable-request/-/cacheable-request-6.0.3.tgz",
+			"integrity": "sha512-IQ3EbTzGxIigb1I3qPZc1rWJnH0BmSKv5QYTalEwweFvyBDLSAe24zP0le/hyi7ecGfZVlIVAg4BZqb8WBwKqw==",
+			"requires": {
+				"@types/http-cache-semantics": "*",
+				"@types/keyv": "^3.1.4",
+				"@types/node": "*",
+				"@types/responselike": "^1.0.0"
+			}
+		},
 		"@types/docker-modem": {
 			"version": "3.0.2",
 			"resolved": "https://registry.npmjs.org/@types/docker-modem/-/docker-modem-3.0.2.tgz",
@@ -43162,6 +43353,14 @@
 			"integrity": "sha512-wOuvG1SN4Us4rez+tylwwwCV1psiNVOkJeM3AUWUNWg/jDQY2+HE/444y5gc+jBmRqASOm2Oeh5c1axHobwRKQ==",
 			"dev": true
 		},
+		"@types/keyv": {
+			"version": "3.1.4",
+			"resolved": "https://registry.npmjs.org/@types/keyv/-/keyv-3.1.4.tgz",
+			"integrity": "sha512-BQ5aZNSCpj7D6K2ksrRCTmKRLEpnPvWDiLPfoGyhZ++8YtiK9d/3DBKPJgry359X/P1PfruyYwvnvwFjuEiEIg==",
+			"requires": {
+				"@types/node": "*"
+			}
+		},
 		"@types/lodash": {
 			"version": "4.14.195",
 			"resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.195.tgz",
@@ -43243,6 +43442,14 @@
 			"resolved": "https://registry.npmjs.org/@types/readdir-glob/-/readdir-glob-1.1.1.tgz",
 			"integrity": "sha512-ImM6TmoF8bgOwvehGviEj3tRdRBbQujr1N+0ypaln/GWjaerOB26jb93vsRHmdMtvVQZQebOlqt2HROark87mQ==",
 			"dev": true,
+			"requires": {
+				"@types/node": "*"
+			}
+		},
+		"@types/responselike": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/@types/responselike/-/responselike-1.0.0.tgz",
+			"integrity": "sha512-85Y2BjiufFzaMIlvJDvTTB8Fxl2xfLo4HgmHzVBz08w4wDePCTjYw66PdrolO0kzli3yam/YCgRufyo1DdQVTA==",
 			"requires": {
 				"@types/node": "*"
 			}
@@ -46662,6 +46869,21 @@
 					"requires": {
 						"isobject": "^3.0.1"
 					}
+				}
+			}
+		},
+		"clone-response": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/clone-response/-/clone-response-1.0.3.tgz",
+			"integrity": "sha512-ROoL94jJH2dUVML2Y/5PEDNaSHgeOdSDicUyS7izcF63G6sTc/FTjLub4b8Il9S8S0beOfYt0TaA5qvFK+w0wA==",
+			"requires": {
+				"mimic-response": "^1.0.0"
+			},
+			"dependencies": {
+				"mimic-response": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.1.tgz",
+					"integrity": "sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ=="
 				}
 			}
 		},
@@ -52049,7 +52271,99 @@
 			"version": "file:packages/integration-functions",
 			"requires": {
 				"@azure/service-bus": "^7.9.0",
-				"got": "*"
+				"got": "11.8.3"
+			},
+			"dependencies": {
+				"@sindresorhus/is": {
+					"version": "4.6.0",
+					"resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-4.6.0.tgz",
+					"integrity": "sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw=="
+				},
+				"@szmarczak/http-timer": {
+					"version": "4.0.6",
+					"resolved": "https://registry.npmjs.org/@szmarczak/http-timer/-/http-timer-4.0.6.tgz",
+					"integrity": "sha512-4BAffykYOgO+5nzBWYwE3W90sBgLJoUPRWWcL8wlyiM8IB8ipJz3UMJ9KXQd1RKQXpKp8Tutn80HZtWsu2u76w==",
+					"requires": {
+						"defer-to-connect": "^2.0.0"
+					}
+				},
+				"cacheable-lookup": {
+					"version": "5.0.4",
+					"resolved": "https://registry.npmjs.org/cacheable-lookup/-/cacheable-lookup-5.0.4.tgz",
+					"integrity": "sha512-2/kNscPhpcxrOigMZzbiWF7dz8ilhb/nIHU3EyZiXWXpeq/au8qJ8VhdftMkty3n7Gj6HIGalQG8oiBNB3AJgA=="
+				},
+				"cacheable-request": {
+					"version": "7.0.4",
+					"resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-7.0.4.tgz",
+					"integrity": "sha512-v+p6ongsrp0yTGbJXjgxPow2+DL93DASP4kXCDKb8/bwRtt9OEF3whggkkDkGNzgcWy2XaF4a8nZglC7uElscg==",
+					"requires": {
+						"clone-response": "^1.0.2",
+						"get-stream": "^5.1.0",
+						"http-cache-semantics": "^4.0.0",
+						"keyv": "^4.0.0",
+						"lowercase-keys": "^2.0.0",
+						"normalize-url": "^6.0.1",
+						"responselike": "^2.0.0"
+					}
+				},
+				"get-stream": {
+					"version": "5.2.0",
+					"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
+					"integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
+					"requires": {
+						"pump": "^3.0.0"
+					}
+				},
+				"got": {
+					"version": "11.8.3",
+					"resolved": "https://registry.npmjs.org/got/-/got-11.8.3.tgz",
+					"integrity": "sha512-7gtQ5KiPh1RtGS9/Jbv1ofDpBFuq42gyfEib+ejaRBJuj/3tQFeR5+gw57e4ipaU8c/rCjvX6fkQz2lyDlGAOg==",
+					"requires": {
+						"@sindresorhus/is": "^4.0.0",
+						"@szmarczak/http-timer": "^4.0.5",
+						"@types/cacheable-request": "^6.0.1",
+						"@types/responselike": "^1.0.0",
+						"cacheable-lookup": "^5.0.3",
+						"cacheable-request": "^7.0.2",
+						"decompress-response": "^6.0.0",
+						"http2-wrapper": "^1.0.0-beta.5.2",
+						"lowercase-keys": "^2.0.0",
+						"p-cancelable": "^2.0.0",
+						"responselike": "^2.0.0"
+					}
+				},
+				"http2-wrapper": {
+					"version": "1.0.3",
+					"resolved": "https://registry.npmjs.org/http2-wrapper/-/http2-wrapper-1.0.3.tgz",
+					"integrity": "sha512-V+23sDMr12Wnz7iTcDeJr3O6AIxlnvT/bmaAAAP/Xda35C90p9599p0F1eHR/N1KILWSoWVAiOMFjBBXaXSMxg==",
+					"requires": {
+						"quick-lru": "^5.1.1",
+						"resolve-alpn": "^1.0.0"
+					}
+				},
+				"lowercase-keys": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-2.0.0.tgz",
+					"integrity": "sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA=="
+				},
+				"p-cancelable": {
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-2.1.1.tgz",
+					"integrity": "sha512-BZOr3nRQHOntUjTrH8+Lh54smKHoHyur8We1V8DSMVrl5A2malOOwuJRnKRDjSnkoeBh4at6BwEnb5I7Jl31wg=="
+				},
+				"quick-lru": {
+					"version": "5.1.1",
+					"resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-5.1.1.tgz",
+					"integrity": "sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA=="
+				},
+				"responselike": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/responselike/-/responselike-2.0.1.tgz",
+					"integrity": "sha512-4gl03wn3hj1HP3yzgdI7d3lCkF95F21Pz4BPGvKHinyQzALR5CapwC8yIi0Rh58DEMQ/SguC03wFj2k0M/mHhw==",
+					"requires": {
+						"lowercase-keys": "^2.0.0"
+					}
+				}
 			}
 		},
 		"internal-slot": {
@@ -55879,8 +56193,7 @@
 		"normalize-url": {
 			"version": "6.1.0",
 			"resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-6.1.0.tgz",
-			"integrity": "sha512-DlL+XwOy3NxAQ8xuC0okPgK46iuVNAK01YN7RueYBqqFeGsBjV9XmCAzAdgt+667bCl5kPh9EqKKDwnaPG1I7A==",
-			"dev": true
+			"integrity": "sha512-DlL+XwOy3NxAQ8xuC0okPgK46iuVNAK01YN7RueYBqqFeGsBjV9XmCAzAdgt+667bCl5kPh9EqKKDwnaPG1I7A=="
 		},
 		"notifications-node-client": {
 			"version": "5.2.3",

--- a/packages/integration-functions/appeals-case-data-fo-integration/index.js
+++ b/packages/integration-functions/appeals-case-data-fo-integration/index.js
@@ -1,4 +1,4 @@
-const got = require('../node_modules/got');
+const got = require('got');
 
 module.exports = async function (context, appealsCaseMessage) {
 	context.log('JavaScript ServiceBus topic trigger function processed message', appealsCaseMessage);

--- a/packages/integration-functions/package-lock.json
+++ b/packages/integration-functions/package-lock.json
@@ -8,7 +8,7 @@
 			"name": "integration-functions",
 			"version": "1.0.0",
 			"dependencies": {
-				"got": "*"
+				"got": "11.8.3"
 			},
 			"devDependencies": {
 				"@azure/service-bus": "^7.9.0"
@@ -197,25 +197,25 @@
 			}
 		},
 		"node_modules/@sindresorhus/is": {
-			"version": "5.6.0",
-			"resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-5.6.0.tgz",
-			"integrity": "sha512-TV7t8GKYaJWsn00tFDqBw8+Uqmr8A0fRU1tvTQhyZzGv0sJCGRQL3JGMI3ucuKo3XIZdUP+Lx7/gh2t3lewy7g==",
+			"version": "4.6.0",
+			"resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-4.6.0.tgz",
+			"integrity": "sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw==",
 			"engines": {
-				"node": ">=14.16"
+				"node": ">=10"
 			},
 			"funding": {
 				"url": "https://github.com/sindresorhus/is?sponsor=1"
 			}
 		},
 		"node_modules/@szmarczak/http-timer": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/@szmarczak/http-timer/-/http-timer-5.0.1.tgz",
-			"integrity": "sha512-+PmQX0PiAYPMeVYe237LJAYvOMYW1j2rH5YROyS3b4CTVJum34HfRvKvAzozHAQG0TnHNdUfY9nCeUyRAs//cw==",
+			"version": "4.0.6",
+			"resolved": "https://registry.npmjs.org/@szmarczak/http-timer/-/http-timer-4.0.6.tgz",
+			"integrity": "sha512-4BAffykYOgO+5nzBWYwE3W90sBgLJoUPRWWcL8wlyiM8IB8ipJz3UMJ9KXQd1RKQXpKp8Tutn80HZtWsu2u76w==",
 			"dependencies": {
-				"defer-to-connect": "^2.0.1"
+				"defer-to-connect": "^2.0.0"
 			},
 			"engines": {
-				"node": ">=14.16"
+				"node": ">=10"
 			}
 		},
 		"node_modules/@tootallnate/once": {
@@ -225,6 +225,17 @@
 			"dev": true,
 			"engines": {
 				"node": ">= 10"
+			}
+		},
+		"node_modules/@types/cacheable-request": {
+			"version": "6.0.3",
+			"resolved": "https://registry.npmjs.org/@types/cacheable-request/-/cacheable-request-6.0.3.tgz",
+			"integrity": "sha512-IQ3EbTzGxIigb1I3qPZc1rWJnH0BmSKv5QYTalEwweFvyBDLSAe24zP0le/hyi7ecGfZVlIVAg4BZqb8WBwKqw==",
+			"dependencies": {
+				"@types/http-cache-semantics": "*",
+				"@types/keyv": "^3.1.4",
+				"@types/node": "*",
+				"@types/responselike": "^1.0.0"
 			}
 		},
 		"node_modules/@types/http-cache-semantics": {
@@ -241,11 +252,26 @@
 				"@types/node": "*"
 			}
 		},
+		"node_modules/@types/keyv": {
+			"version": "3.1.4",
+			"resolved": "https://registry.npmjs.org/@types/keyv/-/keyv-3.1.4.tgz",
+			"integrity": "sha512-BQ5aZNSCpj7D6K2ksrRCTmKRLEpnPvWDiLPfoGyhZ++8YtiK9d/3DBKPJgry359X/P1PfruyYwvnvwFjuEiEIg==",
+			"dependencies": {
+				"@types/node": "*"
+			}
+		},
 		"node_modules/@types/node": {
 			"version": "20.5.3",
 			"resolved": "https://registry.npmjs.org/@types/node/-/node-20.5.3.tgz",
-			"integrity": "sha512-ITI7rbWczR8a/S6qjAW7DMqxqFMjjTo61qZVWJ1ubPvbIQsL5D/TvwjYEalM8Kthpe3hTzOGrF2TGbAu2uyqeA==",
-			"dev": true
+			"integrity": "sha512-ITI7rbWczR8a/S6qjAW7DMqxqFMjjTo61qZVWJ1ubPvbIQsL5D/TvwjYEalM8Kthpe3hTzOGrF2TGbAu2uyqeA=="
+		},
+		"node_modules/@types/responselike": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/@types/responselike/-/responselike-1.0.0.tgz",
+			"integrity": "sha512-85Y2BjiufFzaMIlvJDvTTB8Fxl2xfLo4HgmHzVBz08w4wDePCTjYw66PdrolO0kzli3yam/YCgRufyo1DdQVTA==",
+			"dependencies": {
+				"@types/node": "*"
+			}
 		},
 		"node_modules/agent-base": {
 			"version": "6.0.2",
@@ -322,28 +348,28 @@
 			}
 		},
 		"node_modules/cacheable-lookup": {
-			"version": "7.0.0",
-			"resolved": "https://registry.npmjs.org/cacheable-lookup/-/cacheable-lookup-7.0.0.tgz",
-			"integrity": "sha512-+qJyx4xiKra8mZrcwhjMRMUhD5NR1R8esPkzIYxX96JiecFoxAXFuz/GpR3+ev4PE1WamHip78wV0vcmPQtp8w==",
+			"version": "5.0.4",
+			"resolved": "https://registry.npmjs.org/cacheable-lookup/-/cacheable-lookup-5.0.4.tgz",
+			"integrity": "sha512-2/kNscPhpcxrOigMZzbiWF7dz8ilhb/nIHU3EyZiXWXpeq/au8qJ8VhdftMkty3n7Gj6HIGalQG8oiBNB3AJgA==",
 			"engines": {
-				"node": ">=14.16"
+				"node": ">=10.6.0"
 			}
 		},
 		"node_modules/cacheable-request": {
-			"version": "10.2.13",
-			"resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-10.2.13.tgz",
-			"integrity": "sha512-3SD4rrMu1msNGEtNSt8Od6enwdo//U9s4ykmXfA2TD58kcLkCobtCDiby7kNyj7a/Q7lz/mAesAFI54rTdnvBA==",
+			"version": "7.0.4",
+			"resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-7.0.4.tgz",
+			"integrity": "sha512-v+p6ongsrp0yTGbJXjgxPow2+DL93DASP4kXCDKb8/bwRtt9OEF3whggkkDkGNzgcWy2XaF4a8nZglC7uElscg==",
 			"dependencies": {
-				"@types/http-cache-semantics": "^4.0.1",
-				"get-stream": "^6.0.1",
-				"http-cache-semantics": "^4.1.1",
-				"keyv": "^4.5.3",
-				"mimic-response": "^4.0.0",
-				"normalize-url": "^8.0.0",
-				"responselike": "^3.0.0"
+				"clone-response": "^1.0.2",
+				"get-stream": "^5.1.0",
+				"http-cache-semantics": "^4.0.0",
+				"keyv": "^4.0.0",
+				"lowercase-keys": "^2.0.0",
+				"normalize-url": "^6.0.1",
+				"responselike": "^2.0.0"
 			},
 			"engines": {
-				"node": ">=14.16"
+				"node": ">=8"
 			}
 		},
 		"node_modules/call-bind": {
@@ -357,6 +383,17 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/clone-response": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/clone-response/-/clone-response-1.0.3.tgz",
+			"integrity": "sha512-ROoL94jJH2dUVML2Y/5PEDNaSHgeOdSDicUyS7izcF63G6sTc/FTjLub4b8Il9S8S0beOfYt0TaA5qvFK+w0wA==",
+			"dependencies": {
+				"mimic-response": "^1.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/combined-stream": {
@@ -430,6 +467,14 @@
 				"node": ">=0.4.0"
 			}
 		},
+		"node_modules/end-of-stream": {
+			"version": "1.4.4",
+			"resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
+			"integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
+			"dependencies": {
+				"once": "^1.4.0"
+			}
+		},
 		"node_modules/events": {
 			"version": "3.3.0",
 			"resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
@@ -484,14 +529,6 @@
 				"node": ">= 6"
 			}
 		},
-		"node_modules/form-data-encoder": {
-			"version": "2.1.4",
-			"resolved": "https://registry.npmjs.org/form-data-encoder/-/form-data-encoder-2.1.4.tgz",
-			"integrity": "sha512-yDYSgNMraqvnxiEXO4hi88+YZxaHC6QKzb5N84iRCTDeRO7ZALpir/lVmf/uXUhnwUr2O4HU8s/n6x+yNjQkHw==",
-			"engines": {
-				"node": ">= 14.17"
-			}
-		},
 		"node_modules/function-bind": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
@@ -514,11 +551,14 @@
 			}
 		},
 		"node_modules/get-stream": {
-			"version": "6.0.1",
-			"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
-			"integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
+			"integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
+			"dependencies": {
+				"pump": "^3.0.0"
+			},
 			"engines": {
-				"node": ">=10"
+				"node": ">=8"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
@@ -537,24 +577,24 @@
 			}
 		},
 		"node_modules/got": {
-			"version": "13.0.0",
-			"resolved": "https://registry.npmjs.org/got/-/got-13.0.0.tgz",
-			"integrity": "sha512-XfBk1CxOOScDcMr9O1yKkNaQyy865NbYs+F7dr4H0LZMVgCj2Le59k6PqbNHoL5ToeaEQUYh6c6yMfVcc6SJxA==",
+			"version": "11.8.3",
+			"resolved": "https://registry.npmjs.org/got/-/got-11.8.3.tgz",
+			"integrity": "sha512-7gtQ5KiPh1RtGS9/Jbv1ofDpBFuq42gyfEib+ejaRBJuj/3tQFeR5+gw57e4ipaU8c/rCjvX6fkQz2lyDlGAOg==",
 			"dependencies": {
-				"@sindresorhus/is": "^5.2.0",
-				"@szmarczak/http-timer": "^5.0.1",
-				"cacheable-lookup": "^7.0.0",
-				"cacheable-request": "^10.2.8",
+				"@sindresorhus/is": "^4.0.0",
+				"@szmarczak/http-timer": "^4.0.5",
+				"@types/cacheable-request": "^6.0.1",
+				"@types/responselike": "^1.0.0",
+				"cacheable-lookup": "^5.0.3",
+				"cacheable-request": "^7.0.2",
 				"decompress-response": "^6.0.0",
-				"form-data-encoder": "^2.1.2",
-				"get-stream": "^6.0.1",
-				"http2-wrapper": "^2.1.10",
-				"lowercase-keys": "^3.0.0",
-				"p-cancelable": "^3.0.0",
-				"responselike": "^3.0.0"
+				"http2-wrapper": "^1.0.0-beta.5.2",
+				"lowercase-keys": "^2.0.0",
+				"p-cancelable": "^2.0.0",
+				"responselike": "^2.0.0"
 			},
 			"engines": {
-				"node": ">=16"
+				"node": ">=10.19.0"
 			},
 			"funding": {
 				"url": "https://github.com/sindresorhus/got?sponsor=1"
@@ -631,12 +671,12 @@
 			}
 		},
 		"node_modules/http2-wrapper": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/http2-wrapper/-/http2-wrapper-2.2.0.tgz",
-			"integrity": "sha512-kZB0wxMo0sh1PehyjJUWRFEd99KC5TLjZ2cULC4f9iqJBAmKQQXEICjxl5iPJRwP40dpeHFqqhm7tYCvODpqpQ==",
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/http2-wrapper/-/http2-wrapper-1.0.3.tgz",
+			"integrity": "sha512-V+23sDMr12Wnz7iTcDeJr3O6AIxlnvT/bmaAAAP/Xda35C90p9599p0F1eHR/N1KILWSoWVAiOMFjBBXaXSMxg==",
 			"dependencies": {
 				"quick-lru": "^5.1.1",
-				"resolve-alpn": "^1.2.0"
+				"resolve-alpn": "^1.0.0"
 			},
 			"engines": {
 				"node": ">=10.19.0"
@@ -791,14 +831,11 @@
 			"dev": true
 		},
 		"node_modules/lowercase-keys": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-3.0.0.tgz",
-			"integrity": "sha512-ozCC6gdQ+glXOQsveKD0YsDy8DSQFjDTz4zyzEHNV5+JP5D62LmfDZ6o1cycFx9ouG940M5dE8C8CTewdj2YWQ==",
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-2.0.0.tgz",
+			"integrity": "sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA==",
 			"engines": {
-				"node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
+				"node": ">=8"
 			}
 		},
 		"node_modules/mime-db": {
@@ -823,14 +860,11 @@
 			}
 		},
 		"node_modules/mimic-response": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-4.0.0.tgz",
-			"integrity": "sha512-e5ISH9xMYU0DzrT+jl8q2ze9D6eWBto+I8CNpe+VI+K2J/F/k3PdkdTdz4wvGVH4NTpo+NRYTVIuMQEMMcsLqg==",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.1.tgz",
+			"integrity": "sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ==",
 			"engines": {
-				"node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
+				"node": ">=4"
 			}
 		},
 		"node_modules/ms": {
@@ -840,22 +874,30 @@
 			"dev": true
 		},
 		"node_modules/normalize-url": {
-			"version": "8.0.0",
-			"resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-8.0.0.tgz",
-			"integrity": "sha512-uVFpKhj5MheNBJRTiMZ9pE/7hD1QTeEvugSJW/OmLzAp78PB5O6adfMNTvmfKhXBkvCzC+rqifWcVYpGFwTjnw==",
+			"version": "6.1.0",
+			"resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-6.1.0.tgz",
+			"integrity": "sha512-DlL+XwOy3NxAQ8xuC0okPgK46iuVNAK01YN7RueYBqqFeGsBjV9XmCAzAdgt+667bCl5kPh9EqKKDwnaPG1I7A==",
 			"engines": {
-				"node": ">=14.16"
+				"node": ">=10"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
+		"node_modules/once": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+			"integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+			"dependencies": {
+				"wrappy": "1"
+			}
+		},
 		"node_modules/p-cancelable": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-3.0.0.tgz",
-			"integrity": "sha512-mlVgR3PGuzlo0MmTdk4cXqXWlwQDLnONTAg6sm62XkMJEiRxN3GL3SffkYvqwonbkJBcrI7Uvv5Zh9yjvn2iUw==",
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-2.1.1.tgz",
+			"integrity": "sha512-BZOr3nRQHOntUjTrH8+Lh54smKHoHyur8We1V8DSMVrl5A2malOOwuJRnKRDjSnkoeBh4at6BwEnb5I7Jl31wg==",
 			"engines": {
-				"node": ">=12.20"
+				"node": ">=8"
 			}
 		},
 		"node_modules/process": {
@@ -865,6 +907,15 @@
 			"dev": true,
 			"engines": {
 				"node": ">= 0.6.0"
+			}
+		},
+		"node_modules/pump": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
+			"integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
+			"dependencies": {
+				"end-of-stream": "^1.1.0",
+				"once": "^1.3.1"
 			}
 		},
 		"node_modules/quick-lru": {
@@ -884,14 +935,11 @@
 			"integrity": "sha512-0a1F4l73/ZFZOakJnQ3FvkJ2+gSTQWz/r2KE5OdDY0TxPm5h4GkqkWWfM47T7HsbnOtcJVEF4epCVy6u7Q3K+g=="
 		},
 		"node_modules/responselike": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/responselike/-/responselike-3.0.0.tgz",
-			"integrity": "sha512-40yHxbNcl2+rzXvZuVkrYohathsSJlMTXKryG5y8uciHv1+xDLHQpgjG64JUO9nrEq2jGLH6IZ8BcZyw3wrweg==",
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/responselike/-/responselike-2.0.1.tgz",
+			"integrity": "sha512-4gl03wn3hj1HP3yzgdI7d3lCkF95F21Pz4BPGvKHinyQzALR5CapwC8yIi0Rh58DEMQ/SguC03wFj2k0M/mHhw==",
 			"dependencies": {
-				"lowercase-keys": "^3.0.0"
-			},
-			"engines": {
-				"node": ">=14.16"
+				"lowercase-keys": "^2.0.0"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
@@ -969,6 +1017,11 @@
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
 			}
+		},
+		"node_modules/wrappy": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+			"integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
 		}
 	}
 }

--- a/packages/integration-functions/package.json
+++ b/packages/integration-functions/package.json
@@ -18,6 +18,6 @@
 		"@azure/service-bus": "^7.9.0"
 	},
 	"dependencies": {
-		"got": "*"
+		"got": "11.8.3"
 	}
 }


### PR DESCRIPTION
The last version of got that supports the require syntax is 11.8.3

AAPD-45

## Ticket Number

<!-- Add the number from the Jira board -->

https://pins-ds.atlassian.net/browse/AAPD-45

## Description of change

Downgrade got package so it supports require syntax

## Checklist

<!-- Put an `x` in all the boxes that apply: -->

- [ ] Requires infrastructure changes
- [ ] If adding or remove environment variables (e.g. in `docker-compose.yaml`) then I have updated the appropriate Helm chart
- [ ] I have updated the documentation accordingly
- [x] My commit history in this PR is linear
- [ ] New features have tests
- [ ] Breaking change (team conversation required)

## Important

Please do not merge from `main` (please only [rebase](https://github.com/foundry4/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
