### PR TITLE
fix(aapd-974): allow download of pdf after losing session

### DIFF
--- a/packages/appeals-service-api/src/controllers/save.js
+++ b/packages/appeals-service-api/src/controllers/save.js
@@ -10,8 +10,15 @@ async function saveAndReturnCreate(req, res) {
 		res.status(400).send('Invalid Id');
 		throw new Error('');
 	}
+
+	const sendEmail = appeal.skipReturnEmail !== true;
+
 	await createSavedAppealDocument(appeal.id);
-	await sendContinueWithAppealEmail(appeal);
+
+	if (sendEmail) {
+		await sendContinueWithAppealEmail(appeal);
+	}
+
 	res.status(201).send(appeal);
 }
 

--- a/packages/forms-web-app/__tests__/unit/controllers/document.test.js
+++ b/packages/forms-web-app/__tests__/unit/controllers/document.test.js
@@ -60,12 +60,21 @@ describe('controllers/document', () => {
 			expect(mockFetchDocument.body.pipe).toHaveBeenCalledWith(res);
 		});
 
-		it('should redirect s78 if no appeal in session', async () => {
+		it.each([
+			{
+				appealType: constants.APPEAL_ID.PLANNING_SECTION_78,
+				url: `/full-appeal/submit-appeal/enter-code/`
+			},
+			{
+				appealType: constants.APPEAL_ID.HOUSEHOLDER,
+				url: `/appeal-householder-decision/enter-code/`
+			}
+		])('should redirect: $appealType if no appeal in session', async ({ appealType, url }) => {
 			delete req.session.appeal;
 
 			getExistingAppeal.mockResolvedValue({
 				id: req.params.appealOrQuestionnaireId,
-				appealType: constants.APPEAL_ID.PLANNING_SECTION_78
+				appealType
 			});
 
 			req.baseUrl = '/document';
@@ -74,28 +83,7 @@ describe('controllers/document', () => {
 			await getDocument(req, res);
 
 			expect(req.session.loginRedirect).toBe(req.baseUrl + req.url);
-			expect(res.redirect).toHaveBeenCalledWith(
-				`/full-appeal/submit-appeal/enter-code/${req.params.appealOrQuestionnaireId}`
-			);
-		});
-
-		it('should redirect HAS if no appeal in session', async () => {
-			delete req.session.appeal;
-
-			getExistingAppeal.mockResolvedValue({
-				id: req.params.appealOrQuestionnaireId,
-				appealType: constants.APPEAL_ID.HOUSEHOLDER
-			});
-
-			req.baseUrl = '/document';
-			req.url = `/${req.params.appealOrQuestionnaireId}/doc-id`;
-
-			await getDocument(req, res);
-
-			expect(req.session.loginRedirect).toBe(req.baseUrl + req.url);
-			expect(res.redirect).toHaveBeenCalledWith(
-				`/appeal-householder-decision/enter-code/${req.params.appealOrQuestionnaireId}`
-			);
+			expect(res.redirect).toHaveBeenCalledWith(`${url}${req.params.appealOrQuestionnaireId}`);
 		});
 
 		it('should return an error if an error is thrown', async () => {

--- a/packages/forms-web-app/__tests__/unit/controllers/document.test.js
+++ b/packages/forms-web-app/__tests__/unit/controllers/document.test.js
@@ -1,3 +1,7 @@
+const { constants } = require('@pins/business-rules');
+
+const { getExistingAppeal } = require('../../../src/lib/appeals-api-wrapper');
+
 const mockFetchDocument = {
 	headers: {
 		get: (item) => {
@@ -22,6 +26,8 @@ jest.mock('../../../src/lib/documents-api-wrapper', () => ({
 		})
 }));
 
+jest.mock('../../../src/lib/appeals-api-wrapper');
+
 const { getDocument } = require('../../../src/controllers/document');
 const { mockReq, mockRes } = require('../mocks');
 
@@ -38,6 +44,8 @@ describe('controllers/document', () => {
 			...mockRes(),
 			set: jest.fn()
 		};
+
+		req.params.appealOrQuestionnaireId = req.session.appeal.id;
 	});
 
 	describe('getDocument', () => {
@@ -50,6 +58,44 @@ describe('controllers/document', () => {
 				'content-type': 'application/pdf'
 			});
 			expect(mockFetchDocument.body.pipe).toHaveBeenCalledWith(res);
+		});
+
+		it('should redirect s78 if no appeal in session', async () => {
+			delete req.session.appeal;
+
+			getExistingAppeal.mockResolvedValue({
+				id: req.params.appealOrQuestionnaireId,
+				appealType: constants.APPEAL_ID.PLANNING_SECTION_78
+			});
+
+			req.baseUrl = '/document';
+			req.url = `/${req.params.appealOrQuestionnaireId}/doc-id`;
+
+			await getDocument(req, res);
+
+			expect(req.session.loginRedirect).toBe(req.baseUrl + req.url);
+			expect(res.redirect).toHaveBeenCalledWith(
+				`/full-appeal/submit-appeal/enter-code/${req.params.appealOrQuestionnaireId}`
+			);
+		});
+
+		it('should redirect HAS if no appeal in session', async () => {
+			delete req.session.appeal;
+
+			getExistingAppeal.mockResolvedValue({
+				id: req.params.appealOrQuestionnaireId,
+				appealType: constants.APPEAL_ID.HOUSEHOLDER
+			});
+
+			req.baseUrl = '/document';
+			req.url = `/${req.params.appealOrQuestionnaireId}/doc-id`;
+
+			await getDocument(req, res);
+
+			expect(req.session.loginRedirect).toBe(req.baseUrl + req.url);
+			expect(res.redirect).toHaveBeenCalledWith(
+				`/appeal-householder-decision/enter-code/${req.params.appealOrQuestionnaireId}`
+			);
 		});
 
 		it('should return an error if an error is thrown', async () => {

--- a/packages/forms-web-app/src/controllers/common/enter-code.js
+++ b/packages/forms-web-app/src/controllers/common/enter-code.js
@@ -233,7 +233,13 @@ const postEnterCode = (views) => {
 		req.session.appeal = await getExistingAppeal(savedAppeal.appealId);
 
 		// redirect
-		if (req.session.appeal.state === 'SUBMITTED') {
+		if (req.session.loginRedirect) {
+			// before appeal.state check in case this is an attempt to download the appeal pdf
+			const redirect = req.session.loginRedirect;
+			delete req.session.loginRedirect;
+			res.redirect(redirect);
+			return;
+		} else if (req.session.appeal.state === 'SUBMITTED') {
 			return res.redirect(`/${views.APPEAL_ALREADY_SUBMITTED}`);
 		} else {
 			return res.redirect(`/${views.TASK_LIST}`);


### PR DESCRIPTION
## Ticket Number

<!-- Add the number from the Jira board -->

https://pins-ds.atlassian.net/browse/AAPD-974

## Description of change

This is intended as a temporary fix for appeal pdf downloads until appeal dashboard is complete

If a user tries to access a document from their appeal when the session is ended:

- create a save and return entry in mongo, without sending an email
- store doc url in session
- redirect to enter code page
- after user enters code redirect back to doc url - downloading file

## Checklist

<!-- Put an `x` in all the boxes that apply: -->

- [ ] Requires infrastructure changes
- [ ] I have updated the documentation accordingly
- [x] My commit history in this PR is linear
- [ ] New features have tests
- [ ] Breaking change (team conversation required)

## Important

Please do not merge from `main` (please only [rebase](https://github.com/foundry4/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
