### PR TITLE
feat(journey): provide unqiue question lookup check

### DIFF
--- a/packages/forms-web-app/src/dynamic-forms/has-questionnaire/journey.js
+++ b/packages/forms-web-app/src/dynamic-forms/has-questionnaire/journey.js
@@ -30,7 +30,7 @@ class HasJourney extends Journey {
 		);
 
 		this.sections.push(
-			new Section('Constraints, designations and other issues', 'constraints')
+			new Section('Constraints, designations and other issues', 'constraints', this.urlSet)
 				.addQuestion(questions.appealTypeAppropriate)
 				.addQuestion(questions.listedBuildingCheck)
 				.addQuestion(questions.affectedListedBuildings)
@@ -50,7 +50,7 @@ class HasJourney extends Journey {
 				// .addQuestion(questions.conservationAreaUpload)
 				// .withCondition(response.answers[questions.conservationArea.fieldName] == 'yes')
 				.addQuestion(questions.greenBelt),
-			new Section('Notifying relevant parties of the application', 'notified')
+			new Section('Notifying relevant parties of the application', 'notified', this.urlSet)
 				.addQuestion(questions.whoWasNotified)
 				// .addQuestion(questions.howYouNotifiedPeople)
 				.addQuestion(questions.displaySiteNotice)
@@ -84,7 +84,7 @@ class HasJourney extends Journey {
 			// 		'Advertisement'
 			// 	)
 			// )
-			new Section('Consultation responses and representations', 'consultation')
+			new Section('Consultation responses and representations', 'consultation', this.urlSet)
 				.addQuestion(questions.representationsFromOthers)
 				.addQuestion(questions.representationUpload)
 				.withCondition(
@@ -93,9 +93,10 @@ class HasJourney extends Journey {
 				),
 			new Section(
 				"Planning officer's report and supplementary documents",
-				'planning-officer-report'
+				'planning-officer-report',
+				this.urlSet
 			).addQuestion(questions.planningOfficersReportUpload),
-			new Section('Site access', 'site-access')
+			new Section('Site access', 'site-access', this.urlSet)
 				.addQuestion(questions.accessForInspection)
 				.addQuestion(questions.neighbouringSite)
 				.addQuestion(questions.neighbouringSitesToBeVisited)
@@ -103,7 +104,7 @@ class HasJourney extends Journey {
 					response.answers && response.answers[questions.neighbouringSite.fieldName] == 'yes'
 				)
 				.addQuestion(questions.potentialSafetyRisks),
-			new Section('Appeal process', 'appeal-process')
+			new Section('Appeal process', 'appeal-process', this.urlSet)
 				.addQuestion(questions.appealsNearSite)
 				.addQuestion(questions.nearbyAppeals)
 				.withCondition(

--- a/packages/forms-web-app/src/dynamic-forms/journey.js
+++ b/packages/forms-web-app/src/dynamic-forms/journey.js
@@ -8,7 +8,6 @@
  * @typedef {import('./journey-response').JourneyResponse} JourneyResponse
  * @typedef {import('./section').Section} Section
  * @typedef {import('./question')} Question
- * @typedef {import('./question')} Question
  */
 
 /**
@@ -78,6 +77,8 @@ class Journey {
 		this.journeyTitle = journeyTitle;
 
 		this.response = response;
+
+		this.urlSet = new Set();
 	}
 
 	/**

--- a/packages/forms-web-app/src/dynamic-forms/s78-questionnaire/journey.js
+++ b/packages/forms-web-app/src/dynamic-forms/s78-questionnaire/journey.js
@@ -31,7 +31,7 @@ class S78Journey extends Journey {
 		);
 
 		this.sections.push(
-			new Section('Constraints, designations and other issues', 'constraints')
+			new Section('Constraints, designations and other issues', 'constraints', this.urlSet)
 				.addQuestion(questions.appealTypeAppropriate)
 				.addQuestion(questions.changesListedBuilding)
 				.addQuestion(questions.changedListedBuildingNumber)
@@ -53,8 +53,8 @@ class S78Journey extends Journey {
 				.addQuestion(questions.uploadDefinitiveMap)
 				.addQuestion(questions.gypsyOrTraveller)
 				.addQuestion(questions.rightOfWayCheck),
-			new Section('Environmental impact assessment', 'environmental-impact'),
-			new Section('Notifying relevant parties of the application', 'notified')
+			new Section('Environmental impact assessment', 'environmental-impact', this.urlSet),
+			new Section('Notifying relevant parties of the application', 'notified', this.urlSet)
 				.addQuestion(questions.whoWasNotified)
 				.addQuestion(questions.howYouNotifiedPeople)
 				.addQuestion(questions.uploadSiteNotice)
@@ -81,7 +81,7 @@ class S78Journey extends Journey {
 							'advert'
 						)
 				),
-			new Section('Consultation responses and representations', 'consultation')
+			new Section('Consultation responses and representations', 'consultation', this.urlSet)
 				.addQuestion(questions.statutoryConsultees)
 				.addQuestion(questions.consultationResponses)
 				.addQuestion(questions.consultationResponsesUpload)
@@ -91,7 +91,11 @@ class S78Journey extends Journey {
 					response.answers &&
 						response.answers[questions.representationsFromOthers.fieldName] == 'yes'
 				),
-			new Section('Planning officer’s report and supporting documents', 'planning-officer-report')
+			new Section(
+				'Planning officer’s report and supporting documents',
+				'planning-officer-report',
+				this.urlSet
+			)
 				.addQuestion(questions.emergingPlan)
 				.addQuestion(questions.emergingPlanUpload)
 				.withCondition(
@@ -126,7 +130,7 @@ class S78Journey extends Journey {
 						response.answers[questions.communityInfrastructureLevy.fieldName] == 'yes' &&
 						response.answers[questions.communityInfrastructureLevyAdopted.fieldName] == 'no'
 				),
-			new Section('Site access', 'site-access')
+			new Section('Site access', 'site-access', this.urlSet)
 				.addQuestion(questions.accessForInspection)
 				.addQuestion(questions.neighbouringSite)
 				.addQuestion(questions.neighbouringSitesToBeVisited)
@@ -134,7 +138,7 @@ class S78Journey extends Journey {
 					response.answers && response.answers[questions.neighbouringSite.fieldName] == 'yes'
 				)
 				.addQuestion(questions.potentialSafetyRisks),
-			new Section('Appeal process', 'appeal-process')
+			new Section('Appeal process', 'appeal-process', this.urlSet)
 				.addQuestion(questions.appealsNearSite)
 				.addQuestion(questions.nearbyAppeals)
 				.addQuestion(questions.addNewConditions)

--- a/packages/forms-web-app/src/dynamic-forms/section.js
+++ b/packages/forms-web-app/src/dynamic-forms/section.js
@@ -30,10 +30,12 @@ class Section {
 	 * creates an instance of a section
 	 * @param {string} name
 	 * @param {string} segment
+	 * @param {Set} [urlSet]
 	 */
-	constructor(name, segment) {
+	constructor(name, segment, urlSet) {
 		this.name = name;
 		this.segment = segment;
+		this.urlSet = urlSet || new Set();
 	}
 
 	/**
@@ -43,7 +45,33 @@ class Section {
 	 */
 	addQuestion(question) {
 		this.questions.push(question);
+
+		this.#checkUrlIsUnique(question, this.urlSet);
+
 		return this;
+	}
+
+	/**
+	 * @param {Question} question
+	 * @param {Set} set
+	 */
+	#checkUrlIsUnique(question, set) {
+		const hasFieldName = set.has(question.fieldName);
+		const hasUrl = set.has(question.url);
+
+		if (hasFieldName) {
+			throw new Error('Duplicate question lookup added to section');
+		}
+
+		if (hasUrl && typeof question.url !== 'undefined') {
+			throw new Error('Duplicate question lookup added to section');
+		}
+
+		set.add(question.fieldName);
+
+		if (typeof question.url !== 'undefined') {
+			set.add(question.url);
+		}
 	}
 
 	/**

--- a/packages/forms-web-app/src/dynamic-forms/section.test.js
+++ b/packages/forms-web-app/src/dynamic-forms/section.test.js
@@ -159,4 +159,77 @@ describe('./src/dynamic-forms/section.js', () => {
 		expect(section.questions.length).toEqual(1);
 		expect(section.questions[0]).toEqual(question);
 	});
+
+	it('should error with duplicate question fieldName', () => {
+		const commonUrl = 'visitFrequently';
+		const section = new Section();
+		const question = {
+			title: 'ice breaker',
+			question: 'Do you come here often?',
+			description: 'Chit chat',
+			type: 'Boolean',
+			fieldName: commonUrl
+		};
+		section.addQuestion(question);
+
+		expect(() =>
+			section.addQuestion({
+				...question,
+				fieldName: commonUrl
+			})
+		).toThrowError('Duplicate question lookup added to section');
+
+		expect(() =>
+			section.addQuestion({
+				...question,
+				fieldName: 'different',
+				url: commonUrl
+			})
+		).toThrowError('Duplicate question lookup added to section');
+
+		expect(() =>
+			section.addQuestion({
+				...question,
+				fieldName: 'different',
+				url: 'different2'
+			})
+		).not.toThrowError();
+	});
+
+	it('should error with duplicate question url', () => {
+		const commonUrl = 'visitFrequently';
+		const section = new Section();
+		const question = {
+			title: 'ice breaker',
+			question: 'Do you come here often?',
+			description: 'Chit chat',
+			type: 'Boolean',
+			fieldName: 'a-field',
+			url: commonUrl
+		};
+		section.addQuestion(question);
+
+		expect(() =>
+			section.addQuestion({
+				...question,
+				fieldName: commonUrl
+			})
+		).toThrowError('Duplicate question lookup added to section');
+
+		expect(() =>
+			section.addQuestion({
+				...question,
+				fieldName: 'different',
+				url: commonUrl
+			})
+		).toThrowError('Duplicate question lookup added to section');
+
+		expect(() =>
+			section.addQuestion({
+				...question,
+				fieldName: 'different',
+				url: 'different2'
+			})
+		).not.toThrowError();
+	});
 });


### PR DESCRIPTION
## Ticket Number

<!-- Add the number from the Jira board -->

## Description of change
Thoughts on the following:

It's concerning me we have no test to check for duplicate questions being added to a journey

This PR:

- Checks urls being added to a section are unique
- if a journey level map is provided will check at a journey level as well as section level

for the journey level check it's a bit messy needing to pass through the map on every question
potentially could change how the withCondition works to allow for a check to be done, as the way it works currently we can't just loop through all questions after a journey is created as some questions will only be present given a certain response.

Potentially could remove the journey level bits and refactor as needed if we remove the section from the url/lookup at a later date

## Checklist

<!-- Put an `x` in all the boxes that apply: -->

- [ ] Requires infrastructure changes
- [ ] If adding or remove environment variables (e.g. in `docker-compose.yaml`) then I have updated the appropriate Helm chart
- [ ] I have updated the documentation accordingly
- [x] My commit history in this PR is linear
- [x] New features have tests
- [ ] Breaking change (team conversation required)

## Important

Please do not merge from `main` (please only [rebase](https://github.com/foundry4/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
