### PR TITLE
feat(aapd-371): listed building indexes and local data

### DIFF
--- a/data/data/appeals-service-api/006-listedBuilding.json
+++ b/data/data/appeals-service-api/006-listedBuilding.json
@@ -1,0 +1,17 @@
+[
+	{
+		"name": "10 and 10A Special House",
+		"reference": "1010101",
+		"listedBuildingGrade": "II"
+	},
+	{
+		"name": "AN IMPORTANT BUILDING",
+		"reference": "1010102",
+		"listedBuildingGrade": "II*"
+	},
+	{
+		"name": "Exceptional Building",
+		"reference": "1010103",
+		"listedBuildingGrade": "I"
+	}
+]

--- a/data/init.js
+++ b/data/init.js
@@ -34,6 +34,12 @@ async function getConnection() {
 	return db;
 }
 
+function isValidYearFormat(input) {
+	// checks string starts with "YYYY-MM-DD" format
+	const dateFormatRegex = /^\d{4}-\d{2}-\d{2}/;
+	return dateFormatRegex.test(input);
+}
+
 module.exports = async function main(log = true) {
 	const connection = await getConnection();
 
@@ -106,7 +112,7 @@ module.exports = async function main(log = true) {
 					}
 					if (name !== 'appealsCaseData') {
 						Object.keys(item).forEach(function (key) {
-							if (typeof item[key] === 'string') {
+							if (typeof item[key] === 'string' && isValidYearFormat(item[key])) {
 								const parsedDate = parseISO(item[key]);
 								if (isValid(parsedDate)) {
 									item[key] = parsedDate;

--- a/packages/appeals-service-api/src/db/setup.js
+++ b/packages/appeals-service-api/src/db/setup.js
@@ -91,12 +91,24 @@ async function setupDocumentMetadataIndexes() {
 	}
 }
 
+async function setupListedBuildingIndexes() {
+	try {
+		const collection = mongodb.get().collection('listedBuilding');
+
+		await collection.createIndex({ reference: 1 }, { unique: true });
+	} catch (err) {
+		logger.error(err, `Error: error setting up listedBuilding indexes in mongo`);
+		throw err;
+	}
+}
+
 async function setupIndexes() {
 	try {
 		await setupLpaIndexes();
 		await setupUserIndexes();
 		await setupAppealCaseDataIndexes();
 		await setupDocumentMetadataIndexes();
+		await setupListedBuildingIndexes();
 	} catch (err) {
 		logger.error(err, `Error: error setting up indexes in mongo`);
 	}


### PR DESCRIPTION
## Ticket Number

<!-- Add the number from the Jira board -->

https://pins-ds.atlassian.net/browse/AAPD-371

## Description of change

Have added the collections with shard keys manually in azure, shard keys are not automatically indexed

parseISO apparently accepts strings like 1010101 as a valid date

## Checklist

<!-- Put an `x` in all the boxes that apply: -->

- [ ] Requires infrastructure changes
- [ ] If adding or remove environment variables (e.g. in `docker-compose.yaml`) then I have updated the appropriate Helm chart
- [ ] I have updated the documentation accordingly
- [x] My commit history in this PR is linear
- [ ] New features have tests
- [ ] Breaking change (team conversation required)

## Important

Please do not merge from `main` (please only [rebase](https://github.com/foundry4/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
