### PR TITLE
docs(docs): remove unused docs and PR template check

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -13,7 +13,6 @@ https://pins-ds.atlassian.net/browse/AAPD-
 <!-- Put an `x` in all the boxes that apply: -->
 
 - [ ] Requires infrastructure changes
-- [ ] If adding or remove environment variables (e.g. in `docker-compose.yaml`) then I have updated the appropriate Helm chart
 - [ ] I have updated the documentation accordingly
 - [ ] My commit history in this PR is linear
 - [ ] New features have tests


### PR DESCRIPTION
## Description of change

Removed helm from PR template
Removed some redundant docs, infra documentation can be handled by that repo, may become out of date otherwise
I don't think the group info is relevant anymore
Deployment we are documenting in confluence

## Checklist

<!-- Put an `x` in all the boxes that apply: -->

- [ ] Requires infrastructure changes
- [ ] If adding or remove environment variables (e.g. in `docker-compose.yaml`) then I have updated the appropriate Helm chart
- [ ] I have updated the documentation accordingly
- [x] My commit history in this PR is linear
- [ ] New features have tests
- [ ] Breaking change (team conversation required)

## Important

Please do not merge from `main` (please only [rebase](https://github.com/foundry4/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
