### PR TITLE
fix(aapd-654): standardise max file size logic

### DIFF
--- a/packages/forms-web-app/__tests__/unit/lib/file-size-display-helper.test.js
+++ b/packages/forms-web-app/__tests__/unit/lib/file-size-display-helper.test.js
@@ -27,6 +27,16 @@ describe('lib/file-size-display-helper', () => {
 			expected: '1MB'
 		},
 		{
+			given: 26214400,
+			expected: '25MB',
+			binary: true
+		},
+		{
+			given: 26214400,
+			expected: '26MB',
+			binary: false
+		},
+		{
 			given: 1024 ** 3,
 			expected: '1GB'
 		},
@@ -82,9 +92,9 @@ describe('lib/file-size-display-helper', () => {
 			given: 52428800,
 			expected: '52MB'
 		}
-	].forEach(({ given, expected }) => {
+	].forEach(({ given, expected, binary = false }) => {
 		it(`should display the expected file size - ${expected}`, () => {
-			expect(fileSizeDisplayHelper(given)).toBe(expected);
+			expect(fileSizeDisplayHelper(given, binary)).toBe(expected);
 		});
 	});
 });

--- a/packages/forms-web-app/__tests__/unit/validators/common/multifile-upload.test.js
+++ b/packages/forms-web-app/__tests__/unit/validators/common/multifile-upload.test.js
@@ -80,7 +80,7 @@ describe('validators/common/multifile-upload', () => {
 							'supporting-documents': [
 								{
 									mimetype: config.fileUpload.pins.allowedFileTypes.MIME_TYPE_JPEG,
-									size: config.fileUpload.pins.uploadApplicationMaxFileSize + 1
+									size: config.fileUpload.pins.maxFileUploadSize + 1
 								}
 							]
 						}
@@ -100,7 +100,7 @@ describe('validators/common/multifile-upload', () => {
 						'supporting-documents': [
 							{
 								mimetype: config.fileUpload.pins.allowedFileTypes.MIME_TYPE_JPEG,
-								size: config.fileUpload.pins.uploadApplicationMaxFileSize - 1
+								size: config.fileUpload.pins.maxFileUploadSize - 1
 							}
 						]
 					}

--- a/packages/forms-web-app/__tests__/unit/validators/common/schemas/file-upload.test.js
+++ b/packages/forms-web-app/__tests__/unit/validators/common/schemas/file-upload.test.js
@@ -1,6 +1,6 @@
 const {
 	fileUpload: {
-		pins: { uploadApplicationMaxFileSize }
+		pins: { maxFileUploadSize }
 	}
 } = require('../../../../../src/config');
 const fileUploadSchema = require('../../../../../src/validators/common/schemas/file-upload');
@@ -111,11 +111,7 @@ describe('validators/common/schemas/file-upload', () => {
 
 			await schema(null, { req, path: 'file-upload' });
 
-			expect(validateFileSize).toHaveBeenCalledWith(
-				file.size,
-				uploadApplicationMaxFileSize,
-				file.name
-			);
+			expect(validateFileSize).toHaveBeenCalledWith(file.size, maxFileUploadSize, file.name);
 		});
 
 		it('should call the antivirus validator when given a single file', async () => {
@@ -132,11 +128,7 @@ describe('validators/common/schemas/file-upload', () => {
 
 			await schema(null, { req, path: 'file-upload' });
 
-			expect(validateFileSize).toHaveBeenCalledWith(
-				file.size,
-				uploadApplicationMaxFileSize,
-				file.name
-			);
+			expect(validateFileSize).toHaveBeenCalledWith(file.size, maxFileUploadSize, file.name);
 		});
 
 		it('should return true when given a single valid file', async () => {

--- a/packages/forms-web-app/__tests__/unit/validators/common/schemas/multifile-upload-schema.test.js
+++ b/packages/forms-web-app/__tests__/unit/validators/common/schemas/multifile-upload-schema.test.js
@@ -46,7 +46,7 @@ describe('validators/common/schemas/multifile-upload-schema', () => {
 			});
 			expect(validateFileSize).toHaveBeenCalledWith(
 				12345,
-				config.fileUpload.pins.supportingDocumentsMaxFileSize,
+				config.fileUpload.pins.maxFileUploadSize,
 				'pingu.penguin'
 			);
 		});

--- a/packages/forms-web-app/src/config.js
+++ b/packages/forms-web-app/src/config.js
@@ -49,19 +49,7 @@ module.exports = {
 	fileUpload: {
 		debug: process.env.FILE_UPLOAD_DEBUG === 'true',
 		pins: {
-			appealStatementMaxFileSize: numberWithDefault(
-				process.env.FILE_UPLOAD_MAX_FILE_SIZE_BYTES,
-				oneGigabyte
-			),
-			supportingDocumentsMaxFileSize: numberWithDefault(
-				process.env.FILE_UPLOAD_MAX_FILE_SIZE_BYTES,
-				oneGigabyte
-			),
-			uploadApplicationMaxFileSize: numberWithDefault(
-				process.env.FILE_UPLOAD_MAX_FILE_SIZE_BYTES,
-				oneGigabyte
-			),
-			uploadDecisionMaxFileSize: numberWithDefault(
+			maxFileUploadSize: numberWithDefault(
 				process.env.FILE_UPLOAD_MAX_FILE_SIZE_BYTES,
 				oneGigabyte
 			),

--- a/packages/forms-web-app/src/dynamic-forms/validator/multifile-upload-validator.test.js
+++ b/packages/forms-web-app/src/dynamic-forms/validator/multifile-upload-validator.test.js
@@ -67,7 +67,7 @@ describe('./src/dynamic-forms/validator/multifile-upload-validator.js', () => {
 							{
 								mimetype: config.fileUpload.pins.allowedFileTypes.MIME_TYPE_DOC,
 								name: 'invalidFile2tooBig.doc',
-								size: config.fileUpload.pins.uploadApplicationMaxFileSize + 1
+								size: config.fileUpload.pins.maxFileUploadSize + 1
 							},
 							{
 								mimetype: config.fileUpload.pins.allowedFileTypes.MIME_TYPE_JPEG,

--- a/packages/forms-web-app/src/lib/file-size-display-helper.js
+++ b/packages/forms-web-app/src/lib/file-size-display-helper.js
@@ -1,7 +1,13 @@
 // https://stackoverflow.com/questions/10420352/converting-file-size-in-bytes-to-human-readable-string/10420404
 const suffixes = ['Bytes', 'KB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB', 'YB'];
 
-module.exports = (bytes) => {
-	const i = Math.floor(Math.log(bytes) / Math.log(1000));
-	return (!bytes && '0Bytes') || `${(bytes / 1000 ** i).toFixed()}${suffixes[i]}`;
+/**
+ * @param {number} bytes
+ * @param {boolean} binary
+ * @returns {string}
+ */
+module.exports = (bytes, binary = true) => {
+	const base = binary ? 1024 : 1000;
+	const i = Math.floor(Math.log(bytes) / Math.log(base));
+	return (!bytes && '0Bytes') || `${(bytes / base ** i).toFixed()}${suffixes[i]}`;
 };

--- a/packages/forms-web-app/src/validators/common/schemas/file-upload.js
+++ b/packages/forms-web-app/src/validators/common/schemas/file-upload.js
@@ -1,6 +1,6 @@
 const {
 	fileUpload: {
-		pins: { uploadApplicationMaxFileSize, allowedFileTypes }
+		pins: { maxFileUploadSize, allowedFileTypes }
 	}
 } = require('../../../config');
 const validateFileSize = require('../../custom/file-size');
@@ -40,7 +40,7 @@ const schema = (noFilesError) => ({
 				});
 
 				uploadedFiles.forEach(({ size, name }) => {
-					validateFileSize(size, uploadApplicationMaxFileSize, name);
+					validateFileSize(size, maxFileUploadSize, name);
 				});
 
 				//check file for virus

--- a/packages/forms-web-app/src/validators/common/schemas/multifile-upload-schema.js
+++ b/packages/forms-web-app/src/validators/common/schemas/multifile-upload-schema.js
@@ -19,7 +19,7 @@ const schema = (path) => ({
 				}
 
 				// check file size
-				validateFileSize(size, config.fileUpload.pins.uploadApplicationMaxFileSize, name);
+				validateFileSize(size, config.fileUpload.pins.maxFileUploadSize, name);
 
 				// check file for Virus
 				const clamAVClient = getClamAVClient();

--- a/packages/forms-web-app/src/views/appellant-submission/appeal-statement.njk
+++ b/packages/forms-web-app/src/views/appellant-submission/appeal-statement.njk
@@ -114,7 +114,7 @@
         </details>
 
         {{ govukInsetText({
-          text: "File size should be no more than " + fileSizeLimits.appealStatementMaxFileSize | formatBytes
+          text: "File size should be no more than " + fileSizeLimits.maxFileUploadSize | formatBytes
         }) }}
 
         {% if appeal.yourAppealSection.appealStatement.uploadedFile.id %}

--- a/packages/forms-web-app/src/views/appellant-submission/supporting-documents.njk
+++ b/packages/forms-web-app/src/views/appellant-submission/supporting-documents.njk
@@ -71,7 +71,7 @@
         <p>You do not need to upload the plans from your original planning application.</p>
 
         {{ govukInsetText({
-          text: "File size should be no more than " + fileSizeLimits.supportingDocumentsMaxFileSize | formatBytes
+          text: "File size should be no more than " + fileSizeLimits.maxFileUploadSize | formatBytes
         }) }}
 
         {{ mojMultiFileUpload({

--- a/packages/forms-web-app/src/views/appellant-submission/upload-application.njk
+++ b/packages/forms-web-app/src/views/appellant-submission/upload-application.njk
@@ -36,7 +36,7 @@
         <p>If you do not have your original planning application form, you can find it by searching for your planning application on your local planning department's website.</p>
 
         {{ govukInsetText({
-          text: "File size should be no more than " + fileSizeLimits.uploadApplicationMaxFileSize | formatBytes
+          text: "File size should be no more than " + fileSizeLimits.maxFileUploadSize | formatBytes
         }) }}
 
         {% if appeal.requiredDocumentsSection.originalApplication.uploadedFile.id %}

--- a/packages/forms-web-app/src/views/appellant-submission/upload-decision.njk
+++ b/packages/forms-web-app/src/views/appellant-submission/upload-decision.njk
@@ -29,7 +29,7 @@
         <p>This is the letter from the local planning department telling you about the decision on your planning application.</p>
 
         {{ govukInsetText({
-          text: "File size should be no more than " + fileSizeLimits.uploadDecisionMaxFileSize | formatBytes
+          text: "File size should be no more than " + fileSizeLimits.maxFileUploadSize | formatBytes
         }) }}
 
         {% if appeal.requiredDocumentsSection.decisionLetter.uploadedFile.id %}

--- a/packages/forms-web-app/src/views/full-appeal/submit-appeal/appeal-statement.njk
+++ b/packages/forms-web-app/src/views/full-appeal/submit-appeal/appeal-statement.njk
@@ -80,9 +80,7 @@
                   <li>PNG</li>
                   <li>TIF or TIFF</li>
                 </ul>
-                <p class="govuk-body">
-                  Your file must be smaller than 25MB.
-                </p>'
+                <p class="govuk-body">Your file must be smaller than ' + fileSizeLimits.maxFileUploadSize | formatBytes + '.</p>'
         }) }}
 
         {{ govukCheckboxes({

--- a/packages/forms-web-app/src/views/full-appeal/submit-appeal/application-form.njk
+++ b/packages/forms-web-app/src/views/full-appeal/submit-appeal/application-form.njk
@@ -54,9 +54,7 @@
                   <li>PNG</li>
                   <li>TIF or TIFF</li>
                 </ul>
-                <p class="govuk-body">
-                  Your file must be smaller than 25MB.
-                </p>'
+                <p class="govuk-body">Your file must be smaller than ' + fileSizeLimits.maxFileUploadSize | formatBytes + '.</p>'
         }) }}
 
         <div class="govuk-button-group">

--- a/packages/forms-web-app/src/views/full-appeal/submit-appeal/certificates.njk
+++ b/packages/forms-web-app/src/views/full-appeal/submit-appeal/certificates.njk
@@ -57,9 +57,7 @@
                 <li>PNG</li>
                 <li>TIF or TIFF</li>
               </ul>
-              <p class="govuk-body">
-                Your file must be smaller than 25MB.
-              </p>'
+              <p class="govuk-body">Your file must be smaller than ' + fileSizeLimits.maxFileUploadSize | formatBytes + '.</p>'
         }) }}
 
         <div class="govuk-button-group">

--- a/packages/forms-web-app/src/views/full-appeal/submit-appeal/decision-letter.njk
+++ b/packages/forms-web-app/src/views/full-appeal/submit-appeal/decision-letter.njk
@@ -55,9 +55,7 @@
                   <li>PNG</li>
                   <li>TIF or TIFF</li>
                 </ul>
-                <p class="govuk-body">
-                  Your file must be smaller than 25MB.
-                </p>'
+                <p class="govuk-body">Your file must be smaller than ' + fileSizeLimits.maxFileUploadSize | formatBytes + '.</p>'
         }) }}
         <div class="govuk-button-group">
           {{ govukButton({

--- a/packages/forms-web-app/src/views/full-appeal/submit-appeal/design-access-statement.njk
+++ b/packages/forms-web-app/src/views/full-appeal/submit-appeal/design-access-statement.njk
@@ -51,9 +51,7 @@
                   <li>PNG</li>
                   <li>TIF or TIFF</li>
                 </ul>
-                <p class="govuk-body">
-                  Your file must be smaller than 25MB.
-                </p>'
+                <p class="govuk-body">Your file must be smaller than ' + fileSizeLimits.maxFileUploadSize | formatBytes + '.</p>'
         }) }}
 
         <div class="govuk-button-group">

--- a/packages/forms-web-app/src/views/full-appeal/submit-appeal/draft-statement-common-ground.njk
+++ b/packages/forms-web-app/src/views/full-appeal/submit-appeal/draft-statement-common-ground.njk
@@ -52,9 +52,7 @@
                   <li>PNG</li>
                   <li>TIF or TIFF</li>
                 </ul>
-                <p class="govuk-body">
-                  Your file must be smaller than 25MB.
-                </p>'
+                <p class="govuk-body">Your file must be smaller than ' + fileSizeLimits.maxFileUploadSize | formatBytes + '.</p>'
         }) }}
         <div class="govuk-button-group">
           {{ govukButton({

--- a/packages/forms-web-app/src/views/full-appeal/submit-appeal/letter-confirming-application.njk
+++ b/packages/forms-web-app/src/views/full-appeal/submit-appeal/letter-confirming-application.njk
@@ -54,9 +54,7 @@
                   <li>PNG</li>
                   <li>TIF or TIFF</li>
                 </ul>
-                <p class="govuk-body">
-                  Your file must be smaller than 25MB.
-                </p>'
+                <p class="govuk-body">Your file must be smaller than ' + fileSizeLimits.maxFileUploadSize | formatBytes + '.</p>'
         }) }}
 
         <div class="govuk-button-group">

--- a/packages/forms-web-app/src/views/full-appeal/submit-appeal/original-decision-notice.njk
+++ b/packages/forms-web-app/src/views/full-appeal/submit-appeal/original-decision-notice.njk
@@ -53,9 +53,7 @@
                   <li>PNG</li>
                   <li>TIF or TIFF</li>
                 </ul>
-                <p class="govuk-body">
-                  Your file must be smaller than 25MB.
-                </p>'
+                <p class="govuk-body">Your file must be smaller than ' + fileSizeLimits.maxFileUploadSize | formatBytes + '.</p>'
         }) }}
 
         {{ govukButton({

--- a/packages/forms-web-app/src/views/full-appeal/submit-final-comment/upload-documents.njk
+++ b/packages/forms-web-app/src/views/full-appeal/submit-final-comment/upload-documents.njk
@@ -26,8 +26,8 @@
       classes: 'govuk-label--m'
     },
     hint: {
-      text: 'The files must be a DOC, DOCX, PDF, TIF, JPG or PNG and be smaller than 25MB'
-      },
+      text: 'The files must be a DOC, DOCX, PDF, TIF, JPG or PNG and be smaller than ' + fileSizeLimits.maxFileUploadSize | formatBytes
+    },
     attributes: { multiple: '' },
     errorMessage: errorSummary and {
       html:uploadDocumentsErrorMessage

--- a/packages/forms-web-app/src/views/layouts/multi-file-upload.njk
+++ b/packages/forms-web-app/src/views/layouts/multi-file-upload.njk
@@ -29,8 +29,8 @@
             classes: 'govuk-label--m'
           },
     hint: {
-      text: 'The files must be a DOC, DOCX, PDF, TIF, JPG or PNG and be smaller than 25MB'
-      },
+      text: 'The files must be a DOC, DOCX, PDF, TIF, JPG or PNG and be smaller than ' + fileSizeLimits.maxFileUploadSize | formatBytes
+    },
     attributes: { multiple: '' },
     errorMessage: errorSummary and {
       html: errorMessageHtml


### PR DESCRIPTION
## Ticket Number

<!-- Add the number from the Jira board -->

https://pins-ds.atlassian.net/browse/AAPD-654

## Description of change

Issues with max file size displayed to user,
Didn't know file-size-display-helper existed, have fixed that for binary sizes
Have made the hardcoded values use this filter
Have removed the file type size variations as it wasn't used in the actual file size check and we have no current variations

## Checklist

<!-- Put an `x` in all the boxes that apply: -->

- [ ] Requires infrastructure changes
- [ ] I have updated the documentation accordingly
- [x] My commit history in this PR is linear
- [x] New features have tests
- [ ] Breaking change (team conversation required)

## Important

Please do not merge from `main` (please only [rebase](https://github.com/Planning-Inspectorate/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
