### PR TITLE
fix(aapd-938): fix lpaUser decided list order

### DIFF
--- a/packages/common/src/lib/appeal-sorting.js
+++ b/packages/common/src/lib/appeal-sorting.js
@@ -1,0 +1,45 @@
+/**
+ * @typedef {import('appeals-service-api').Api.AppealCaseWithAppellant} AppealCaseWithAppellant
+ */
+
+/**
+ * @typedef {function(AppealCaseWithAppellant, AppealCaseWithAppellant): number} AppealSorter
+ */
+
+// /** @type {AppealSorter} */
+// const sortByInterestedPartyRepsDueDate = sortByDateFieldDesc('interestedPartyRepsDueDate');
+
+/** @type {AppealSorter} */
+const sortByCaseReference = (a, b) => {
+	return a.caseReference.localeCompare(b.caseReference, undefined, { numeric: true });
+};
+
+/** @type {AppealSorter} */
+const sortByCaseDecisionDate = sortByDateFieldDesc('caseDecisionDate');
+
+/**
+ * @param {string} field
+ * @returns {function(any, any): number}
+ */
+function sortByDateFieldDesc(field) {
+	return (a, b) => {
+		const aSet = typeof a[field] === 'string';
+		const bSet = typeof b[field] === 'string';
+		if (aSet && !bSet) {
+			return -1;
+		}
+		if (!aSet && bSet) {
+			return 1;
+		}
+		if (!aSet && !bSet) {
+			return 0;
+		}
+		return new Date(b[field]).getTime() - new Date(a[field]).getTime();
+	};
+}
+
+module.exports = {
+	sortByCaseReference,
+	sortByCaseDecisionDate,
+	sortByDateFieldDesc
+};

--- a/packages/common/src/lib/appeal-sorting.test.js
+++ b/packages/common/src/lib/appeal-sorting.test.js
@@ -1,0 +1,61 @@
+const { sortByDateFieldDesc } = require('./appeal-sorting');
+
+describe('appealSorting', () => {
+	describe('sortByDateFieldDesc', () => {
+		/**
+		 * @param {string} field
+		 * @param {number} day
+		 * @returns {Object<string, string>}
+		 */
+		function objWithDateField(field, day) {
+			return {
+				[field]: `2023-12-${day}T10:00Z`
+			};
+		}
+		const tests = [
+			{
+				name: 'empty',
+				field: 'empty',
+				list: [],
+				want: []
+			},
+			{
+				name: 'all present',
+				field: 'caseDecisionDate',
+				list: [
+					objWithDateField('caseDecisionDate', 15),
+					objWithDateField('caseDecisionDate', 20),
+					objWithDateField('caseDecisionDate', 18),
+					objWithDateField('caseDecisionDate', 12)
+				],
+				want: [
+					objWithDateField('caseDecisionDate', 20),
+					objWithDateField('caseDecisionDate', 18),
+					objWithDateField('caseDecisionDate', 15),
+					objWithDateField('caseDecisionDate', 12)
+				]
+			},
+			{
+				name: 'some missing',
+				field: 'caseDecisionDate',
+				list: [
+					objWithDateField('caseDecisionDate', 15),
+					{ case: 1 },
+					objWithDateField('caseDecisionDate', 18),
+					objWithDateField('caseDecisionDate', 12)
+				],
+				want: [
+					objWithDateField('caseDecisionDate', 18),
+					objWithDateField('caseDecisionDate', 15),
+					objWithDateField('caseDecisionDate', 12),
+					{ case: 1 }
+				]
+			}
+		];
+
+		test.each(tests)('$name', ({ field, list, want }) => {
+			const got = list.sort(sortByDateFieldDesc(field));
+			expect(got).toEqual(want);
+		});
+	});
+});

--- a/packages/forms-web-app/src/controllers/lpa-dashboard/decided-appeals.js
+++ b/packages/forms-web-app/src/controllers/lpa-dashboard/decided-appeals.js
@@ -1,6 +1,7 @@
 const { getLPAUserFromSession } = require('../../services/lpa-user.service');
 const { getDecidedAppealsCaseDataV2 } = require('../../lib/appeals-api-wrapper');
 const { mapToLPADecidedData } = require('../../lib/dashboard-functions');
+const { sortByCaseDecisionDate } = require('@pins/common/src/lib/appeal-sorting');
 
 const {
 	VIEW: {
@@ -15,7 +16,7 @@ const getDecidedAppeals = async (req, res) => {
 
 	const decidedAppeals = appealsCaseData.map(mapToLPADecidedData);
 
-	decidedAppeals.sort((a, b) => a.caseDecisionDate - b.caseDecisionDate);
+	decidedAppeals.sort(sortByCaseDecisionDate);
 
 	return res.render(DECIDED_APPEALS, {
 		lpaName: user.lpaName,


### PR DESCRIPTION
## Ticket Number

https://pins-ds.atlassian.net/browse/AAPD-938

## Description of change

Add sort-appeal functions to common package, uses these in sorting lpaUser decided dashboard

## Checklist

<!-- Put an `x` in all the boxes that apply: -->

- [ ] Requires infrastructure changes
- [ ] I have updated the documentation accordingly
- [ ] My commit history in this PR is linear
- [ ] New features have tests
- [ ] Breaking change (team conversation required)

## Important

Please do not merge from `main` (please only [rebase](https://github.com/foundry4/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
