### PR TITLE
fix(AAPD-313): typo on appeals ref field name

### DIFF
--- a/packages/appeals-service-api/src/mappers/questionnaire-submission/has-mapper.js
+++ b/packages/appeals-service-api/src/mappers/questionnaire-submission/has-mapper.js
@@ -58,7 +58,7 @@ class HasQuestionnaireMapper {
 					// journeyResponse.answers['other-ongoing-appeals'] // fieldname needs clarifying
 					nearbyCaseReferences:
 						journeyResponse.answers['other-ongoing-appeals'] == 'yes'
-							? this.#convertFromAddMore(journeyResponse.answers['other-appeal-references'])
+							? this.#convertFromAddMore(journeyResponse.answers['other-appeals-references'])
 							: null,
 					// todo we need to fix the formatting on these and there is technical debt in order to collect the correct metadata, commenting out for now as BO are not yet ready for this
 					documents: [


### PR DESCRIPTION
## Ticket Number

<!-- Add the number from the Jira board -->

https://pins-ds.atlassian.net/browse/AAPD-313

## Description of change
Typo in other appeals refs field name on has
 mapper

<!-- Please describe the change -->

## Checklist

<!-- Put an `x` in all the boxes that apply: -->

- [ ] Requires infrastructure changes
- [ ] If adding or remove environment variables (e.g. in `docker-compose.yaml`) then I have updated the appropriate Helm chart
- [ ] I have updated the documentation accordingly
- [ ] My commit history in this PR is linear
- [ ] New features have tests
- [ ] Breaking change (team conversation required)

## Important

Please do not merge from `main` (please only [rebase](https://github.com/foundry4/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
