### PR TITLE
Feature/aapd 582 fix documents property has mappers

### DIFF
--- a/packages/appeals-service-api/__tests__/unit/testConstants.js
+++ b/packages/appeals-service-api/__tests__/unit/testConstants.js
@@ -75,40 +75,40 @@ const submittedQuestionnaireObjectPostMap = [
 			doPlansAffectNeighbouringSite: false,
 			hasExtraConditions: false,
 			extraConditions: undefined,
-			nearbyCaseReferences: undefined,
-			documents: [
-				{
-					filename: 'APP-Q9999-W-22-1234567-Hero-shot-3.jpg',
-					originalFilename: 'Hero-shot-3.jpg',
-					size: '216963',
-					mime: 'image/jpeg',
-					documentURI:
-						'http://blob-storage:10000/devstoreaccount1/uploads/has-questionnaire%3AAPP_Q9999_W_22_1234567/5b857ec6-9317-4530-81c3-d4ed5994ade2/APP-Q9999-W-22-1234567-original_sparkling-enamel-pin-badge-gift-for-awesome-friends.jpg',
-					dateCreated: testDate,
-					lastModified: testDate,
-					documentType: undefined,
-					sourceSystem: 'appeals',
-					origin: 'citizen',
-					stage: 'lpa_questionnaire'
-				},
+			nearbyCaseReferences: undefined
+		},
+		documents: [
+			{
+				filename: 'APP-Q9999-W-22-1234567-Hero-shot-3.jpg',
+				originalFilename: 'Hero-shot-3.jpg',
+				size: '216963',
+				mime: 'image/jpeg',
+				documentURI:
+					'http://blob-storage:10000/devstoreaccount1/uploads/has-questionnaire%3AAPP_Q9999_W_22_1234567/5b857ec6-9317-4530-81c3-d4ed5994ade2/APP-Q9999-W-22-1234567-original_sparkling-enamel-pin-badge-gift-for-awesome-friends.jpg',
+				dateCreated: testDate,
+				lastModified: testDate,
+				documentType: undefined,
+				sourceSystem: 'appeals',
+				origin: 'citizen',
+				stage: 'lpa_questionnaire'
+			},
 
-				{
-					filename:
-						'APP-Q9999-W-22-1234567-original_sparkling-enamel-pin-badge-gift-for-awesome-friends.jpg',
-					originalFilename: 'original_sparkling-enamel-pin-badge-gift-for-awesome-friends.jpg',
-					size: '234337',
-					mime: 'image/jpeg',
-					documentURI:
-						'http://blob-storage:10000/devstoreaccount1/uploads/has-questionnaire%3AAPP_Q9999_W_22_1234567/5b857ec6-9317-4530-81c3-d4ed5994ade2/APP-Q9999-W-22-1234567-original_sparkling-enamel-pin-badge-gift-for-awesome-friends.jpg',
-					dateCreated: testDate,
-					lastModified: testDate,
-					documentType: undefined,
-					sourceSystem: 'appeals',
-					origin: 'citizen',
-					stage: 'lpa_questionnaire'
-				}
-			]
-		}
+			{
+				filename:
+					'APP-Q9999-W-22-1234567-original_sparkling-enamel-pin-badge-gift-for-awesome-friends.jpg',
+				originalFilename: 'original_sparkling-enamel-pin-badge-gift-for-awesome-friends.jpg',
+				size: '234337',
+				mime: 'image/jpeg',
+				documentURI:
+					'http://blob-storage:10000/devstoreaccount1/uploads/has-questionnaire%3AAPP_Q9999_W_22_1234567/5b857ec6-9317-4530-81c3-d4ed5994ade2/APP-Q9999-W-22-1234567-original_sparkling-enamel-pin-badge-gift-for-awesome-friends.jpg',
+				dateCreated: testDate,
+				lastModified: testDate,
+				documentType: undefined,
+				sourceSystem: 'appeals',
+				origin: 'citizen',
+				stage: 'lpa_questionnaire'
+			}
+		]
 	}
 ];
 

--- a/packages/appeals-service-api/src/mappers/appeal-submission/has-mapper.js
+++ b/packages/appeals-service-api/src/mappers/appeal-submission/has-mapper.js
@@ -61,10 +61,10 @@ class HasAppealMapper {
 					doesSiteHaveHealthAndSafetyIssues: appeal.appealSiteSection.healthAndSafety.hasIssues,
 					healthAndSafetyIssuesDetails: appeal.appealSiteSection.healthAndSafety.hasIssues
 						? appeal.appealSiteSection.healthAndSafety.healthAndSafetyIssues
-						: undefined,
-					// todo we need to fix the formatting on these and there is technical debt in order to collect the correct metadata, commenting out for now as BO are not yet ready for this
-					documents: []
-				}
+						: undefined
+				},
+				// todo we need to fix the formatting on these and there is technical debt in order to collect the correct metadata, commenting out for now as BO are not yet ready for this
+				documents: []
 			}
 		];
 	}

--- a/packages/appeals-service-api/src/mappers/questionnaire-submission/has-mapper.js
+++ b/packages/appeals-service-api/src/mappers/questionnaire-submission/has-mapper.js
@@ -49,27 +49,27 @@ class HasQuestionnaireMapper {
 					nearbyCaseReferences:
 						journeyResponse.answers['other-ongoing-appeals'] == 'yes'
 							? this.#convertFromAddMore(journeyResponse.answers['other-appeals-references'])
-							: undefined,
-					// todo we need to fix the formatting on these and there is technical debt in order to collect the correct metadata, commenting out for now as BO are not yet ready for this
-					documents: Array.from(uploadedFilesAndBlobMeta).map(
-						([
-							{ fileName, originalFileName, size },
-							{ lastModified, createdOn, document_type, metadata, _response }
-						]) => ({
-							filename: fileName,
-							originalFilename: originalFileName,
-							size: size,
-							mime: metadata.mime_type,
-							documentURI: _response.request.url,
-							dateCreated: createdOn,
-							lastModified,
-							documentType: document_type,
-							sourceSystem: 'appeals',
-							origin: 'citizen',
-							stage: 'lpa_questionnaire'
-						})
-					)
-				}
+							: undefined
+				},
+				// todo we need to fix the formatting on these and there is technical debt in order to collect the correct metadata, commenting out for now as BO are not yet ready for this
+				documents: Array.from(uploadedFilesAndBlobMeta).map(
+					([
+						{ fileName, originalFileName, size },
+						{ lastModified, createdOn, document_type, metadata, _response }
+					]) => ({
+						filename: fileName,
+						originalFilename: originalFileName,
+						size: size,
+						mime: metadata.mime_type,
+						documentURI: _response.request.url,
+						dateCreated: createdOn,
+						lastModified,
+						documentType: document_type,
+						sourceSystem: 'appeals',
+						origin: 'citizen',
+						stage: 'lpa_questionnaire'
+					})
+				)
 			}
 		];
 	}


### PR DESCRIPTION
## Ticket Number

<!-- Add the number from the Jira board -->

https://pins-ds.atlassian.net/browse/AAPD-

## Description of change

The documents array needs to be at the root level of the mapped data to be sent to back office

## Checklist

<!-- Put an `x` in all the boxes that apply: -->

- [ ] Requires infrastructure changes
- [ ] If adding or remove environment variables (e.g. in `docker-compose.yaml`) then I have updated the appropriate Helm chart
- [ ] I have updated the documentation accordingly
- [x] My commit history in this PR is linear
- [x] New features have tests
- [ ] Breaking change (team conversation required)

## Important

Please do not merge from `main` (please only [rebase](https://github.com/foundry4/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
