### PR TITLE
feat(aapd-359): change identifier to use label instead of pageHeading

### DIFF
--- a/packages/forms-web-app/src/dynamic-forms/dynamic-components/identifier/index.njk
+++ b/packages/forms-web-app/src/dynamic-forms/dynamic-components/identifier/index.njk
@@ -28,9 +28,9 @@
     <div class="govuk-grid-row">
         <div class="govuk-grid-column-two-thirds">  
             <form action="" method="post" novalidate>
-                {% if question.pageHeading %}
+                {% if question.label %}
                     <h1 class="govuk-heading-l">
-                        {{question.pageHeading}}
+                        {{question.question}}
                     </h1>
 
                     {% if question.html %}
@@ -39,7 +39,7 @@
 
                     {{ govukInput({
                         label: {
-                            text: question.question
+                            text: question.label
                         },
                         id: question.fieldName,
                         name: question.fieldName,

--- a/packages/forms-web-app/src/dynamic-forms/dynamic-components/identifier/question.js
+++ b/packages/forms-web-app/src/dynamic-forms/dynamic-components/identifier/question.js
@@ -16,8 +16,8 @@ class IdentifierQuestion extends Question {
 	 * @param {string} [params.description]
 	 * @param {string} [params.html]
 	 * @param {string} [params.hint]
-	 * @param {string} [params.inputClasses]
-	 * @param {string|undefined} [params.pageHeading]
+	 * @param {string} [params.inputClasses] css class string to be added to the input
+	 * @param {string|undefined} [params.label] if defined this show as a label for the input and the question will just be a standard h1
 	 * @param {Array.<import('../../question').BaseValidator>} [params.validators]
 	 */
 	constructor({
@@ -31,7 +31,7 @@ class IdentifierQuestion extends Question {
 		html,
 		hint,
 		inputClasses = 'govuk-input--width-10',
-		pageHeading
+		label
 	}) {
 		super({
 			title,
@@ -47,7 +47,7 @@ class IdentifierQuestion extends Question {
 		});
 
 		this.inputClasses = inputClasses;
-		this.pageHeading = pageHeading;
+		this.label = label;
 	}
 
 	/**
@@ -56,7 +56,7 @@ class IdentifierQuestion extends Question {
 	prepQuestionForRendering(section, journey, customViewData) {
 		let viewModel = super.prepQuestionForRendering(section, journey, customViewData);
 		viewModel.question.inputClasses = this.inputClasses;
-		viewModel.question.pageHeading = this.pageHeading;
+		viewModel.question.label = this.label;
 		return viewModel;
 	}
 }

--- a/packages/forms-web-app/src/dynamic-forms/dynamic-components/identifier/question.test.js
+++ b/packages/forms-web-app/src/dynamic-forms/dynamic-components/identifier/question.test.js
@@ -12,7 +12,7 @@ describe('./src/dynamic-forms/dynamic-components/identifier/question.js', () => 
 		const HTML = '/path/to/html.njk';
 		const HINT = 'hint';
 		const INPUT_CLASSES = 'govuk-body';
-		const PAGE_HEADING = 'A Heading';
+		const LABEL = 'A label';
 
 		const question = new IdentifierQuestion({
 			title: TITLE,
@@ -25,7 +25,7 @@ describe('./src/dynamic-forms/dynamic-components/identifier/question.js', () => 
 			html: HTML,
 			hint: HINT,
 			inputClasses: INPUT_CLASSES,
-			pageHeading: PAGE_HEADING
+			label: LABEL
 		});
 
 		expect(question.title).toEqual(TITLE);
@@ -39,6 +39,6 @@ describe('./src/dynamic-forms/dynamic-components/identifier/question.js', () => 
 		expect(question.html).toEqual(HTML);
 		expect(question.hint).toEqual(HINT);
 		expect(question.inputClasses).toEqual(INPUT_CLASSES);
-		expect(question.pageHeading).toEqual(PAGE_HEADING);
+		expect(question.label).toEqual(LABEL);
 	});
 });

--- a/packages/forms-web-app/src/dynamic-forms/questions.js
+++ b/packages/forms-web-app/src/dynamic-forms/questions.js
@@ -41,8 +41,8 @@ exports.questions = {
 	}),
 	listedBuildingNumber: new IdentifierQuestion({
 		title: 'Tell us the list entry number',
-		pageHeading: 'Tell us the list entry number',
-		question: 'Seven digit number',
+		question: 'Tell us the list entry number',
+		label: 'Seven digit number',
 		fieldName: 'listed-building-number',
 		html: 'resources/listed-building-number/content.html',
 		validators: [new StringEntryValidator(listedBuildingNumberValidation)]
@@ -271,18 +271,6 @@ exports.questions = {
 		question: 'Do you want to add new planning conditions to this appeal?',
 		fieldName: 'new-planning-conditions'
 	})
-	// exampleAddMoreQuestion: new ListAddMoreQuestion({
-	// 	title: 'Add More',
-	// 	question: 'Add more?',
-	// 	fieldName: 'add-more',
-	// 	validators: [new RequiredValidator()],
-	// 	subQuestion: new IdentifierQuestion({
-	// 		title: 'Sub',
-	// 		question: 'sub?',
-	// 		fieldName: 'sub-question',
-	// 		validators: [new RequiredValidator()]
-	// 	})
-	// })
 	// /*S78 questions */
 	// rightOfWayCheck: new BooleanQuestion({
 	// 	title: 'Public right of way',


### PR DESCRIPTION
## Ticket Number

<!-- Add the number from the Jira board -->

https://pins-ds.atlassian.net/browse/AAPD-359

## Description of change
Inverts the identifier class to specify using a custom label rather than a custom pageHeading
This allows the visually hidden text on task list to use the question property, as it currently reads out 'Seven digit number'
Think it keeps the use of the question property more consistent

## Checklist

<!-- Put an `x` in all the boxes that apply: -->

- [ ] Requires infrastructure changes
- [ ] If adding or remove environment variables (e.g. in `docker-compose.yaml`) then I have updated the appropriate Helm chart
- [ ] I have updated the documentation accordingly
- [x] My commit history in this PR is linear
- [x] New features have tests
- [ ] Breaking change (team conversation required)

## Important

Please do not merge from `main` (please only [rebase](https://github.com/foundry4/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
