### PR TITLE
fix(AAPD-582): handle condtional appeal response for has mapper

### DIFF
--- a/packages/appeals-service-api/src/mappers/appeal-submission/has-mapper.js
+++ b/packages/appeals-service-api/src/mappers/appeal-submission/has-mapper.js
@@ -37,12 +37,18 @@ class HasAppealMapper {
 					siteAddressCounty: appeal.appealSiteSection.siteAddress.county,
 					siteAddressPostcode: appeal.appealSiteSection.siteAddress.postcode,
 					isSiteFullyOwned: appeal.appealSiteSection.siteOwnership.ownsWholeSite,
-					hasToldOwners: appeal.appealSiteSection.siteOwnership.haveOtherOwnersBeenTold,
+					hasToldOwners: !appeal.appealSiteSection.siteOwnership.ownsWholeSite
+						? appeal.appealSiteSection.siteOwnership.haveOtherOwnersBeenTold
+						: undefined,
 					isSiteVisible: appeal.appealSiteSection.siteAccess.canInspectorSeeWholeSiteFromPublicRoad,
-					inspectorAccessDetails: appeal.appealSiteSection.siteAccess.howIsSiteAccessRestricted,
+					inspectorAccessDetails: !appeal.appealSiteSection.siteAccess
+						.canInspectorSeeWholeSiteFromPublicRoad
+						? appeal.appealSiteSection.siteAccess.howIsSiteAccessRestricted
+						: undefined,
 					doesSiteHaveHealthAndSafetyIssues: appeal.appealSiteSection.healthAndSafety.hasIssues,
-					healthAndSafetyIssuesDetails:
-						appeal.appealSiteSection.healthAndSafety.healthAndSafetyIssuesDetails,
+					healthAndSafetyIssuesDetails: appeal.appealSiteSection.healthAndSafety.hasIssues
+						? appeal.appealSiteSection.healthAndSafety.healthAndSafetyIssuesDetails
+						: undefined,
 					// todo we need to fix the formatting on these and there is technical debt in order to collect the correct metadata, commenting out for now as BO are not yet ready for this
 					documents: []
 				}


### PR DESCRIPTION
## Ticket Number

<!-- Add the number from the Jira board -->

https://pins-ds.atlassian.net/browse/AAPD-582

## Description of change

<!-- Please describe the change -->
The schema validation for back office doesn't handle nulls, so pass undefined instead

## Checklist

<!-- Put an `x` in all the boxes that apply: -->

- [ ] Requires infrastructure changes
- [ ] If adding or remove environment variables (e.g. in `docker-compose.yaml`) then I have updated the appropriate Helm chart
- [ ] I have updated the documentation accordingly
- [x] My commit history in this PR is linear
- [ ] New features have tests
- [ ] Breaking change (team conversation required)

## Important

Please do not merge from `main` (please only [rebase](https://github.com/foundry4/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
