### PR TITLE
feat(session): allow session secrets to be rotated by using an array

### DIFF
--- a/packages/forms-web-app/__tests__/unit/lib/session.test.js
+++ b/packages/forms-web-app/__tests__/unit/lib/session.test.js
@@ -55,4 +55,12 @@ describe('lib/session', () => {
 		expect(connectMongodb).toHaveBeenCalledWith(expressSession);
 		expect(mockOn.mock.calls[0][0]).toEqual('error');
 	});
+
+	it('should parse secrets as a json array', () => {
+		config.server.sessionSecret = '["test1","test2"]';
+
+		const configuredSession = session();
+
+		expect(configuredSession.secret).toEqual(['test1', 'test2']);
+	});
 });

--- a/packages/forms-web-app/src/lib/session.js
+++ b/packages/forms-web-app/src/lib/session.js
@@ -4,10 +4,16 @@ const logger = require('./logger');
 const config = require('../config');
 
 module.exports = () => {
-	const { sessionSecret } = config.server;
+	let { sessionSecret } = config.server;
 
 	if (!sessionSecret) {
 		throw new Error('Session secret must be set');
+	}
+
+	try {
+		sessionSecret = JSON.parse(sessionSecret);
+	} catch (err) {
+		logger.warn('session secret not valid json, entire value will be used as a string');
 	}
 
 	const MongoDBStore = connectMongodb(session);


### PR DESCRIPTION
## Description of change

Allows session secrets to be rotated by using an array.
Session secrets to be added as new||old1||old2

## Checklist

<!-- Put an `x` in all the boxes that apply: -->

- [ ] Requires infrastructure changes
- [ ] If adding or remove environment variables (e.g. in `docker-compose.yaml`) then I have updated the appropriate Helm chart
- [ ] I have updated the documentation accordingly
- [x] My commit history in this PR is linear
- [x] New features have tests
- [ ] Breaking change (team conversation required)

## Important

Please do not merge from `main` (please only [rebase](https://github.com/foundry4/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
