### PR TITLE
fix(aapd-617): move generate to docker build

### DIFF
--- a/packages/appeals-service-api/Dockerfile
+++ b/packages/appeals-service-api/Dockerfile
@@ -19,6 +19,8 @@ COPY packages/business-rules /opt/packages/business-rules
 # install from root
 WORKDIR /opt
 RUN npm ci --omit=dev
+# generate prisma client
+RUN npm run db:generate
 
 # Stage 2/2: App Run
 FROM build AS app

--- a/packages/appeals-service-api/package.json
+++ b/packages/appeals-service-api/package.json
@@ -17,7 +17,7 @@
 		"db:seed": "npx prisma db seed",
 		"lint": "eslint ./",
 		"lint:fix": "eslint ./ --fix",
-		"start": "npm run db:generate && node ./",
+		"start": "node ./",
 		"start:dev": "npm run db:generate && nodemon -e .js,.json,.yml,.yaml ./ | pino-pretty -tlc",
 		"start:dev:debug": "npm run db:generate && node --inspect-brk=0.0.0.0 ./",
 		"test": "jest",


### PR DESCRIPTION
## Ticket Number

<!-- Add the number from the Jira board -->

https://pins-ds.atlassian.net/browse/AAPD-617

## Description of change

Move prisma generate to Docker build to fix
` Can't write to /opt/node_modules/prisma please make sure you install "prisma" with the right permissions.`
error

## Checklist

<!-- Put an `x` in all the boxes that apply: -->

- [ ] Requires infrastructure changes
- [ ] If adding or remove environment variables (e.g. in `docker-compose.yaml`) then I have updated the appropriate Helm chart
- [ ] I have updated the documentation accordingly
- [ ] My commit history in this PR is linear
- [ ] New features have tests
- [ ] Breaking change (team conversation required)

## Important

Please do not merge from `main` (please only [rebase](https://github.com/foundry4/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
