### PR TITLE
feat(api): v2 folder structure

### DIFF
--- a/jsconfig.json
+++ b/jsconfig.json
@@ -1,0 +1,12 @@
+{
+	"compilerOptions": {
+		"baseUrl": ".",
+		"allowSyntheticDefaultImports": true,
+		"checkJs": true,
+		"esModuleInterop": true,
+		"moduleResolution": "node",
+		"target": "esnext",
+		"module": "CommonJS",
+		"strict": true
+	}
+}

--- a/packages/appeals-service-api/jsconfig.json
+++ b/packages/appeals-service-api/jsconfig.json
@@ -1,0 +1,13 @@
+{
+	"extends": "../../jsconfig.json",
+	"include": ["**/*.js"],
+	"compilerOptions": {
+		"baseUrl": ".",
+		"paths": {
+			"#db-client": ["./src/db/db-client.js"],
+			"#errors/*": ["./src/errors/*.js"],
+			"#lib/*": ["./src/lib/*.js"],
+			"#repositories/*": ["./src/repositories/*.js"]
+		}
+	}
+}

--- a/packages/appeals-service-api/package.json
+++ b/packages/appeals-service-api/package.json
@@ -86,5 +86,11 @@
 		"prisma": "^5.6.0",
 		"rhea-promise": "^2.1.0",
 		"testcontainers": "^9.8.0"
+	},
+	"imports": {
+		"#db-client": "./src/db/db-client.js",
+		"#errors/*": "./src/errors/*.js",
+		"#lib/*": "./src/lib/*.js",
+		"#repositories/*": "./src/repositories/*.js"
 	}
 }

--- a/packages/appeals-service-api/src/routes/appeal-users.js
+++ b/packages/appeals-service-api/src/routes/appeal-users.js
@@ -1,8 +1,0 @@
-const express = require('express');
-const { userGet } = require('../controllers/user');
-const { userPost } = require('../controllers/appeal-user');
-const router = express.Router();
-
-router.get('/:email', userGet);
-router.post('/', userPost);
-module.exports = router;

--- a/packages/appeals-service-api/src/routes/appeals.spec.yaml
+++ b/packages/appeals-service-api/src/routes/appeals.spec.yaml
@@ -5,8 +5,10 @@ paths:
       responses:
         201:
           description: Returns the appeal submission
-          schema:
-            $ref: '#/components/schemas/AppealSubmission'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AppealSubmission'
         500:
           description: Something went wrong
   /api/v1/appeals/{id}:
@@ -22,9 +24,13 @@ paths:
       responses:
         200:
           description: Returns the appeal submission
-          schema:
-            $ref: '#/components/schemas/AppealSubmission'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AppealSubmission'
         404:
           description: Appeal not found
-          schema:
-            $ref: '#/components/schemas/ErrorBody'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorBody'

--- a/packages/appeals-service-api/src/routes/index.js
+++ b/packages/appeals-service-api/src/routes/index.js
@@ -20,7 +20,7 @@ const lpaDashboardAppealsRouter = require('./appeals-case-data');
 const documentMetadataRouter = require('./documentMetadata');
 const responsesRouter = require('./responses');
 const listedBuildingRouter = require('./listed-building');
-const appealUsersRouter = require('./appeal-users');
+const { routes: v2Routes } = require('./v2');
 
 router.use('/api/v1/appeals', appealsRouter);
 router.use('/api/v1/back-office', backOfficeRouter);
@@ -35,6 +35,10 @@ router.use('/api/v1/appeals-case-data', lpaDashboardAppealsRouter);
 router.use('/api/v1/document-meta-data', documentMetadataRouter);
 router.use('/api/v1/responses', responsesRouter);
 router.use('/api/v1/listed-buildings', listedBuildingRouter);
-router.use('/api/v2/users', appealUsersRouter);
+
+// v2 routes loaded from the file structure
+for (const [url, handler] of Object.entries(v2Routes)) {
+	router.use(`/api/v2/${url}`, handler);
+}
 
 module.exports = router;

--- a/packages/appeals-service-api/src/routes/v2/index.js
+++ b/packages/appeals-service-api/src/routes/v2/index.js
@@ -1,0 +1,24 @@
+const { readdirSync, lstatSync } = require('fs');
+const path = require('path');
+
+/**
+ * folders in this directory
+ * @type {string[]}
+ */
+const dirNames = readdirSync(__dirname).filter((name) =>
+	lstatSync(path.join(__dirname, name)).isDirectory()
+);
+
+/**
+ * Routes loaded from each directory
+ *
+ * @type {Object<string, import('express').IRouter>}
+ */
+const routes = {};
+
+for (const dirName of dirNames) {
+	const { router } = require(`./${dirName}`);
+	routes[dirName] = router;
+}
+
+module.exports = { routes };

--- a/packages/appeals-service-api/src/routes/v2/users/controller.js
+++ b/packages/appeals-service-api/src/routes/v2/users/controller.js
@@ -1,6 +1,6 @@
-const { getUserByEmail, createUser } = require('../services/appeal-user.service');
-const logger = require('../lib/logger');
-const ApiError = require('../errors/apiError');
+const { getUserByEmail, createUser } = require('./service');
+const logger = require('#lib/logger');
+const ApiError = require('#errors/apiError');
 
 /**
  * @type {import('express').Handler}
@@ -19,7 +19,7 @@ async function userGet(req, res) {
 		} else {
 			logger.error('Error:', error);
 			statusCode = 500;
-			body = 'An unexpected error occured';
+			body = 'An unexpected error occurred';
 		}
 	} finally {
 		res.status(statusCode).send(body);
@@ -30,6 +30,9 @@ async function userGet(req, res) {
  * @type {import('express').Handler}
  */
 async function userPost(req, res) {
+	if ('id' in req.body) {
+		throw ApiError.badRequest({ errors: ['id is not allowed'] });
+	}
 	let statusCode = 200;
 	let body = {};
 
@@ -43,7 +46,7 @@ async function userPost(req, res) {
 		} else {
 			logger.error('Error:', error);
 			statusCode = 500;
-			body = 'An unexpected error occured';
+			body = 'An unexpected error occurred';
 		}
 	} finally {
 		res.status(statusCode).send(body);

--- a/packages/appeals-service-api/src/routes/v2/users/index.js
+++ b/packages/appeals-service-api/src/routes/v2/users/index.js
@@ -1,0 +1,8 @@
+const express = require('express');
+const { userGet, userPost } = require('./controller');
+const router = express.Router();
+
+router.get('/:email', userGet);
+router.post('/', userPost);
+
+module.exports = { router };

--- a/packages/appeals-service-api/src/routes/v2/users/service.js
+++ b/packages/appeals-service-api/src/routes/v2/users/service.js
@@ -1,5 +1,5 @@
-const { AppealUserRepository } = require('../repositories/sql/appeal-user-repository');
-const ApiError = require('../errors/apiError');
+const { AppealUserRepository } = require('#repositories/sql/appeal-user-repository');
+const ApiError = require('#errors/apiError');
 
 const appealUserRepository = new AppealUserRepository();
 

--- a/packages/appeals-service-api/src/routes/v2/users/spec.yaml
+++ b/packages/appeals-service-api/src/routes/v2/users/spec.yaml
@@ -1,0 +1,47 @@
+paths:
+  /api/v2/users/:
+    post:
+      description: Create a new user
+      requestBody:
+        description: user to create, `id` is not allowed
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/AppealUser'
+      responses:
+        200:
+          description: Created user
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AppealUser'
+        400:
+          description: Bad request
+          content:
+            application/json:
+              schema:
+                 $ref: '#/components/schemas/ErrorBody'
+  /api/v2/users/{email}:
+    get:
+      parameters:
+        - in: path
+          name: email
+          required: true
+          schema:
+            type: string
+            format: email
+          example: 'me@example.com'
+          description: user email
+      responses:
+        200:
+          description: The appeal user
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AppealUser'
+        404:
+          description: User not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorBody'

--- a/packages/appeals-service-api/src/spec/appeal-submission.yaml
+++ b/packages/appeals-service-api/src/spec/appeal-submission.yaml
@@ -16,5 +16,5 @@ components:
           type: string
           format: date-time
         lpaCode:
-          type: 
+          type: string
         # todo: add existing properties

--- a/packages/appeals-service-api/src/spec/appeal-user.yaml
+++ b/packages/appeals-service-api/src/spec/appeal-user.yaml
@@ -1,0 +1,36 @@
+components:
+  schemas:
+    AppealUser:
+      description: An appeal user
+      type: object
+      required:
+        - id
+        - email
+      properties:
+        id:
+          type: string
+          format: uuid
+          description: appeal user ID
+        email:
+          type: string
+          format: email
+          description: the user's email address
+        isEnrolled:
+          type: boolean
+          description: is this user enrolled? (have they been sent a registration confirmation email)
+        serviceUserId:
+          type: number
+          description: service user ID to map to service users
+        isLpaUser:
+          type: boolean
+          description: is this an LPA user?
+        lpaCode:
+          type: string
+          description: if an LPA user, the LPA this user belongs to
+        isLpaAdmin:
+          type: boolean
+          description: if an LPA user, whether this user is an admin for that LPA
+        lpaStatus:
+          type: string
+          enum: ['added', 'confirmed', 'removed']
+          description: if an LPA user, the status of this user, e.g. have they logged in and confirmed their email?

--- a/packages/appeals-service-api/src/spec/errors.yaml
+++ b/packages/appeals-service-api/src/spec/errors.yaml
@@ -1,7 +1,12 @@
 components:
   schemas:
     ErrorBody:
-      type: array
-      items:
-        type: string
+      type: object
+      properties:
+        code:
+          type: string
+        errors:
+          type: array
+          items:
+            type: string
 

--- a/packages/appeals-service-api/src/spec/gen-api-spec.js
+++ b/packages/appeals-service-api/src/spec/gen-api-spec.js
@@ -18,7 +18,7 @@ const options = {
 		servers: [{ url: 'http://localhost:3000/', description: 'local dev' }]
 	},
 	// files containing annotations and any other yaml files that can be included
-	apis: ['./src/routes/*.js', './src/routes/*.yaml', './src/spec/*.yaml']
+	apis: ['./src/routes/**/*.js', './src/routes/**/*.yaml', './src/spec/*.yaml']
 };
 
 /**


### PR DESCRIPTION
## Ticket Number

<!-- Add the number from the Jira board -->

N/A

## Description of change

Move the new /v2/users route to a new folder structure. Based off the work done in `web-comment` to load routes dynamically from the file structure. Moves controllers, services, routers, and spec into a single folder per route.

## Checklist

<!-- Put an `x` in all the boxes that apply: -->

- [ ] Requires infrastructure changes
- [ ] If adding or remove environment variables (e.g. in `docker-compose.yaml`) then I have updated the appropriate Helm chart
- [ ] I have updated the documentation accordingly
- [ ] My commit history in this PR is linear
- [ ] New features have tests
- [ ] Breaking change (team conversation required)

## Important

Please do not merge from `main` (please only [rebase](https://github.com/foundry4/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
