### PR TITLE
fix(aapd-1440): amend section isComplete check to account for sql document upload

### DIFF
--- a/packages/forms-web-app/src/dynamic-forms/section.js
+++ b/packages/forms-web-app/src/dynamic-forms/section.js
@@ -79,6 +79,7 @@ class Section {
 		let requiredQuestionCount = 0;
 		let requiredAnswerCount = 0;
 		let answerCount = 0;
+		let missingRequiredFiles = false;
 
 		for (let question of this.questions) {
 			//todo: rather than use instanceof can isRequired be a property on BaseValidator?
@@ -92,8 +93,15 @@ class Section {
 				requiredQuestionCount++;
 			}
 
-			// move to next question if answer not provided for this questio or for file upload questions the length of uploaded files is less than 1
-			if (!answer || answer.uploadedFiles?.length < 1) {
+			if (question.documentType && answer === 'yes') {
+				const relevantDocs = journeyResponse.answers.SubmissionDocumentUpload.filter(
+					(upload) => upload.type === question.documentType.name
+				);
+				missingRequiredFiles = relevantDocs.length < 1 ? true : false;
+			}
+
+			// move to next question if answer not provided for this question or for file upload questions the length of uploaded files is less than 1
+			if (!answer || missingRequiredFiles) {
 				continue;
 			}
 

--- a/packages/forms-web-app/src/dynamic-forms/section.js
+++ b/packages/forms-web-app/src/dynamic-forms/section.js
@@ -94,10 +94,9 @@ class Section {
 			}
 
 			if (question.documentType && answer === 'yes') {
-				const relevantDocs = journeyResponse.answers.SubmissionDocumentUpload.filter(
+				missingRequiredFiles = !journeyResponse.answers.SubmissionDocumentUpload.some(
 					(upload) => upload.type === question.documentType.name
 				);
-				missingRequiredFiles = relevantDocs.length < 1 ? true : false;
 			}
 
 			// move to next question if answer not provided for this question or for file upload questions the length of uploaded files is less than 1

--- a/packages/forms-web-app/src/dynamic-forms/section.test.js
+++ b/packages/forms-web-app/src/dynamic-forms/section.test.js
@@ -137,11 +137,16 @@ describe('./src/dynamic-forms/section.js', () => {
 			expect(isComplete).toBe(true);
 		});
 	});
-	it('should not return COMPLETE when a file upload question has no files associated with it', () => {
+	it('should return COMPLETE when a file upload question has files associated with it', () => {
 		const mockJourneyResponse = {
 			answers: {
 				visitFrequently: 'Answer 1',
-				anotherFieldName: { uploadedFiles: [] }
+				anotherFieldName: 'yes',
+				SubmissionDocumentUpload: [
+					{
+						type: 'testDocType'
+					}
+				]
 			}
 		};
 
@@ -152,7 +157,51 @@ describe('./src/dynamic-forms/section.js', () => {
 
 		const anotherRequiredQuestion = {
 			fieldName: 'anotherFieldName',
-			validators: [new RequiredFileUploadValidator()]
+			validators: [new RequiredFileUploadValidator()],
+			documentType: {
+				name: 'testDocType'
+			}
+		};
+
+		const notARequiredQuestion = {
+			fieldName: 'someQuestion',
+			validators: []
+		};
+
+		const section = new Section();
+		section.addQuestion(requiredQuestion);
+		section.addQuestion(anotherRequiredQuestion);
+		section.addQuestion(notARequiredQuestion);
+
+		const result = section.getStatus(mockJourneyResponse);
+		expect(result).toBe(SECTION_STATUS.COMPLETE);
+		const isComplete = section.isComplete(mockJourneyResponse);
+		expect(isComplete).toBe(true);
+	});
+	it('should not return COMPLETE when a file upload question has no files associated with it', () => {
+		const mockJourneyResponse = {
+			answers: {
+				visitFrequently: 'Answer 1',
+				anotherFieldName: 'yes',
+				SubmissionDocumentUpload: [
+					{
+						type: 'notTestDocType'
+					}
+				]
+			}
+		};
+
+		const requiredQuestion = {
+			fieldName: 'visitFrequently',
+			validators: [new RequiredValidator()]
+		};
+
+		const anotherRequiredQuestion = {
+			fieldName: 'anotherFieldName',
+			validators: [new RequiredFileUploadValidator()],
+			documentType: {
+				name: 'testDocType'
+			}
 		};
 
 		const notARequiredQuestion = {


### PR DESCRIPTION
## Ticket Number

https://pins-ds.atlassian.net/browse/AAPD-1440

## Description of change

Amend the isComplete check for sections when displaying on the task list, now check is relevant uploaded files for question

## Checklist

- [ ] Requires infrastructure changes
- [ ] I have updated the documentation accordingly
- X My commit history in this PR is linear
- X New features have tests
- [ ] Breaking change (team conversation required)

## Important

Please do not merge from `main` (please only [rebase](https://github.com/Planning-Inspectorate/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
