### PR TITLE
feat(AAPD-45): don't use date object for appeals case data

### DIFF
--- a/data/init.js
+++ b/data/init.js
@@ -104,15 +104,16 @@ module.exports = async function main(log = true) {
 							item.updatedAt = now;
 						}
 					}
-
-					Object.keys(item).forEach(function (key) {
-						if (typeof item[key] === 'string') {
-							const parsedDate = parseISO(item[key]);
-							if (isValid(parsedDate)) {
-								item[key] = parsedDate;
+					if (name !== 'appealsCaseData') {
+						Object.keys(item).forEach(function (key) {
+							if (typeof item[key] === 'string') {
+								const parsedDate = parseISO(item[key]);
+								if (isValid(parsedDate)) {
+									item[key] = parsedDate;
+								}
 							}
-						}
-					});
+						});
+					}
 
 					return item;
 				});

--- a/packages/appeals-service-api/__tests__/unit/services/appeals-case-data.service.test.js
+++ b/packages/appeals-service-api/__tests__/unit/services/appeals-case-data.service.test.js
@@ -6,7 +6,6 @@ const AppealsCaseDataRepository = require('../../../src/repositories/appeals-cas
 const mongodb = require('../../../src/db/db');
 const ApiError = require('../../../src/errors/apiError');
 const logger = require('../../../src/lib/logger');
-const { APPEALS_CASE_DATA } = require('@pins/common/src/constants');
 
 jest.mock('../../../src/lib/logger');
 
@@ -26,16 +25,8 @@ describe('src/services/appeals-case-data.service.test', () => {
 		}));
 	});
 
-	it('should fetch and sort relevant appeals case data from db with specified LPA code', async () => {
+	it('should fetch relevant appeals case data from db with specified LPA code', async () => {
 		const lpaCode = 'Q9999';
-
-		const appealsProjection = {
-			projection: {
-				caseReference: 1,
-				LPAApplicationReference: 1,
-				questionnaireDueDate: 1
-			}
-		};
 
 		const appealCaseData = [
 			{
@@ -44,7 +35,7 @@ describe('src/services/appeals-case-data.service.test', () => {
 				validity: 'Valid',
 				caseReference: '3221288',
 				LPAApplicationReference: '2323232/pla',
-				questionnaireDueDate: new Date('2023-07-07T13:53:31.6003126+00:00'),
+				questionnaireDueDate: '2023-07-07T13:53:31.6003126+00:00',
 				questionnaireReceived: ''
 			},
 			{
@@ -53,7 +44,7 @@ describe('src/services/appeals-case-data.service.test', () => {
 				validity: 'Valid',
 				caseReference: '3221289',
 				LPAApplicationReference: '2323232/pla',
-				questionnaireDueDate: new Date('2023-07-05T13:53:31.6003126+00:00'),
+				questionnaireDueDate: '2023-07-05T13:53:31.6003126+00:00',
 				questionnaireReceived: ''
 			},
 			{
@@ -62,7 +53,7 @@ describe('src/services/appeals-case-data.service.test', () => {
 				validity: 'Valid',
 				caseReference: '3221290',
 				LPAApplicationReference: '2323232/pla',
-				questionnaireDueDate: new Date('2023-07-06T13:53:31.6003126+00:00'),
+				questionnaireDueDate: '2023-07-06T13:53:31.6003126+00:00',
 				questionnaireReceived: ''
 			}
 		];
@@ -75,20 +66,11 @@ describe('src/services/appeals-case-data.service.test', () => {
 
 		const result = await getAppeals(lpaCode);
 
-		expect(collectionMock.find).toHaveBeenCalledWith(
-			{
-				LPACode: lpaCode,
-				appealType: APPEALS_CASE_DATA.APPEAL_TYPE.HAS,
-				validity: APPEALS_CASE_DATA.VALIDITY.IS_VALID,
-				questionnaireDueDate: { $type: 'date' },
-				questionnaireReceived: { $not: { $type: 'date' } }
-			},
-			appealsProjection
-		);
+		expect(collectionMock.find).toHaveBeenCalled();
 
-		expect(result[0].caseReference).toEqual('3221289');
-		expect(result[1].caseReference).toEqual('3221290');
-		expect(result[2].caseReference).toEqual('3221288');
+		expect(result[0].caseReference).toEqual('3221288');
+		expect(result[1].caseReference).toEqual('3221289');
+		expect(result[2].caseReference).toEqual('3221290');
 	});
 
 	it('should return a url friendly slug for appeal case ref', async () => {

--- a/packages/appeals-service-api/src/repositories/appeals-case-data-repository.js
+++ b/packages/appeals-service-api/src/repositories/appeals-case-data-repository.js
@@ -24,23 +24,13 @@ class AppealsCaseDataRepository extends MongoRepository {
 			{
 				LPACode: lpaCode,
 				appealType: HAS,
-				validity: IS_VALID,
-				questionnaireDueDate: { $type: 'date' },
-				questionnaireReceived: { $not: { $type: 'date' } }
+				validity: IS_VALID
 			},
-			{}, //empty sort to ensure projection is sent through correctly
+			{ questionnaireDueDate: -1 },
 			appealsProjection
 		);
 		result.forEach((item) => {
 			item.caseReferenceSlug = encodeUrlSlug(item.caseReference);
-		});
-
-		result.sort((a, b) => {
-			if (!a.questionnaireDueDate || !b.questionnaireDueDate) {
-				return 0;
-			}
-
-			return a.questionnaireDueDate.getTime() - b.questionnaireDueDate.getTime();
 		});
 
 		return result;
@@ -50,9 +40,7 @@ class AppealsCaseDataRepository extends MongoRepository {
 			LPACode: lpaCode,
 			caseReference: caseRef,
 			appealType: HAS,
-			validity: IS_VALID,
-			questionnaireDueDate: { $type: 'date' },
-			questionnaireReceived: { $not: { $type: 'date' } }
+			validity: IS_VALID
 		});
 
 		result.caseReferenceSlug = encodeUrlSlug(result.caseReference);


### PR DESCRIPTION
Appeals case data that comnes from the back office will use UTC ISO date string format, we don't need or want keep converting that. Mongo sort can handle date strings as long as they are ISO 8601

## Ticket Number

<!-- Add the number from the Jira board -->

https://pins-ds.atlassian.net/browse/AAPD-45

## Description of change

No need to use iso date object for appeals case data, mongo can support valid iso 8601 date strings for querying and sorting purposes

## Checklist

<!-- Put an `x` in all the boxes that apply: -->

- [ ] Requires infrastructure changes
- [ ] If adding or remove environment variables (e.g. in `docker-compose.yaml`) then I have updated the appropriate Helm chart
- [ ] I have updated the documentation accordingly
- [ ] My commit history in this PR is linear
- [x] New features have tests
- [ ] Breaking change (team conversation required)

## Important

Please do not merge from `main` (please only [rebase](https://github.com/foundry4/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
