### PR TITLE
Feature/aapd 861

### DIFF
--- a/packages/appeals-service-api/__tests__/developer/appeals.test.js
+++ b/packages/appeals-service-api/__tests__/developer/appeals.test.js
@@ -1,0 +1,229 @@
+const http = require('http');
+const supertest = require('supertest');
+const { MongoClient } = require('mongodb');
+const container = require('rhea');
+const uuid = require('uuid');
+
+const app = require('../../src/app');
+const appDbConnection = require('../../src/db/db');
+const appConfiguration = require('../../src/configuration/config');
+const { createPrismaClient } = require('../../src/db/db-client');
+
+const MockedExternalApis = require('./external-dependencies/rest-apis/mocked-external-apis');
+const AppealFixtures = require('./fixtures/appeals');
+
+const { isFeatureActive } = require('../../src/configuration/featureFlag');
+
+/** @type {import('@prisma/client').PrismaClient} */
+let sqlClient;
+/** @type {import('supertest').SuperTest<import('supertest').Test>} */
+let appealsApi;
+/** @type {import('mongodb').MongoClient} */
+let databaseConnection;
+/** @type {import('./external-dependencies/rest-apis/mocked-external-apis')} */
+let mockedExternalApis;
+/** @type {Array.<*>} */
+let expectedNotifyInteractions;
+let testLpaEmail = 'appealplanningdecisiontest@planninginspectorate.gov.uk';
+let testLpaCodeEngland = 'E69999999';
+let testLpaCodeWales = 'W69999999';
+let testLpaNameEngland = 'System Test Borough Council England';
+let testLpaNameWales = 'System Test Borough Council Wales';
+let testHorizonLpaCodeWales = 'H1234';
+
+jest.setTimeout(240000); // The Horizon integration tests need a bit of time to complete! This seemed like a good number (4 mins)
+jest.mock('../../src/db/db'); // TODO: We shouldn't need to do this, but we didn't have time to look at making this better. It should be possible to use the DB connection directly (not mock it)
+jest.mock('../../src/configuration/featureFlag');
+
+const dbName = 'integration-test-appeals-db';
+
+beforeAll(async () => {
+	///////////////////////////////
+	///// SETUP EXTERNAL APIs /////
+	///////////////////////////////
+
+	mockedExternalApis = await MockedExternalApis.setup();
+
+	///////////////////////////////
+	///// SETUP TEST DATABASE /////
+	///////////////////////////////
+	if (!process.env.INTEGRATION_TEST_DB_URL) {
+		throw new Error('process.env.INTEGRATION_TEST_DB_URL not set');
+	}
+
+	databaseConnection = await MongoClient.connect(process.env.INTEGRATION_TEST_DB_URL, {
+		useNewUrlParser: true,
+		useUnifiedTopology: true
+	});
+	let mockedDatabase = await databaseConnection.db(dbName);
+	appDbConnection.get.mockReturnValue(mockedDatabase);
+
+	const test_listener = container.create_container();
+
+	test_listener.on('disconnected', (context) => {
+		context.connection.close();
+	});
+
+	// sql client
+	sqlClient = createPrismaClient();
+
+	/////////////////////////////
+	///// SETUP TEST CONFIG /////
+	/////////////////////////////
+	appConfiguration.services.notify.apiKey =
+		'hasserviceapikey-u89q754j-s87j-1n35-s351-789245as890k-1545v789-8s79-0124-qwe7-j2vfds34w5nm';
+	appConfiguration.services.notify.baseUrl = mockedExternalApis.getNotifyUrl();
+	appConfiguration.services.notify.serviceId = 'g09j298f-q59t-9a34-f123-782342hj910l';
+	appConfiguration.services.notify.templates[
+		'1001'
+	].appealSubmissionConfirmationEmailToAppellant = 1;
+	appConfiguration.services.notify.templates['1001'].appealNotificationEmailToLpa = 2;
+	appConfiguration.services.notify.templates[
+		'1005'
+	].appealSubmissionConfirmationEmailToAppellant = 3;
+	appConfiguration.services.notify.templates['1005'].appealNotificationEmailToLpa = 4;
+	appConfiguration.services.notify.templates.SAVE_AND_RETURN.enterCodeIntoServiceEmailToAppellant = 5;
+	appConfiguration.services.notify.templates.ERROR_MONITORING.failureToUploadToHorizon = 6;
+	appConfiguration.services.notify.emails.adminMonitoringEmail = 'test@pins.gov.uk';
+	appConfiguration.documents.url = mockedExternalApis.getDocumentsAPIUrl();
+
+	/////////////////////
+	///// SETUP APP /////
+	/////////////////////
+
+	let server = http.createServer(app);
+	appealsApi = supertest(server);
+
+	/////////////////////////
+	///// POPULATE LPAS /////
+	/////////////////////////
+
+	const testLpaJson = `{OBJECTID;LPA19CD;LPA CODE;LPA19NM;EMAIL;DOMAIN;LPA ONBOARDED\n323;${testLpaCodeEngland};;${testLpaNameEngland};${testLpaEmail};;TRUE\n324;${testLpaCodeWales};${testHorizonLpaCodeWales};${testLpaNameWales};${testLpaEmail};;TRUE}`;
+	await appealsApi.post('/api/v1/local-planning-authorities').send(testLpaJson);
+});
+
+beforeEach(async () => {
+	await _clearDatabaseCollections();
+	await _clearSqlData();
+	expectedNotifyInteractions = [];
+	await mockedExternalApis.mockNotifyResponse({}, 200);
+	isFeatureActive.mockImplementation(() => {
+		return true;
+	});
+});
+
+// We check mock and message interactions consistently here so that they're not forgotten for each test :)
+afterEach(async () => {
+	await mockedExternalApis.checkInteractions(expectedNotifyInteractions);
+	await mockedExternalApis.clearAllMockedResponsesAndRecordedInteractions();
+	jest.clearAllMocks(); // We need to do this so that mock interactions are reset correctly between tests :)
+});
+
+afterAll(async () => {
+	await sqlClient.$disconnect();
+	await databaseConnection.close();
+	await mockedExternalApis.teardown();
+});
+
+describe('Appeals', () => {
+	it(`should return an error if we try to update an appeal that doesn't exist`, async () => {
+		// When: an appeal is sent via a PUT or PATCH request, but hasn't yet been created
+		const householderAppeal = AppealFixtures.newHouseholderAppeal(uuid.v4());
+		const putResponse = await appealsApi
+			.put(`/api/v1/appeals/${householderAppeal.id}`)
+			.send(householderAppeal);
+
+		const patchResponse = await appealsApi
+			.patch(`/api/v1/appeals/${householderAppeal.id}`)
+			.send(householderAppeal);
+
+		// Then: we should get a 404 status code for both requests
+		expect(putResponse.status).toBe(404);
+		expect(patchResponse.status).toBe(404);
+
+		// And: external systems should be interacted with in the following ways
+		expectedNotifyInteractions = [];
+	});
+
+	it("should apply patch updates correctly when data to patch-in isn't a full appeal", async () => {
+		// Given: an appeal is created
+		const savedAppealResponse = await _createAppeal();
+		let savedAppeal = savedAppealResponse.body;
+
+		// When: the appeal is patched
+		const patchedAppealResponse = await appealsApi
+			.patch(`/api/v1/appeals/${savedAppeal.id}`)
+			.send({ horizonId: 'foo' });
+
+		// Then: when we retrieve the appeal, it should have the patch applied
+		savedAppeal.horizonId = 'foo';
+		savedAppeal.updatedAt = patchedAppealResponse.body.updatedAt;
+		expect(patchedAppealResponse.body).toMatchObject(savedAppeal);
+
+		// And: no external systems should be interacted with
+		expectedNotifyInteractions = [];
+	});
+
+	it('should return the relevant appeal when requested after the appeal has been saved', async () => {
+		// Given: an appeal is created
+		const savedAppeal = await _createAppeal();
+
+		// When: we try to request that appeal
+		const requestedAppeal = await appealsApi.get(`/api/v1/appeals/${savedAppeal.body.id}`);
+
+		// Then: we should get a 200 status
+		expect(requestedAppeal.status).toEqual(200);
+
+		// And: the correct appeal should be returned
+		expect(requestedAppeal.body.id).toEqual(savedAppeal.body.id);
+
+		// And: external systems should be interacted with in the following ways
+		expectedNotifyInteractions = [];
+	});
+
+	it(`should return an error if an appeal is requested that doesn't exist`, async () => {
+		// When: we try to access a non-existent appeal
+		const getAppealResponse = await appealsApi.get(`/api/v1/appeals/${uuid.v4()}`);
+
+		// Then: we should get a 404 status
+		expect(getAppealResponse.status).toEqual(404);
+
+		// And: external systems should be interacted with in the following ways
+		expectedNotifyInteractions = [];
+	});
+});
+
+const _createAppeal = async (householderAppeal = AppealFixtures.newHouseholderAppeal()) => {
+	const appealCreatedResponse = await appealsApi.post('/api/v1/appeals');
+	const appealCreated = appealCreatedResponse.body;
+
+	householderAppeal.id = appealCreated.id;
+	const savedAppealResponse = await appealsApi
+		.put(`/api/v1/appeals/${appealCreated.id}`)
+		.send(householderAppeal);
+
+	return savedAppealResponse;
+};
+
+/**
+ * Clears out all collection from the database EXCEPT the LPA collection, since this is needed
+ * from one test to the next, and its data does not change during any test execution.
+ */
+const _clearDatabaseCollections = async () => {
+	const databaseCollections = await databaseConnection.db(dbName).collections();
+
+	const databaseCollectionsFiltered = databaseCollections.filter(
+		(collection) => collection.namespace.split('.')[1] !== 'lpa'
+	);
+
+	for (const collection of databaseCollectionsFiltered) {
+		await collection.drop();
+	}
+};
+
+const _clearSqlData = async () => {
+	// await sqlClient.appealToUser.deleteMany();
+	// await sqlClient.appealUser.deleteMany();
+	// await sqlClient.appealCase.(deleteMany);
+	// await sqlClient.appeal.deleteMany();
+};

--- a/packages/appeals-service-api/__tests__/developer/external-dependencies/rest-apis/mocked-external-apis.js
+++ b/packages/appeals-service-api/__tests__/developer/external-dependencies/rest-apis/mocked-external-apis.js
@@ -65,8 +65,12 @@ module.exports = class MockedExternalApis {
 		const actualHorizonInteractions = await this.getRecordedRequestsForHorizon();
 		const actualNotifyInteractions = await this.getRecordedRequestsForNotify();
 
-		this.verifyInteractions(expectedHorizonInteractions, actualHorizonInteractions);
-		this.verifyInteractions(expectedNotifyInteractions, actualNotifyInteractions);
+		if (expectedHorizonInteractions !== undefined) {
+			this.verifyInteractions(expectedHorizonInteractions, actualHorizonInteractions);
+		}
+		if (expectedNotifyInteractions !== undefined) {
+			this.verifyInteractions(expectedNotifyInteractions, actualNotifyInteractions);
+		}
 	}
 
 	async teardown() {

--- a/packages/appeals-service-api/__tests__/developer/final-comments.test.js
+++ b/packages/appeals-service-api/__tests__/developer/final-comments.test.js
@@ -1,0 +1,299 @@
+const http = require('http');
+const supertest = require('supertest');
+const { MongoClient } = require('mongodb');
+const container = require('rhea');
+const crypto = require('crypto');
+
+const app = require('../../src/app');
+const appDbConnection = require('../../src/db/db');
+const appConfiguration = require('../../src/configuration/config');
+
+const MockedExternalApis = require('./external-dependencies/rest-apis/mocked-external-apis');
+const FinalCommentFixtures = require('./fixtures/finalComments');
+
+const { isFeatureActive } = require('../../src/configuration/featureFlag');
+
+/** @type {import('supertest').SuperTest<import('supertest').Test>} */
+let appealsApi;
+/** @type {import('mongodb').MongoClient} */
+let databaseConnection;
+/** @type {import('./external-dependencies/rest-apis/mocked-external-apis')} */
+let mockedExternalApis;
+/** @type {Array.<*>} */
+let expectedNotifyInteractions;
+let testLpaEmail = 'appealplanningdecisiontest@planninginspectorate.gov.uk';
+let testLpaCodeEngland = 'E69999999';
+let testLpaCodeWales = 'W69999999';
+let testLpaNameEngland = 'System Test Borough Council England';
+let testLpaNameWales = 'System Test Borough Council Wales';
+let testHorizonLpaCodeWales = 'H1234';
+
+jest.setTimeout(240000); // The Horizon integration tests need a bit of time to complete! This seemed like a good number (4 mins)
+jest.mock('../../src/db/db'); // TODO: We shouldn't need to do this, but we didn't have time to look at making this better. It should be possible to use the DB connection directly (not mock it)
+jest.mock('../../src/configuration/featureFlag');
+
+const dbName = 'integration-test-final-comments-db';
+
+beforeAll(async () => {
+	///////////////////////////////
+	///// SETUP EXTERNAL APIs /////
+	///////////////////////////////
+
+	mockedExternalApis = await MockedExternalApis.setup();
+
+	///////////////////////////////
+	///// SETUP TEST DATABASE /////
+	///////////////////////////////
+	if (!process.env.INTEGRATION_TEST_DB_URL) {
+		throw new Error('process.env.INTEGRATION_TEST_DB_URL not set');
+	}
+
+	databaseConnection = await MongoClient.connect(process.env.INTEGRATION_TEST_DB_URL, {
+		useNewUrlParser: true,
+		useUnifiedTopology: true
+	});
+	let mockedDatabase = await databaseConnection.db(dbName);
+	appDbConnection.get.mockReturnValue(mockedDatabase);
+
+	const test_listener = container.create_container();
+
+	test_listener.on('disconnected', (context) => {
+		context.connection.close();
+	});
+
+	/////////////////////////////
+	///// SETUP TEST CONFIG /////
+	/////////////////////////////
+
+	appConfiguration.secureCodes.finalComments.length = 4;
+	appConfiguration.secureCodes.finalComments.expirationTimeInMinutes = 30;
+	appConfiguration.secureCodes.finalComments.decipher.algorithm = 'aes-256-cbc';
+	appConfiguration.secureCodes.finalComments.decipher.initVector = crypto.randomBytes(16);
+	appConfiguration.secureCodes.finalComments.decipher.securityKey = crypto.randomBytes(32);
+	appConfiguration.secureCodes.finalComments.decipher.inputEncoding = 'hex';
+	appConfiguration.secureCodes.finalComments.decipher.outputEncoding = 'utf-8';
+	appConfiguration.services.notify.apiKey =
+		'hasserviceapikey-u89q754j-s87j-1n35-s351-789245as890k-1545v789-8s79-0124-qwe7-j2vfds34w5nm';
+	appConfiguration.services.notify.baseUrl = mockedExternalApis.getNotifyUrl();
+	appConfiguration.services.notify.serviceId = 'g09j298f-q59t-9a34-f123-782342hj910l';
+	appConfiguration.services.notify.templates[
+		'1001'
+	].appealSubmissionConfirmationEmailToAppellant = 1;
+	appConfiguration.services.notify.templates['1001'].appealNotificationEmailToLpa = 2;
+	appConfiguration.services.notify.templates[
+		'1005'
+	].appealSubmissionConfirmationEmailToAppellant = 3;
+	appConfiguration.services.notify.templates['1005'].appealNotificationEmailToLpa = 4;
+	appConfiguration.services.notify.emails.adminMonitoringEmail = 'test@pins.gov.uk';
+	appConfiguration.documents.url = mockedExternalApis.getDocumentsAPIUrl();
+
+	/////////////////////
+	///// SETUP APP /////
+	/////////////////////
+
+	let server = http.createServer(app);
+	appealsApi = supertest(server);
+
+	/////////////////////////
+	///// POPULATE LPAS /////
+	/////////////////////////
+
+	const testLpaJson = `{OBJECTID;LPA19CD;LPA CODE;LPA19NM;EMAIL;DOMAIN;LPA ONBOARDED\n323;${testLpaCodeEngland};;${testLpaNameEngland};${testLpaEmail};;TRUE\n324;${testLpaCodeWales};${testHorizonLpaCodeWales};${testLpaNameWales};${testLpaEmail};;TRUE}`;
+	await appealsApi.post('/api/v1/local-planning-authorities').send(testLpaJson);
+});
+
+beforeEach(async () => {
+	await _clearDatabaseCollections();
+	expectedNotifyInteractions = [];
+	await mockedExternalApis.mockNotifyResponse({}, 200);
+	isFeatureActive.mockImplementation(() => {
+		return true;
+	});
+});
+
+// We check mock and message interactions consistently here so that they're not forgotten for each test :)
+afterEach(async () => {
+	await mockedExternalApis.checkInteractions(expectedNotifyInteractions);
+	await mockedExternalApis.clearAllMockedResponsesAndRecordedInteractions();
+	jest.clearAllMocks(); // We need to do this so that mock interactions are reset correctly between tests :)
+});
+
+afterAll(async () => {
+	await databaseConnection.close();
+	await mockedExternalApis.teardown();
+});
+
+describe('Final comments', () => {
+	it('Should submit the final comment to the back-end when submitted before the expiry date', async () => {
+		// Given: a final comment with an expiry date of tomorrow
+		let today = new Date();
+		let tomorrow = new Date();
+		tomorrow.setDate(today.getDate() + 1);
+		let expiryDate = tomorrow.toISOString();
+		let horizonId = 1345678;
+
+		let finalCommentToSubmit = FinalCommentFixtures.newFinalComment({
+			finalCommentExpiryDate: expiryDate,
+			horizonId: horizonId
+		});
+
+		// When: it is submitted to the back-end
+		let response = await _createFinalComment(finalCommentToSubmit);
+
+		// Then: It should return a status code of 201
+		expect(response.status).toBe(201);
+
+		// And: The back-end should contain one appeal for that horizon Id
+		let submittedFinalComment = await appealsApi.get(`/api/v1/final-comments/${horizonId}`);
+		expect(submittedFinalComment.status).toBe(201);
+		expect(submittedFinalComment.body.length).toBe(1);
+	});
+
+	it('Should not submit the final comment if a final comment exists with the same horizonId and email', async () => {
+		// Given: a final comment with an expiry date of tomorrow
+		let today = new Date();
+		let tomorrow = new Date();
+		tomorrow.setDate(today.getDate() + 1);
+		let expiryDate = tomorrow.toISOString();
+		let horizonId = 1345678;
+
+		let finalCommentToSubmit = FinalCommentFixtures.newFinalComment({
+			finalCommentExpiryDate: expiryDate,
+			horizonId: horizonId
+		});
+
+		// When: it is submitted to the back-end twice
+		let firstResponse = await _createFinalComment(finalCommentToSubmit);
+		let secondResponse = await _createFinalComment(finalCommentToSubmit);
+
+		// Then: It should return a status code of 201 for the first
+		expect(firstResponse.status).toBe(201);
+
+		// And: Return a status code of 409 for the second
+		expect(secondResponse.status).toBe(409);
+
+		// And: The back-end should contain one final comment for that horizon Id
+		let submittedFinalComment = await appealsApi.get(`/api/v1/final-comments/${horizonId}`);
+		expect(submittedFinalComment.status).toBe(201);
+		expect(submittedFinalComment.body.length).toBe(1);
+	});
+
+	it('Should not submit the final comment if the expiry date is in the past', async () => {
+		// Given: A final comment with an expiry date in the past
+		let today = new Date();
+		let yesterday = new Date();
+		yesterday.setDate(today.getDate() - 1);
+		let expiryDate = yesterday.toISOString();
+		let horizonId = 1345678;
+
+		let finalCommentToSubmit = FinalCommentFixtures.newFinalComment({
+			finalCommentExpiryDate: expiryDate,
+			horizonId: horizonId
+		});
+
+		// When: it is submitted to the back end
+		let response = await _createFinalComment(finalCommentToSubmit);
+
+		// Then: It should return a status code of 409
+		expect(response.status).toBe(409);
+
+		// And: The back-end should not contain an final comment for the horizon Id
+		let submittedFinalComment = await appealsApi.get(`/api/v1/final-comments/${horizonId}`);
+		expect(submittedFinalComment.status).toBe(404);
+	});
+
+	it('Should submit 2 final comments if the final comments have a different horizonId', async () => {
+		// Given: a final comment with an expiry date of tomorrow
+		let today = new Date();
+		let tomorrow = new Date();
+		tomorrow.setDate(today.getDate() + 1);
+		let expiryDate = tomorrow.toISOString();
+		let firstHorizonId = 1345678;
+		let secondHorizonId = 9999999;
+
+		let firstFinalCommentToSubmit = FinalCommentFixtures.newFinalComment({
+			finalCommentExpiryDate: expiryDate,
+			horizonId: firstHorizonId
+		});
+
+		let secondFinalCommentToSubmit = FinalCommentFixtures.newFinalComment({
+			finalCommentExpiryDate: expiryDate,
+			horizonId: secondHorizonId
+		});
+
+		// When: it is submitted to the back-end twice
+		let firstResponse = await _createFinalComment(firstFinalCommentToSubmit);
+		let secondResponse = await _createFinalComment(secondFinalCommentToSubmit);
+
+		// Then: It should return a status code of 201 for the both
+		expect(firstResponse.status).toBe(201);
+		expect(secondResponse.status).toBe(201);
+
+		// And: The back-end should contain one final comment for each horizon Id
+		let firstSubmittedFinalComment = await appealsApi.get(
+			`/api/v1/final-comments/${firstHorizonId}`
+		);
+		expect(firstSubmittedFinalComment.status).toBe(201);
+		expect(firstSubmittedFinalComment.body.length).toBe(1);
+
+		let secondSubmittedFinalComment = await appealsApi.get(
+			`/api/v1/final-comments/${secondHorizonId}`
+		);
+		expect(secondSubmittedFinalComment.status).toBe(201);
+		expect(secondSubmittedFinalComment.body.length).toBe(1);
+	});
+
+	it('Should submit 2 final comments if the final comments have the same horizonId but different emails', async () => {
+		// Given: a final comment with an expiry date of tomorrow
+		let today = new Date();
+		let tomorrow = new Date();
+		tomorrow.setDate(today.getDate() + 1);
+		let expiryDate = tomorrow.toISOString();
+		let horizonId = 9999999;
+
+		let firstFinalCommentToSubmit = FinalCommentFixtures.newFinalComment({
+			finalCommentExpiryDate: expiryDate,
+			horizonId: horizonId,
+			email: 'test@example.com'
+		});
+
+		let secondFinalCommentToSubmit = FinalCommentFixtures.newFinalComment({
+			finalCommentExpiryDate: expiryDate,
+			horizonId: horizonId,
+			email: 'test2@example.com'
+		});
+
+		// When: it is submitted to the back-end twice
+		let firstResponse = await _createFinalComment(firstFinalCommentToSubmit);
+		let secondResponse = await _createFinalComment(secondFinalCommentToSubmit);
+
+		// Then: It should return a status code of 201 for the both
+		expect(firstResponse.status).toBe(201);
+		expect(secondResponse.status).toBe(201);
+
+		// And: The back-end should contain two final comments for that horizonId
+		let submittedFinalComments = await appealsApi.get(`/api/v1/final-comments/${horizonId}`);
+		expect(submittedFinalComments.status).toBe(201);
+		expect(submittedFinalComments.body.length).toBe(2);
+	});
+});
+
+const _createFinalComment = async (finalComment) => {
+	return await appealsApi.post('/api/v1/final-comments').send(finalComment);
+};
+
+/**
+ * Clears out all collection from the database EXCEPT the LPA collection, since this is needed
+ * from one test to the next, and its data does not change during any test execution.
+ */
+const _clearDatabaseCollections = async () => {
+	const databaseCollections = await databaseConnection.db(dbName).collections();
+
+	const databaseCollectionsFiltered = databaseCollections.filter(
+		(collection) => collection.namespace.split('.')[1] !== 'lpa'
+	);
+
+	for (const collection of databaseCollectionsFiltered) {
+		await collection.drop();
+	}
+};

--- a/packages/appeals-service-api/__tests__/developer/globalSetup.js
+++ b/packages/appeals-service-api/__tests__/developer/globalSetup.js
@@ -14,7 +14,7 @@ function run(cmd) {
 
 module.exports = async () => {
 	const { create } = require('./external-dependencies/database/test-database');
-	process.env.LOGGER_LEVEL = 'fatal';
+	process.env.LOGGER_LEVEL = 'info';
 	await create();
 
 	await run(`npx prisma migrate deploy`);

--- a/packages/appeals-service-api/__tests__/developer/tokens-v2.test.js
+++ b/packages/appeals-service-api/__tests__/developer/tokens-v2.test.js
@@ -16,10 +16,15 @@ const { isFeatureActive } = require('../../src/configuration/featureFlag');
 const enterCodeConfig = require('@pins/common/src/enter-code-config');
 const { MILLISECONDS_BETWEEN_TOKENS } = require('../../src/routes/v2/token/controller');
 
+/** @type {import('@prisma/client').PrismaClient} */
 let sqlClient;
+/** @type {import('supertest').SuperTest<import('supertest').Test>} */
 let appealsApi;
+/** @type {import('mongodb').MongoClient} */
 let databaseConnection;
+/** @type {import('./external-dependencies/rest-apis/mocked-external-apis')} */
 let mockedExternalApis;
+// /** @type {Array.<*>} */
 // let expectedNotifyInteractions;
 
 jest.setTimeout(140000);
@@ -48,6 +53,9 @@ beforeAll(async () => {
 	///////////////////////////////
 	///// SETUP TEST DATABASE ////
 	/////////////////////////////
+	if (!process.env.INTEGRATION_TEST_DB_URL) {
+		throw new Error('process.env.INTEGRATION_TEST_DB_URL not set');
+	}
 
 	databaseConnection = await MongoClient.connect(process.env.INTEGRATION_TEST_DB_URL, {
 		useNewUrlParser: true,

--- a/packages/appeals-service-api/__tests__/unit/controllers/save-and-return.test.js
+++ b/packages/appeals-service-api/__tests__/unit/controllers/save-and-return.test.js
@@ -9,6 +9,8 @@ const {
 jest.mock('../../../src/services/save-and-return.service');
 jest.mock('../../../src/services/appeal.service');
 jest.mock('../../../../common/src/lib/notify/notify-builder', () => ({}));
+jest.mock('../../../src/repositories/sql/appeal-user-repository');
+jest.mock('../../../src/repositories/sql/appeals-repository');
 
 describe('Save And Return API', () => {
 	let req;

--- a/packages/appeals-service-api/__tests__/unit/controllers/token.test.js
+++ b/packages/appeals-service-api/__tests__/unit/controllers/token.test.js
@@ -12,6 +12,7 @@ jest.mock('../../../src/services/token.service');
 jest.mock('../../../src/services/appeal.service');
 jest.mock('../../../src/lib/notify');
 jest.mock('../../../src/repositories/sql/appeal-user-repository');
+jest.mock('../../../src/repositories/sql/appeals-repository');
 jest.mock('../../../src/db/db-client');
 
 describe('controllers/token', () => {

--- a/packages/appeals-service-api/__tests__/unit/services/appeal.service.test.js
+++ b/packages/appeals-service-api/__tests__/unit/services/appeal.service.test.js
@@ -1,6 +1,8 @@
 const { getAppealByLPACodeAndId } = require('../../../src/services/appeal.service');
 // eslint-disable-next-line no-unused-vars
 const { AppealsRepository } = require('../../../src/repositories/appeals-repository');
+jest.mock('../../../src/repositories/sql/appeal-user-repository');
+jest.mock('../../../src/repositories/sql/appeals-repository');
 
 describe('./src/services/appeal.service', () => {
 	it('should retrieve', async () => {

--- a/packages/appeals-service-api/src/db/db-client.js
+++ b/packages/appeals-service-api/src/db/db-client.js
@@ -1,6 +1,7 @@
 const { PrismaClient } = require('@prisma/client');
 const config = require('../configuration/config');
 
+/** @type {import('@prisma/client').Prisma.PrismaClientOptions} */
 let prismaConfig = {
 	datasourceUrl: config.db.sql.connectionString
 };
@@ -10,6 +11,7 @@ if (config.logger.level === 'debug') {
 	prismaConfig.log = ['query'];
 }
 
+/** @type {import('@prisma/client').PrismaClient} */
 let prisma;
 
 /**

--- a/packages/appeals-service-api/src/db/seed/data-static.js
+++ b/packages/appeals-service-api/src/db/seed/data-static.js
@@ -1,5 +1,7 @@
+/** @typedef { 'appellant' | 'agent' | 'interestedParty' } AppealToUserRoles */
+
 /**
- * @type {import('@prisma/client').Prisma.AppealToUserRoleCreateInput}
+ * @type {Array.<import('@prisma/client').Prisma.AppealToUserRoleCreateInput>}
  */
 const appealToUserRoles = [
 	{
@@ -17,7 +19,7 @@ const appealToUserRoles = [
 ];
 
 /**
- * @param {import('@prisma/client')} dbClient
+ * @param {import('@prisma/client').PrismaClient} dbClient
  */
 async function seedStaticData(dbClient) {
 	for (const role of appealToUserRoles) {

--- a/packages/appeals-service-api/src/db/seed/data-static.js
+++ b/packages/appeals-service-api/src/db/seed/data-static.js
@@ -1,28 +1,33 @@
-/** @typedef { 'appellant' | 'agent' | 'interestedParty' } AppealToUserRoles */
+/**
+ * @typedef { 'appellant' | 'agent' | 'interestedParty' } AppealToUserRoles
+ * @typedef {import('@prisma/client').Prisma.AppealToUserRoleCreateInput} AppealToUserRoleCreateInput
+ */
 
 /**
- * @type {Array.<import('@prisma/client').Prisma.AppealToUserRoleCreateInput>}
+ * @type {Object<string, AppealToUserRoleCreateInput>}
  */
-const appealToUserRoles = [
-	{
+const APPEAL_USER_ROLES = {
+	appellant: {
 		name: 'appellant',
-		description: `Appellant is the person who's planning application decision is being appealled`
+		description: `Appellant is the person who's planning application decision is being appealed`
 	},
-	{
+	agent: {
 		name: 'agent',
 		description: `An agent is a user who submits an appeal on behalf of an appellant`
 	},
-	{
+	interestedParty: {
 		name: 'interestedParty',
 		description: `An interested party is a user who submits a comment on an appeal`
 	}
-];
+};
+
+const APPEAL_USER_ROLES_ARRAY = Object.values(APPEAL_USER_ROLES);
 
 /**
  * @param {import('@prisma/client').PrismaClient} dbClient
  */
 async function seedStaticData(dbClient) {
-	for (const role of appealToUserRoles) {
+	for (const role of APPEAL_USER_ROLES_ARRAY) {
 		await dbClient.appealToUserRole.upsert({
 			create: role,
 			update: role,
@@ -33,5 +38,7 @@ async function seedStaticData(dbClient) {
 }
 
 module.exports = {
-	seedStaticData
+	seedStaticData,
+	APPEAL_USER_ROLES,
+	APPEAL_USER_ROLES_ARRAY
 };

--- a/packages/appeals-service-api/src/errors/apiError.js
+++ b/packages/appeals-service-api/src/errors/apiError.js
@@ -1,20 +1,43 @@
+/**
+ * @typedef {Object} ErrorMessages
+ * @property {Array.<string>} errors
+ */
+
 class ApiError {
-	constructor(code, message) {
+	/**
+	 * @param {number} code
+	 * @param {ErrorMessages} messages
+	 */
+	constructor(code, messages) {
 		this.code = code;
-		this.message = message;
+		this.message = messages;
+	}
+
+	/**
+	 * @param {String|ErrorMessages|undefined} message
+	 * @returns {ErrorMessages}
+	 */
+	static buildErrorFormat(message) {
+		if (!message) return { errors: [] };
+
+		return typeof message === 'string' ? { errors: [message] } : message;
 	}
 
 	// generic
+
 	/**
 	 * @param {number} code
-	 * @param {string} message
+	 * @param {string|ErrorMessages} message
 	 */
 	static withMessage(code, message) {
-		return new ApiError(code, { errors: [message] });
+		return new ApiError(code, ApiError.buildErrorFormat(message));
 	}
 
+	/**
+	 * @param {string|ErrorMessages|undefined} msg
+	 */
 	static badRequest(msg) {
-		return new ApiError(400, msg);
+		return new ApiError(400, ApiError.buildErrorFormat(msg));
 	}
 
 	// appeal
@@ -36,6 +59,10 @@ class ApiError {
 		return new ApiError(409, {
 			errors: ['The provided id in path must be the same as the appeal id in the request body']
 		});
+	}
+
+	static appealDuplicate() {
+		return new ApiError(400, { errors: [`This appeal already exists`] });
 	}
 
 	static appealAlreadySubmitted() {

--- a/packages/appeals-service-api/src/repositories/sql/appeals-repository.js
+++ b/packages/appeals-service-api/src/repositories/sql/appeals-repository.js
@@ -1,0 +1,90 @@
+const { createPrismaClient } = require('../../db/db-client');
+const { Prisma } = require('@prisma/client');
+const logger = require('../../lib/logger');
+const ApiError = require('../../errors/apiError');
+
+/**
+ * @typedef { import("@prisma/client").Appeal } Appeal
+ * @typedef { import("@prisma/client").Prisma.AppealCreateInput } AppealCreateInput
+ */
+
+class AppealsRepository {
+	dbClient;
+
+	constructor() {
+		this.dbClient = createPrismaClient();
+	}
+
+	/**
+	 * Create a new Appeal
+	 *
+	 * @param {AppealCreateInput} appeal
+	 * @returns {Promise<Appeal>}
+	 */
+	async createAppeal(appeal) {
+		try {
+			return await this.dbClient.appeal.create({
+				data: appeal
+			});
+		} catch (err) {
+			logger.error(err);
+			if (err instanceof Prisma.PrismaClientKnownRequestError) {
+				throw ApiError.appealDuplicate();
+			}
+			throw err;
+		}
+	}
+
+	/**
+	 * Updates Appeal
+	 *
+	 * @param {AppealCreateInput} appeal
+	 * @returns {Promise<Appeal>}
+	 */
+	async updateAppeal(appeal) {
+		try {
+			return await this.dbClient.appeal.update({
+				data: appeal,
+				where: {
+					id: appeal.id
+				}
+			});
+		} catch (err) {
+			logger.error(err);
+			if (err instanceof Prisma.PrismaClientKnownRequestError) {
+				throw ApiError.appealNotFound();
+			}
+			throw err;
+		}
+	}
+
+	/**
+	 * Get an appeal by id
+	 *
+	 * @param {string} id
+	 * @returns {Promise<Appeal|null>}
+	 */
+	async getById(id) {
+		return await this.dbClient.appeal.findUnique({
+			where: {
+				id
+			}
+		});
+	}
+
+	/**
+	 * Get by legacy appeal id
+	 *
+	 * @param {string} id
+	 * @returns {Promise<Appeal|null>}
+	 */
+	async getByLegacyId(id) {
+		return await this.dbClient.appeal.findFirst({
+			where: {
+				legacyAppealSubmissionId: id
+			}
+		});
+	}
+}
+
+module.exports = { AppealsRepository };

--- a/packages/appeals-service-api/src/routes/appeals.js
+++ b/packages/appeals-service-api/src/routes/appeals.js
@@ -6,47 +6,60 @@ const {
 	appealUpdateValidationRules
 } = require('../validators/appeals/appeals.validator');
 
+const asyncHandler = require('../middleware/async-handler');
+
 const router = express.Router();
 
-router.get('/:id', async (req, res) => {
-	let statusCode = 200;
-	let body = '';
-	try {
-		body = await getAppeal(req.params.id);
-	} catch (error) {
-		statusCode = error.code;
-		body = error.message.errors;
-	} finally {
-		res.status(statusCode).send(body);
-	}
-});
+router.get(
+	'/:id',
+	asyncHandler(async (req, res) => {
+		let statusCode = 200;
+		let body = '';
+		try {
+			body = await getAppeal(req.params.id);
+		} catch (error) {
+			statusCode = error.code;
+			body = error.message.errors;
+		} finally {
+			res.status(statusCode).send(body);
+		}
+	})
+);
 
-router.post('/', createAppeal);
+router.post('/', asyncHandler(createAppeal));
 
-router.put('/:id', appealInsertValidationRules, async (req, res) => {
-	let statusCode = 200;
-	let body = '';
-	try {
-		body = await updateAppeal(req.params.id, req.body);
-	} catch (error) {
-		statusCode = error.code;
-		body = error.message.errors;
-	} finally {
-		res.status(statusCode).send(body);
-	}
-});
+router.put(
+	'/:id',
+	appealInsertValidationRules,
+	asyncHandler(async (req, res) => {
+		let statusCode = 200;
+		let body = '';
+		try {
+			body = await updateAppeal(req.params.id, req.body);
+		} catch (error) {
+			statusCode = error.code;
+			body = error.message.errors;
+		} finally {
+			res.status(statusCode).send(body);
+		}
+	})
+);
 
-router.patch('/:id', appealUpdateValidationRules, async (req, res) => {
-	let statusCode = 200;
-	let body = '';
-	try {
-		body = await updateAppeal(req.params.id, req.body);
-	} catch (error) {
-		statusCode = error.code;
-		body = error.message.errors;
-	} finally {
-		res.status(statusCode).send(body);
-	}
-});
+router.patch(
+	'/:id',
+	appealUpdateValidationRules,
+	asyncHandler(async (req, res) => {
+		let statusCode = 200;
+		let body = '';
+		try {
+			body = await updateAppeal(req.params.id, req.body);
+		} catch (error) {
+			statusCode = error.code;
+			body = error.message.errors;
+		} finally {
+			res.status(statusCode).send(body);
+		}
+	})
+);
 
 module.exports = router;

--- a/packages/appeals-service-api/src/routes/v2/users/controller.js
+++ b/packages/appeals-service-api/src/routes/v2/users/controller.js
@@ -1,4 +1,4 @@
-const { getUserByEmail, createUser } = require('./service');
+const { getUserByEmail, createUser, linkUserToAppeal } = require('./service');
 const logger = require('#lib/logger');
 const ApiError = require('#errors/apiError');
 
@@ -53,7 +53,24 @@ async function userPost(req, res) {
 	}
 }
 
+/**
+ * @type {import('express').Handler}
+ */
+async function userLink(req, res) {
+	const { email, appealId } = req.params;
+	const role = req.body.role;
+
+	const result = await linkUserToAppeal(email, appealId, role);
+
+	res.status(200).send({
+		email,
+		appealId: result.appealId,
+		role: result.role
+	});
+}
+
 module.exports = {
 	userGet,
-	userPost
+	userPost,
+	userLink
 };

--- a/packages/appeals-service-api/src/routes/v2/users/index.js
+++ b/packages/appeals-service-api/src/routes/v2/users/index.js
@@ -1,8 +1,10 @@
 const express = require('express');
-const { userGet, userPost } = require('./controller');
+const { userGet, userPost, userLink } = require('./controller');
 const router = express.Router();
+const asyncHandler = require('../../../middleware/async-handler');
 
-router.get('/:email', userGet);
-router.post('/', userPost);
+router.get('/:email', asyncHandler(userGet));
+router.post('/', asyncHandler(userPost));
+router.post('/:email/appeal/:appealId', asyncHandler(userLink));
 
 module.exports = { router };

--- a/packages/appeals-service-api/src/routes/v2/users/service.js
+++ b/packages/appeals-service-api/src/routes/v2/users/service.js
@@ -1,7 +1,12 @@
 const { AppealUserRepository } = require('#repositories/sql/appeal-user-repository');
 const ApiError = require('#errors/apiError');
+const { APPEAL_USER_ROLES_ARRAY } = require('../../../db/seed/data-static');
 
 const appealUserRepository = new AppealUserRepository();
+
+/**
+ * @typedef { import("@prisma/client").AppealToUser } AppealToUser
+ */
 
 async function createUser(user) {
 	if (!user || !user.lpaCode || !user.email) {
@@ -18,7 +23,33 @@ async function getUserByEmail(email) {
 	throw ApiError.userNotFound();
 }
 
+/**
+ * Sets user's role on an appeal
+ * @param {string} email
+ * @param {string} appealId
+ * @param {string|undefined} role
+ * @returns {Promise<AppealToUser>}
+ */
+async function linkUserToAppeal(email, appealId, role) {
+	// allow undefined through as we can provide default on creation
+	if (
+		role !== undefined &&
+		!APPEAL_USER_ROLES_ARRAY.some((appealRole) => appealRole.name === role)
+	) {
+		throw ApiError.badRequest('invalid role');
+	}
+
+	const user = await getUserByEmail(email);
+
+	if (!user) {
+		throw ApiError.userNotFound();
+	}
+
+	return await appealUserRepository.linkUserToAppeal(user.id, appealId, role);
+}
+
 module.exports = {
 	createUser,
-	getUserByEmail
+	getUserByEmail,
+	linkUserToAppeal
 };

--- a/packages/appeals-service-api/src/routes/v2/users/spec.yaml
+++ b/packages/appeals-service-api/src/routes/v2/users/spec.yaml
@@ -22,7 +22,7 @@ paths:
           content:
             application/json:
               schema:
-                 $ref: '#/components/schemas/ErrorBody'
+                $ref: '#/components/schemas/ErrorBody'
   /api/v2/users/{email}:
     get:
       tags:
@@ -49,3 +49,50 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorBody'
+  /api/v2/users/{email}/appeal/{appealId}:
+    put:
+      tags:
+        - users
+      description: Link a user to an appeal
+      parameters:
+        - in: path
+          name: email
+          required: true
+          schema:
+            type: string
+            format: email
+          example: me@example.com
+          description: user email
+        - in: appealId
+          name: appealId
+          required: true
+          schema:
+            type: string
+            format: uuid
+          example: 3fa85f64-5717-4562-b3fc-2c963f66afa6
+          description: Unique identifier of appeal (SQL)
+      requestBody:
+        description: role
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                role:
+                  type: string
+                  enum: ['appellant', 'agent', 'interestedParty']
+      responses:
+        200:
+          description: Created role
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AppealToUser'
+        400:
+          description: Bad request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorBody'
+        500:
+          description: Something went wrong

--- a/packages/appeals-service-api/src/spec/appeal-to-user.yaml
+++ b/packages/appeals-service-api/src/spec/appeal-to-user.yaml
@@ -1,0 +1,23 @@
+components:
+  schemas:
+    AppealToUser:
+      description: An mapping of an appeal to a user
+      type: object
+      required:
+        - email
+        - appealId
+        - role
+      properties:
+        email:
+          type: string
+          format: email
+          example: 'me@example.com'
+          description: user email
+        appealId:
+          type: string
+          format: uuid
+          description: Unique identifier of appeal (SQL)
+        role:
+          type: string
+          enum: ['appellant', 'agent', 'interestedParty']
+          description: Role user has on the appeal

--- a/packages/forms-web-app/src/controllers/index.js
+++ b/packages/forms-web-app/src/controllers/index.js
@@ -1,8 +1,9 @@
 const config = require('../config');
 const { isFeatureActive } = require('../featureFlag');
+const { FLAG } = require('@pins/common/src/feature-flags');
 
 exports.getIndex = async (_, res) => {
-	const isEnrolUsersActive = await isFeatureActive('enrol-users');
+	const isEnrolUsersActive = await isFeatureActive(FLAG.ENROL_USERS);
 	res.redirect(
 		isEnrolUsersActive ? config.appeals.startingPointEnrolUsersActive : config.appeals.startingPoint
 	);


### PR DESCRIPTION
## Ticket Number

<!-- Add the number from the Jira board -->

https://pins-ds.atlassian.net/browse/AAPD-861

## Description of change
This PR links users to appeals in sql at two separate occasions
When doing enter code to confirm an email for an appeal, it sets user as an appellant
When setting isOriginalApplicant on the appeal update either agent/appellant role

There may probably need to be an addition to this in future to for users creating a new appeal when already logged in

## Checklist

<!-- Put an `x` in all the boxes that apply: -->

- [ ] Requires infrastructure changes
- [ ] If adding or remove environment variables (e.g. in `docker-compose.yaml`) then I have updated the appropriate Helm chart
- [ ] I have updated the documentation accordingly
- [x] My commit history in this PR is linear
- [x] New features have tests
- [ ] Breaking change (team conversation required)

## Important

Please do not merge from `main` (please only [rebase](https://github.com/foundry4/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
