### PR TITLE
feat(AAPD-313): map notified who values

### DIFF
--- a/packages/appeals-service-api/src/mappers/questionnaire-submission/has-mapper.js
+++ b/packages/appeals-service-api/src/mappers/questionnaire-submission/has-mapper.js
@@ -17,17 +17,7 @@ class HasQuestionnaireMapper {
 							: undefined,
 					inCAOrRelatesToCA: this.#convertToBoolean(journeyResponse.answers['conservation-area']),
 					siteWithinGreenBelt: this.#convertToBoolean(journeyResponse.answers['green-belt']),
-					howYouNotifiedPeople: [
-						journeyResponse.answers['display-site-notice'] == 'yes'
-							? 'A public notice at the site'
-							: undefined,
-						journeyResponse.answers['letters-to-neighbours'] == 'yes'
-							? 'Letters to neighbours'
-							: undefined,
-						journeyResponse.answers['press-advert'] == 'yes'
-							? 'Advert in the local press'
-							: undefined
-					],
+					howYouNotifiedPeople: this.#howYouNotifiedPeople(journeyResponse),
 					hasRepresentationsFromOtherParties: this.#convertToBoolean(
 						journeyResponse.answers['representations-other-parties']
 					),
@@ -120,6 +110,20 @@ class HasQuestionnaireMapper {
 			sanitisedValues.push(sanitisedValue);
 		});
 		return sanitisedValues;
+	}
+
+	#howYouNotifiedPeople(journeyResponse) {
+		let notifiedPeople = [];
+		if (journeyResponse.answers['display-site-notice'] == 'yes') {
+			notifiedPeople.push('A public notice at the site');
+		}
+		if (journeyResponse.answers['letters-to-neighbours'] == 'yes') {
+			notifiedPeople.push('Letters to neighbours');
+		}
+		if (journeyResponse.answers['press-advert'] == 'yes') {
+			notifiedPeople.push('Advert in the local press');
+		}
+		return notifiedPeople;
 	}
 }
 


### PR DESCRIPTION
We should add the notified reasons to the array if they exist instead of adding undefined

## Ticket Number

<!-- Add the number from the Jira board -->

https://pins-ds.atlassian.net/browse/AAPD-313

## Description of change

<!-- Please describe the change -->

Instead of adding undefined into the array for how people were notified we should only add the items if they exist

## Checklist

<!-- Put an `x` in all the boxes that apply: -->

- [ ] Requires infrastructure changes
- [ ] If adding or remove environment variables (e.g. in `docker-compose.yaml`) then I have updated the appropriate Helm chart
- [ ] I have updated the documentation accordingly
- [ ] My commit history in this PR is linear
- [ ] New features have tests
- [ ] Breaking change (team conversation required)

## Important

Please do not merge from `main` (please only [rebase](https://github.com/foundry4/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
