### PR TITLE
Feat/aapd 1656 multifield tasklist display

### DIFF
--- a/packages/forms-web-app/src/dynamic-forms/dynamic-components/multi-field-input/question.js
+++ b/packages/forms-web-app/src/dynamic-forms/dynamic-components/multi-field-input/question.js
@@ -126,7 +126,7 @@ class MultiFieldInputQuestion extends Question {
 	formatAnswerForSummary(sectionSegment, journey) {
 		const summaryDetails = this.inputFields.reduce((acc, field) => {
 			const answer = journey.response.answers[field.fieldName];
-			return answer ? acc + answer + field.formatJoinString : acc;
+			return answer ? acc + answer + (field.formatJoinString || '\n') : acc;
 		}, '');
 
 		const formattedAnswer = summaryDetails || this.NOT_STARTED;
@@ -138,22 +138,6 @@ class MultiFieldInputQuestion extends Question {
 				action: this.getAction(sectionSegment, journey, summaryDetails)
 			}
 		];
-	}
-
-	/**
-	 * Returns the action link for the question
-	 * @param {Object} answer
-	 * @param {Journey} journey
-	 * @param {String} sectionSegment
-	 * @returns {{ href: string; text: string; visuallyHiddenText: string; }}
-	 */
-	getAction(sectionSegment, journey, answer) {
-		const action = {
-			href: journey.getCurrentQuestionUrl(sectionSegment, this.fieldName),
-			text: answer ? 'Change' : 'Answer',
-			visuallyHiddenText: this.question
-		};
-		return action;
 	}
 }
 

--- a/packages/forms-web-app/src/dynamic-forms/dynamic-components/multi-field-input/question.js
+++ b/packages/forms-web-app/src/dynamic-forms/dynamic-components/multi-field-input/question.js
@@ -156,7 +156,7 @@ class MultiFieldInputQuestion extends Question {
 		const contactName = `${journey.response.answers[firstNameField]} ${journey.response.answers[lastNameField]}`;
 		const companyName = journey.response.answers[companyNameField];
 
-		return contactName + (companyName ? `\n${companyName}` : '');
+		return contactName + (companyName ? `<br>${companyName}` : '');
 	}
 }
 

--- a/packages/forms-web-app/src/dynamic-forms/dynamic-components/multi-field-input/question.js
+++ b/packages/forms-web-app/src/dynamic-forms/dynamic-components/multi-field-input/question.js
@@ -153,10 +153,28 @@ class MultiFieldInputQuestion extends Question {
 			inputFields.find((inputField) => inputField.fieldName.includes('CompanyName'))?.fieldName ||
 			'';
 
+		if (!journey.response.answers[firstNameField]) return this.NOT_STARTED;
+
 		const contactName = `${journey.response.answers[firstNameField]} ${journey.response.answers[lastNameField]}`;
 		const companyName = journey.response.answers[companyNameField];
 
 		return contactName + (companyName ? `<br>${companyName}` : '');
+	}
+
+	/**
+	 * Returns the action link for the question
+	 * @param {Object} answer
+	 * @param {Journey} journey
+	 * @param {String} sectionSegment
+	 * @returns {{ href: string; text: string; visuallyHiddenText: string; }}
+	 */
+	getAction(sectionSegment, journey, answer) {
+		const action = {
+			href: journey.getCurrentQuestionUrl(sectionSegment, this.fieldName),
+			text: !answer || answer === this.NOT_STARTED ? 'Answer' : 'Change',
+			visuallyHiddenText: this.question
+		};
+		return action;
 	}
 }
 

--- a/packages/forms-web-app/src/dynamic-forms/dynamic-components/multi-field-input/question.js
+++ b/packages/forms-web-app/src/dynamic-forms/dynamic-components/multi-field-input/question.js
@@ -14,7 +14,7 @@ const { nl2br } = require('@pins/common/src/utils');
  * @typedef {Object} InputField
  * @property {string} fieldName
  * @property {string} label
- * @property {string} formatJoinString
+ * @property {string} [formatJoinString] optional property, used by formatAnswerForSummary (eg task list display), effective default to line break
  */
 
 /**
@@ -49,8 +49,7 @@ class MultiFieldInputQuestion extends Question {
 		html,
 		label,
 		inputAttributes = {},
-		inputFields,
-		formatType
+		inputFields
 	}) {
 		super({
 			title,
@@ -64,7 +63,6 @@ class MultiFieldInputQuestion extends Question {
 		});
 		this.label = label;
 		this.inputAttributes = inputAttributes;
-		this.formatType = formatType || 'standard';
 
 		if (inputFields) {
 			this.inputFields = inputFields;

--- a/packages/forms-web-app/src/dynamic-forms/questions.js
+++ b/packages/forms-web-app/src/dynamic-forms/questions.js
@@ -1606,15 +1606,18 @@ exports.questions = {
 		inputFields: [
 			{
 				fieldName: 'appellantFirstName',
-				label: 'First name'
+				label: 'First name',
+				formatJoinString: ' '
 			},
 			{
 				fieldName: 'appellantLastName',
-				label: 'Last name'
+				label: 'Last name',
+				formatJoinString: '\n'
 			},
 			{
 				fieldName: 'appellantCompanyName',
-				label: 'Company name (optional)'
+				label: 'Company name (optional)',
+				formatJoinString: ''
 			}
 		],
 		validators: [
@@ -1650,15 +1653,18 @@ exports.questions = {
 		inputFields: [
 			{
 				fieldName: 'contactFirstName',
-				label: 'First name'
+				label: 'First name',
+				formatJoinString: ' '
 			},
 			{
 				fieldName: 'contactLastName',
-				label: 'Last name'
+				label: 'Last name',
+				formatJoinString: '\n'
 			},
 			{
 				fieldName: 'contactCompanyName',
-				label: 'Organisation name (optional)'
+				label: 'Organisation name (optional)',
+				formatJoinString: ''
 			}
 		],
 		validators: [

--- a/packages/forms-web-app/src/dynamic-forms/questions.js
+++ b/packages/forms-web-app/src/dynamic-forms/questions.js
@@ -1602,6 +1602,7 @@ exports.questions = {
 		html: 'resources/your-details/applicant-name.html',
 		fieldName: 'applicantName',
 		url: 'applicant-name',
+		formatType: 'contactDetails',
 		inputFields: [
 			{
 				fieldName: 'appellantFirstName',
@@ -1645,6 +1646,7 @@ exports.questions = {
 		question: 'Contact details',
 		fieldName: 'contactDetails',
 		url: 'contact-details',
+		formatType: 'contactDetails',
 		inputFields: [
 			{
 				fieldName: 'contactFirstName',


### PR DESCRIPTION
## Ticket Number

https://pins-ds.atlassian.net/browse/AAPD-1656

## Description of change

Amends the way that contact details questions are displayed on the task list - adds a formatType param to the MultiFieldInputQuestion type which determines the task list display method.

## Checklist

<!-- Put an `x` in all the boxes that apply: -->

- [ ] Requires infrastructure changes
- [ ] I have updated the documentation accordingly
- [ ] My commit history in this PR is linear
- [ ] New features have tests
- [ ] Breaking change (team conversation required)

## Important

Please do not merge from `main` (please only [rebase](https://github.com/Planning-Inspectorate/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
