### PR TITLE
fix(aapd-939): use shared function for decision colour

### DIFF
--- a/packages/business-rules/src/utils/decision-outcome.js
+++ b/packages/business-rules/src/utils/decision-outcome.js
@@ -1,0 +1,21 @@
+const { DECISION_OUTCOME } = require('../constants');
+
+/**
+ * Map an appeal decision outcome to it's corresponding tag colour
+ *
+ * @param {string|undefined} decision
+ * @returns {string}
+ */
+function mapDecisionColour(decision) {
+	const decisionColourMap = new Map([
+		[DECISION_OUTCOME.ALLOWED, 'green'],
+		[DECISION_OUTCOME.DISMISSED, 'orange'],
+		[DECISION_OUTCOME.SPLIT_DECISION, 'yellow']
+	]);
+
+	return (decision && decisionColourMap.get(decision)) || 'grey';
+}
+
+module.exports = {
+	mapDecisionColour
+};

--- a/packages/forms-web-app/src/lib/dashboard-functions.js
+++ b/packages/forms-web-app/src/lib/dashboard-functions.js
@@ -1,3 +1,5 @@
+const { mapDecisionColour } = require('@pins/business-rules/src/utils/decision-outcome');
+
 /**
  * @typedef {import('appeals-service-api').Api.AppealCaseWithAppellant} AppealCaseWithAppellant
  * @typedef {import('appeals-service-api').Api.AppealSubmission} AppealSubmission
@@ -13,6 +15,7 @@
  * @property {boolean} [isNewAppeal] whether this is a new appeal
  * @property {boolean} [isDraft] whether the appeal submission is in draft state
  * @property {string | undefined | null} appealDecision the PINS decision in respect of the appeal
+ * @property {string | null} [appealDecisionColor] tag color to use for the decision
  * @property {string | undefined | null} caseDecisionDate
  */
 
@@ -49,6 +52,7 @@ const mapToLPADashboardDisplayData = (appealCaseData) => ({
 	nextDocumentDue: determineDocumentToDisplayLPADashboard(appealCaseData),
 	isNewAppeal: isNewAppeal(appealCaseData),
 	appealDecision: appealCaseData.outcome,
+	appealDecisionColor: mapDecisionColour(appealCaseData.outcome),
 	caseDecisionDate: appealCaseData.caseDecisionDate
 });
 
@@ -63,6 +67,9 @@ const mapToAppellantDashboardDisplayData = (appealData) => ({
 	nextDocumentDue: determineDocumentToDisplayAppellantDashboard(appealData),
 	isDraft: isAppealSubmission(appealData),
 	appealDecision: isAppealSubmission(appealData) ? null : getDecisionOutcome(appealData.outcome),
+	appealDecisionColor: isAppealSubmission(appealData)
+		? null
+		: mapDecisionColour(appealData.outcome),
 	caseDecisionDate: isAppealSubmission(appealData) ? null : appealData.caseDecisionDate
 });
 

--- a/packages/forms-web-app/src/views/appeals/your-appeals/decided-appeals.njk
+++ b/packages/forms-web-app/src/views/appeals/your-appeals/decided-appeals.njk
@@ -5,6 +5,7 @@
  {% from "govuk/components/radios/macro.njk" import govukRadios %}
  {% from "govuk/components/tabs/macro.njk" import govukTabs %}
  {% from "govuk/components/table/macro.njk" import govukTable %}
+ {%- from "govuk/components/tag/macro.njk" import govukTag -%}
 
  {% set title="
  Decided appeals - Appeal a planning decision - GOV.UK" %}
@@ -62,16 +63,10 @@
                   </td>
                   <td class="govuk-table__cell">{{item.appealType}}</td>
                   <td class="govuk-table__cell">
-                    {% if item.appealDecision == 'allowed'%}
-                      {% set tagClass = "govuk-tag--green" %}
-                    {% elif item.appealDecision == 'dismissed'%}
-                      {% set tagClass = "govuk-tag--orange" %}
-                    {% elif item.appealDecision == 'allowed in part'%}
-                      {% set tagClass = "govuk-tag--yellow" %}
-                    {% else %}
-                      {% set tagClass = "govuk-tag--grey"%}
-                    {% endif %}
-                    <strong class='govuk-tag {{ tagClass }}'>{{ item.appealDecision | capitalize }}</strong>
+                    {{ govukTag({
+                      text: item.appealDecision | capitalize,
+                      classes: "govuk-tag--{{item.appealDecisionColor}}"
+                    }) }}
                   </td>
                 </tr>
               {% endfor %}

--- a/packages/forms-web-app/src/views/manage-appeals/decided-appeals.njk
+++ b/packages/forms-web-app/src/views/manage-appeals/decided-appeals.njk
@@ -1,5 +1,6 @@
 {% extends "layouts/lpa-dashboard/main.njk" %}
 {% from "govuk/components/back-link/macro.njk" import govukBackLink %}
+{%- from "govuk/components/tag/macro.njk" import govukTag -%}
 
 {% block backButton %}
     {{ govukBackLink({
@@ -54,12 +55,10 @@
                 <td class="govuk-table__cell">{{appeal.caseDecisionDate}}</td>
 								<td class="govuk-table__cell">{{appeal.appealType}}</td>
 								<td class="govuk-table__cell">
-									{% if appeal.appealDecision === 'ALLOWED' %}
-										<strong class='govuk-tag govuk-tag--green'>
-          				{% else %}
-            				<strong class='govuk-tag govuk-tag--yellow'>
-          				{% endif %}
-									{{appeal.appealDecision}}
+                  {{ govukTag({
+                      text: item.appealDecision,
+                      classes: "govuk-tag--{{item.appealDecisionColor}}"
+                    }) }}
 								</td>
               </tr>
 					{% endfor %}

--- a/packages/web-comment/src/routes/decided-appeals/controller.js
+++ b/packages/web-comment/src/routes/decided-appeals/controller.js
@@ -2,9 +2,7 @@ const { formatAddress } = require('#utils/format-address');
 const { formatDate } = require('#utils/format-date');
 const { sortByCaseDecisionDate } = require('#utils/appeal-sorting');
 const { apiClient } = require('#utils/appeals-api-client');
-const {
-	constants: { DECISION_OUTCOME }
-} = require('@pins/business-rules');
+const { mapDecisionColour } = require('@pins/business-rules/src/utils/decision-outcome');
 
 /** @type {import('express').RequestHandler} */
 const decidedAppeals = async (req, res) => {
@@ -27,20 +25,6 @@ const decidedAppeals = async (req, res) => {
 	decidedAppeals.sort(sortByCaseDecisionDate);
 
 	res.render(`decided-appeals/index`, { postcode, decidedAppeals });
-};
-
-/**
- * @param {string|undefined} decision
- * @returns {string}
- */
-const mapDecisionColour = (decision) => {
-	const decisionColourMap = new Map([
-		[DECISION_OUTCOME.ALLOWED, 'green'],
-		[DECISION_OUTCOME.DISMISSED, 'orange'],
-		[DECISION_OUTCOME.SPLIT_DECISION, 'yellow']
-	]);
-
-	return (decision && decisionColourMap.get(decision)) || 'grey';
 };
 
 module.exports = { decidedAppeals };

--- a/packages/web-comment/src/routes/decided-appeals/index.njk
+++ b/packages/web-comment/src/routes/decided-appeals/index.njk
@@ -2,6 +2,8 @@
 {% set title = "Decided Appeals" %}
 {% from "govuk/components/input/macro.njk" import govukInput %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
+ {%- from "govuk/components/tag/macro.njk" import govukTag -%}
+
 {% block content %}
   <div class="govuk-form-group">
     <h1 class="govuk-label govuk-label--l">{{ decidedAppeals.length }} decided Appeals found {{ postcode }}</h1>
@@ -23,7 +25,10 @@
             <td class="govuk-table__cell">{{ appeal.formattedCaseDecisionDate }}</td>
             <td class="govuk-table__cell">{{ appeal.appealTypeName }}</td>
             <td class="govuk-table__cell">
-              <strong class="govuk-tag govuk-tag--{{ appeal.formattedDecisionColour }}">{{ appeal.outcome }}</strong>
+              {{ govukTag({
+                text: item.outcome,
+                classes: "govuk-tag--{{item.formattedDecisionColour}}"
+              }) }}
             </td>
           </tr>
         {% endfor %}


### PR DESCRIPTION
## Ticket Number

<!-- Add the number from the Jira board -->

https://pins-ds.atlassian.net/browse/AAPD-922
https://pins-ds.atlassian.net/browse/AAPD-939
https://pins-ds.atlassian.net/browse/AAPD-995

## Description of change

Consolidate the appeal decision colour logic - we had three slightly different approaches.

## Checklist

<!-- Put an `x` in all the boxes that apply: -->

- [ ] Requires infrastructure changes
- [ ] I have updated the documentation accordingly
- [ ] My commit history in this PR is linear
- [ ] New features have tests
- [ ] Breaking change (team conversation required)

## Important

Please do not merge from `main` (please only [rebase](https://github.com/Planning-Inspectorate/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
