### PR TITLE
chore: allow choice of csv separator in release utils

### DIFF
--- a/dev/release-util/src/commit-summary.js
+++ b/dev/release-util/src/commit-summary.js
@@ -29,6 +29,7 @@ async function run() {
 	const argv = docopt(docs);
 	const from = argv['<from>'];
 	const to = argv['<to>'] || 'main';
+	const separator = ',';
 
 	const jira = new JiraApi({ baseUrl, username, apiKey });
 
@@ -38,16 +39,18 @@ async function run() {
 		.split('\n') // split into lines
 		.filter(Boolean); // filter out blank lines
 
-	const rows = [`commit,ticket,title,parent,status,commit link`];
+	const rows = [
+		`commit${separator}ticket${separator}title${separator}parent${separator}status${separator}commit link`
+	];
 	const tickets = new Map();
 	for await (const commitLine of commits) {
 		const commit = new Commit(commitLine);
 		if (!commit.hasScope) {
-			rows.push(`"${commit.message}","N/A"`);
+			rows.push(`"${commit.message}"${separator}"N/A"`);
 			continue;
 		}
 		if (!commit.scopeEndsInDigits) {
-			rows.push(`"${commit.message}","N/A"`);
+			rows.push(`"${commit.message}"${separator}"N/A"`);
 			continue;
 		}
 		const ticketNumber = commit.ticketNumber;
@@ -69,7 +72,7 @@ async function run() {
 				commitLink(commit.hash)
 			]
 				.map((value) => `"${value}"`)
-				.join(',')
+				.join(separator)
 		);
 	}
 


### PR DESCRIPTION
## Ticket Number

<!-- Add the number from the Jira board -->

## Description of change

allow choice of csv separator in release utils

## Checklist

<!-- Put an `x` in all the boxes that apply: -->

- [ ] Requires infrastructure changes
- [ ] I have updated the documentation accordingly
- [ ] My commit history in this PR is linear
- [ ] New features have tests
- [ ] Breaking change (team conversation required)

## Important

Please do not merge from `main` (please only [rebase](https://github.com/Planning-Inspectorate/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
