### PR TITLE
feat(aapd-987): make your appeals and decided appeals page display with no user found

### DIFF
--- a/packages/forms-web-app/src/controllers/appeals/your-appeals.js
+++ b/packages/forms-web-app/src/controllers/appeals/your-appeals.js
@@ -1,11 +1,21 @@
 const { getUserAppealsById, getUserByEmail } = require('../../lib/appeals-api-wrapper');
 const { mapToAppellantDashboardDisplayData } = require('../../lib/dashboard-functions');
 const { VIEW } = require('../../lib/views');
+const logger = require('../../lib/logger');
 
 exports.get = async (req, res) => {
-	const { email } = req.session.appeal;
-	const user = await getUserByEmail(email, true);
-	let appeals = await getUserAppealsById(user.id);
-	appeals = appeals.map(mapToAppellantDashboardDisplayData);
-	res.render(VIEW.APPEALS.YOUR_APPEALS, { toDoAppeals: appeals, waitingForReviewAppeals: appeals });
+	const email = req.session.appeal?.email;
+	let viewContext = {};
+	try {
+		const user = await getUserByEmail(email, true);
+		let appeals = await getUserAppealsById(user.id);
+		if (appeals?.length > 0) {
+			appeals = appeals.map(mapToAppellantDashboardDisplayData);
+			viewContext = { toDoAppeals: appeals, waitingForReviewAppeals: appeals };
+		}
+	} catch (error) {
+		logger.error(`Failed to get user appeals: ${error}`);
+	} finally {
+		res.render(VIEW.APPEALS.YOUR_APPEALS, viewContext);
+	}
 };

--- a/packages/forms-web-app/src/controllers/appeals/your-appeals/decided-appeals.js
+++ b/packages/forms-web-app/src/controllers/appeals/your-appeals/decided-appeals.js
@@ -1,11 +1,21 @@
 const { getUserByEmail, getUserAppealsById } = require('../../../lib/appeals-api-wrapper');
 const { mapToAppellantDashboardDisplayData } = require('../../../lib/dashboard-functions');
 const { VIEW } = require('../../../lib/views');
+const logger = require('../../../lib/logger');
 
 exports.get = async (req, res) => {
-	const { email } = req.session.appeal;
-	const user = await getUserByEmail(email, true);
-	let appeals = await getUserAppealsById(user.id);
-	appeals = appeals.map(mapToAppellantDashboardDisplayData).filter((item) => item.decisionOutcome);
-	res.render(VIEW.YOUR_APPEALS.DECIDED_APPEALS, { appeals });
+	const email = req.session.appeal?.email;
+	let viewContext = {};
+	try {
+		const user = await getUserByEmail(email, true);
+		let appeals = await getUserAppealsById(user.id);
+		if (appeals?.length > 0) {
+			appeals = appeals.map(mapToAppellantDashboardDisplayData);
+			viewContext = { appeals };
+		}
+	} catch (error) {
+		logger.error(`Failed to get user decided appeals: ${error}`);
+	} finally {
+		res.render(VIEW.YOUR_APPEALS.DECIDED_APPEALS, viewContext);
+	}
 };


### PR DESCRIPTION


## Ticket Number

https://pins-ds.atlassian.net/browse/AAPD-987

## Description of change

Allow your appeals and decided appeals page display with no users in session to allow testing

## Checklist

<!-- Put an `x` in all the boxes that apply: -->

- [ ] Requires infrastructure changes
- [ ] I have updated the documentation accordingly
- [x] My commit history in this PR is linear
- [ ] New features have tests
- [ ] Breaking change (team conversation required)

## Important

Please do not merge from `main` (please only [rebase](https://github.com/foundry4/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
