### PR TITLE
feat(aapd-95): enable adding more listed buildings

### DIFF
--- a/packages/forms-web-app/src/dynamic-forms/dynamic-components/add-more/question.js
+++ b/packages/forms-web-app/src/dynamic-forms/dynamic-components/add-more/question.js
@@ -21,14 +21,15 @@ class AddMoreQuestion extends Question {
 	 * @param {string} [params.hint]
 	 * @param {Array.<BaseValidator>} [params.validators]
 	 */
-	constructor({ title, question, fieldName, hint, validators, viewFolder }) {
+	constructor({ title, question, fieldName, hint, validators, viewFolder, html }) {
 		super({
-			title: title,
-			viewFolder: viewFolder,
-			fieldName: fieldName,
-			question: question,
-			validators: validators,
-			hint: hint
+			title,
+			viewFolder,
+			fieldName,
+			question,
+			validators,
+			hint,
+			html
 		});
 	}
 

--- a/packages/forms-web-app/src/dynamic-forms/dynamic-components/identifier/index.njk
+++ b/packages/forms-web-app/src/dynamic-forms/dynamic-components/identifier/index.njk
@@ -43,6 +43,7 @@
                         },
                         id: question.fieldName,
                         name: question.fieldName,
+                        value: payload and payload[question.fieldName],
                         hint: { text: question.hint },
                         errorMessage: errors[question.fieldName] and {
                             text: errors[question.fieldName].msg
@@ -64,6 +65,7 @@
                     {{ govukInput({
                         id: question.fieldName,
                         name: question.fieldName,
+                        value: payload and payload[question.fieldName],
                         hint: { text: question.hint },
                         errorMessage: errors[question.fieldName] and {
                             text: errors[question.fieldName].msg

--- a/packages/forms-web-app/src/dynamic-forms/dynamic-components/list-add-more/question.js
+++ b/packages/forms-web-app/src/dynamic-forms/dynamic-components/list-add-more/question.js
@@ -43,6 +43,8 @@ class ListAddMoreQuestion extends Question {
 		pageTitle,
 		description,
 		subQuestionLabel,
+		subQuestionFieldLabel,
+		subQuestionInputClasses,
 		validators,
 		width
 	}) {
@@ -63,6 +65,8 @@ class ListAddMoreQuestion extends Question {
 
 		this.subQuestion = subQuestion;
 		this.subQuestionLabel = subQuestionLabel ?? 'Answer';
+		this.subQuestionFieldLabel = subQuestionFieldLabel;
+		this.subQuestionInputClasses = subQuestionInputClasses;
 		this.width = width ?? ListAddMoreQuestion.TWO_THIRDS_WIDTH;
 	}
 	/**
@@ -108,7 +112,10 @@ class ListAddMoreQuestion extends Question {
 		}
 
 		// get viewModel for addMore subquestion
-		return this.subQuestion.prepQuestionForRendering(section, journey, customViewData);
+		const viewModel = this.subQuestion.prepQuestionForRendering(section, journey, customViewData);
+		viewModel.question.label = this.subQuestionFieldLabel;
+		viewModel.question.inputClasses = this.subQuestionInputClasses;
+		return viewModel;
 	}
 
 	/**
@@ -245,6 +252,8 @@ class ListAddMoreQuestion extends Question {
 				const viewModel = this.subQuestion.prepQuestionForRendering(section, journey);
 				viewModel.backLink = journey.getCurrentQuestionUrl(section.segment, this.fieldName);
 				viewModel.navigation = ['', viewModel.backLink];
+				viewModel.question.label = this.subQuestionFieldLabel;
+				viewModel.question.inputClasses = this.subQuestionInputClasses;
 				return this.renderAction(res, viewModel);
 			} else if (addMoreAnswer === 'no') {
 				return res.redirect(journey.getNextQuestionUrl(section.segment, this.fieldName, false));
@@ -254,6 +263,8 @@ class ListAddMoreQuestion extends Question {
 		// check for validation errors
 		const errorViewModel = this.subQuestion.checkForValidationErrors(req, section, journey);
 		if (errorViewModel) {
+			errorViewModel.question.label = this.subQuestionFieldLabel;
+			errorViewModel.question.inputClasses = this.subQuestionInputClasses;
 			return this.renderAction(res, errorViewModel);
 		}
 

--- a/packages/forms-web-app/src/dynamic-forms/dynamic-components/list-add-more/question.test.js
+++ b/packages/forms-web-app/src/dynamic-forms/dynamic-components/list-add-more/question.test.js
@@ -240,7 +240,8 @@ describe('./src/dynamic-forms/dynamic-components/question.js', () => {
 
 		it('should handle subquestion validation errors', async () => {
 			const expectedErrors = {
-				errorViewModel: 'mocked-validation-error'
+				errorViewModel: 'mocked-validation-error',
+				question: {}
 			};
 			const question = getTestQuestion();
 			question.subQuestion.checkForValidationErrors = jest.fn(() => expectedErrors);

--- a/packages/forms-web-app/src/dynamic-forms/dynamic-components/listed-building-add-more/question.js
+++ b/packages/forms-web-app/src/dynamic-forms/dynamic-components/listed-building-add-more/question.js
@@ -1,0 +1,39 @@
+const AddMoreQuestion = require('../add-more/question');
+
+const uuid = require('uuid');
+
+class ListedBuildingAddMoreQuestion extends AddMoreQuestion {
+	constructor({ title, question, fieldName, viewFolder, html, validators }) {
+		super({
+			title,
+			viewFolder,
+			fieldName,
+			question,
+			html,
+			validators
+		});
+	}
+
+	/**
+	 * adds a uuid to save the listed building
+	 * @param {ExpressRequest} req
+	 * @returns
+	 */
+	async getDataToSave(req) {
+		return { addMoreId: uuid.v4(), value: { [this.fieldName]: req.body[this.fieldName] } };
+	}
+
+	/**
+	 *
+	 * @param {Object.<Any>} answer
+	 * @returns The formatted string to be presented in the UI
+	 */
+	format(answer) {
+		const identifier = answer[this.fieldName];
+		const grade = 'Grade';
+		const address = 'Address';
+		return [identifier, grade, address].join('<br>');
+	}
+}
+
+module.exports = ListedBuildingAddMoreQuestion;

--- a/packages/forms-web-app/src/dynamic-forms/dynamic-components/listed-building-add-more/question.test.js
+++ b/packages/forms-web-app/src/dynamic-forms/dynamic-components/listed-building-add-more/question.test.js
@@ -1,0 +1,50 @@
+const AddMoreQuestion = require('../add-more/question');
+const ListedBuildingAddMoreQuestion = require('./question');
+const uuid = require('uuid');
+
+describe('ListedBuildingAddMoreQuestion', () => {
+	const TITLE = 'title';
+	const QUESTION = 'question';
+	const FIELDNAME = 'fieldName';
+	const VIEWFOLDER = 'viewFolder';
+	const VALIDATORS = [];
+	const HTML = 'html';
+
+	describe('constructor', () => {
+		it('should instantiate and inherit from AddMoreQuestion', () => {
+			const listedBuildingAddMoreQuestion = new ListedBuildingAddMoreQuestion({
+				title: TITLE,
+				question: QUESTION,
+				fieldName: FIELDNAME,
+				viewFolder: VIEWFOLDER,
+				validators: VALIDATORS,
+				html: HTML
+			});
+			expect(listedBuildingAddMoreQuestion instanceof ListedBuildingAddMoreQuestion).toBeTruthy();
+			expect(listedBuildingAddMoreQuestion instanceof AddMoreQuestion).toBeTruthy();
+		});
+	});
+
+	describe('getDataToSave', () => {
+		it('should return data correctly', async () => {
+			const listedBuildingAddMoreQuestion = new ListedBuildingAddMoreQuestion({
+				title: TITLE,
+				question: QUESTION,
+				fieldName: FIELDNAME,
+				viewFolder: VIEWFOLDER,
+				validators: VALIDATORS
+			});
+
+			const req = {
+				body: {
+					[FIELDNAME]: '1234567'
+				}
+			};
+
+			const result = await listedBuildingAddMoreQuestion.getDataToSave(req);
+
+			expect(uuid.validate(result.addMoreId)).toBeTruthy();
+			expect(result.value).toEqual({ fieldName: '1234567' });
+		});
+	});
+});

--- a/packages/forms-web-app/src/dynamic-forms/has-questionnaire/journey.js
+++ b/packages/forms-web-app/src/dynamic-forms/has-questionnaire/journey.js
@@ -33,7 +33,7 @@ class HasJourney extends Journey {
 			new Section('Constraints, designations and other issues', 'constraints')
 				.addQuestion(questions.appealTypeAppropriate)
 				.addQuestion(questions.listedBuildingCheck)
-				.addQuestion(questions.listedBuildingNumber)
+				.addQuestion(questions.affectedListedBuildings)
 				.withCondition(
 					response.answers && response.answers[questions.listedBuildingCheck.fieldName] == 'yes'
 				)

--- a/packages/forms-web-app/src/dynamic-forms/questions.js
+++ b/packages/forms-web-app/src/dynamic-forms/questions.js
@@ -11,7 +11,6 @@ const BooleanQuestion = require('./dynamic-components/boolean/question');
 const ListAddMoreQuestion = require('./dynamic-components/list-add-more/question');
 const AddMoreQuestion = require('./dynamic-components/add-more/question');
 const AddressAddMoreQuestion = require('./dynamic-components/address-add-more/question');
-const IdentifierQuestion = require('./dynamic-components/identifier/question');
 const RadioQuestion = require('./dynamic-components/radio/question');
 
 const RequiredValidator = require('./validator/required-validator');
@@ -33,6 +32,7 @@ const {
 } = require('../config');
 const { getConditionalFieldName } = require('./dynamic-components/utils/question-utils');
 const ConditionalRequiredValidator = require('./validator/conditional-required-validator');
+const ListedBuildingAddMoreQuestion = require('./dynamic-components/listed-building-add-more/question');
 
 // Define all questions
 exports.questions = {
@@ -48,13 +48,25 @@ exports.questions = {
 		fieldName: 'affects-listed-building',
 		validators: [new RequiredValidator()]
 	}),
-	listedBuildingNumber: new IdentifierQuestion({
-		title: 'Tell us the list entry number',
-		question: 'Tell us the list entry number',
-		label: 'Seven digit number',
-		fieldName: 'listed-building-number',
-		html: 'resources/listed-building-number/content.html',
-		validators: [new StringEntryValidator(listedBuildingNumberValidation)]
+	affectedListedBuildings: new ListAddMoreQuestion({
+		title: 'Listed building or site added',
+		pageTitle: 'Listed building or site has been added to the case',
+		question: 'Add another building or site?',
+		fieldName: 'add-listed-buildings',
+		url: 'affected-listed-buildings',
+		subQuestionLabel: 'Listed Building',
+		subQuestionFieldLabel: 'Seven digit number',
+		subQuestionInputClasses: 'govuk-input--width-10',
+		width: ListAddMoreQuestion.FULL_WIDTH,
+		validators: [new RequiredValidator()],
+		subQuestion: new ListedBuildingAddMoreQuestion({
+			title: 'Tell us the list entry number',
+			question: 'Tell us the list entry number',
+			fieldName: 'listed-building-number',
+			html: 'resources/listed-building-number/content.html',
+			validators: [new StringEntryValidator(listedBuildingNumberValidation)],
+			viewFolder: 'identifier'
+		})
 	}),
 	// listedBuildingDetail: {
 	// 	title: 'Listed buildings',


### PR DESCRIPTION
## Ticket Number

https://pins-ds.atlassian.net/browse/AAPD-95

## Description of change

Added the functionality of adding more than 1 listed building

## Checklist

<!-- Put an `x` in all the boxes that apply: -->

- [ ] Requires infrastructure changes
- [ ] If adding or remove environment variables (e.g. in `docker-compose.yaml`) then I have updated the appropriate Helm chart
- [ ] I have updated the documentation accordingly
- [x] My commit history in this PR is linear
- [x] New features have tests
- [ ] Breaking change (team conversation required)

## Important

Please do not merge from `main` (please only [rebase](https://github.com/foundry4/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
