### PR TITLE
fix(AAPD-663): hotfix regex validation to allow blank string

### DIFF
--- a/packages/forms-web-app/src/dynamic-forms/questions.js
+++ b/packages/forms-web-app/src/dynamic-forms/questions.js
@@ -372,7 +372,7 @@ exports.questions = {
 			new ConditionalRequiredValidator('Enter how many days you expect the inquiry to last'),
 			new StringValidator({
 				regex: {
-					regex: '^[1-9]\\d{0,2}$',
+					regex: '^(?:[1-9]\\d{0,2})?$',
 					regexMessage:
 						'The days you would expect the inquiry to last must be a whole number between 1 and 999'
 				},
@@ -493,7 +493,9 @@ exports.questions = {
 		question: 'Upload relevant policies from your statutory development plan',
 		fieldName: 'upload-other-policies',
 		validators: [
-			new RequiredFileUploadValidator('Select the planning officer’s report or what your decision notice would have said'),
+			new RequiredFileUploadValidator(
+				'Select the planning officer’s report or what your decision notice would have said'
+			),
 			new MultifileUploadValidator()
 		]
 	}),


### PR DESCRIPTION
still needs another validator class to only run given a specific answer is selected. StringValidator currently always runs regardless of which option is selected

## Ticket Number

<!-- Add the number from the Jira board -->

https://pins-ds.atlassian.net/browse/AAPD-

## Description of change

<!-- Please describe the change -->

## Checklist

<!-- Put an `x` in all the boxes that apply: -->

- [ ] Requires infrastructure changes
- [ ] If adding or remove environment variables (e.g. in `docker-compose.yaml`) then I have updated the appropriate Helm chart
- [ ] I have updated the documentation accordingly
- [ ] My commit history in this PR is linear
- [ ] New features have tests
- [ ] Breaking change (team conversation required)

## Important

Please do not merge from `main` (please only [rebase](https://github.com/foundry4/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
