### PR TITLE
fix(aapd-951): fix setting user email by userType instead of from ses…

### DIFF
--- a/packages/forms-web-app/src/controllers/selected-appeal/selected-appeal.js
+++ b/packages/forms-web-app/src/controllers/selected-appeal/selected-appeal.js
@@ -2,6 +2,7 @@ const { VIEW } = require('../../lib/views');
 const { apiClient } = require('../../lib/appeals-api-client');
 const { formatHeadlineData } = require('@pins/common');
 const { determineUser } = require('../../lib/determine-user');
+const { LPA_USER_ROLE } = require('@pins/common/src/constants');
 
 /**
  * @typedef {import('appeals-service-api').Api.AppealCaseWithAppellant} AppealCaseWithAppellant
@@ -22,9 +23,9 @@ exports.get = async (req, res) => {
 
 	let userEmail;
 
-	if (req.session.lpaUser) {
+	if (userType === LPA_USER_ROLE) {
 		userEmail = req.session.lpaUser.email;
-	} else if (req.session.email) {
+	} else {
 		userEmail = req.session.email;
 	}
 


### PR DESCRIPTION
## Ticket Number

https://pins-ds.atlassian.net/browse/AAPD-951

## Description of change

fix setting user email with user type instead of from session. as currently unable to view selected appeal from lpa dashboard

## Checklist

<!-- Put an `x` in all the boxes that apply: -->

- [ ] Requires infrastructure changes
- [ ] I have updated the documentation accordingly
- [ x] My commit history in this PR is linear
- [ ] New features have tests
- [ ] Breaking change (team conversation required)

## Important

Please do not merge from `main` (please only [rebase](https://github.com/Planning-Inspectorate/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
