### PR TITLE
fix(aapd-809): reference correct horizon-functions artifact

### DIFF
--- a/azure-pipelines-deploy.yml
+++ b/azure-pipelines-deploy.yml
@@ -88,7 +88,7 @@ extends:
                   repository: appeal-planning-decision/documents-api
           - name: Deploy Horizon Functions
             artifact:
-              name: azure-functions
+              name: horizon-functions
               sourcePipeline: Appeals Service Build
             condition: eq(${{ parameters.deployHorizonFunctions }}, 'true')
             steps:


### PR DESCRIPTION
## Ticket Number

https://pins-ds.atlassian.net/browse/AAPD-809

## Description of change

Horizon function deploy was broken. Not required anymore but cleaner to fix it.

## Checklist

<!-- Put an `x` in all the boxes that apply: -->

- [ ] Requires infrastructure changes
- [ ] If adding or remove environment variables (e.g. in `docker-compose.yaml`) then I have updated the appropriate Helm chart
- [ ] I have updated the documentation accordingly
- [ ] My commit history in this PR is linear
- [ ] New features have tests
- [ ] Breaking change (team conversation required)

## Important

Please do not merge from `main` (please only [rebase](https://github.com/foundry4/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
