### PR TITLE
fix(1682): correct display of appeal status and sections completed

### DIFF
--- a/packages/forms-web-app/src/dynamic-forms/dynamic-components/task-list/submission.njk
+++ b/packages/forms-web-app/src/dynamic-forms/dynamic-components/task-list/submission.njk
@@ -24,17 +24,12 @@
       <p class="govuk-body"><a href="/appeals/your-appeals" class="govuk-link--no-visited-state">Save and come back later</a>.</p>
       <hr class="govuk-section-break govuk-section-break--visible govuk-section-break--l">
     </div>
-
   </div>
 
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-three-quarters-from-desktop">
-      {% if journeyComplete %}
-          <h2 class="govuk-heading-s">Appeal complete</h2>
-        {% else %}
-          <h2 class="govuk-heading-s">Appeal incomplete</h2>
-      {% endif %}
-      <p class="govuk-!-margin-bottom-7">You have completed {{summaryListData.completedSectionCount}} of {{summaryListData.sections.length}} sections.</p>
+      <h2 class="govuk-heading-s">Appeal incomplete</h2>
+      <p class="govuk-!-margin-bottom-7">You have completed {{summaryListData.completedSectionCount}} of {{summaryListData.sections.length + 1}} sections.</p>
     </div>
   </div>
 {% endblock %}


### PR DESCRIPTION
## Ticket Number

https://pins-ds.atlassian.net/browse/AAPD-1682

## Description of change

Amends the appeal status on task list so that it shows incomplete and adds another section to total (representing submission from task list)

## Checklist

<!-- Put an `x` in all the boxes that apply: -->

- [ ] Requires infrastructure changes
- [ ] I have updated the documentation accordingly
- X My commit history in this PR is linear
- [ ] New features have tests
- [ ] Breaking change (team conversation required)

## Important

Please do not merge from `main` (please only [rebase](https://github.com/Planning-Inspectorate/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
