### PR TITLE
feat(946): add appeals documents block macro

### DIFF
--- a/packages/common/src/frontend/pins/components/appeal-documents-block.njk
+++ b/packages/common/src/frontend/pins/components/appeal-documents-block.njk
@@ -1,0 +1,15 @@
+{% macro appealDocumentsBlock(documents) %}
+
+{%for document in documents %}
+
+			<h2 class="govuk-heading-l"> {{document.heading}} </h2>
+
+	{%for link in document.links%}
+			<p class="govuk-body">
+				<a href="{{link.link}}"> {{link.linkText}} </a>
+			</p>
+{% endfor %}
+			<hr class="govuk-section-break govuk-section-break--visible govuk-section-break--m">
+
+		{% endfor %}
+{% endmacro %}

--- a/packages/common/src/frontend/pins/components/appeal-sections-block.njk
+++ b/packages/common/src/frontend/pins/components/appeal-sections-block.njk
@@ -1,12 +1,12 @@
-{% macro appealSectionsBlock(documents) %}
+{% macro appealSectionsBlock(sections) %}
 
-{%for document in documents %}
+{%for section in sections %}
 
-			<h2 class="govuk-heading-l"> {{document.heading}} </h2>
+			<h2 class="govuk-heading-l"> {{section.heading}} </h2>
 
-	{%for link in document.links%}
+	{%for link in section.links%}
 			<p class="govuk-body">
-				<a href="{{link.link}}"> {{link.linkText}} </a>
+				<a href="{{link.url}}"> {{link.text}} </a>
 			</p>
 {% endfor %}
 			<hr class="govuk-section-break govuk-section-break--visible govuk-section-break--m">

--- a/packages/common/src/frontend/pins/components/appeal-sections-block.njk
+++ b/packages/common/src/frontend/pins/components/appeal-sections-block.njk
@@ -1,15 +1,11 @@
 {% macro appealSectionsBlock(sections) %}
-
-{%for section in sections %}
-
-			<h2 class="govuk-heading-l"> {{section.heading}} </h2>
-
-	{%for link in section.links%}
+	{%for section in sections %}
+		<h2 class="govuk-heading-l"> {{section.heading}} </h2>
+		{%for link in section.links%}
 			<p class="govuk-body">
 				<a href="{{link.url}}"> {{link.text}} </a>
 			</p>
-{% endfor %}
-			<hr class="govuk-section-break govuk-section-break--visible govuk-section-break--m">
-
 		{% endfor %}
+		<hr class="govuk-section-break govuk-section-break--visible govuk-section-break--m">
+	{% endfor %}
 {% endmacro %}

--- a/packages/common/src/frontend/pins/components/appeal-sections-block.njk
+++ b/packages/common/src/frontend/pins/components/appeal-sections-block.njk
@@ -1,4 +1,4 @@
-{% macro appealDocumentsBlock(documents) %}
+{% macro appealSectionsBlock(documents) %}
 
 {%for document in documents %}
 

--- a/packages/forms-web-app/src/controllers/selected-appeal/selected-appeal.js
+++ b/packages/forms-web-app/src/controllers/selected-appeal/selected-appeal.js
@@ -46,14 +46,14 @@ exports.get = async (req, res) => {
 		appeal: {
 			appealNumber: appealNumber,
 			headlineData,
-			// placeholder documents info
-			documents: [
+			// placeholder sections info
+			sections: [
 				{
 					heading: 'Questionnaire',
 					links: [
 						{
-							link: 'anything',
-							linkText: '3 points each'
+							url: 'anything',
+							text: 'View questionnaire'
 						}
 					]
 				}

--- a/packages/forms-web-app/src/controllers/selected-appeal/selected-appeal.js
+++ b/packages/forms-web-app/src/controllers/selected-appeal/selected-appeal.js
@@ -45,7 +45,19 @@ exports.get = async (req, res) => {
 	const viewContext = {
 		appeal: {
 			appealNumber: appealNumber,
-			headlineData
+			headlineData,
+			// placeholder documents info
+			documents: [
+				{
+					heading: 'Questionnaire',
+					links: [
+						{
+							link: 'anything',
+							linkText: '3 points each'
+						}
+					]
+				}
+			]
 		}
 	};
 

--- a/packages/forms-web-app/src/views/selected-appeal/appeal.njk
+++ b/packages/forms-web-app/src/views/selected-appeal/appeal.njk
@@ -2,7 +2,7 @@
 
  {% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
  {% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
-	{% from  "pins/components/appeal-documents-block.njk" import appealDocumentsBlock %}
+	{% from  "pins/components/appeal-sections-block.njk" import appealSectionsBlock %}
 
  {% set title="
  Appeal " + appeal.appealNumber + " - Appeal a planning decision - GOV.UK" %}
@@ -35,7 +35,7 @@
 		</div>
 
 		<div class="govuk-grid-column-two-thirds">
-				{{ appealDocumentsBlock(appeal.documents) }}
+				{{ appealSectionsBlock(appeal.documents) }}
 		</div>
 
 	</div>

--- a/packages/forms-web-app/src/views/selected-appeal/appeal.njk
+++ b/packages/forms-web-app/src/views/selected-appeal/appeal.njk
@@ -35,7 +35,7 @@
 		</div>
 
 		<div class="govuk-grid-column-two-thirds">
-				{{ appealSectionsBlock(appeal.documents) }}
+				{{ appealSectionsBlock(appeal.sections) }}
 		</div>
 
 	</div>

--- a/packages/forms-web-app/src/views/selected-appeal/appeal.njk
+++ b/packages/forms-web-app/src/views/selected-appeal/appeal.njk
@@ -2,6 +2,7 @@
 
  {% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
  {% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
+	{% from  "pins/components/appeal-documents-block.njk" import appealDocumentsBlock %}
 
  {% set title="
  Appeal " + appeal.appealNumber + " - Appeal a planning decision - GOV.UK" %}
@@ -12,7 +13,7 @@
 
  {% block content %}
   <div class="govuk-grid-row">
-    <div class="govuk-grid-column-two-thirds">
+    <div class="govuk-grid-column-full">
 
        {% if errorSummary %}
          {{ govukErrorSummary({
@@ -28,7 +29,15 @@
 			rows: appeal.headlineData
 		}) }}
 
+		<hr class="govuk-section-break govuk-section-break--visible govuk-section-break--m">
+
+
 		</div>
+
+		<div class="govuk-grid-column-two-thirds">
+				{{ appealDocumentsBlock(appeal.documents) }}
+		</div>
+
 	</div>
 
  {% endblock %}


### PR DESCRIPTION
## Ticket Number

https://pins-ds.atlassian.net/browse/AAPD-946

## Description of change

Adds a reusable macro in common package - this builds the documents blocks which are seen on the view appeal page.

## Checklist

<!-- Put an `x` in all the boxes that apply: -->

- [ ] Requires infrastructure changes
- [ ] I have updated the documentation accordingly
- X My commit history in this PR is linear
- [ ] New features have tests
- [ ] Breaking change (team conversation required)

## Important

Please do not merge from `main` (please only [rebase](https://github.com/Planning-Inspectorate/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
