### PR TITLE
feat(api): return appellant data with appeal-case

### DIFF
--- a/packages/appeals-service-api/src/db/migrations/20231212112838_service_user/migration.sql
+++ b/packages/appeals-service-api/src/db/migrations/20231212112838_service_user/migration.sql
@@ -1,0 +1,29 @@
+BEGIN TRY
+
+BEGIN TRAN;
+
+-- CreateTable
+CREATE TABLE [dbo].[ServiceUser] (
+    [internalId] UNIQUEIDENTIFIER NOT NULL CONSTRAINT [ServiceUser_internalId_df] DEFAULT newid(),
+    [id] NVARCHAR(1000) NOT NULL,
+    [salutation] NVARCHAR(1000),
+    [firstName] NVARCHAR(1000),
+    [lastName] NVARCHAR(1000),
+    [emailAddress] NVARCHAR(1000),
+    [serviceUserType] NVARCHAR(1000) NOT NULL,
+    [caseReference] NVARCHAR(1000) NOT NULL,
+    CONSTRAINT [ServiceUser_pkey] PRIMARY KEY CLUSTERED ([internalId])
+);
+
+COMMIT TRAN;
+
+END TRY
+BEGIN CATCH
+
+IF @@TRANCOUNT > 0
+BEGIN
+    ROLLBACK TRAN;
+END;
+THROW
+
+END CATCH

--- a/packages/appeals-service-api/src/db/schema.prisma
+++ b/packages/appeals-service-api/src/db/schema.prisma
@@ -215,3 +215,21 @@ model AppealCase {
 
   // todo: indexes
 }
+
+/// ServiceUser represents any user of PINS Services, and follows the PINS Data Model
+/// A given person may be represented by multiple ServiceUser entries, for example an agent
+/// would have one entry per appeal
+model ServiceUser {
+  /// this ID is for front office only and won't correlate to other systems
+  internalId String @id @default(dbgenerated("newid()")) @db.UniqueIdentifier
+
+  id              String
+  salutation      String?
+  firstName       String?
+  lastName        String?
+  emailAddress    String?
+  /// one of "Applicant", "Appellant", "Agent", "RepresentationContact", "Subscriber"
+  serviceUserType String
+  /// case reference this user + user-type relates to
+  caseReference   String
+}

--- a/packages/appeals-service-api/src/db/seed/data-dev.js
+++ b/packages/appeals-service-api/src/db/seed/data-dev.js
@@ -52,6 +52,28 @@ const appeals = [
 ];
 
 /**
+ * @type {import('@prisma/client').Prisma.ServiceUserCreateInput[]}
+ */
+const serviceUsers = [
+	{
+		internalId: '19d01551-e0cb-414f-95d9-fd71422c9a80',
+		id: '12345',
+		serviceUserType: 'Appellant',
+		caseReference: '1010101',
+		firstName: 'Appellant',
+		lastName: 'One'
+	},
+	{
+		internalId: '90e7e328-0631-4373-8bd6-0d431b736120',
+		id: '12346',
+		serviceUserType: 'Agent',
+		caseReference: '1010101',
+		firstName: 'Agent',
+		lastName: 'One'
+	}
+];
+
+/**
  * @param {import('@prisma/client').PrismaClient} dbClient
  */
 async function seedDev(dbClient) {
@@ -67,6 +89,13 @@ async function seedDev(dbClient) {
 			create: appeal,
 			update: appeal,
 			where: { caseReference: appeal.caseReference }
+		});
+	}
+	for (const serviceUser of serviceUsers) {
+		await dbClient.serviceUser.upsert({
+			create: serviceUser,
+			update: serviceUser,
+			where: { internalId: serviceUser.internalId }
 		});
 	}
 

--- a/packages/appeals-service-api/src/repositories/sql/service-user-repository.js
+++ b/packages/appeals-service-api/src/repositories/sql/service-user-repository.js
@@ -1,0 +1,37 @@
+const { createPrismaClient } = require('#db-client');
+
+/**
+ * @typedef {import("@prisma/client").ServiceUser} ServiceUser
+ */
+
+class ServiceUserRepository {
+	dbClient;
+
+	constructor() {
+		this.dbClient = createPrismaClient();
+	}
+
+	/**
+	 * Get service user(s) by case reference and type
+	 *
+	 * @param {string} caseReference
+	 * @param {string} serviceUserType
+	 * @returns {Promise<ServiceUser[]|null>}
+	 */
+	getForCaseAndType(caseReference, serviceUserType) {
+		return this.dbClient.serviceUser.findMany({
+			where: {
+				caseReference,
+				serviceUserType
+			}
+		});
+	}
+}
+
+module.exports = {
+	ServiceUserType: {
+		Agent: 'Agent',
+		Appellant: 'Appellant'
+	},
+	ServiceUserRepository
+};

--- a/packages/appeals-service-api/src/routes/v2/appeal-cases/controller.js
+++ b/packages/appeals-service-api/src/routes/v2/appeal-cases/controller.js
@@ -1,6 +1,11 @@
 const logger = require('#lib/logger');
 const ApiError = require('#errors/apiError');
 const { AppealCaseRepository } = require('./repo');
+const {
+	getCaseAndAppellant,
+	listByLpaCodeWithAppellant,
+	listByPostcodeWithAppellant
+} = require('./service');
 
 const repo = new AppealCaseRepository();
 
@@ -14,7 +19,7 @@ async function getByCaseReference(req, res) {
 		throw ApiError.withMessage(400, 'case reference is required');
 	}
 	try {
-		const appealCase = await repo.getByCaseReference(caseReference);
+		const appealCase = await getCaseAndAppellant(caseReference);
 		if (!appealCase) {
 			throw ApiError.withMessage(404, 'not found');
 		}
@@ -44,14 +49,23 @@ async function list(req, res, next) {
  * @type {import('express').RequestHandler}
  */
 async function listByLpaCode(req, res) {
-	const { 'lpa-code': lpaCode, 'decided-only': decidedOnly } = req.query;
+	const {
+		'lpa-code': lpaCode,
+		'decided-only': decidedOnly,
+		'with-appellant': withAppellant
+	} = req.query;
 
 	if (!lpaCode || typeof lpaCode !== 'string') {
 		throw ApiError.withMessage(400, 'lpa-code is required');
 	}
 	const isDecidedOnly = decidedOnly === 'true';
+	const isWithAppellant = withAppellant === 'true';
 	try {
-		const appealCases = await repo.listByLpaCode({ lpaCode, decidedOnly: isDecidedOnly });
+		const appealCases = await listByLpaCodeWithAppellant({
+			lpaCode,
+			decidedOnly: isDecidedOnly,
+			withAppellant: isWithAppellant
+		});
 		res.status(200).send(appealCases);
 	} catch (err) {
 		logger.error({ error: err, lpaCode, decidedOnly }, 'error fetching cases by lpa code');
@@ -63,14 +77,23 @@ async function listByLpaCode(req, res) {
  * @type {import('express').RequestHandler}
  */
 async function listByPostcode(req, res) {
-	const { postcode: postcode, 'decided-only': decidedOnly } = req.query;
+	const {
+		postcode: postcode,
+		'decided-only': decidedOnly,
+		'with-appellant': withAppellant
+	} = req.query;
 
 	if (!postcode || typeof postcode !== 'string') {
 		throw ApiError.withMessage(400, 'postcode is required');
 	}
 	const isDecidedOnly = decidedOnly === 'true';
+	const isWithAppellant = withAppellant === 'true';
 	try {
-		const appealCases = await repo.listByPostCode({ postcode, decidedOnly: isDecidedOnly });
+		const appealCases = await listByPostcodeWithAppellant({
+			postcode,
+			decidedOnly: isDecidedOnly,
+			withAppellant: isWithAppellant
+		});
 		res.status(200).send(appealCases);
 	} catch (err) {
 		logger.error({ error: err, postcode, decidedOnly }, 'error fetching cases by postcode');

--- a/packages/appeals-service-api/src/routes/v2/appeal-cases/repo.js
+++ b/packages/appeals-service-api/src/routes/v2/appeal-cases/repo.js
@@ -1,4 +1,4 @@
-const dbClient = require('#db-client');
+const { createPrismaClient } = require('#db-client');
 
 /**
  * @typedef {import("@prisma/client").AppealCase} AppealCase
@@ -8,6 +8,12 @@ const dbClient = require('#db-client');
  */
 
 class AppealCaseRepository {
+	dbClient;
+
+	constructor() {
+		this.dbClient = createPrismaClient();
+	}
+
 	/**
 	 * Get an appeal by case reference (aka appeal number)
 	 *
@@ -15,7 +21,7 @@ class AppealCaseRepository {
 	 * @returns {Promise<AppealCase|null>}
 	 */
 	getByCaseReference(caseReference) {
-		return dbClient.appealCase.findUnique({
+		return this.dbClient.appealCase.findUnique({
 			where: {
 				caseReference
 			}
@@ -41,7 +47,7 @@ class AppealCaseRepository {
 			}
 		};
 		// todo: probably pagination
-		return await dbClient.appealCase.findMany(query);
+		return await this.dbClient.appealCase.findMany(query);
 	}
 
 	/**
@@ -62,7 +68,7 @@ class AppealCaseRepository {
 				AND
 			}
 		};
-		return await dbClient.appealCase.count(query);
+		return await this.dbClient.appealCase.count(query);
 	}
 
 	/**
@@ -84,7 +90,7 @@ class AppealCaseRepository {
 			}
 		};
 		// todo: probably pagination
-		return await dbClient.appealCase.findMany(query);
+		return await this.dbClient.appealCase.findMany(query);
 	}
 }
 

--- a/packages/appeals-service-api/src/routes/v2/appeal-cases/service.js
+++ b/packages/appeals-service-api/src/routes/v2/appeal-cases/service.js
@@ -1,0 +1,91 @@
+const {
+	ServiceUserRepository,
+	ServiceUserType
+} = require('#repositories/sql/service-user-repository');
+const { AppealCaseRepository } = require('./repo');
+
+const repo = new AppealCaseRepository();
+const serviceUserRepo = new ServiceUserRepository();
+
+/**
+ * @typedef {import("@prisma/client").AppealCase} AppealCase
+ * @typedef {import("@prisma/client").ServiceUser} ServiceUser
+ * @typedef {AppealCase & {appellant?: ServiceUser}} AppealCaseWithAppellant
+ */
+
+/**
+ * Get an appeal case and appellant by case reference
+ *
+ * @param {string} caseReference
+ * @returns {Promise<AppealCaseWithAppellant|null>}
+ */
+async function getCaseAndAppellant(caseReference) {
+	const appeal = await repo.getByCaseReference(caseReference);
+	if (!appeal) {
+		return null;
+	}
+	return await appendAppellant(appeal);
+}
+
+/**
+ * List cases for an LPA
+ *
+ * @param {Object} options
+ * @param {string} options.lpaCode
+ * @param {boolean} options.decidedOnly - if true, only decided cases; else ONLY cases not decided
+ * @param {boolean} options.withAppellant - if true, include the appellant if available
+ * @returns {Promise<AppealCaseWithAppellant[]>}
+ */
+async function listByLpaCodeWithAppellant(options) {
+	const appeals = await repo.listByLpaCode(options);
+
+	if (options.withAppellant) {
+		await Promise.all(appeals.map(appendAppellant));
+	}
+
+	return appeals;
+}
+
+/**
+ * List cases by postcode
+ *
+ * @param {Object} options
+ * @param {string} options.postcode
+ * @param {boolean} options.decidedOnly - if true, only decided cases; else ONLY cases not decided
+ * @param {boolean} options.withAppellant - if true, include the appellant if available
+ * @returns {Promise<AppealCaseWithAppellant[]>}
+ */
+async function listByPostcodeWithAppellant(options) {
+	const appeals = await repo.listByPostCode(options);
+
+	if (options.withAppellant) {
+		await Promise.all(appeals.map(appendAppellant));
+	}
+
+	return appeals;
+}
+
+/**
+ * Add the appellant field to an appeal if there is one.
+ *
+ * @param {AppealCaseWithAppellant} appeal
+ * @returns {Promise<AppealCaseWithAppellant>}
+ */
+async function appendAppellant(appeal) {
+	// find appellant
+	const serviceUsers = await serviceUserRepo.getForCaseAndType(
+		appeal.caseReference,
+		ServiceUserType.Appellant
+	);
+	if (!serviceUsers || serviceUsers.length !== 1) {
+		return appeal;
+	}
+	appeal.appellant = serviceUsers[0];
+	return appeal;
+}
+
+module.exports = {
+	getCaseAndAppellant,
+	listByLpaCodeWithAppellant,
+	listByPostcodeWithAppellant
+};

--- a/packages/appeals-service-api/src/routes/v2/appeal-cases/spec.yaml
+++ b/packages/appeals-service-api/src/routes/v2/appeal-cases/spec.yaml
@@ -8,6 +8,7 @@ paths:
           - $ref: '#/components/parameters/lpa-code'
           - $ref: '#/components/parameters/decided-only'
           - $ref: '#/components/parameters/postcode'
+          - $ref: '#/components/parameters/with-appellant'
       responses:
         200:
           description: List of appeal cases
@@ -16,7 +17,7 @@ paths:
               schema:
                 type: array
                 items:
-                  $ref: '#/components/schemas/AppealCase'
+                  $ref: '#/components/schemas/AppealCaseWithAppellant'
         400:
           description: Bad request
           content:
@@ -41,7 +42,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/AppealCase'
+                $ref: '#/components/schemas/AppealCaseWithAppellant'
         404:
           description: Appeal not found
           content:
@@ -98,3 +99,10 @@ components:
         full:
           value: BS1 6PN
       description: full or half postcode to filter on
+    with-appellant:
+      name: with-appellant
+      in: query
+      schema:
+        type: string
+        enum: ['true']
+      description: Include the appellant service user if available

--- a/packages/appeals-service-api/src/spec/appeal-case.yaml
+++ b/packages/appeals-service-api/src/spec/appeal-case.yaml
@@ -1,5 +1,13 @@
 components:
   schemas:
+    AppealCaseWithAppellant:
+      description: An appeal case from the Back Office, with appellant service user
+      allOf:
+          - $ref: '#/components/schemas/AppealCase'
+          - type: object
+            properties:
+              appellant:
+                $ref: '#/components/schemas/ServiceUser'
     AppealCase:
       description: An appeal case from the Back Office
       type: object

--- a/packages/appeals-service-api/src/spec/service-user.yaml
+++ b/packages/appeals-service-api/src/spec/service-user.yaml
@@ -1,0 +1,30 @@
+components:
+  schemas:
+    ServiceUser:
+      description: A Service User
+      type: object
+      required:
+        - id
+        - serviceUserType
+        - caseReference
+      properties:
+        id:
+          type: string
+          format: uuid
+          description: front office appeal case ID
+        caseReference:
+          type: string
+          description: appeal case reference (aka appeal number)
+          example: '6123456'
+        serviceUserType:
+          type: string
+          enum: ['Applicant', 'Appellant', 'Agent', 'RepresentationContact', 'Subscriber']
+        salutation:
+          type: string
+        firstName:
+          type: string
+        lastName:
+          type: string
+        emailAddress:
+          type: string
+


### PR DESCRIPTION
## Ticket Number

<!-- Add the number from the Jira board -->

https://pins-ds.atlassian.net/browse/AAPD-977

## Description of change

- added ServiceUser table
- return appellant if found and query param set, with appeal-case data

(aware we want some tests for this and appeal-case endpoint. Still on the list, just unblocking other work for now)

## Checklist

<!-- Put an `x` in all the boxes that apply: -->

- [ ] Requires infrastructure changes
- [ ] If adding or remove environment variables (e.g. in `docker-compose.yaml`) then I have updated the appropriate Helm chart
- [ ] I have updated the documentation accordingly
- [ ] My commit history in this PR is linear
- [ ] New features have tests
- [ ] Breaking change (team conversation required)

## Important

Please do not merge from `main` (please only [rebase](https://github.com/foundry4/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
