### PR TITLE
Feat/aapd 1619 details formatting

### DIFF
--- a/packages/common/src/lib/format-address.js
+++ b/packages/common/src/lib/format-address.js
@@ -1,3 +1,5 @@
+const escape = require('escape-html');
+
 /**
  * @typedef {import('appeals-service-api').Api.AppealCaseWithAppellant} AppealCaseWithAppellant
  * @typedef {import('appeals-service-api').Api.AppealSubmission} AppealSubmission
@@ -8,7 +10,7 @@
 
 /**
  * @param {AppealCaseWithAppellant | AppealSubmission} appealCaseData
- * @param { boolean } breaks
+ * @param {string } [joinString]
  * @returns {string}
  */
 const formatAddress = (appealCaseData, joinString = ', ') => {
@@ -27,7 +29,7 @@ const formatAddress = (appealCaseData, joinString = ', ') => {
 		appealCaseData.siteAddressPostcode
 	];
 
-	return addressComponents.filter(Boolean).join(joinString);
+	return addressComponents.filter(Boolean).map(escape).join(joinString);
 };
 
 /**
@@ -46,7 +48,7 @@ const formatAddressWithBreaks = (appealCaseData) => {
 		appealCaseData.siteAddressPostcode
 	];
 
-	return addressComponents.filter(Boolean).join('\n');
+	return addressComponents.filter(Boolean).map(escape).join('\n');
 };
 
 /**
@@ -68,7 +70,7 @@ const formatAppealSubmissionAddress = (appealSubmission) => {
 			address.postcode
 		];
 
-		return addressComponents.filter(Boolean).join(', ');
+		return addressComponents.filter(Boolean).map(escape).join(', ');
 	} else if (isV2Submission(appealSubmission)) {
 		// appellant submission should only contain one address
 		const v2Address = appealSubmission?.AppellantSubmission?.SubmissionAddress[0];
@@ -83,7 +85,7 @@ const formatAppealSubmissionAddress = (appealSubmission) => {
 			v2Address.county,
 			v2Address.postcode
 		];
-		return addressComponents.filter(Boolean).join(', ');
+		return addressComponents.filter(Boolean).map(escape).join(', ');
 	} else {
 		return '';
 	}
@@ -101,7 +103,7 @@ const formatNeibouringAddressWithBreaks = (neighbourAddress) => {
 		neighbourAddress.postcode
 	];
 
-	return addressComponents.filter(Boolean).join('\n');
+	return addressComponents.filter(Boolean).map(escape).join('\n');
 };
 
 /**
@@ -117,7 +119,7 @@ const formatSubmissionAddress = (submissionAddress, joinString = ', ') => {
 		submissionAddress.postcode
 	];
 
-	return addressComponents.filter(Boolean).join(joinString);
+	return addressComponents.filter(Boolean).map(escape).join(joinString);
 };
 
 /**

--- a/packages/common/src/lib/format-address.js
+++ b/packages/common/src/lib/format-address.js
@@ -1,5 +1,3 @@
-const escape = require('escape-html');
-
 /**
  * @typedef {import('appeals-service-api').Api.AppealCaseWithAppellant} AppealCaseWithAppellant
  * @typedef {import('appeals-service-api').Api.AppealSubmission} AppealSubmission
@@ -29,7 +27,7 @@ const formatAddress = (appealCaseData, joinString = ', ') => {
 		appealCaseData.siteAddressPostcode
 	];
 
-	return addressComponents.filter(Boolean).map(escape).join(joinString);
+	return addressComponents.filter(Boolean).join(joinString);
 };
 
 /**
@@ -48,7 +46,7 @@ const formatAddressWithBreaks = (appealCaseData) => {
 		appealCaseData.siteAddressPostcode
 	];
 
-	return addressComponents.filter(Boolean).map(escape).join('\n');
+	return addressComponents.filter(Boolean).join('\n');
 };
 
 /**
@@ -70,7 +68,7 @@ const formatAppealSubmissionAddress = (appealSubmission) => {
 			address.postcode
 		];
 
-		return addressComponents.filter(Boolean).map(escape).join(', ');
+		return addressComponents.filter(Boolean).join(', ');
 	} else if (isV2Submission(appealSubmission)) {
 		// appellant submission should only contain one address
 		const v2Address = appealSubmission?.AppellantSubmission?.SubmissionAddress[0];
@@ -85,7 +83,7 @@ const formatAppealSubmissionAddress = (appealSubmission) => {
 			v2Address.county,
 			v2Address.postcode
 		];
-		return addressComponents.filter(Boolean).map(escape).join(', ');
+		return addressComponents.filter(Boolean).join(', ');
 	} else {
 		return '';
 	}
@@ -103,7 +101,7 @@ const formatNeibouringAddressWithBreaks = (neighbourAddress) => {
 		neighbourAddress.postcode
 	];
 
-	return addressComponents.filter(Boolean).map(escape).join('\n');
+	return addressComponents.filter(Boolean).join('\n');
 };
 
 /**
@@ -119,7 +117,7 @@ const formatSubmissionAddress = (submissionAddress, joinString = ', ') => {
 		submissionAddress.postcode
 	];
 
-	return addressComponents.filter(Boolean).map(escape).join(joinString);
+	return addressComponents.filter(Boolean).join(joinString);
 };
 
 /**

--- a/packages/common/src/lib/format-appeal-details.js
+++ b/packages/common/src/lib/format-appeal-details.js
@@ -1,19 +1,30 @@
+const escape = require('escape-html');
+
+// NOTE - consider requirement to escape string values from caseData
+
 /**
  * @param {import("../client/appeals-api-client").AppealCaseWithAppellant} caseData
  */
 exports.formatContactDetails = (caseData) => {
-	const contactName = `${caseData.contactFirstName} ${caseData.contactLastName}`;
+	const contactName = `${escape(caseData.contactFirstName)} ${escape(caseData.contactLastName)}`;
 
-	return contactName + (caseData.contactCompanyName ? `\n${caseData.contactCompanyName}` : '');
+	return (
+		contactName + (caseData.contactCompanyName ? `\n${escape(caseData.contactCompanyName)}` : '')
+	);
 };
 
 /**
  * @param {import("../client/appeals-api-client").AppealCaseWithAppellant} caseData
  */
 exports.formatApplicantDetails = (caseData) => {
-	const contactName = `${caseData.appellantFirstName} ${caseData.appellantLastName}`;
+	const contactName = `${escape(caseData.appellantFirstName)} ${escape(
+		caseData.appellantLastName
+	)}`;
 
-	return contactName + (caseData.appellantCompanyName ? `\n${caseData.appellantCompanyName}` : '');
+	return (
+		contactName +
+		(caseData.appellantCompanyName ? `\n${escape(caseData.appellantCompanyName)}` : '')
+	);
 };
 
 /**
@@ -24,7 +35,7 @@ exports.formatAccessDetails = (caseData) => {
 
 	return (
 		visibility +
-		(caseData.appellantSiteAccessDetails ? `\n${caseData.appellantSiteAccessDetails}` : '')
+		(caseData.appellantSiteAccessDetails ? `\n${escape(caseData.appellantSiteAccessDetails)}` : '')
 	);
 };
 
@@ -36,7 +47,7 @@ exports.formatHealthAndSafety = (caseData) => {
 
 	return (
 		safetyIssues +
-		(caseData.appellantSiteSafetyDetails ? `\n${caseData.appellantSiteSafetyDetails}` : '')
+		(caseData.appellantSiteSafetyDetails ? `\n${escape(caseData.appellantSiteSafetyDetails)}` : '')
 	);
 };
 
@@ -50,7 +61,7 @@ exports.formatProcedure = (caseData) => {
 		caseData.appellantPreferInquiryDetails ?? ''
 	];
 
-	const valueText = possibleProcedures.filter(Boolean).join('\n');
+	const valueText = possibleProcedures.filter(Boolean).map(escape).join('\n');
 
 	return valueText;
 };

--- a/packages/common/src/lib/format-appeal-details.js
+++ b/packages/common/src/lib/format-appeal-details.js
@@ -6,25 +6,18 @@ const escape = require('escape-html');
  * @param {import("../client/appeals-api-client").AppealCaseWithAppellant} caseData
  */
 exports.formatContactDetails = (caseData) => {
-	const contactName = `${escape(caseData.contactFirstName)} ${escape(caseData.contactLastName)}`;
+	const contactName = `${caseData.contactFirstName} ${caseData.contactLastName}`;
 
-	return (
-		contactName + (caseData.contactCompanyName ? `\n${escape(caseData.contactCompanyName)}` : '')
-	);
+	return contactName + (caseData.contactCompanyName ? `\n${caseData.contactCompanyName}` : '');
 };
 
 /**
  * @param {import("../client/appeals-api-client").AppealCaseWithAppellant} caseData
  */
 exports.formatApplicantDetails = (caseData) => {
-	const contactName = `${escape(caseData.appellantFirstName)} ${escape(
-		caseData.appellantLastName
-	)}`;
+	const contactName = `${caseData.appellantFirstName} ${caseData.appellantLastName}`;
 
-	return (
-		contactName +
-		(caseData.appellantCompanyName ? `\n${escape(caseData.appellantCompanyName)}` : '')
-	);
+	return contactName + (caseData.appellantCompanyName ? `\n${caseData.appellantCompanyName}` : '');
 };
 
 /**
@@ -35,7 +28,7 @@ exports.formatAccessDetails = (caseData) => {
 
 	return (
 		visibility +
-		(caseData.appellantSiteAccessDetails ? `\n${escape(caseData.appellantSiteAccessDetails)}` : '')
+		(caseData.appellantSiteAccessDetails ? `\n${caseData.appellantSiteAccessDetails}` : '')
 	);
 };
 
@@ -47,7 +40,7 @@ exports.formatHealthAndSafety = (caseData) => {
 
 	return (
 		safetyIssues +
-		(caseData.appellantSiteSafetyDetails ? `\n${escape(caseData.appellantSiteSafetyDetails)}` : '')
+		(caseData.appellantSiteSafetyDetails ? `\n${caseData.appellantSiteSafetyDetails}` : '')
 	);
 };
 
@@ -61,7 +54,7 @@ exports.formatProcedure = (caseData) => {
 		caseData.appellantPreferInquiryDetails ?? ''
 	];
 
-	const valueText = possibleProcedures.filter(Boolean).map(escape).join('\n');
+	const valueText = possibleProcedures.filter(Boolean).join('\n');
 
 	return valueText;
 };
@@ -87,5 +80,5 @@ exports.formatLinkedAppeals = (caseData) => {
  * @param {import('appeals-service-api').Api.SubmissionLinkedCase} linkedAppeal
  */
 const formatLinkedAppealHyperlink = (linkedAppeal) => {
-	return `<a href=# class="govuk-link">${linkedAppeal.caseReference}</a>`;
+	return `<a href=# class="govuk-link">${escape(linkedAppeal.caseReference)}</a>`;
 };

--- a/packages/common/src/lib/format-appeal-documents.js
+++ b/packages/common/src/lib/format-appeal-documents.js
@@ -1,3 +1,4 @@
+const escape = require('escape-html');
 /**
  * @param {import('appeals-service-api').Api.Document[]} documents
  * @param {string} documentType
@@ -25,5 +26,5 @@ exports.formatNewDescription = (caseData) => {
  * @returns {string}
  */
 const formatDocumentLink = (document) => {
-	return `<a href=# class="govuk-link">${document.filename}</a>`;
+	return `<a href=# class="govuk-link">${escape(document.filename)}</a>`;
 };

--- a/packages/common/src/view-model-maps/rows/def.d.ts
+++ b/packages/common/src/view-model-maps/rows/def.d.ts
@@ -4,6 +4,7 @@ export interface Row {
 	keyText: string;
 	valueText: string;
 	condition: (caseData: Api.AppealCaseWithAppellant) => string | boolean | undefined;
+	isEscaped?: boolean | undefined;
 }
 
 export type Rows = Array<Row>;

--- a/packages/common/src/view-model-maps/rows/index.js
+++ b/packages/common/src/view-model-maps/rows/index.js
@@ -1,3 +1,4 @@
+const escape = require('escape-html');
 const { nl2br } = require('../../utils');
 
 /**
@@ -7,7 +8,7 @@ const { nl2br } = require('../../utils');
 exports.formatRows = (rows, caseData) => {
 	const displayRows = rows.filter(({ condition }) => condition(caseData));
 
-	return displayRows.map((row) => createRow(row.keyText, row.valueText));
+	return displayRows.map((row) => createRow(row.keyText, row.valueText, row.isEscaped));
 };
 
 /**
@@ -20,17 +21,18 @@ exports.formatQuestionnaireRows = (rows, questionnaireData) => {
 			condition(questionnaireData) !== undefined && condition(questionnaireData) !== null
 	);
 
-	return displayRows.map((row) => createRow(row.keyText, row.valueText));
+	return displayRows.map((row) => createRow(row.keyText, row.valueText, row.isEscaped));
 };
 
 /**
  * @param { string } keyText
  * @param { string } valueText
+ * @param { boolean | undefined } isEscaped
  */
-const createRow = (keyText, valueText) => {
+const createRow = (keyText, valueText, isEscaped) => {
 	valueText = valueText ?? '';
 	return {
 		key: { text: keyText },
-		value: { html: nl2br(valueText) }
+		value: { html: isEscaped ? nl2br(valueText) : nl2br(escape(valueText)) }
 	};
 };

--- a/packages/common/src/view-model-maps/rows/index.js
+++ b/packages/common/src/view-model-maps/rows/index.js
@@ -1,4 +1,3 @@
-const escape = require('escape-html');
 const { nl2br } = require('../../utils');
 
 /**
@@ -32,6 +31,6 @@ const createRow = (keyText, valueText) => {
 	valueText = valueText ?? '';
 	return {
 		key: { text: keyText },
-		value: { html: nl2br(escape(valueText)) }
+		value: { html: nl2br(valueText) }
 	};
 };

--- a/packages/forms-web-app/src/controllers/selected-appeal/appeal-details/appeal-details-rows.js
+++ b/packages/forms-web-app/src/controllers/selected-appeal/appeal-details/appeal-details-rows.js
@@ -58,7 +58,7 @@ exports.detailsRows = (caseData, userType) => {
 		},
 		{
 			keyText: 'What is the area of the appeal site?',
-			valueText: `${caseData.siteAreaSquareMetres} m<sup>2</sup>`,
+			valueText: `${caseData.siteAreaSquareMetres} m\u00B2`,
 			condition: (caseData) => caseData.siteAreaSquareMetres
 		},
 		{

--- a/packages/forms-web-app/src/controllers/selected-appeal/appeal-details/appeal-details-rows.js
+++ b/packages/forms-web-app/src/controllers/selected-appeal/appeal-details/appeal-details-rows.js
@@ -103,8 +103,8 @@ exports.detailsRows = (caseData, userType) => {
 		},
 		{
 			keyText: 'Agricultural holding',
-			valueText: caseData.agriculturalHolding ? 'Yes' : 'No',
-			condition: (caseData) => caseData.agriculturalHolding
+			valueText: formatYesOrNo(caseData, 'agriculturalHolding'),
+			condition: () => true
 		},
 		{
 			keyText: 'Tenant on agricultural holding',
@@ -157,9 +157,9 @@ exports.detailsRows = (caseData, userType) => {
 			condition: () => true
 		},
 		{
-			keyText: 'Award of costs',
-			valueText: 'Yes',
-			condition: (caseData) => isAppellantOrAgent && caseData.costsAppliedForIndicator
+			keyText: 'Do you need to apply for an award of appeal costs?',
+			valueText: formatYesOrNo(caseData, 'costsAppliedForIndicator'),
+			condition: () => isAppellantOrAgent
 		}
 	];
 };

--- a/packages/forms-web-app/src/controllers/selected-appeal/appeal-details/appeal-details-rows.js
+++ b/packages/forms-web-app/src/controllers/selected-appeal/appeal-details/appeal-details-rows.js
@@ -1,4 +1,3 @@
-const escape = require('escape-html');
 const { formatAddress } = require('@pins/common/src/lib/format-address');
 const {
 	formatApplicantDetails,
@@ -23,8 +22,6 @@ const { APPEAL_USER_ROLES } = require('@pins/common/src/constants');
  * @returns {Rows}
  */
 
-// NOTE - if using an unformatted string from the caseData as the valueText, please 'escape' it
-
 exports.detailsRows = (caseData, userType) => {
 	const isAppellantOrAgent = userType === (APPEAL_USER_ROLES.APPELLANT || APPEAL_USER_ROLES.AGENT);
 
@@ -48,7 +45,7 @@ exports.detailsRows = (caseData, userType) => {
 		},
 		{
 			keyText: 'Phone number',
-			valueText: escape(caseData.appellantPhoneNumber),
+			valueText: caseData.appellantPhoneNumber,
 			condition: (caseData) => caseData.appellantPhoneNumber
 		},
 		{
@@ -128,7 +125,7 @@ exports.detailsRows = (caseData, userType) => {
 		},
 		{
 			keyText: 'Application reference',
-			valueText: escape(caseData.LPAApplicationReference),
+			valueText: caseData.LPAApplicationReference,
 			condition: (caseData) => caseData.LPAApplicationReference
 		},
 		{
@@ -138,7 +135,7 @@ exports.detailsRows = (caseData, userType) => {
 		},
 		{
 			keyText: 'Enter the description of development',
-			valueText: escape(caseData.developmentDescriptionDetails),
+			valueText: caseData.developmentDescriptionDetails,
 			condition: (caseData) => caseData.developmentDescriptionDetails
 		},
 		{
@@ -154,7 +151,8 @@ exports.detailsRows = (caseData, userType) => {
 		{
 			keyText: 'Are there other appeals linked to your development?',
 			valueText: formatLinkedAppeals(caseData),
-			condition: () => true
+			condition: () => true,
+			isEscaped: true
 		},
 		{
 			keyText: 'Do you need to apply for an award of appeal costs?',

--- a/packages/forms-web-app/src/controllers/selected-appeal/appeal-details/appeal-details-rows.js
+++ b/packages/forms-web-app/src/controllers/selected-appeal/appeal-details/appeal-details-rows.js
@@ -55,7 +55,7 @@ exports.detailsRows = (caseData, userType) => {
 		},
 		{
 			keyText: 'What is the area of the appeal site?',
-			valueText: `${caseData.siteAreaSquareMeters}m<sup>2</sup>`,
+			valueText: `${caseData.siteAreaSquareMetres}m<sup>2</sup>`,
 			condition: (caseData) => caseData.siteAreaSquareMetres
 		},
 		{

--- a/packages/forms-web-app/src/controllers/selected-appeal/appeal-details/appeal-details-rows.js
+++ b/packages/forms-web-app/src/controllers/selected-appeal/appeal-details/appeal-details-rows.js
@@ -1,3 +1,4 @@
+const escape = require('escape-html');
 const { formatAddress } = require('@pins/common/src/lib/format-address');
 const {
 	formatApplicantDetails,
@@ -22,6 +23,8 @@ const { APPEAL_USER_ROLES } = require('@pins/common/src/constants');
  * @returns {Rows}
  */
 
+// NOTE - if using an unformatted string from the caseData as the valueText, please 'escape' it
+
 exports.detailsRows = (caseData, userType) => {
 	const isAppellantOrAgent = userType === (APPEAL_USER_ROLES.APPELLANT || APPEAL_USER_ROLES.AGENT);
 
@@ -45,7 +48,7 @@ exports.detailsRows = (caseData, userType) => {
 		},
 		{
 			keyText: 'Phone number',
-			valueText: caseData.appellantPhoneNumber,
+			valueText: escape(caseData.appellantPhoneNumber),
 			condition: (caseData) => caseData.appellantPhoneNumber
 		},
 		{
@@ -55,7 +58,7 @@ exports.detailsRows = (caseData, userType) => {
 		},
 		{
 			keyText: 'What is the area of the appeal site?',
-			valueText: `${caseData.siteAreaSquareMetres} square metres`,
+			valueText: `${caseData.siteAreaSquareMetres} m<sup>2</sup>`,
 			condition: (caseData) => caseData.siteAreaSquareMetres
 		},
 		{
@@ -100,13 +103,8 @@ exports.detailsRows = (caseData, userType) => {
 		},
 		{
 			keyText: 'Agricultural holding',
-			valueText: 'Yes',
+			valueText: caseData.agriculturalHolding ? 'Yes' : 'No',
 			condition: (caseData) => caseData.agriculturalHolding
-		},
-		{
-			keyText: 'Agricultural holding',
-			valueText: 'No',
-			condition: (caseData) => !caseData.agriculturalHolding
 		},
 		{
 			keyText: 'Tenant on agricultural holding',
@@ -130,7 +128,7 @@ exports.detailsRows = (caseData, userType) => {
 		},
 		{
 			keyText: 'Application reference',
-			valueText: caseData.LPAApplicationReference,
+			valueText: escape(caseData.LPAApplicationReference),
 			condition: (caseData) => caseData.LPAApplicationReference
 		},
 		{
@@ -140,12 +138,12 @@ exports.detailsRows = (caseData, userType) => {
 		},
 		{
 			keyText: 'Enter the description of development',
-			valueText: caseData.developmentDescriptionDetails,
+			valueText: escape(caseData.developmentDescriptionDetails),
 			condition: (caseData) => caseData.developmentDescriptionDetails
 		},
 		{
 			keyText: 'Did the local planning authority change the description of development?',
-			valueText: caseData.updateDevelopmentDescription,
+			valueText: formatYesOrNo(caseData, 'updateDevelopmentDescription'),
 			condition: (caseData) => caseData.updateDevelopmentDescription
 		},
 		{

--- a/packages/forms-web-app/src/controllers/selected-appeal/appeal-details/appeal-details-rows.js
+++ b/packages/forms-web-app/src/controllers/selected-appeal/appeal-details/appeal-details-rows.js
@@ -55,7 +55,7 @@ exports.detailsRows = (caseData, userType) => {
 		},
 		{
 			keyText: 'What is the area of the appeal site?',
-			valueText: `${caseData.siteAreaSquareMetres}m<sup>2</sup>`,
+			valueText: `${caseData.siteAreaSquareMetres} square metres`,
 			condition: (caseData) => caseData.siteAreaSquareMetres
 		},
 		{
@@ -96,7 +96,7 @@ exports.detailsRows = (caseData, userType) => {
 		{
 			keyText: 'Will an inspector need to access the land or property?',
 			valueText: formatAccessDetails(caseData),
-			condition: (caseData) => caseData.appellantSiteAccess
+			condition: () => true
 		},
 		{
 			keyText: 'Agricultural holding',

--- a/packages/forms-web-app/src/controllers/selected-appeal/appeal-details/appeal-documents-rows.js
+++ b/packages/forms-web-app/src/controllers/selected-appeal/appeal-details/appeal-documents-rows.js
@@ -19,7 +19,8 @@ exports.documentsRows = (caseData, userType) => {
 		{
 			keyText: 'Application form',
 			valueText: formatDocumentDetails(documents, 'originalApplicationForm'),
-			condition: () => true
+			condition: () => true,
+			isEscaped: true
 		},
 		{
 			keyText: 'New description of development',
@@ -29,32 +30,38 @@ exports.documentsRows = (caseData, userType) => {
 		{
 			keyText: 'Plans, drawings and supporting documents',
 			valueText: formatDocumentDetails(documents, 'plansDrawings'),
-			condition: () => true
+			condition: () => true,
+			isEscaped: true
 		},
 		{
 			keyText: 'Separate ownership certificate in application',
 			valueText: formatDocumentDetails(documents, 'ownershipCertificate'),
-			condition: () => true
+			condition: () => true,
+			isEscaped: true
 		},
 		{
 			keyText: 'Design and access statement in application',
 			valueText: formatDocumentDetails(documents, 'designAccessStatement'),
-			condition: () => true
+			condition: () => true,
+			isEscaped: true
 		},
 		{
 			keyText: 'Decision letter',
 			valueText: formatDocumentDetails(documents, 'lpaDecisionLetter'),
-			condition: () => true
+			condition: () => true,
+			isEscaped: true
 		},
 		{
 			keyText: 'Appeal statement',
 			valueText: formatDocumentDetails(documents, 'appellantStatement'),
-			condition: () => true
+			condition: () => true,
+			isEscaped: true
 		},
 		{
 			keyText: 'New plans or drawings',
 			valueText: formatDocumentDetails(documents, 'newPlansDrawings'),
-			condition: () => true
+			condition: () => true,
+			isEscaped: true
 		},
 		{
 			keyText: 'Planning obligation status',
@@ -64,27 +71,32 @@ exports.documentsRows = (caseData, userType) => {
 		{
 			keyText: 'Planning obligation',
 			valueText: formatDocumentDetails(documents, 'planningObligation'),
-			condition: () => true
+			condition: () => true,
+			isEscaped: true
 		},
 		{
 			keyText: 'New supporting documents',
 			valueText: formatDocumentDetails(documents, 'otherNewDocuments'),
-			condition: () => true
+			condition: () => true,
+			isEscaped: true
 		},
 		{
 			keyText: 'Draft statement of common ground',
 			valueText: formatDocumentDetails(documents, 'statementCommonGround'),
-			condition: () => true
+			condition: () => true,
+			isEscaped: true
 		},
 		{
 			keyText: 'Evidence of agreement to change description of development',
 			valueText: formatDocumentDetails(documents, 'changedDescription'),
-			condition: () => true
+			condition: () => true,
+			isEscaped: true
 		},
 		{
 			keyText: 'Costs application',
 			valueText: formatDocumentDetails(documents, 'costsApplication'),
-			condition: (caseData) => isAppellantOrAgent && caseData.costsAppliedForIndicator
+			condition: (caseData) => isAppellantOrAgent && caseData.costsAppliedForIndicator,
+			isEscaped: true
 		}
 	];
 };

--- a/packages/forms-web-app/src/controllers/selected-appeal/questionnaire-details/constraints-details-rows.js
+++ b/packages/forms-web-app/src/controllers/selected-appeal/questionnaire-details/constraints-details-rows.js
@@ -48,7 +48,8 @@ exports.constraintsRows = (caseData, user) => {
 		{
 			keyText: 'Uploaded conservation area map and guidance',
 			valueText: formatDocumentDetails(documents, 'conservationMap'),
-			condition: () => caseData.uploadConservation
+			condition: () => caseData.uploadConservation,
+			isEscaped: true
 		},
 		{
 			keyText: 'Protected species',
@@ -78,7 +79,8 @@ exports.constraintsRows = (caseData, user) => {
 		{
 			keyText: 'Uploaded Tree Preservation Order extent',
 			valueText: formatDocumentDetails(documents, 'treePreservationPlan'),
-			condition: () => caseData.uploadTreePreservationOrder
+			condition: () => caseData.uploadTreePreservationOrder,
+			isEscaped: true
 		},
 		{
 			keyText: 'Gypsy or Traveller',
@@ -93,7 +95,8 @@ exports.constraintsRows = (caseData, user) => {
 		{
 			keyText: 'Uploaded definitive map and statement extract',
 			valueText: formatDocumentDetails(documents, 'definitiveMap'),
-			condition: () => caseData.uploadDefinitiveMapStatement
+			condition: () => caseData.uploadDefinitiveMapStatement,
+			isEscaped: true
 		}
 	];
 

--- a/packages/forms-web-app/src/controllers/selected-appeal/questionnaire-details/consultation-details-rows.js
+++ b/packages/forms-web-app/src/controllers/selected-appeal/questionnaire-details/consultation-details-rows.js
@@ -20,17 +20,20 @@ exports.consultationRows = (caseData) => {
 		{
 			keyText: 'Uploaded consultation responses and standing advice',
 			valueText: formatDocumentDetails(documents, 'consultationResponses'),
-			condition: () => caseData.uploadConsultationResponses
+			condition: () => caseData.uploadConsultationResponses,
+			isEscaped: true
 		},
 		{
 			keyText: 'Representations from other parties',
 			valueText: formatYesOrNo(caseData, 'otherPartyRepresentations'),
-			condition: () => caseData.otherPartyRepresentations
+			condition: () => caseData.otherPartyRepresentations,
+			isEscaped: true
 		},
 		{
 			keyText: 'Uploaded representations from other parties',
 			valueText: formatDocumentDetails(documents, 'otherPartyRepresentations'),
-			condition: () => caseData.uploadRepresentations
+			condition: () => caseData.uploadRepresentations,
+			isEscaped: true
 		}
 	];
 };

--- a/packages/forms-web-app/src/controllers/selected-appeal/questionnaire-details/environmental-details-rows.js
+++ b/packages/forms-web-app/src/controllers/selected-appeal/questionnaire-details/environmental-details-rows.js
@@ -36,7 +36,8 @@ exports.environmentalRows = (caseData) => {
 		{
 			keyText: 'Uploaded screening direction',
 			valueText: formatDocumentDetails(documents, 'screeningDirection'),
-			condition: () => caseData.uploadScreeningDirection
+			condition: () => caseData.uploadScreeningDirection,
+			isEscaped: true
 		},
 		{
 			keyText: 'Issued screening opinion',
@@ -46,7 +47,8 @@ exports.environmentalRows = (caseData) => {
 		{
 			keyText: 'Uploaded screening opinion',
 			valueText: formatDocumentDetails(documents, 'screeningOpinion'),
-			condition: () => caseData.uploadScreeningOpinion
+			condition: () => caseData.uploadScreeningOpinion,
+			isEscaped: true
 		},
 		{
 			keyText: 'Screening opinion indicated environmental statement needed',
@@ -61,7 +63,8 @@ exports.environmentalRows = (caseData) => {
 		{
 			keyText: 'Uploaded environmental statement',
 			valueText: formatDocumentDetails(documents, 'environmentalStatement'),
-			condition: () => caseData.uploadEnvironmentalStatement
+			condition: () => caseData.uploadEnvironmentalStatement,
+			isEscaped: true
 		}
 	];
 };

--- a/packages/forms-web-app/src/controllers/selected-appeal/questionnaire-details/notified-details-rows.js
+++ b/packages/forms-web-app/src/controllers/selected-appeal/questionnaire-details/notified-details-rows.js
@@ -1,4 +1,5 @@
 const { formatDocumentDetails } = require('@pins/common');
+const { toHaveFormValues } = require('@testing-library/jest-dom/matchers');
 
 /**
  * @param {import('appeals-service-api').Api.AppealCaseWithAppellant } caseData
@@ -10,7 +11,8 @@ exports.notifiedRows = (caseData) => {
 		{
 			keyText: 'Who was notified',
 			valueText: formatDocumentDetails(documents, 'whoNotified'),
-			condition: () => caseData.uploadWhoNotified
+			condition: () => caseData.uploadWhoNotified,
+			isEscaped: toHaveFormValues
 		},
 		// TODO data model will need adjusting for possible multiple answers
 		// {
@@ -21,17 +23,20 @@ exports.notifiedRows = (caseData) => {
 		{
 			keyText: 'Site notice',
 			valueText: formatDocumentDetails(documents, 'siteNotice'),
-			condition: () => caseData.uploadSiteNotice
+			condition: () => caseData.uploadSiteNotice,
+			isEscaped: true
 		},
 		{
 			keyText: 'Letters sent to neighbours',
 			valueText: formatDocumentDetails(documents, 'lettersNeighbours'),
-			condition: () => caseData.uploadLettersEmails
+			condition: () => caseData.uploadLettersEmails,
+			isEscaped: true
 		},
 		{
 			keyText: 'Press advert',
 			valueText: formatDocumentDetails(documents, 'pressAdvert'),
-			condition: () => caseData.uploadPressAdvert
+			condition: () => caseData.uploadPressAdvert,
+			isEscaped: true
 		}
 	];
 };

--- a/packages/forms-web-app/src/controllers/selected-appeal/questionnaire-details/notified-details-rows.js
+++ b/packages/forms-web-app/src/controllers/selected-appeal/questionnaire-details/notified-details-rows.js
@@ -1,5 +1,4 @@
 const { formatDocumentDetails } = require('@pins/common');
-const { toHaveFormValues } = require('@testing-library/jest-dom/matchers');
 
 /**
  * @param {import('appeals-service-api').Api.AppealCaseWithAppellant } caseData
@@ -12,7 +11,7 @@ exports.notifiedRows = (caseData) => {
 			keyText: 'Who was notified',
 			valueText: formatDocumentDetails(documents, 'whoNotified'),
 			condition: () => caseData.uploadWhoNotified,
-			isEscaped: toHaveFormValues
+			isEscaped: true
 		},
 		// TODO data model will need adjusting for possible multiple answers
 		// {

--- a/packages/forms-web-app/src/controllers/selected-appeal/questionnaire-details/planning-officer-details-rows.js
+++ b/packages/forms-web-app/src/controllers/selected-appeal/questionnaire-details/planning-officer-details-rows.js
@@ -10,12 +10,14 @@ exports.planningOfficerReportRows = (caseData) => {
 		{
 			keyText: 'Uploaded planning officer’s report',
 			valueText: formatDocumentDetails(documents, 'planningOfficerReport'),
-			condition: () => caseData.uploadPlanningOfficerReport
+			condition: () => caseData.uploadPlanningOfficerReport,
+			isEscaped: true
 		},
 		{
 			keyText: 'Uploaded policies from statutory development plan',
 			valueText: formatDocumentDetails(documents, 'developmentPlanPolicies'),
-			condition: () => caseData.uploadDevelopmentPlanPolicies
+			condition: () => caseData.uploadDevelopmentPlanPolicies,
+			isEscaped: true
 		},
 		{
 			keyText: 'Emerging plan',
@@ -25,12 +27,14 @@ exports.planningOfficerReportRows = (caseData) => {
 		{
 			keyText: 'Uploaded emerging plan and supporting information',
 			valueText: formatDocumentDetails(documents, 'emergingPlan'),
-			condition: () => caseData.uploadEmergingPlan
+			condition: () => caseData.uploadEmergingPlan,
+			isEscaped: true
 		},
 		{
 			keyText: 'Uploaded other relevant policies',
 			valueText: formatDocumentDetails(documents, 'otherRelevantPolicies'),
-			condition: () => caseData.uploadOtherPolicies
+			condition: () => caseData.uploadOtherPolicies,
+			isEscaped: true
 		},
 		{
 			keyText: 'Supplementary planning documents',
@@ -40,7 +44,8 @@ exports.planningOfficerReportRows = (caseData) => {
 		{
 			keyText: 'Uploaded supplementary planning documents',
 			valueText: formatDocumentDetails(documents, 'supplementaryPlanningDocs'),
-			condition: () => caseData.uploadSupplementaryPlanningDocs
+			condition: () => caseData.uploadSupplementaryPlanningDocs,
+			isEscaped: true
 		},
 		{
 			keyText: 'Community infrastructure levy',
@@ -50,7 +55,8 @@ exports.planningOfficerReportRows = (caseData) => {
 		{
 			keyText: 'Uploaded community infrastructure levy',
 			valueText: formatDocumentDetails(documents, 'infrastructureLevy'),
-			condition: () => caseData.uploadInfrastructureLevy
+			condition: () => caseData.uploadInfrastructureLevy,
+			isEscaped: true
 		},
 		{
 			keyText: 'Community infrastructure levy formally adopted',


### PR DESCRIPTION
## Ticket Number

https://pins-ds.atlassian.net/browse/AAPD-1619

## Description of change

Refactors display of appeal details.  Shifts the 'escaping' logic out of 'formatRows' in order to preserve html formatting where required.

## Checklist

<!-- Put an `x` in all the boxes that apply: -->

- [ ] Requires infrastructure changes
- [ ] I have updated the documentation accordingly
- X My commit history in this PR is linear
- [ ] New features have tests
- [ ] Breaking change (team conversation required)

## Important

Please do not merge from `main` (please only [rebase](https://github.com/Planning-Inspectorate/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
