### PR TITLE
chore(local-dev): setup docker profiles and mock services

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,9 +19,25 @@ run:
 		${CMD}
 .PHONY: run
 
+# all services
 serve:
-	docker-compose up
+	docker compose --profile all -f docker-compose.yml -f docker-compose.full.yml up
 .PHONY: serve
+
+# all services slimmed down by mocking some more services
+slim:
+	docker compose --profile all -f docker-compose.yml -f docker-compose.slim.yml up
+.PHONY: slim
+
+# only services required for web-comment
+web-comment:
+	docker compose --profile comment -f docker-compose.yml -f docker-compose.slim.yml up
+.PHONY: web-comment
+
+# only services required for appeals/forms-web-app
+appeals:
+	docker compose --profile appeals -f docker-compose.yml -f docker-compose.slim.yml up
+.PHONY: appeals
 
 uninstall:
 	rm -Rf node_modules

--- a/README.md
+++ b/README.md
@@ -100,13 +100,37 @@ To run the development stack, you can run this in Docker Compose. This will
 run all services, including databases, and pre-fill all stubbed data into the
 databases.
 
-To run the whole stack:
+To run the whole stack
+
+With make:
 
 ```
 make serve
 ```
 
-You have to manually populate the LPA database - once the server is running go to the `/packages/appeals-service-api/data` directory and run: `curl -X POST -d @lpa-list.csv http://localhost:3000/api/v1/local-planning-authorities`
+With npm: 
+
+```
+npm run docker:all
+```
+
+You can run less services at once using a combination of profiles and compose files
+
+see the following make/equivalent npm scripts
+
+```
+make slim
+make appeals
+make web-comment
+```
+
+```
+npm run docker:slim
+npm run docker:appeals
+npm run docker:comment
+```
+
+You can add more LPAs to the db - once the server is running go to the `/packages/appeals-service-api/data` directory and run: `curl -X POST -d @lpa-list.csv http://localhost:3000/api/v1/local-planning-authorities`
 
 Then go to [localhost:9003/before-you-start](http://localhost:9003/before-you-start) (forms-web-app) or
 [localhost:3000](http://localhost:3000) (appeals-service-api)

--- a/dev/mock-clamav/index.js
+++ b/dev/mock-clamav/index.js
@@ -1,0 +1,51 @@
+const net = require('net');
+
+/**
+ * @param {net.Socket} socket
+ */
+const server = net.createServer((socket) => {
+	socket.on('data', (data) => {
+		try {
+			const command = data.toString().trim();
+
+			if (!command) {
+				return;
+			}
+			// console.log(command);
+
+			switch (command) {
+				case 'PING':
+					console.log(command);
+					socket.write('PONG');
+					break;
+				case 'nVERSION':
+					console.log(command);
+					socket.write('mock clam av');
+					socket.end();
+					break;
+				default: {
+					console.log('checking file');
+					socket.write(`: OK`);
+				}
+			}
+		} catch (err) {
+			console.log(err);
+			socket.end();
+		}
+	});
+
+	socket.on('error', (err) => {
+		console.log(err, 'error');
+		socket.end();
+	});
+
+	socket.on('end', () => {
+		console.log('client disconnected');
+		socket.end();
+	});
+});
+
+const PORT = process.env.PORT || 3310;
+server.listen(PORT, () => {
+	console.log(`listening on port: ${PORT}`);
+});

--- a/dev/mock-clamav/package.json
+++ b/dev/mock-clamav/package.json
@@ -1,0 +1,15 @@
+{
+	"name": "mock-clamav",
+	"version": "0.0.0",
+	"description": "ClamAV mock",
+	"main": "index.js",
+	"scripts": {
+		"start": "node index.js",
+		"start:dev": "nodemon index.js"
+	},
+	"author": "",
+	"license": "ISC",
+	"devDependencies": {
+		"nodemon": "^3.0.2"
+	}
+}

--- a/dev/mock-pdf/index.js
+++ b/dev/mock-pdf/index.js
@@ -1,0 +1,51 @@
+const http = require('http');
+const url = require('url');
+
+/**
+ * @type {Object.<string, function>}
+ */
+const routes = {
+	/**
+	 * @param {http.IncomingMessage} req
+	 * @param {http.ServerResponse} res
+	 */
+	'/': (req, res) => {
+		console.log(`handled: ${req.method}: ${req.url}`);
+		res.writeHead(200, { 'Content-Type': 'text/plain' });
+		res.end('Home');
+	}
+};
+
+/**
+ * @param {http.IncomingMessage} req
+ * @param {http.ServerResponse} res
+ */
+const server = http.createServer((req, res) => {
+	try {
+		if (typeof req.url !== 'string') {
+			throw new Error('bad url');
+		}
+
+		const parsedUrl = url.parse(req.url, true);
+
+		console.log(parsedUrl.pathname);
+
+		if (parsedUrl.pathname && routes[parsedUrl.pathname]) {
+			return routes[parsedUrl.pathname](req, res);
+		}
+
+		console.log(`catch all: ${req.method}: ${req.url}`);
+		res.writeHead(200, { 'Content-Type': 'text/plain' });
+		res.end('Test');
+	} catch (err) {
+		console.error(err, `error for: ${req.method}: ${req.url}`);
+		res.writeHead(500, { 'Content-Type': 'text/plain' });
+		res.end('Internal Server Error');
+	}
+});
+
+const PORT = process.env.PORT || 3003;
+
+server.listen(PORT, () => {
+	console.log(`listening on port: ${PORT}`);
+});

--- a/dev/mock-pdf/package.json
+++ b/dev/mock-pdf/package.json
@@ -1,0 +1,15 @@
+{
+	"name": "mock-pdf",
+	"version": "0.0.0",
+	"description": "Notify pdf",
+	"main": "index.js",
+	"scripts": {
+		"start": "node index.js",
+		"start:dev": "nodemon index.js"
+	},
+	"author": "",
+	"license": "ISC",
+	"devDependencies": {
+		"nodemon": "^3.0.2"
+	}
+}

--- a/docker-compose.full.yml
+++ b/docker-compose.full.yml
@@ -1,0 +1,28 @@
+# Port ranges (by convention):
+#  - API: 3000-3999
+#  - Services: 4000-4999
+#  - Mocks: 5000-5999
+#  - Documentation: 7000-7999
+#  - Websites: 9000-9999
+#
+
+version: '3.7'
+
+services:
+  clamav-server:
+    profiles: ['all', 'appeals']
+    image: 'clamav/clamav:stable'
+    ports:
+      - 3310:3310
+    restart: unless-stopped
+
+  pdf-service-api:
+    profiles: ['all', 'appeals']
+    build:
+      context: .
+      dockerfile: ./packages/pdf-service-api/Dockerfile
+    environment:
+      SERVER_SHOW_ERRORS: 'true'
+      LOGGER_LEVEL: 'debug'
+    ports:
+      - 3003:3000

--- a/docker-compose.slim.yml
+++ b/docker-compose.slim.yml
@@ -1,0 +1,34 @@
+# Port ranges (by convention):
+#  - API: 3000-3999
+#  - Services: 4000-4999
+#  - Mocks: 5000-5999
+#  - Documentation: 7000-7999
+#  - Websites: 9000-9999
+#
+
+version: '3.7'
+
+services:
+  clamav-server:
+    profiles: ['all', 'appeals']
+    image: node:18-alpine
+    ports:
+      - 3310:3310
+    working_dir: /opt/mock-clamav
+    volumes:
+      # mount the root node_modules for shared packages
+      - ./node_modules:/opt/node_modules
+      - ./dev/mock-clamav:/opt/mock-clamav
+    command: npm run start
+
+  pdf-service-api:
+    profiles: ['all', 'appeals']
+    image: node:18-alpine
+    ports:
+      - 3003:3003
+    working_dir: /opt/mock-pdf
+    volumes:
+      # mount the root node_modules for shared packages
+      - ./node_modules:/opt/node_modules
+      - ./dev/mock-pdf:/opt/mock-pdf
+    command: npm run start

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,29 +8,12 @@
 
 version: '3.7'
 services:
-  pdf-service-api:
-    build:
-      context: .
-      dockerfile: ./packages/pdf-service-api/Dockerfile
-    environment:
-      SERVER_SHOW_ERRORS: 'true'
-      LOGGER_LEVEL: 'debug'
-    ports:
-      - 3003:3000
-
-  clamav-server:
-    image: 'clamav/clamav:stable'
-    ports:
-      - 3310:3310
-    restart: unless-stopped
-
   clamav-rest-server:
     image: node:18-alpine
+    profiles: ['all', 'appeals']
     ports:
       - 3100:3000
     depends_on:
-      - clamav-server
-    links:
       - clamav-server
     environment:
       CLAMAV_HOST: clamav-server
@@ -45,6 +28,7 @@ services:
     command: npm run start:dev
 
   appeals-service-api:
+    profiles: ['all', 'appeals', 'comment']
     image: node:18-alpine
     environment:
       APP_APPEALS_BASE_URL: http://forms-web-app:9003
@@ -95,11 +79,6 @@ services:
       # node debugger
       # - 9229:9229
     working_dir: /opt/app
-    links:
-      - document-service-api
-      - mock-horizon
-      - mock-notify
-      - mongodb
     depends_on:
       - appeals-service-api-data
       - document-service-api
@@ -118,6 +97,7 @@ services:
     # command: npm run start:dev:debug
 
   document-service-api: &document-service
+    profiles: ['all', 'appeals']
     image: node:18-alpine
     environment:
       BLOB_STORAGE_CONNECTION_STRING: DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;BlobEndpoint=http://blob-storage:10000/devstoreaccount1;QueueEndpoint=http://blob-storage:10001/devstoreaccount1;
@@ -131,9 +111,6 @@ services:
     ports:
       - 3001:3000
     working_dir: /opt/app
-    links:
-      - mongodb
-      - blob-storage
     depends_on:
       - mongodb
     volumes:
@@ -145,6 +122,7 @@ services:
     command: npm run start:dev
 
   forms-web-app:
+    profiles: ['all', 'appeals']
     image: node:18-alpine
     environment:
       CLAM_AV_HOST: http://clamav-rest-server:3000
@@ -160,7 +138,7 @@ services:
       # please override this locally if using not using localhost or ip address to browse the site in dev.
       SUBDOMAIN_OFFSET: 0
       USE_SECURE_SESSION_COOKIES: 'false'
-      PDF_SERVICE_API_URL: 'http://pdf-service-api:3000'
+      PDF_SERVICE_API_URL: 'http://pdf-service-api:3003'
       LOGGER_LEVEL: 'debug'
       PINS_FEATURE_FLAG_AZURE_CONNECTION_STRING:
       FEATURE_FLAGS_SETTING: 'ALL_ON'
@@ -170,15 +148,11 @@ services:
       # node debugger
       # - 9229:9229
     working_dir: /opt/app
-    links:
-      - appeals-service-api
-      - document-service-api
-      - mongodb
-      - pdf-service-api
     depends_on:
       - appeals-service-api
       - document-service-api
       - mongodb
+      - clamav-rest-server
       - pdf-service-api
     volumes:
       # mount the root node_modules for shared packages
@@ -191,6 +165,7 @@ services:
     # command: npm run start:dev:debug
 
   web-comment:
+    profiles: ['all', 'comment']
     image: node:18-alpine
     environment:
       LOGGER_LEVEL: 'debug'
@@ -200,8 +175,6 @@ services:
       # node debugger
       # - 9229:9229
     working_dir: /opt/app
-    links:
-      - appeals-service-api
     depends_on:
       - appeals-service-api
     volumes:
@@ -216,11 +189,10 @@ services:
 
   # Populate the database with data - one instance per service
   appeals-service-api-data:
+    profiles: ['all', 'appeals', 'comment']
     build:
       context: .
       dockerfile: ./dev/data/Dockerfile
-    links:
-      - mongodb
     depends_on:
       - mongodb
     volumes:
@@ -235,6 +207,7 @@ services:
 
   # Mocked services
   mock-horizon:
+    profiles: ['all', 'appeals']
     # @todo generate from Swagger Docs
     build:
       context: .
@@ -243,6 +216,7 @@ services:
       - 5000:3000
 
   mock-notify:
+    profiles: ['all', 'appeals', 'comment']
     build:
       context: .
       dockerfile: ./dev/mock-notify/Dockerfile
@@ -250,6 +224,7 @@ services:
       - 5001:3000
 
   docs-horizon:
+    profiles: ['all', 'appeals']
     image: swaggerapi/swagger-ui
     environment:
       SWAGGER_JSON: /app/swagger.yaml
@@ -262,6 +237,7 @@ services:
 
   # Third-party services
   blob-storage:
+    profiles: ['all', 'appeals', 'comment']
     image: mcr.microsoft.com/azure-storage/azurite:3.26.0
     ports:
       - 4002:10000
@@ -270,11 +246,17 @@ services:
       - ./tmp/blob-storage:/data
 
   mongodb:
+    profiles: ['all', 'appeals', 'comment']
     image: mongo:3.6.21
     ports:
       - 4000:27017
+    # deploy:
+    #   resources:
+    #     limits:
+    #       memory: 250M
 
   mssql:
+    profiles: ['all', 'appeals', 'comment']
     image: mcr.microsoft.com/azure-sql-edge:latest
     container_name: appeals-mssql
     cap_add: ['SYS_PTRACE']
@@ -289,11 +271,12 @@ services:
       - ./dev/mssql.conf:/var/opt/mssql/mssql.conf
       - ./tmp/mssql-data:/var/opt/mssql/data
 
-  mongoExpress:
-    image: mongo-express
-    environment:
-      - ME_CONFIG_MONGODB_SERVER=mongodb
-    depends_on:
-      - mongodb
-    ports:
-      - '5003:8081'
+  # do people use this?
+  # mongoExpress:
+  #   image: mongo-express
+  #   environment:
+  #     - ME_CONFIG_MONGODB_SERVER=mongodb
+  #   depends_on:
+  #     - mongodb
+  #   ports:
+  #     - '5003:8081'

--- a/package-lock.json
+++ b/package-lock.json
@@ -67,6 +67,86 @@
 				"eslint": "^8.50.0"
 			}
 		},
+		"dev/mock-clamav": {
+			"version": "0.0.0",
+			"license": "ISC",
+			"devDependencies": {
+				"nodemon": "^3.0.2"
+			}
+		},
+		"dev/mock-clamav/node_modules/lru-cache": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+			"integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+			"dev": true,
+			"dependencies": {
+				"yallist": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"dev/mock-clamav/node_modules/nodemon": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/nodemon/-/nodemon-3.0.2.tgz",
+			"integrity": "sha512-9qIN2LNTrEzpOPBaWHTm4Asy1LxXLSickZStAQ4IZe7zsoIpD/A7LWxhZV3t4Zu352uBcqVnRsDXSMR2Sc3lTA==",
+			"dev": true,
+			"dependencies": {
+				"chokidar": "^3.5.2",
+				"debug": "^4",
+				"ignore-by-default": "^1.0.1",
+				"minimatch": "^3.1.2",
+				"pstree.remy": "^1.1.8",
+				"semver": "^7.5.3",
+				"simple-update-notifier": "^2.0.0",
+				"supports-color": "^5.5.0",
+				"touch": "^3.1.0",
+				"undefsafe": "^2.0.5"
+			},
+			"bin": {
+				"nodemon": "bin/nodemon.js"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/nodemon"
+			}
+		},
+		"dev/mock-clamav/node_modules/semver": {
+			"version": "7.5.4",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+			"integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
+			"dev": true,
+			"dependencies": {
+				"lru-cache": "^6.0.0"
+			},
+			"bin": {
+				"semver": "bin/semver.js"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"dev/mock-clamav/node_modules/simple-update-notifier": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/simple-update-notifier/-/simple-update-notifier-2.0.0.tgz",
+			"integrity": "sha512-a2B9Y0KlNXl9u/vsW6sTIu9vGEpfKu2wRV6l1H3XEas/0gUIzGzBoP/IouTcUQbm9JWZLH3COxyn03TYlFax6w==",
+			"dev": true,
+			"dependencies": {
+				"semver": "^7.5.3"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"dev/mock-clamav/node_modules/yallist": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+			"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+			"dev": true
+		},
 		"dev/mock-horizon": {
 			"version": "0.0.0",
 			"license": "ISC",
@@ -81,6 +161,86 @@
 				"json-server": "^0.16.2",
 				"notifications-node-client": "^5.0.0"
 			}
+		},
+		"dev/mock-pdf": {
+			"version": "0.0.0",
+			"license": "ISC",
+			"devDependencies": {
+				"nodemon": "^3.0.2"
+			}
+		},
+		"dev/mock-pdf/node_modules/lru-cache": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+			"integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+			"dev": true,
+			"dependencies": {
+				"yallist": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"dev/mock-pdf/node_modules/nodemon": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/nodemon/-/nodemon-3.0.2.tgz",
+			"integrity": "sha512-9qIN2LNTrEzpOPBaWHTm4Asy1LxXLSickZStAQ4IZe7zsoIpD/A7LWxhZV3t4Zu352uBcqVnRsDXSMR2Sc3lTA==",
+			"dev": true,
+			"dependencies": {
+				"chokidar": "^3.5.2",
+				"debug": "^4",
+				"ignore-by-default": "^1.0.1",
+				"minimatch": "^3.1.2",
+				"pstree.remy": "^1.1.8",
+				"semver": "^7.5.3",
+				"simple-update-notifier": "^2.0.0",
+				"supports-color": "^5.5.0",
+				"touch": "^3.1.0",
+				"undefsafe": "^2.0.5"
+			},
+			"bin": {
+				"nodemon": "bin/nodemon.js"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/nodemon"
+			}
+		},
+		"dev/mock-pdf/node_modules/semver": {
+			"version": "7.5.4",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+			"integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
+			"dev": true,
+			"dependencies": {
+				"lru-cache": "^6.0.0"
+			},
+			"bin": {
+				"semver": "bin/semver.js"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"dev/mock-pdf/node_modules/simple-update-notifier": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/simple-update-notifier/-/simple-update-notifier-2.0.0.tgz",
+			"integrity": "sha512-a2B9Y0KlNXl9u/vsW6sTIu9vGEpfKu2wRV6l1H3XEas/0gUIzGzBoP/IouTcUQbm9JWZLH3COxyn03TYlFax6w==",
+			"dev": true,
+			"dependencies": {
+				"semver": "^7.5.3"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"dev/mock-pdf/node_modules/yallist": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+			"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+			"dev": true
 		},
 		"dev/release-util": {
 			"version": "1.0.0",
@@ -18090,12 +18250,20 @@
 			"resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
 			"integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A=="
 		},
+		"node_modules/mock-clamav": {
+			"resolved": "dev/mock-clamav",
+			"link": true
+		},
 		"node_modules/mock-horizon": {
 			"resolved": "dev/mock-horizon",
 			"link": true
 		},
 		"node_modules/mock-notify": {
 			"resolved": "dev/mock-notify",
+			"link": true
+		},
+		"node_modules/mock-pdf": {
+			"resolved": "dev/mock-pdf",
 			"link": true
 		},
 		"node_modules/modify-values": {

--- a/package.json
+++ b/package.json
@@ -13,6 +13,10 @@
 		"test-packages/*"
 	],
 	"scripts": {
+		"docker:all": "docker compose --profile all -f docker-compose.yml -f docker-compose.full.yml up",
+		"docker:slim": "docker compose --profile all -f docker-compose.yml -f docker-compose.slim.yml up",
+		"docker:appeals": "docker compose --profile comment -f docker-compose.yml -f docker-compose.slim.yml up",
+		"docker:comment": "docker compose --profile appeals -f docker-compose.yml -f docker-compose.slim.yml up",
 		"commit": "cz",
 		"commitlint": "commitlint --from=$(git log origin/main..$(git rev-parse HEAD) --pretty=format:\"%H\" | tail -n 1)",
 		"db:migrate:dev": "npm run db:migrate:dev --workspace appeals-service-api",


### PR DESCRIPTION
## Description of change

**Profiles:**
Setup 3 docker profiles and a make script to run them
- all
- appeals (forms web app and dependencies)
- comment  (web comment and dependencies, guessed with these having not worked on it)

**Service Mocks**
Mock clam av and pdf service to have slimmer option for running locally
Use these mocks with docker-compose.slim.yml

## Checklist

<!-- Put an `x` in all the boxes that apply: -->

- [ ] Requires infrastructure changes
- [ ] I have updated the documentation accordingly
- [x] My commit history in this PR is linear
- [ ] New features have tests
- [ ] Breaking change (team conversation required)

## Important

Please do not merge from `main` (please only [rebase](https://github.com/foundry4/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
