### PR TITLE
fix: delete v1 appeal after creating a v2

### DIFF
--- a/packages/appeals-service-api/src/repositories/appeals-repository.js
+++ b/packages/appeals-service-api/src/repositories/appeals-repository.js
@@ -71,6 +71,14 @@ class AppealsRepository extends MongoRepository {
 				{ returnDocument: 'after' }
 			);
 	}
+
+	/**
+	 * @param {string} appealId
+	 * @return {Promise<any>}
+	 */
+	async delete(appealId) {
+		return await mongodb.get().collection(this.collectionName).deleteOne({ _id: appealId });
+	}
 }
 
 module.exports = { AppealsRepository };

--- a/packages/appeals-service-api/src/routes/appeals.js
+++ b/packages/appeals-service-api/src/routes/appeals.js
@@ -1,6 +1,11 @@
 const express = require('express');
 
-const { updateAppeal, getAppeal, createAppeal } = require('../services/appeal.service');
+const {
+	updateAppeal,
+	getAppeal,
+	createAppeal,
+	deleteAppeal
+} = require('../services/appeal.service');
 const {
 	appealInsertValidationRules,
 	appealUpdateValidationRules
@@ -41,6 +46,19 @@ router.patch('/:id', appealUpdateValidationRules, async (req, res) => {
 	let body = '';
 	try {
 		body = await updateAppeal(req.params.id, req.body);
+	} catch (error) {
+		statusCode = error.code;
+		body = error.message.errors;
+	} finally {
+		res.status(statusCode).send(body);
+	}
+});
+
+router.delete('/:id', async (req, res) => {
+	let statusCode = 200;
+	let body = {};
+	try {
+		await deleteAppeal(req.params.id);
 	} catch (error) {
 		statusCode = error.code;
 		body = error.message.errors;

--- a/packages/appeals-service-api/src/services/appeal.service.js
+++ b/packages/appeals-service-api/src/services/appeal.service.js
@@ -161,6 +161,17 @@ async function updateAppeal(id, appealUpdate) {
 }
 
 /**
+ * @param {string} id
+ */
+async function deleteAppeal(id) {
+	logger.info(`Attempting to delete appeal with ID ${id}`);
+
+	await appealsCosmosRepository.delete(id);
+
+	logger.info(`Appeal ${id} deleted`);
+}
+
+/**
  * @param {*} appeal - existing appeal
  * @param {*} appealUpdate - updated appeal
  * @returns {Promise<void>}
@@ -366,6 +377,7 @@ module.exports = {
 	createAppeal,
 	getAppeal,
 	updateAppeal,
+	deleteAppeal,
 	validateAppeal,
 	getAppealDocumentInBase64Encoding,
 	getAppealByLPACodeAndId,

--- a/packages/forms-web-app/src/controllers/appeal-householder-decision/list-of-documents.js
+++ b/packages/forms-web-app/src/controllers/appeal-householder-decision/list-of-documents.js
@@ -1,6 +1,6 @@
 const logger = require('../../lib/logger');
 const { getDepartmentFromId } = require('../../services/department.service');
-const { getLPAById } = require('../../lib/appeals-api-wrapper');
+const { getLPAById, deleteAppeal } = require('../../lib/appeals-api-wrapper');
 const { postSaveAndReturn } = require('../appeal-householder-decision/save');
 const { FLAG } = require('@pins/common/src/feature-flags');
 const { APPEALS_CASE_DATA } = require('@pins/common/src/constants');
@@ -41,7 +41,10 @@ const postListOfDocuments = async (req, res) => {
 				applicationReference: appeal.planningApplicationNumber,
 				applicationDecision: appeal.eligibility.applicationDecision
 			});
+
+			await deleteAppeal(appeal.id);
 			req.session.appeal = null;
+
 			return res.redirect(`${baseHASSubmissionUrl}/${taskListUrl}?id=${appealSubmission.id}`);
 		}
 

--- a/packages/forms-web-app/src/lib/appeals-api-wrapper.js
+++ b/packages/forms-web-app/src/lib/appeals-api-wrapper.js
@@ -82,6 +82,22 @@ exports.createOrUpdateAppeal = (appeal) => {
 	});
 };
 
+/**
+ * deletes an appeal v1
+ * @param {string} appealId
+ * @returns {Promise<void>}
+ */
+exports.deleteAppeal = (appealId) => {
+	if (!appealId) {
+		throw new Error('need an appeal id');
+	}
+
+	const appealsServiceApiUrl = `/api/v1/appeals/${appealId}`;
+	const method = 'DELETE';
+
+	return handler(appealsServiceApiUrl, method);
+};
+
 exports.submitAppealForBackOfficeProcessing = async (appeal) => {
 	const savedAppeal = await handler(`/api/v1/appeals/${appeal.id}`, 'PUT', {
 		body: JSON.stringify(appeal)


### PR DESCRIPTION
## Ticket Number

<!-- Add the number from the Jira board -->

## Description of change

when creating a v2 appeal we need to delete the v1 created during before you start to avoid duplicates in the dashboard

## Checklist

<!-- Put an `x` in all the boxes that apply: -->

- [ ] Requires infrastructure changes
- [ ] I have updated the documentation accordingly
- [x] My commit history in this PR is linear
- [ ] New features have tests
- [ ] Breaking change (team conversation required)

## Important

Please do not merge from `main` (please only [rebase](https://github.com/Planning-Inspectorate/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
