### PR TITLE
chore: add rule-6-party seed data

### DIFF
--- a/packages/appeals-service-api/src/db/seed/data-dev.js
+++ b/packages/appeals-service-api/src/db/seed/data-dev.js
@@ -3,6 +3,7 @@ const { lpaAppealCaseData, lpaAppeals } = require('./lpa-appeal-case-data-dev');
 const {
 	constants: { DECISION_OUTCOME }
 } = require('@pins/business-rules');
+const { APPEAL_USER_ROLES } = require('@pins/common/src/constants');
 
 // some data here so we can reference in multiple places
 // IDs have no specific meaning, just valid UUIDs and used for upsert/relations
@@ -39,6 +40,41 @@ const appellants = {
 	appellantEight: {
 		id: '29670d0f-c4b4-4047-8ee0-d62b93e91a18',
 		email: 'appellant8@planninginspectorate.gov.uk'
+	}
+};
+
+const rule6Parties = {
+	r6One: {
+		id: '29670d0f-c4b4-4047-8ee0-d62b93e91b11',
+		email: 'r6-1@planninginspectorate.gov.uk'
+	},
+	r6Two: {
+		id: '29670d0f-c4b4-4047-8ee0-d62b93e91b12',
+		email: 'r6-2@planninginspectorate.gov.uk'
+	},
+	r6Three: {
+		id: '29670d0f-c4b4-4047-8ee0-d62b93e91b13',
+		email: 'r6-3@planninginspectorate.gov.uk'
+	},
+	r6Four: {
+		id: '29670d0f-c4b4-4047-8ee0-d62b93e91b14',
+		email: 'r6-4@planninginspectorate.gov.uk'
+	},
+	r6Five: {
+		id: '29670d0f-c4b4-4047-8ee0-d62b93e91b15',
+		email: 'r6-5@planninginspectorate.gov.uk'
+	},
+	r6Six: {
+		id: '29670d0f-c4b4-4047-8ee0-d62b93e91b16',
+		email: 'r6-6@planninginspectorate.gov.uk'
+	},
+	r6Seven: {
+		id: '29670d0f-c4b4-4047-8ee0-d62b93e91b17',
+		email: 'r6-7@planninginspectorate.gov.uk'
+	},
+	r6Eight: {
+		id: '29670d0f-c4b4-4047-8ee0-d62b93e91b18',
+		email: 'r6-8@planninginspectorate.gov.uk'
 	}
 };
 
@@ -94,7 +130,15 @@ const users = [
 	appellants.appellantFive,
 	appellants.appellantSix,
 	appellants.appellantSeven,
-	appellants.appellantEight
+	appellants.appellantEight,
+	rule6Parties.r6One,
+	rule6Parties.r6Two,
+	rule6Parties.r6Three,
+	rule6Parties.r6Four,
+	rule6Parties.r6Five,
+	rule6Parties.r6Six,
+	rule6Parties.r6Seven,
+	rule6Parties.r6Eight
 ];
 
 /**
@@ -126,7 +170,8 @@ const commonAppealProperties = {
 	siteAddressTown: 'Testville',
 	siteAddressCounty: 'Countyshire',
 	siteAddressPostcode: 'BS1 6PN',
-	costsAppliedForIndicator: false
+	costsAppliedForIndicator: false,
+	casePublished: true
 };
 
 /**
@@ -245,60 +290,105 @@ const appealCases = [
  *
  * @type {{appealId: string, userId: string, role: string}[]}
  */
-
 const linkedLpaAppeals = lpaAppeals.map((appeal) => ({
 	appealId: appeal.id,
 	userId: appellants.appellantOne.id,
-	role: 'appellant'
+	role: APPEAL_USER_ROLES.APPELLANT
 }));
 
 const appealToUsers = [
 	{
 		appealId: appealIds.appealOne,
 		userId: appellants.appellantOne.id,
-		role: 'appellant'
+		role: APPEAL_USER_ROLES.APPELLANT
 	},
 	{
 		appealId: appealIds.appealTwo,
 		userId: appellants.appellantTwo.id,
-		role: 'appellant'
+		role: APPEAL_USER_ROLES.APPELLANT
 	},
 	{
 		appealId: appealIds.appealThree,
 		userId: appellants.appellantThree.id,
-		role: 'appellant'
+		role: APPEAL_USER_ROLES.APPELLANT
 	},
 	{
 		appealId: appealIds.appealFour,
 		userId: appellants.appellantFour.id,
-		role: 'appellant'
+		role: APPEAL_USER_ROLES.APPELLANT
 	},
 	{
 		appealId: appealIds.appealFive,
 		userId: appellants.appellantFive.id,
-		role: 'appellant'
+		role: APPEAL_USER_ROLES.APPELLANT
 	},
 	{
 		appealId: appealIds.appealSix,
 		userId: appellants.appellantSix.id,
-		role: 'appellant'
+		role: APPEAL_USER_ROLES.APPELLANT
 	},
 	{
 		appealId: appealIds.appealSeven,
 		userId: appellants.appellantSeven.id,
-		role: 'appellant'
+		role: APPEAL_USER_ROLES.APPELLANT
 	},
 	{
 		appealId: appealIds.appealEight,
 		userId: appellants.appellantEight.id,
-		role: 'appellant'
+		role: APPEAL_USER_ROLES.APPELLANT
 	},
 	{
 		appealId: appealSubmissionDraft.id,
 		userId: appellants.appellantOne.id,
-		role: 'appellant'
+		role: APPEAL_USER_ROLES.APPELLANT
 	},
-	...linkedLpaAppeals
+	...linkedLpaAppeals,
+	// rule 6 party links
+	{
+		appealId: appealIds.appealOne,
+		userId: rule6Parties.r6One.id,
+		role: APPEAL_USER_ROLES.RULE_6_PARTY
+	},
+	{
+		appealId: appealIds.appealOne,
+		userId: rule6Parties.r6Two.id,
+		role: APPEAL_USER_ROLES.RULE_6_PARTY
+	},
+	{
+		appealId: appealIds.appealTwo,
+		userId: rule6Parties.r6Two.id,
+		role: APPEAL_USER_ROLES.RULE_6_PARTY
+	},
+	{
+		appealId: appealIds.appealThree,
+		userId: rule6Parties.r6Three.id,
+		role: APPEAL_USER_ROLES.RULE_6_PARTY
+	},
+	{
+		appealId: appealIds.appealFour,
+		userId: rule6Parties.r6Four.id,
+		role: APPEAL_USER_ROLES.RULE_6_PARTY
+	},
+	{
+		appealId: appealIds.appealFive,
+		userId: rule6Parties.r6Five.id,
+		role: APPEAL_USER_ROLES.RULE_6_PARTY
+	},
+	{
+		appealId: appealIds.appealSix,
+		userId: rule6Parties.r6Six.id,
+		role: APPEAL_USER_ROLES.RULE_6_PARTY
+	},
+	{
+		appealId: appealIds.appealSeven,
+		userId: rule6Parties.r6Seven.id,
+		role: APPEAL_USER_ROLES.RULE_6_PARTY
+	},
+	{
+		appealId: appealIds.appealEight,
+		userId: rule6Parties.r6Eight.id,
+		role: APPEAL_USER_ROLES.RULE_6_PARTY
+	}
 ];
 
 /**

--- a/packages/appeals-service-api/src/routes/v2/users/_id/appeal-cases/_caseReference/repo.js
+++ b/packages/appeals-service-api/src/routes/v2/users/_id/appeal-cases/_caseReference/repo.js
@@ -3,23 +3,7 @@ const { APPEAL_USER_ROLES } = require('@pins/common/src/constants');
 const { PrismaClientKnownRequestError } = require('@prisma/client/runtime/library');
 
 /**
- * @typedef {import('@prisma/client').Prisma.AppealCaseGetPayload<{
- *  where: {
- *    caseReference: any;
- *  };
- *  include: {
- *    Appeal: {
- *      include: {
- *        Users: {
- *          where: {
- *            userId: string;
- *            role: any;
- *          };
- *        };
- *      };
- *    };
- *  };
- *}>} AppealCaseWithUser
+ * @typedef {import('@prisma/client').AppealCase} AppealCase
  */
 
 module.exports = class Repo {
@@ -33,7 +17,7 @@ module.exports = class Repo {
 	 * Get appeals for the given user
 	 *
 	 * @param {{ caseReference: string, userId: string, role: string }} params
-	 * @returns {Promise<AppealCaseWithUser|null>}
+	 * @returns {Promise<AppealCase|null>}
 	 */
 	async get({ caseReference, role, userId }) {
 		try {
@@ -55,14 +39,10 @@ module.exports = class Repo {
 
 			return await this.dbClient.appealCase.findUnique({
 				where: {
-					caseReference
-				},
-				include: {
+					caseReference,
 					Appeal: {
-						include: {
-							Users: {
-								where
-							}
+						Users: {
+							some: where
 						}
 					}
 				}
@@ -82,7 +62,7 @@ module.exports = class Repo {
 	 * Get appeals for the given LPA user
 	 *
 	 * @param {{ caseReference: string, userId: string }} params
-	 * @returns {Promise<import('@prisma/client').AppealCase|null>}
+	 * @returns {Promise<AppealCase|null>}
 	 */
 	async getForLpaUser({ caseReference, userId }) {
 		try {

--- a/packages/appeals-service-api/src/routes/v2/users/_id/appeal-cases/_caseReference/spec.yaml
+++ b/packages/appeals-service-api/src/routes/v2/users/_id/appeal-cases/_caseReference/spec.yaml
@@ -3,7 +3,7 @@ paths:
     get:
       tags:
         - users
-      description: Get appeals for a user
+      description: Get an appeal for a user
       parameters:
         - in: path
           name: userId
@@ -25,7 +25,7 @@ paths:
           description: user role
       responses:
         200:
-          description: Appeal submissions
+          description: Appeal case
           content:
             application/json:
               schema:


### PR DESCRIPTION
## Ticket Number

<!-- Add the number from the Jira board -->

https://pins-ds.atlassian.net/browse/AAPD-1075

## Description of change

Fix API that returned cases even if no link to the user
Add some rule-6-parties to seed data, and link to some appeals. Also mark most seeded appeals as published.

## Checklist

<!-- Put an `x` in all the boxes that apply: -->

- [ ] Requires infrastructure changes
- [ ] I have updated the documentation accordingly
- [ ] My commit history in this PR is linear
- [ ] New features have tests
- [ ] Breaking change (team conversation required)

## Important

Please do not merge from `main` (please only [rebase](https://github.com/Planning-Inspectorate/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
