### PR TITLE
feat(AAPD-291): add neighbouring properties

### DIFF
--- a/packages/forms-web-app/src/dynamic-forms/dynamic-components/address-add-more/question.js
+++ b/packages/forms-web-app/src/dynamic-forms/dynamic-components/address-add-more/question.js
@@ -35,6 +35,20 @@ class AddressAddMoreQuestion extends AddMoreQuestion {
 		});
 		return { addMoreId: uuid.v4(), value: address };
 	}
+
+	/**
+	 *
+	 * @param {Object.<Any>} answer
+	 * @returns The formatted address to be presented in the UI
+	 */
+	format(answer) {
+		let addressString = '';
+		addressString += `${answer.addressLine1}, `;
+		addressString += answer.addressLine2 ? `${answer.addressLine2}, ` : ``;
+		addressString += `${answer.townCity}, `;
+		addressString += answer.postcode ? `${answer.postcode} ` : ``;
+		return addressString;
+	}
 }
 
 module.exports = AddressAddMoreQuestion;

--- a/packages/forms-web-app/src/dynamic-forms/dynamic-components/list-add-more/index.njk
+++ b/packages/forms-web-app/src/dynamic-forms/dynamic-components/list-add-more/index.njk
@@ -10,7 +10,7 @@
 
 {% block content %}
   <div class="govuk-grid-row">
-    <div class="govuk-grid-column-two-thirds">
+    <div class="{{question.width}}">
       {# TODO update to persist main question header text #}
       
       <p class="govuk-heading-l">{{question.question}}</p>

--- a/packages/forms-web-app/src/dynamic-forms/dynamic-components/list-add-more/question.js
+++ b/packages/forms-web-app/src/dynamic-forms/dynamic-components/list-add-more/question.js
@@ -29,6 +29,7 @@ class ListAddMoreQuestion extends Question {
 	 * @param {string} [params.pageTitle]
 	 * @param {string} [params.description]
 	 * @param {string} [params.subQuestionLabel]
+	 * @param {string} [params.width]
 	 * @param {Array.<import('../../question').BaseValidator>} [params.validators]
 	 */
 	constructor({
@@ -40,7 +41,8 @@ class ListAddMoreQuestion extends Question {
 		pageTitle,
 		description,
 		subQuestionLabel,
-		validators
+		validators,
+		width
 	}) {
 		super({
 			title,
@@ -59,8 +61,10 @@ class ListAddMoreQuestion extends Question {
 
 		this.subQuestion = subQuestion;
 		this.subQuestionLabel = subQuestionLabel ?? 'Answer';
+		this.width = width ?? this.TWO_THIRDS_WIDTH;
 	}
-
+	static FULL_WIDTH = 'govuk-grid-column-full';
+	static TWO_THIRDS_WIDTH = 'govuk-grid-column-two-thirds';
 	/**
 	 * Answers to the question
 	 * @param {Object} answers
@@ -115,11 +119,11 @@ class ListAddMoreQuestion extends Question {
 	 */
 	formatAnswerForSummary(sectionSegment, journey, answer) {
 		let rowParams = [];
-		for (let i = 0; i < answer.length; i++) {
+		for (let i = 0; i < answer?.length; i++) {
 			const action = this.getAction(sectionSegment, journey);
 			rowParams.push({
 				key: `${this.subQuestionLabel} ${i + 1}`,
-				value: answer[i].value,
+				value: this.subQuestion.format(answer[i].value),
 				action: action
 			});
 		}
@@ -157,7 +161,7 @@ class ListAddMoreQuestion extends Question {
 			const answer = answers[item];
 			addMoreAnswers.push({
 				label: `${this.subQuestionLabel} ${i}`,
-				answer: answer.value,
+				answer: this.subQuestion.format(answer.value),
 				removeLink:
 					journey.getCurrentQuestionUrl(section.segment, this.fieldName) + '/' + answer.addMoreId
 			});
@@ -220,7 +224,9 @@ class ListAddMoreQuestion extends Question {
 		let isAddMorePage = true;
 		if (!req.body[this.fieldName]) {
 			if (
-				Object.getOwnPropertyNames(req.body).find((prop) => prop === this.subQuestion.fieldName)
+				Object.getOwnPropertyNames(req.body).find(
+					(prop) => prop === this.subQuestion.fieldName || prop.includes(this.subQuestion.fieldName)
+				)
 			) {
 				isAddMorePage = false;
 			}

--- a/packages/forms-web-app/src/dynamic-forms/dynamic-components/macros/answer-list.njk
+++ b/packages/forms-web-app/src/dynamic-forms/dynamic-components/macros/answer-list.njk
@@ -10,7 +10,7 @@
             text: item.label
             },
             value: {
-            text: item.answer
+            html: item.answer
             },
             actions: {
                 items: [

--- a/packages/forms-web-app/src/dynamic-forms/has-questionnaire/journey.js
+++ b/packages/forms-web-app/src/dynamic-forms/has-questionnaire/journey.js
@@ -95,6 +95,10 @@ class HasJourney extends Journey {
 			new Section('Site access', 'site-access')
 				.addQuestion(questions.accessForInspection)
 				.addQuestion(questions.neighbouringSite)
+				.addQuestion(questions.neighbouringSitesToBeVisited)
+				.withCondition(
+					response.answers && response.answers[questions.neighbouringSite.fieldName] == 'yes'
+				)
 				.addQuestion(questions.potentialSafetyRisks),
 			new Section('Appeal process', 'appeal-process')
 				.addQuestion(questions.appealsNearSite)

--- a/packages/forms-web-app/src/dynamic-forms/middleware/utils.js
+++ b/packages/forms-web-app/src/dynamic-forms/middleware/utils.js
@@ -18,7 +18,9 @@ function getAddMoreIfPresent(req, questionObj) {
 	if (!req.body[questionObj.fieldName]) {
 		if (
 			Object.getOwnPropertyNames(req.body).find(
-				(prop) => prop === questionObj.subQuestion.fieldName
+				(prop) =>
+					prop === questionObj.subQuestion.fieldName ||
+					prop.includes(questionObj.subQuestion.fieldName)
 			)
 		) {
 			questionObj = questionObj.subQuestion;

--- a/packages/forms-web-app/src/dynamic-forms/question.js
+++ b/packages/forms-web-app/src/dynamic-forms/question.js
@@ -48,8 +48,6 @@ class Question {
 	fieldName;
 	/** @type {boolean} if the question should appear in the journey overview task list or not */
 	taskList;
-	/** @type {function|undefined} function that customises the formatting of the question in the task list */
-	format;
 	/** @type {Array.<BaseValidator>} array of validators that a question uses to validate answers */
 	validators = [];
 	/** @type {string|undefined} hint text displayed to user */
@@ -304,6 +302,15 @@ class Question {
 			visuallyHiddenText: this.question
 		};
 		return action;
+	}
+
+	/**
+	 *
+	 * @param {Object.<Any>} answer
+	 * @returns The formatted address to be presented in the UI
+	 */
+	format(answer) {
+		return answer;
 	}
 
 	NOT_STARTED = 'Not started';

--- a/packages/forms-web-app/src/dynamic-forms/question.js
+++ b/packages/forms-web-app/src/dynamic-forms/question.js
@@ -307,7 +307,7 @@ class Question {
 	/**
 	 *
 	 * @param {Object.<Any>} answer
-	 * @returns The formatted address to be presented in the UI
+	 * @returns The formatted value to be presented in the UI
 	 */
 	format(answer) {
 		return answer;

--- a/packages/forms-web-app/src/dynamic-forms/questions.js
+++ b/packages/forms-web-app/src/dynamic-forms/questions.js
@@ -12,8 +12,10 @@ const BooleanTextQuestion = require('./dynamic-components/boolean-text/question'
 const RequiredValidator = require('./validator/required-validator');
 const RequiredFileUploadValidator = require('./validator/required-file-upload-validator');
 const MultifileUploadValidator = require('./validator/multifile-upload-validator');
+const AddressValidator = require('./validator/address-validator');
 const ListAddMoreQuestion = require('./dynamic-components/list-add-more/question');
 const AddMoreQuestion = require('./dynamic-components/add-more/question');
+const AddressAddMoreQuestion = require('./dynamic-components/address-add-more/question');
 const IdentifierQuestion = require('./dynamic-components/identifier/question');
 const StringEntryValidator = require('./validator/string-validator');
 
@@ -200,6 +202,22 @@ exports.questions = {
 		fieldName: 'inspector-visit-neighbour', //The name of the html input field / stem of the name for screens with multiple fields
 		validators: [new RequiredValidator()]
 	}),
+	neighbouringSitesToBeVisited: new ListAddMoreQuestion({
+		title: 'Neighbour added',
+		question: 'Do you want to add another neighbour to be visited?',
+		fieldName: 'neighbouring-site-visits',
+		url: 'neighbours',
+		subQuestionLabel: 'Neighbour',
+		width: ListAddMoreQuestion.FULL_WIDTH,
+		validators: [new RequiredValidator()],
+		subQuestion: new AddressAddMoreQuestion({
+			title: 'Tell us the address of the neighbour’s land or property',
+			question: 'Tell us the address of the neighbour’s land or property',
+			fieldName: 'neighbour-site-address',
+			validators: [new AddressValidator()],
+			viewFolder: 'address-entry'
+		})
+	}),
 	potentialSafetyRisks: new BooleanTextQuestion({
 		title: 'Potential safety risks',
 		question: 'Add potential safety risks',
@@ -237,13 +255,13 @@ exports.questions = {
 		question: 'Add another appeal?',
 		fieldName: 'other-appeals-references',
 		url: 'nearby-appeals-list',
-		subQuestionLabel: 'Appeal ',
+		subQuestionLabel: 'Appeal',
 		validators: [new RequiredValidator()],
 		subQuestion: new AddMoreQuestion({
 			title: 'Enter an appeal reference number',
 			question: 'Enter an appeal reference number',
 			fieldName: 'other-appeal-reference',
-			hint: 'Enter an appeal reference number',
+			hint: 'You can add more appeals later if there is more than one nearby',
 			validators: [new RequiredValidator()],
 			viewFolder: 'identifier'
 		})


### PR DESCRIPTION
Adds the ability to add neighbouring properties to a questionnaire response. Fixes a bug with list add more questions that causes a rendering failure when there is only on item in a list for a list add more question

## Ticket Number

<!-- Add the number from the Jira board -->

https://pins-ds.atlassian.net/browse/AAPD-291

## Description of change

Adds the ability to add neighbouring properties to a questionnaire response. 
Fixes a bug with list add more questions that causes a rendering failure when there is only on item in a list for a list add more question. 
Custom format option on base question class

## Checklist

<!-- Put an `x` in all the boxes that apply: -->

- [ ] Requires infrastructure changes
- [ ] If adding or remove environment variables (e.g. in `docker-compose.yaml`) then I have updated the appropriate Helm chart
- [ ] I have updated the documentation accordingly
- [x] My commit history in this PR is linear
- [ ] New features have tests
- [ ] Breaking change (team conversation required)

## Important

Please do not merge from `main` (please only [rebase](https://github.com/foundry4/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
