### PR TITLE
fix(aapd-1046): displays text in the other field for designated sites…

### DIFF
--- a/packages/forms-web-app/src/dynamic-forms/dynamic-components/checkbox/question.js
+++ b/packages/forms-web-app/src/dynamic-forms/dynamic-components/checkbox/question.js
@@ -1,4 +1,5 @@
 const OptionsQuestion = require('../../options-question');
+const questionUtils = require('../utils/question-utils');
 
 class CheckboxQuestion extends OptionsQuestion {
 	/**
@@ -35,10 +36,39 @@ class CheckboxQuestion extends OptionsQuestion {
 	 */
 	formatAnswerForSummary(sectionSegment, journey, answer) {
 		answer = Array.isArray(answer) ? answer : [answer];
-		const formattedAnswer = this.options
-			.filter((option) => answer.includes(option.value))
-			.map((option) => option.text)
-			.join('<br>');
+
+		let formattedAnswerArray = [];
+
+		answer.forEach((answer) => {
+			if (answer?.conditional) {
+				const selectedOption = this.options.find((option) => option.value === answer.value);
+
+				const conditionalAnswerText = selectedOption.conditional?.label
+					? `${selectedOption.conditional.label} ${answer.conditional}`
+					: answer.conditional;
+
+				const formattedConditionalText = [selectedOption.text, conditionalAnswerText].join('<br>');
+
+				formattedAnswerArray.push(formattedConditionalText);
+			} else {
+				const selectedOption = this.options.find((option) => option.value === answer);
+
+				const conditionalAnswer = questionUtils.getConditionalAnswer(
+					journey.response.answers,
+					this,
+					answer
+				);
+
+				if (conditionalAnswer) {
+					const formattedBlag = [selectedOption.text, conditionalAnswer].join('<br>');
+
+					formattedAnswerArray.push(formattedBlag);
+				} else {
+					formattedAnswerArray.push(selectedOption.text);
+				}
+			}
+		});
+		const formattedAnswer = formattedAnswerArray.join('<br>');
 
 		return super.formatAnswerForSummary(sectionSegment, journey, formattedAnswer, false);
 	}

--- a/packages/forms-web-app/src/dynamic-forms/dynamic-components/checkbox/question.test.js
+++ b/packages/forms-web-app/src/dynamic-forms/dynamic-components/checkbox/question.test.js
@@ -1,6 +1,5 @@
 const CheckboxQuestion = require('./question');
 const ValidOptionValidator = require('../../validator/valid-option-validator');
-
 describe('./src/dynamic-forms/dynamic-components/checkbox/question.js', () => {
 	const TITLE = 'title';
 	const QUESTION = 'Question?';
@@ -39,15 +38,25 @@ describe('./src/dynamic-forms/dynamic-components/checkbox/question.js', () => {
 
 	it('should return option label when formatAnswerForSummary is called with one answer', () => {
 		const question = new CheckboxQuestion(CHECKBOX_PARAMS);
+		const journey = {
+			response: {
+				answers: {}
+			}
+		};
 		question.getAction = () => {};
-		const formattedAnswer = question.formatAnswerForSummary({}, {}, '1');
+		const formattedAnswer = question.formatAnswerForSummary({}, journey, '1');
 		expect(formattedAnswer[0].value).toEqual('a');
 	});
 
 	it('should return formatted option labels when formatAnswerForSummary is called with several answers', () => {
 		const question = new CheckboxQuestion(CHECKBOX_PARAMS);
+		const journey = {
+			response: {
+				answers: {}
+			}
+		};
 		question.getAction = () => {};
-		const formattedAnswer = question.formatAnswerForSummary({}, {}, ['1', '2']);
+		const formattedAnswer = question.formatAnswerForSummary({}, journey, ['1', '2']);
 		expect(formattedAnswer[0].value).toEqual('a<br>b');
 	});
 });

--- a/packages/forms-web-app/src/dynamic-forms/dynamic-components/checkbox/question.test.js
+++ b/packages/forms-web-app/src/dynamic-forms/dynamic-components/checkbox/question.test.js
@@ -5,12 +5,20 @@ describe('./src/dynamic-forms/dynamic-components/checkbox/question.js', () => {
 	const QUESTION = 'Question?';
 	const DESCRIPTION = 'Describe';
 	const FIELDNAME = 'field-name';
+	const CONDITIONAL_FIELDNAME = 'conditional-field-name';
 	const URL = 'url';
 	const PAGE_TITLE = 'this appears in <title>';
 	const VALIDATORS = [1, 2];
 	const OPTIONS = [
 		{ text: 'a', value: '1' },
-		{ text: 'b', value: '2' }
+		{ text: 'b', value: '2' },
+		{
+			text: 'c',
+			value: '3',
+			conditional: {
+				fieldName: CONDITIONAL_FIELDNAME
+			}
+		}
 	];
 	const CHECKBOX_PARAMS = {
 		title: TITLE,
@@ -22,6 +30,13 @@ describe('./src/dynamic-forms/dynamic-components/checkbox/question.js', () => {
 		validators: VALIDATORS,
 		options: OPTIONS
 	};
+	const CONDITIONAL_ANSWER_TEXT = 'a conditional answer';
+	const JOURNEY = {
+		response: {
+			answers: {}
+		}
+	};
+	JOURNEY.response.answers[`${FIELDNAME}_${CONDITIONAL_FIELDNAME}`] = CONDITIONAL_ANSWER_TEXT;
 	it('should create', () => {
 		const question = new CheckboxQuestion(CHECKBOX_PARAMS);
 
@@ -38,25 +53,33 @@ describe('./src/dynamic-forms/dynamic-components/checkbox/question.js', () => {
 
 	it('should return option label when formatAnswerForSummary is called with one answer', () => {
 		const question = new CheckboxQuestion(CHECKBOX_PARAMS);
-		const journey = {
-			response: {
-				answers: {}
-			}
-		};
 		question.getAction = () => {};
-		const formattedAnswer = question.formatAnswerForSummary({}, journey, '1');
+		const formattedAnswer = question.formatAnswerForSummary({}, JOURNEY, '1');
 		expect(formattedAnswer[0].value).toEqual('a');
 	});
 
-	it('should return formatted option labels when formatAnswerForSummary is called with several answers', () => {
+	it('should return formatted option labels when formatAnswerForSummary is called with a string representing several non-conditional answers', () => {
 		const question = new CheckboxQuestion(CHECKBOX_PARAMS);
-		const journey = {
-			response: {
-				answers: {}
-			}
+		question.getAction = () => {};
+		const formattedAnswer = question.formatAnswerForSummary({}, JOURNEY, '1,2');
+		expect(formattedAnswer[0].value).toEqual('a<br>b');
+	});
+
+	it('should return formatted option labels when formatAnswerForSummary is called with a string representing several answers including a conditional', () => {
+		const question = new CheckboxQuestion(CHECKBOX_PARAMS);
+		question.getAction = () => {};
+		const formattedAnswer = question.formatAnswerForSummary({}, JOURNEY, '1,2,3');
+		expect(formattedAnswer[0].value).toEqual(`a<br>b<br>c<br>${CONDITIONAL_ANSWER_TEXT}`);
+	});
+
+	it('should return a formatted option label when formatAnswerForSummary is called with a single conditional answer', () => {
+		const question = new CheckboxQuestion(CHECKBOX_PARAMS);
+		const conditionalAnswer = {
+			value: '3',
+			conditional: CONDITIONAL_ANSWER_TEXT
 		};
 		question.getAction = () => {};
-		const formattedAnswer = question.formatAnswerForSummary({}, journey, ['1', '2']);
-		expect(formattedAnswer[0].value).toEqual('a<br>b');
+		const formattedAnswer = question.formatAnswerForSummary({}, JOURNEY, conditionalAnswer);
+		expect(formattedAnswer[0].value).toEqual(`c<br>${CONDITIONAL_ANSWER_TEXT}`);
 	});
 });


### PR DESCRIPTION
… question

## Ticket Number

https://pins-ds.atlassian.net/browse/AAPD-1046

## Description of change

Display the text from the 'other' field for the designated fields question and other checkbox questions from the same dynamic template.

## Checklist

<!-- Put an `x` in all the boxes that apply: -->

- [ ] Requires infrastructure changes
- [ ] I have updated the documentation accordingly
- [X] My commit history in this PR is linear
- [ ] New features have tests
- [ ] Breaking change (team conversation required)

## Important

Please do not merge from `main` (please only [rebase](https://github.com/Planning-Inspectorate/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
