### PR TITLE
fix(aapd-1041): catch errors for each submission to horizon

### DIFF
--- a/packages/appeals-service-api/__tests__/unit/lib/duration.test.js
+++ b/packages/appeals-service-api/__tests__/unit/lib/duration.test.js
@@ -1,0 +1,33 @@
+const { msToDurationString } = require('#lib/duration');
+
+describe('duration', () => {
+	describe('msToDurationString', () => {
+		const tests = [
+			{
+				ms: 0,
+				str: '0'
+			},
+			{
+				ms: 100,
+				str: '100ms'
+			},
+			{
+				ms: 10000,
+				str: '10s'
+			},
+			{
+				ms: 60_000,
+				str: '1min'
+			},
+			{
+				ms: 126_000,
+				str: '2mins 6s'
+			}
+		];
+
+		test.each(tests)('$ms', ({ ms, str }) => {
+			const got = msToDurationString(ms);
+			expect(got).toEqual(str);
+		});
+	});
+});

--- a/packages/appeals-service-api/src/configuration/config.js
+++ b/packages/appeals-service-api/src/configuration/config.js
@@ -72,7 +72,8 @@ let config = {
 	services: {
 		horizon: {
 			timeout: parseInt(process.env.SRV_HORIZON_TIMEOUT, 10) || 30 * 1000, // 30s by default
-			url: process.env.SRV_HORIZON_URL
+			url: process.env.SRV_HORIZON_URL,
+			logRequestTime: process.env.SRV_HORIZON_LOG_REQUEST_TIME === 'true'
 		},
 		notify: {
 			baseUrl: process.env.SRV_NOTIFY_BASE_URL,

--- a/packages/appeals-service-api/src/configuration/config.js
+++ b/packages/appeals-service-api/src/configuration/config.js
@@ -71,6 +71,7 @@ let config = {
 	},
 	services: {
 		horizon: {
+			timeout: parseInt(process.env.SRV_HORIZON_TIMEOUT, 10) || 30 * 1000, // 30s by default
 			url: process.env.SRV_HORIZON_URL
 		},
 		notify: {

--- a/packages/appeals-service-api/src/gateway/horizon-gateway.js
+++ b/packages/appeals-service-api/src/gateway/horizon-gateway.js
@@ -3,6 +3,7 @@ const axios = require('axios');
 const logger = require('../lib/logger');
 const { HorizonMapper } = require('../mappers/horizon-mapper');
 const HorizonResponseValue = require('../value-objects/horizon/horizon-response.value');
+const { msToDurationString } = require('#lib/duration');
 
 class HorizonGateway {
 	#horizonMapper;
@@ -208,10 +209,16 @@ class HorizonGateway {
 		logger.debug(body, `Sending ${descriptionOfRequest} request to ${url} with body`);
 
 		// set request timeout
-		options.timeout = config.services.horizon.timeout;
+		// TODO: enable this when we know how long requests need, document updates could be slow
+		// options.timeout = config.services.horizon.timeout;
 
 		try {
+			const requestStart = Date.now();
 			const responseJson = await axios.post(url, body, options);
+			if (config.services.horizon.logRequestTime) {
+				const requestTime = Date.now() - requestStart;
+				logger.info({ endpoint }, `Horizon request took ${msToDurationString(requestTime)}`);
+			}
 			return new HorizonResponseValue(responseJson.data.Envelope.Body, false);
 		} catch (error) {
 			if (error.response) {

--- a/packages/appeals-service-api/src/gateway/horizon-gateway.js
+++ b/packages/appeals-service-api/src/gateway/horizon-gateway.js
@@ -203,9 +203,12 @@ class HorizonGateway {
 	 * provided by Horizon. If no error occurred, `getValue()` will return the JSON response returned by
 	 * Horizon after digging down to `Envelope.Body` since this JSON path is common to all responses.
 	 */
-	async #makeRequestAndHandleAnyErrors(endpoint, body, descriptionOfRequest, options = null) {
+	async #makeRequestAndHandleAnyErrors(endpoint, body, descriptionOfRequest, options = {}) {
 		const url = `${config.services.horizon.url}/${endpoint}`;
 		logger.debug(body, `Sending ${descriptionOfRequest} request to ${url} with body`);
+
+		// set request timeout
+		options.timeout = config.services.horizon.timeout;
 
 		try {
 			const responseJson = await axios.post(url, body, options);

--- a/packages/appeals-service-api/src/lib/duration.js
+++ b/packages/appeals-service-api/src/lib/duration.js
@@ -1,0 +1,33 @@
+// ms in time units
+const SECONDS = 1000;
+const MINUTES = SECONDS * 60;
+
+/**
+ * Convert a ms duration into a readable string
+ *
+ * @param {number} ms
+ * @returns {string}
+ */
+function msToDurationString(ms) {
+	if (ms === 0) {
+		return '0';
+	}
+	if (ms < SECONDS) {
+		return `${ms}ms`;
+	}
+	const s = Math.floor((ms / SECONDS) % 60);
+	const mins = Math.floor((ms / MINUTES) % 60);
+
+	if (mins === 0) {
+		return `${s}s`;
+	}
+	const suffix = mins > 1 ? 'mins' : 'min';
+	if (s === 0) {
+		return `${mins}${suffix}`;
+	}
+	return `${mins}${suffix} ${s}s`;
+}
+
+module.exports = {
+	msToDurationString
+};

--- a/packages/appeals-service-api/src/services/back-office.service.js
+++ b/packages/appeals-service-api/src/services/back-office.service.js
@@ -42,58 +42,91 @@ class BackOfficeService {
 		}
 	}
 
+	/**
+	 * Submit appeals to Horizon
+	 *
+	 * @returns {Promise<{completed: number, uncompleted: number, failures: number, errors: Object<string, *>}>}
+	 */
 	async submitAppeals() {
 		try {
-			let completedAppealSubmissions = [];
-			let uncompletedAppealSubmissions = [];
+			const completedAppealSubmissions = [];
+			const uncompletedAppealSubmissions = [];
+			let failures = 0;
+			/** @type {Object<string, *>} */
+			const errors = {};
 			const backOfficeSubmissions = await this.#backOfficeRepository.getAppealsForSubmission();
 
 			for (const backOfficeSubmission of backOfficeSubmissions) {
-				const id = backOfficeSubmission.getAppealId();
-				logger.debug(`Attempting to submit appeal with ID ${id} to the back office`);
-				let appealToSubmitToBackOffice = await getAppeal(id);
-
-				const updatedBackOfficeSubmission = await this.#horizonService.submitAppeal(
-					appealToSubmitToBackOffice,
-					backOfficeSubmission
-				);
-
-				if (updatedBackOfficeSubmission.isComplete()) {
-					logger.debug('Appeal submission to back office is complete');
-					const appealAfterSubmissionToBackOffice = await saveAppealAsSubmittedToBackOffice(
-						appealToSubmitToBackOffice,
-						updatedBackOfficeSubmission.getAppealBackOfficeId()
-					);
-					await sendSubmissionReceivedEmailToLpa(appealAfterSubmissionToBackOffice);
-					completedAppealSubmissions.push(updatedBackOfficeSubmission.getId());
-				}
-				else if (updatedBackOfficeSubmission.someEntitiesHaveMaximumFailures()) {
-					await sendFailureToUploadToHorizonEmail(id);
-					await this.#forManualInterventionService.createAppealForManualIntervention(
-						updatedBackOfficeSubmission
-					);
-					await this.#backOfficeRepository.deleteAppealSubmission(
-						updatedBackOfficeSubmission.getId()
-					);
-				}
-				else {
-					logger.debug('Appeal submission to back office is incomplete');
-					uncompletedAppealSubmissions.push(updatedBackOfficeSubmission);
-				}
-
-				if (completedAppealSubmissions.length > 0) {
-					this.#backOfficeRepository.deleteAppealSubmissions(completedAppealSubmissions);
-				}
-
-				if (uncompletedAppealSubmissions.length > 0) {
-					await this.#backOfficeRepository.updateAppealSubmissions(uncompletedAppealSubmissions);
+				// try/catch for each submission so submissions aren't 'blocked' by a failing submission
+				try {
+					const { complete, failed, submission } = await this.submitAppeal(backOfficeSubmission);
+					if (complete) {
+						completedAppealSubmissions.push(submission.getId());
+					} else if (!failed) {
+						uncompletedAppealSubmissions.push(submission);
+					} else {
+						failures++;
+					}
+				} catch (error) {
+					logger.error(error, `error submitting ${backOfficeSubmission.getId()}`);
+					errors[backOfficeSubmission.getId()] = error;
 				}
 			}
-			return `Successfully processed appeals for submission. ${completedAppealSubmissions.length} completed. ${uncompletedAppealSubmissions.length} incomplete`;
+
+			if (completedAppealSubmissions.length > 0) {
+				await this.#backOfficeRepository.deleteAppealSubmissions(completedAppealSubmissions);
+			}
+
+			if (uncompletedAppealSubmissions.length > 0) {
+				await this.#backOfficeRepository.updateAppealSubmissions(uncompletedAppealSubmissions);
+			}
+			return {
+				completed: completedAppealSubmissions.length,
+				uncompleted: uncompletedAppealSubmissions.length,
+				failures,
+				errors
+			};
 		} catch (error) {
-			logger.debug(`Error processing: ${error}`);
+			logger.debug(error, `Error processing`);
 			throw error;
 		}
+	}
+
+	/**
+	 * @param {*} backOfficeSubmission
+	 * @returns {Promise<{complete: boolean, failed: boolean, submission: *}>}
+	 */
+	async submitAppeal(backOfficeSubmission) {
+		const id = backOfficeSubmission.getAppealId();
+		logger.debug(`Attempting to submit appeal with ID ${id} to the back office`);
+		let appealToSubmitToBackOffice = await getAppeal(id);
+
+		const updatedBackOfficeSubmission = await this.#horizonService.submitAppeal(
+			appealToSubmitToBackOffice,
+			backOfficeSubmission
+		);
+
+		let complete = false;
+		let failed = false;
+
+		if (updatedBackOfficeSubmission.isComplete()) {
+			const appealAfterSubmissionToBackOffice = await saveAppealAsSubmittedToBackOffice(
+				appealToSubmitToBackOffice,
+				updatedBackOfficeSubmission.getAppealBackOfficeId()
+			);
+			await sendSubmissionReceivedEmailToLpa(appealAfterSubmissionToBackOffice);
+			complete = true;
+		} else if (updatedBackOfficeSubmission.someEntitiesHaveMaximumFailures()) {
+			// after a certain number of failures, remove the submission from the queue and send a notification (email)
+			await sendFailureToUploadToHorizonEmail(id);
+			await this.#forManualInterventionService.createAppealForManualIntervention(
+				updatedBackOfficeSubmission
+			);
+			await this.#backOfficeRepository.deleteAppealSubmission(updatedBackOfficeSubmission.getId());
+			failed = true;
+		}
+		logger.debug({ complete, failed }, 'appeal submission status');
+		return { complete, failed, submission: updatedBackOfficeSubmission };
 	}
 
 	async getAppealForSubmission(id) {

--- a/packages/appeals-service-api/src/services/back-office.service.js
+++ b/packages/appeals-service-api/src/services/back-office.service.js
@@ -74,11 +74,21 @@ class BackOfficeService {
 			}
 
 			if (completedAppealSubmissions.length > 0) {
-				await this.#backOfficeRepository.deleteAppealSubmissions(completedAppealSubmissions);
+				try {
+					await this.#backOfficeRepository.deleteAppealSubmissions(completedAppealSubmissions);
+				} catch (error) {
+					logger.error(error, `error deleting completed submissions`);
+					errors['deletingCompleted'] = error;
+				}
 			}
 
 			if (uncompletedAppealSubmissions.length > 0) {
-				await this.#backOfficeRepository.updateAppealSubmissions(uncompletedAppealSubmissions);
+				try {
+					await this.#backOfficeRepository.updateAppealSubmissions(uncompletedAppealSubmissions);
+				} catch (error) {
+					logger.error(error, `error updating uncompleted submissions`);
+					errors['updatingUncompleted'] = error;
+				}
 			}
 			return {
 				completed: completedAppealSubmissions.length,


### PR DESCRIPTION
## Ticket Number

<!-- Add the number from the Jira board -->

https://pins-ds.atlassian.net/browse/AAPD-1041

## Description of change

Changes to the scheduled submission to Horizon:

- try/catch for each submission so appeals don't get 'stuck' behind a failing submission
- update/delete submissions after all have been processed rather than one at a time
- return complete/failed/error counts
- log complete/failed/error counts

## Checklist

<!-- Put an `x` in all the boxes that apply: -->

- [ ] Requires infrastructure changes
- [ ] I have updated the documentation accordingly
- [ ] My commit history in this PR is linear
- [ ] New features have tests
- [ ] Breaking change (team conversation required)

## Important

Please do not merge from `main` (please only [rebase](https://github.com/foundry4/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
