### PR TITLE
ci(as-5891): add pr pipeline, without build steps

### DIFF
--- a/azure-pipelines-build.yml
+++ b/azure-pipelines-build.yml
@@ -3,10 +3,7 @@ trigger:
     include:
       - main
 
-pr:
-  branches:
-    include:
-      - '*'
+pr: none
 
 parameters:
   - name: buildAppealsApi

--- a/azure-pipelines-pr.yml
+++ b/azure-pipelines-pr.yml
@@ -1,0 +1,42 @@
+trigger: none
+
+pr:
+  branches:
+    include:
+      - '*'
+
+resources:
+  repositories:
+    - repository: templates
+      type: github
+      endpoint: Planning-Inspectorate
+      name: Planning-Inspectorate/common-pipeline-templates
+      ref: refs/tags/release/3.5.0
+
+extends:
+  template: stages/wrapper_ci.yml@templates
+  parameters:
+    globalVariables:
+      - template: azure-pipelines-variables.yml@self
+    validationJobs:
+      - name: Run Linting & Tests
+        steps:
+          - template: ../steps/node_script.yml
+            parameters:
+              nodeVersion: 18
+              script: make install
+          - template: ../steps/node_script.yml
+            parameters:
+              condition: succeededOrFailed()
+              script: npm run lint
+              nodeVersion: 18
+          - template: ../steps/node_script.yml
+            parameters:
+              condition: succeededOrFailed()
+              script: npm run test
+              nodeVersion: 18
+          - template: ../steps/node_script.yml
+            parameters:
+              condition: succeededOrFailed()
+              script: npm run integration-test
+              nodeVersion: 18


### PR DESCRIPTION
## Ticket Number

[AS-5891](https://pins-ds.atlassian.net/browse/AS-5891)

## Description of change

Add in a PR pipeline which does linting & tests, to avoid building on every PR when the artefacts are not used.

**Note: this will require a rules change as Build checks won't run on PR**

## Checklist

<!-- Put an `x` in all the boxes that apply: -->

- [ ] Requires infrastructure changes
- [ ] If adding or remove environment variables (e.g. in `docker-compose.yaml`) then I have updated the appropriate Helm chart
- [ ] I have updated the documentation accordingly
- [x] My commit history in this PR is linear
- [ ] New features have tests
- [ ] Breaking change (team conversation required)

## Important

Please do not merge from `main` (please only [rebase](https://github.com/foundry4/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
