### PR TITLE
fix(api): only pretty print logs for local dev

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -92,6 +92,7 @@ services:
       HORIZON_HAS_PUBLISHER_QUEUE: docker_queue
       HORIZON_HAS_PUBLISHER_USERNAME: admin
       LOGGER_LEVEL: 'debug'
+      LOGGER_PRETTY_PRINT: 'true'
       LPA_DATA_PATH: /opt/app/data/lpa-list.csv
       LPA_TRIALIST_DATA_PATH: /opt/app/data/lpa-trialists.json
       MONGODB_AUTO_INDEX: 'true'

--- a/packages/appeals-service-api/src/configuration/config.js
+++ b/packages/appeals-service-api/src/configuration/config.js
@@ -46,7 +46,8 @@ let config = {
 	},
 	logger: {
 		level: process.env.LOGGER_LEVEL || 'info',
-		redact: ['config.db.mongodb', 'config.services.notify.apiKey']
+		redact: ['config.db.mongodb', 'config.services.notify.apiKey'],
+		prettyPrint: process.env.LOGGER_PRETTY_PRINT === 'true'
 	},
 	secureCodes: {
 		finalComments: {

--- a/packages/appeals-service-api/src/lib/logger.js
+++ b/packages/appeals-service-api/src/lib/logger.js
@@ -11,5 +11,5 @@ const config = require('../configuration/config');
 module.exports = pino({
 	level: config.logger.level,
 	redact: config.logger.redact,
-	prettyPrint: true
+	prettyPrint: config.logger.prettyPrint
 });


### PR DESCRIPTION
## Ticket Number

N/A

## Description of change

API should log in JSON unless configured to pretty print for local dev.

## Checklist

<!-- Put an `x` in all the boxes that apply: -->

- [ ] Requires infrastructure changes
- [ ] If adding or remove environment variables (e.g. in `docker-compose.yaml`) then I have updated the appropriate Helm chart
- [ ] I have updated the documentation accordingly
- [ ] My commit history in this PR is linear
- [ ] New features have tests
- [ ] Breaking change (team conversation required)

## Important

Please do not merge from `main` (please only [rebase](https://github.com/foundry4/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
