### PR TITLE
fix(AAPD-313): use undefined and json stringify in has mapper

### DIFF
--- a/packages/appeals-service-api/src/mappers/questionnaire-submission/has-mapper.js
+++ b/packages/appeals-service-api/src/mappers/questionnaire-submission/has-mapper.js
@@ -14,7 +14,7 @@ class HasQuestionnaireMapper {
 					affectedListedBuildings:
 						journeyResponse.answers['affects-listed-building'] == 'yes'
 							? this.#convertFromAddMore(journeyResponse.answers['add-listed-buildings'])
-							: null,
+							: undefined,
 					inCAOrRelatesToCA: this.#convertToBoolean(journeyResponse.answers['conservation-area']),
 					siteWithinGreenBelt: this.#convertToBoolean(journeyResponse.answers['green-belt']),
 					howYouNotifiedPeople: [
@@ -37,7 +37,7 @@ class HasQuestionnaireMapper {
 					healthAndSafetyIssuesDetails:
 						journeyResponse.answers['safety-risks'] == 'yes'
 							? journeyResponse.answers['safety-risks_new-safety-risk-value']
-							: null,
+							: undefined,
 					doesSiteRequireInspectorAccess: this.#convertToBoolean(
 						journeyResponse.answers['inspector-access-appeal-site']
 					),
@@ -50,7 +50,7 @@ class HasQuestionnaireMapper {
 					extraConditions:
 						journeyResponse.answers['new-planning-conditions'] == 'yes'
 							? journeyResponse.answers['safety-risks_new-conditions-value']
-							: null,
+							: undefined,
 					// todo waititng on odw
 					//journeyResponse.answers['inspector-visit-neighbour'] - should this be housed in the same property as above possibly doNeightboursAffectNeighboringSite
 					// newPlanningConditions: journeyResponse.answers['new-planning-conditions'],
@@ -59,7 +59,7 @@ class HasQuestionnaireMapper {
 					nearbyCaseReferences:
 						journeyResponse.answers['other-ongoing-appeals'] == 'yes'
 							? this.#convertFromAddMore(journeyResponse.answers['other-appeals-references'])
-							: null,
+							: undefined,
 					// todo we need to fix the formatting on these and there is technical debt in order to collect the correct metadata, commenting out for now as BO are not yet ready for this
 					documents: [
 						// {
@@ -119,7 +119,7 @@ class HasQuestionnaireMapper {
 			let sanitisedValue = item.value;
 			sanitisedValues.push(sanitisedValue);
 		});
-		return sanitisedValues;
+		return JSON.stringify(sanitisedValues);
 	}
 }
 


### PR DESCRIPTION
## Ticket Number

<!-- Add the number from the Jira board -->

https://pins-ds.atlassian.net/browse/AAPD-313

## Description of change

Use undefined to pass schema validation on back office and json stringy to convert object payload to json
<!-- Please describe the change -->

## Checklist

<!-- Put an `x` in all the boxes that apply: -->

- [ ] Requires infrastructure changes
- [ ] If adding or remove environment variables (e.g. in `docker-compose.yaml`) then I have updated the appropriate Helm chart
- [ ] I have updated the documentation accordingly
- [ ] My commit history in this PR is linear
- [ ] New features have tests
- [ ] Breaking change (team conversation required)

## Important

Please do not merge from `main` (please only [rebase](https://github.com/foundry4/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
