### PR TITLE
fix(api): filter out submission drafts not found in the db

### DIFF
--- a/packages/appeals-service-api/src/routes/v2/users/_id/appeals/service.js
+++ b/packages/appeals-service-api/src/routes/v2/users/_id/appeals/service.js
@@ -44,7 +44,11 @@ async function getAppealsForUser(userId) {
 	);
 
 	// return all cases + drafts
-	return [...cases, ...draftSubmissions];
+	return [
+		...cases,
+		// any drafts that aren't found in cosmos will be null, filter those outs
+		...draftSubmissions.filter(filterNotNull)
+	];
 }
 
 module.exports = {


### PR DESCRIPTION
## Ticket Number

<!-- Add the number from the Jira board -->

https://pins-ds.atlassian.net/browse/AAPD-

## Description of change

We noticed on dev/test that an appeal was coming back `null` because there was a SQL entry but no corresponding Cosmos entry.

## Checklist

<!-- Put an `x` in all the boxes that apply: -->

- [ ] Requires infrastructure changes
- [ ] I have updated the documentation accordingly
- [ ] My commit history in this PR is linear
- [ ] New features have tests
- [ ] Breaking change (team conversation required)

## Important

Please do not merge from `main` (please only [rebase](https://github.com/foundry4/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
