### PR TITLE
feat(aapd-1187): add data model fields to appealcase and schema

### DIFF
--- a/packages/appeals-service-api/src/db/migrations/20240112150421_view_appeal_new_fields/migration.sql
+++ b/packages/appeals-service-api/src/db/migrations/20240112150421_view_appeal_new_fields/migration.sql
@@ -1,0 +1,33 @@
+BEGIN TRY
+
+BEGIN TRAN;
+
+-- AlterTable
+ALTER TABLE [dbo].[AppealCase] ADD [appellantCasePublished] BIT NOT NULL CONSTRAINT [AppealCase_appellantCasePublished_df] DEFAULT 0,
+[appellantFinalCommentsSubmitted] BIT NOT NULL CONSTRAINT [AppealCase_appellantFinalCommentsSubmitted_df] DEFAULT 0,
+[appellantFirstName] NVARCHAR(1000) NOT NULL CONSTRAINT [AppealCase_appellantFirstName_df] DEFAULT '',
+[appellantLastName] NVARCHAR(1000) NOT NULL CONSTRAINT [AppealCase_appellantLastName_df] DEFAULT '',
+[appellantProofEvidencePublished] BIT NOT NULL CONSTRAINT [AppealCase_appellantProofEvidencePublished_df] DEFAULT 0,
+[appellantProofEvidenceSubmitted] BIT NOT NULL CONSTRAINT [AppealCase_appellantProofEvidenceSubmitted_df] DEFAULT 0,
+[caseDecisionOutcome] NVARCHAR(1000),
+[interestedPartyCommentsPublished] BIT NOT NULL CONSTRAINT [AppealCase_interestedPartyCommentsPublished_df] DEFAULT 0,
+[lpaFinalCommentsPublished] BIT NOT NULL CONSTRAINT [AppealCase_lpaFinalCommentsPublished_df] DEFAULT 0,
+[lpaProofEvidencePublished] BIT NOT NULL CONSTRAINT [AppealCase_lpaProofEvidencePublished_df] DEFAULT 0,
+[lpaProofEvidenceSubmitted] BIT NOT NULL CONSTRAINT [AppealCase_lpaProofEvidenceSubmitted_df] DEFAULT 0,
+[lpaQuestionnairePublished] BIT NOT NULL CONSTRAINT [AppealCase_lpaQuestionnairePublished_df] DEFAULT 0,
+[lpaQuestionnaireSubmitted] BIT NOT NULL CONSTRAINT [AppealCase_lpaQuestionnaireSubmitted_df] DEFAULT 0,
+[procedure] NVARCHAR(1000),
+[rule6StatementPublished] BIT NOT NULL CONSTRAINT [AppealCase_rule6StatementPublished_df] DEFAULT 0;
+
+COMMIT TRAN;
+
+END TRY
+BEGIN CATCH
+
+IF @@TRANCOUNT > 0
+BEGIN
+    ROLLBACK TRAN;
+END;
+THROW
+
+END CATCH

--- a/packages/appeals-service-api/src/db/schema.prisma
+++ b/packages/appeals-service-api/src/db/schema.prisma
@@ -207,8 +207,23 @@ model AppealCase {
   LPAProofsForwarded        DateTime?
   LPAProofsSubmitted        DateTime?
 
-  // unconfirmed
-  outcome String?
+  // viewAppeal epic aapd-1187
+  outcome                          String?
+  procedure                        String?
+  appellantFirstName               String  @default("")
+  appellantLastName                String  @default("")
+  appellantCasePublished           Boolean @default(false)
+  lpaQuestionnairePublished        Boolean @default(false)
+  lpaQuestionnaireSubmitted        Boolean @default(false)
+  rule6StatementPublished          Boolean @default(false)
+  interestedPartyCommentsPublished Boolean @default(false)
+  appellantFinalCommentsSubmitted  Boolean @default(false)
+  lpaFinalCommentsPublished        Boolean @default(false)
+  appellantProofEvidenceSubmitted  Boolean @default(false)
+  appellantProofEvidencePublished  Boolean @default(false)
+  lpaProofEvidenceSubmitted        Boolean @default(false)
+  lpaProofEvidencePublished        Boolean @default(false)
+  caseDecisionOutcome              String?
 
   // todo: there are many more fields! waiting on the model definition
 


### PR DESCRIPTION
## Ticket Number

https://pins-ds.atlassian.net/browse/AAPD-1187

## Description of change

Added data model fields to prisma schema

## Checklist

<!-- Put an `x` in all the boxes that apply: -->

- [ ] Requires infrastructure changes
- [ ] I have updated the documentation accordingly
- [X] My commit history in this PR is linear
- [ ] New features have tests
- [ ] Breaking change (team conversation required)

## Important

Please do not merge from `main` (please only [rebase](https://github.com/foundry4/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
