### PR TITLE
ci(pipeline): don't auto-deploy all apps

### DIFF
--- a/azure-pipelines-deploy.yml
+++ b/azure-pipelines-deploy.yml
@@ -1,3 +1,4 @@
+# packages with infrequent changes do not auto-deploy to dev/test to speed up pipeline
 parameters:
   - name: deployAppealsApi
     displayName: Deploy Appeals Service API
@@ -6,7 +7,7 @@ parameters:
   - name: deployClamAv
     displayName: Deploy ClamAV API
     type: boolean
-    default: true
+    default: false
   - name: deployDocumentsApi
     displayName: Deploy Documents Service API
     type: boolean
@@ -14,11 +15,11 @@ parameters:
   - name: deployIntegrationFunctions
     displayName: Deploy Integration Functions
     type: boolean
-    default: true
+    default: false
   - name: deployPdfApi
     displayName: Deploy PDF Service API
     type: boolean
-    default: true
+    default: false
   - name: deployWeb
     displayName: Deploy Web
     type: boolean


### PR DESCRIPTION
## Description of change

The deployment pipeline is slow (particularly zip deploying integration functions), this PR stops the auto deployment of less frequently changed apps

It would be preferable to trigger the deployment of the apps only when they have been changed, this is a simple workaround until that can be figured out

## Checklist

<!-- Put an `x` in all the boxes that apply: -->

- [ ] Requires infrastructure changes
- [ ] If adding or remove environment variables (e.g. in `docker-compose.yaml`) then I have updated the appropriate Helm chart
- [ ] I have updated the documentation accordingly
- [x] My commit history in this PR is linear
- [ ] New features have tests
- [ ] Breaking change (team conversation required)

## Important

Please do not merge from `main` (please only [rebase](https://github.com/foundry4/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
