### PR TITLE
fix(AAPD-582): fix lpaCode propertty name on appeal submissions

### DIFF
--- a/packages/appeals-service-api/src/mappers/appeal-submission/has-mapper.js
+++ b/packages/appeals-service-api/src/mappers/appeal-submission/has-mapper.js
@@ -3,7 +3,7 @@ class HasAppealMapper {
 		return [
 			{
 				appeal: {
-					LPACode: appeal.LPACode,
+					LPACode: appeal.lpaCode,
 					appealType: 'Householder (HAS) Appeal',
 					isListedBuilding: false,
 					decision: appeal.eligibility.applicationDecision,


### PR DESCRIPTION
HAS mapper for appeal submissions had incorrect casing for lpa code.

## Ticket Number

<!-- Add the number from the Jira board -->

https://pins-ds.atlassian.net/browse/AAPD-582

## Checklist

<!-- Put an `x` in all the boxes that apply: -->

- [ ] Requires infrastructure changes
- [ ] If adding or remove environment variables (e.g. in `docker-compose.yaml`) then I have updated the appropriate Helm chart
- [ ] I have updated the documentation accordingly
- [x] My commit history in this PR is linear
- [ ] New features have tests
- [ ] Breaking change (team conversation required)

## Important

Please do not merge from `main` (please only [rebase](https://github.com/foundry4/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
