### PR TITLE
fix(1440): amend section complete check for address questions

### DIFF
--- a/packages/forms-web-app/src/dynamic-forms/section.js
+++ b/packages/forms-web-app/src/dynamic-forms/section.js
@@ -1,3 +1,4 @@
+const AddressAddMoreQuestion = require('./dynamic-components/address-add-more/question');
 const RequiredFileUploadValidator = require('./validator/required-file-upload-validator');
 const RequiredValidator = require('./validator/required-validator');
 
@@ -70,7 +71,7 @@ class Section {
 	}
 
 	/**
-	 * checks answers on response to ensure that a answer is provded for each required question in the section
+	 * checks answers on response to ensure that a answer is provided for each required question in the section
 	 * @param {JourneyResponse} journeyResponse
 	 * @returns {SectionStatus}
 	 */
@@ -99,7 +100,13 @@ class Section {
 				);
 			}
 
-			// move to next question if answer not provided for this question or for file upload questions the length of uploaded files is less than 1
+			if (question.subQuestion instanceof AddressAddMoreQuestion) {
+				missingRequiredFiles = !journeyResponse.answers.SubmissionAddress.some(
+					(address) => address.fieldName === question.subQuestion.fieldName
+				);
+			}
+
+			// move to next question if answer not provided for this question or for file / address upload questions the length of uploaded files is less than 1
 			if (!answer || missingRequiredFiles) {
 				continue;
 			}


### PR DESCRIPTION
## Ticket Number

https://pins-ds.atlassian.net/browse/AAPD-1440

## Description of change

Makes an amendment to the getStatus check for displaying sections on the questionnaire task list to account for SQL storage of addresses.

## Checklist

<!-- Put an `x` in all the boxes that apply: -->

- [ ] Requires infrastructure changes
- [ ] I have updated the documentation accordingly
- [ ] My commit history in this PR is linear
- [ ] New features have tests
- [ ] Breaking change (team conversation required)

## Important

Please do not merge from `main` (please only [rebase](https://github.com/Planning-Inspectorate/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
