### PR TITLE
feat(1728): add s78 and has appeal form v2 flags

### DIFF
--- a/packages/common/src/feature-flags.js
+++ b/packages/common/src/feature-flags.js
@@ -3,12 +3,14 @@ const FLAG = {
 	APPEALS_BO_SUBMISSION: 'appeals-bo-submission',
 	ENROL_USERS: 'enrol-users',
 	FINAL_COMMENTS: 'final-comments',
+	HAS_APPEAL_FORM_V2: 'has-appeal-form-v2',
 	HAS_QUESTIONNAIRE: 'has-questionnaire',
 	HORIZON_DOCUMENT_LABELLING: 'horizon-document-labelling',
 	LPA_DASHBOARD: 'lpa-dashboard',
 	SEND_APPEAL_DIRECT_TO_HORIZON_WRAPPER: 'send-appeal-direct-to-horizon-wrapper',
 	SERVE_BO_DOCUMENTS: 'serve-back-office-documents',
-	SQL_USERS: 'sql-users'
+	SQL_USERS: 'sql-users',
+	S78_APPEAL_FORM_V2: 's78-appeal-form-v2'
 };
 
 module.exports = {

--- a/packages/common/src/feature-flags.js
+++ b/packages/common/src/feature-flags.js
@@ -1,5 +1,4 @@
 const FLAG = {
-	APPEAL_FORM_V2: 'appeal-form-v2',
 	APPEALS_BO_SUBMISSION: 'appeals-bo-submission',
 	ENROL_USERS: 'enrol-users',
 	FINAL_COMMENTS: 'final-comments',

--- a/packages/forms-web-app/__tests__/unit/controllers/full-appeal/submit-appeal/list-of-documents.test.js
+++ b/packages/forms-web-app/__tests__/unit/controllers/full-appeal/submit-appeal/list-of-documents.test.js
@@ -9,6 +9,38 @@ const {
 	getListOfDocuments,
 	postListOfDocuments
 } = require('../../../../../src/controllers/full-appeal/submit-appeal/list-of-documents');
+const { isFeatureActive } = require('../../../../../src/featureFlag');
+const { getDepartmentFromId } = require('../../../../../src/services/department.service');
+const { deleteAppeal } = require('../../../../../src/lib/appeals-api-wrapper');
+const {
+	baseS78SubmissionUrl,
+	taskListUrl
+} = require('../../../../../src/dynamic-forms/s78-appeal-form/journey');
+const { APPEALS_CASE_DATA } = require('@pins/common/src/constants');
+
+const apiClient = {
+	createAppellantSubmission: jest.fn()
+};
+
+const mockId = 'mockV1Appeal';
+const mockAppealSqlId = 'mockSqlId';
+const mockDecisionDate = 'mockDate';
+const mockPlanningApplicationNumber = 'mockPAnumber';
+const mockEligibility = {
+	applicationDecision: 'mockDecision'
+};
+
+const mockAppeal = {
+	id: mockId,
+	appealSqlId: mockAppealSqlId,
+	decisionDate: mockDecisionDate,
+	planningApplicationNumber: mockPlanningApplicationNumber,
+	eligibility: mockEligibility
+};
+
+jest.mock('../../../../../src/featureFlag');
+jest.mock('../../../../../src/services/department.service');
+jest.mock('../../../../../src/lib/appeals-api-wrapper');
 
 describe('controllers/full-appeal/submit-appeal/list-of-documents', () => {
 	let req;
@@ -30,10 +62,35 @@ describe('controllers/full-appeal/submit-appeal/list-of-documents', () => {
 	});
 
 	describe('postListOfDocuments', () => {
-		it('should redirect to `/full-appeal/submit-appeal/task-list`', async () => {
+		it('for v1 appeals - should redirect to `/full-appeal/submit-appeal/task-list`', async () => {
+			getDepartmentFromId.mockResolvedValue({ lpaCode: 'testCode' });
+			isFeatureActive.mockResolvedValue(false);
+
 			req.body = {};
 			await postListOfDocuments(req, res);
 			expect(res.redirect).toHaveBeenCalledWith(`/${TASK_LIST}`);
+		});
+
+		it('for v2 appeals - should create an appellantSubmission and redirect to v2 task list', async () => {
+			getDepartmentFromId.mockResolvedValue({ lpaCode: 'testLPACode' });
+			isFeatureActive.mockResolvedValue(true);
+			apiClient.createAppellantSubmission.mockResolvedValue({ id: 'testId' });
+
+			req.body = {};
+			req.session.appeal = mockAppeal;
+			req.appealsApiClient = apiClient;
+
+			await postListOfDocuments(req, res);
+			expect(apiClient.createAppellantSubmission).toHaveBeenCalledWith({
+				appealId: mockAppealSqlId,
+				LPACode: 'testLPACode',
+				appealTypeCode: APPEALS_CASE_DATA.APPEAL_TYPE_CODE.S78,
+				applicationDecisionDate: mockDecisionDate,
+				applicationReference: mockPlanningApplicationNumber,
+				applicationDecision: mockEligibility.applicationDecision
+			});
+			expect(deleteAppeal).toHaveBeenCalledWith(mockId);
+			expect(res.redirect).toHaveBeenCalledWith(`${baseS78SubmissionUrl}/${taskListUrl}?id=testId`);
 		});
 	});
 });

--- a/packages/forms-web-app/src/controllers/appeal-householder-decision/list-of-documents.js
+++ b/packages/forms-web-app/src/controllers/appeal-householder-decision/list-of-documents.js
@@ -25,7 +25,7 @@ const postListOfDocuments = async (req, res) => {
 			const lpa = await getDepartmentFromId(appeal.lpaCode);
 			const lpaCode = lpa.lpaCode ?? (await getLPAById(lpa.id)).lpaCode; // fallback to lookup in case cached lpa doesn't have code
 
-			const usingV2Form = await isFeatureActive(FLAG.APPEAL_FORM_V2, lpaCode);
+			const usingV2Form = await isFeatureActive(FLAG.HAS_APPEAL_FORM_V2, lpaCode);
 
 			// v1
 			if (!usingV2Form) {

--- a/packages/forms-web-app/src/dynamic-forms/journey-factory.js
+++ b/packages/forms-web-app/src/dynamic-forms/journey-factory.js
@@ -2,6 +2,7 @@ const { JOURNEY_TYPES } = require('@pins/common/src/dynamic-forms/journey-types'
 const { HasJourney } = require('./has-questionnaire/journey');
 const { S78Journey } = require('./s78-questionnaire/journey');
 const { HasAppealFormJourney } = require('./has-appeal-form/journey');
+const { S78AppealFormJourney } = require('./s78-appeal-form/journey');
 
 /**
  * @typedef {import('./journey').Journey} Journey
@@ -25,7 +26,7 @@ const JOURNEY_CLASSES = {
 	[JOURNEY_TYPES.HAS_QUESTIONNAIRE]: HasJourney,
 	[JOURNEY_TYPES.S78_QUESTIONNAIRE]: S78Journey,
 	[JOURNEY_TYPES.HAS_APPEAL_FORM]: HasAppealFormJourney,
-	[JOURNEY_TYPES.S78_APPEAL_FORM]: '' // TODO: add appeal form journey when created
+	[JOURNEY_TYPES.S78_APPEAL_FORM]: S78AppealFormJourney
 };
 
 /**

--- a/packages/forms-web-app/src/dynamic-forms/middleware/get-journey-response-for-appellant.js
+++ b/packages/forms-web-app/src/dynamic-forms/middleware/get-journey-response-for-appellant.js
@@ -34,7 +34,7 @@ module.exports = async (request, response, next) => {
 		logger.error(error);
 	}
 
-	if (!submission || !(await isFeatureActive(FLAG.APPEAL_FORM_V2, submission.LPACode))) {
+	if (!submission || !(await appealTypeFlagActive(submission.appealTypeCode, submission.LPACode))) {
 		return response.status(404).render('error/not-found');
 	}
 
@@ -55,4 +55,20 @@ module.exports = async (request, response, next) => {
 	response.locals.journeyResponse = journeyResponse;
 
 	return next();
+};
+
+/**
+ * @param {'HAS' | 'S78' | undefined } appealTypeCode
+ * @param { string | undefined } LPACode
+ * @returns {Promise<boolean>}
+ */
+const appealTypeFlagActive = async (appealTypeCode, LPACode) => {
+	switch (appealTypeCode) {
+		case 'HAS':
+			return await isFeatureActive(FLAG.HAS_APPEAL_FORM_V2, LPACode);
+		case 'S78':
+			return await isFeatureActive(FLAG.S78_APPEAL_FORM_V2, LPACode);
+		default:
+			return false;
+	}
 };

--- a/packages/forms-web-app/src/dynamic-forms/s78-appeal-form/journey.js
+++ b/packages/forms-web-app/src/dynamic-forms/s78-appeal-form/journey.js
@@ -1,0 +1,146 @@
+const { questions } = require('../questions');
+const { Journey } = require('../journey');
+const { Section } = require('../section');
+const {
+	questionHasAnswerBuilder,
+	questionsHaveAnswersBuilder
+} = require('../dynamic-components/utils/question-has-answer');
+
+const baseS78SubmissionUrl = '/appeals/full-planning';
+const taskListUrl = 'appeal-form/your-appeal';
+const s78JourneyTemplate = 'submission-form-template.njk';
+const listingPageViewPath = 'dynamic-components/task-list/submission';
+const journeyTitle = 'Appeal a planning decision';
+
+/**
+ * @typedef {import('../journey-response').JourneyResponse} JourneyResponse
+ */
+
+/**
+ * A Journey for appellants starting an appeal
+ * @class
+ */
+class S78AppealFormJourney extends Journey {
+	/**
+	 * creates an instance of a HAS Journey
+	 * @param {JourneyResponse} response - an object that handles the response for this journey (needs to always be passed in as it contains the journey url segment)
+	 */
+	constructor(response) {
+		super({
+			baseUrl: `${baseS78SubmissionUrl}?id=${response.referenceId}`,
+			taskListUrl: taskListUrl,
+			response: response,
+			journeyTemplate: s78JourneyTemplate,
+			listingPageViewPath: listingPageViewPath,
+			journeyTitle: journeyTitle,
+			returnToListing: true
+		});
+
+		const questionHasAnswer = questionHasAnswerBuilder(response);
+		const questionsHaveAnswers = questionsHaveAnswersBuilder(response);
+
+		const shouldDisplayIdentifyingLandowners = (() => {
+			if (questionHasAnswer(questions.ownsAllLand, 'yes')) return false;
+			if (
+				questionHasAnswer(questions.ownsSomeLand, 'yes') &&
+				questionHasAnswer(questions.knowsWhoOwnsRestOfLand, 'yes')
+			)
+				return false;
+			if (
+				questionHasAnswer(questions.ownsSomeLand, 'no') &&
+				questionHasAnswer(questions.knowsWhoOwnsLandInvolved, 'yes')
+			)
+				return false;
+
+			return true;
+		})();
+
+		const shouldDisplayTellingLandowners = (() => {
+			if (questionHasAnswer(questions.ownsAllLand, 'yes')) return false;
+
+			if (
+				questionsHaveAnswers(
+					[
+						[questions.ownsSomeLand, 'yes'],
+						[questions.knowsWhoOwnsRestOfLand, 'no']
+					],
+					{ logicalCombinator: 'and' }
+				) ||
+				questionsHaveAnswers(
+					[
+						[questions.ownsSomeLand, 'no'],
+						[questions.knowsWhoOwnsLandInvolved, 'no']
+					],
+					{ logicalCombinator: 'and' }
+				)
+			)
+				return false;
+
+			return true;
+		})();
+
+		this.sections.push(
+			new Section('Prepare appeal', 'prepare-appeal')
+				.addQuestion(questions.applicationName)
+				.addQuestion(questions.applicantName)
+				.withCondition(questionHasAnswer(questions.applicationName, 'no'))
+				.addQuestion(questions.contactDetails)
+				.addQuestion(questions.contactPhoneNumber)
+				.addQuestion(questions.appealSiteAddress)
+				.addQuestion(questions.siteArea)
+				.addQuestion(questions.appellantGreenBelt)
+				.addQuestion(questions.ownsAllLand)
+				.addQuestion(questions.ownsSomeLand)
+				.withCondition(questionHasAnswer(questions.ownsAllLand, 'no'))
+				.addQuestion(questions.knowsWhoOwnsRestOfLand)
+				.withCondition(
+					questionsHaveAnswers(
+						[
+							[questions.ownsSomeLand, 'yes'],
+							[questions.ownsAllLand, 'no']
+						],
+						{ logicalCombinator: 'and' }
+					)
+				)
+				.addQuestion(questions.knowsWhoOwnsLandInvolved)
+				.withCondition(
+					questionsHaveAnswers(
+						[
+							[questions.ownsSomeLand, 'no'],
+							[questions.ownsAllLand, 'no']
+						],
+						{ logicalCombinator: 'and' }
+					)
+				)
+				.addQuestion(questions.identifyingLandowners)
+				.withCondition(shouldDisplayIdentifyingLandowners)
+				.addQuestion(questions.advertisingAppeal)
+				.withCondition(
+					shouldDisplayIdentifyingLandowners &&
+						questionHasAnswer(questions.identifyingLandowners, 'yes')
+				)
+				.addQuestion(questions.tellingLandowners)
+				.withCondition(shouldDisplayTellingLandowners)
+				.addQuestion(questions.inspectorAccess)
+				.addQuestion(questions.healthAndSafety)
+				.addQuestion(questions.enterApplicationReference)
+				.addQuestion(questions.planningApplicationDate())
+				.addQuestion(questions.enterDevelopmentDescription)
+				.addQuestion(questions.updateDevelopmentDescription)
+				.addQuestion(questions.anyOtherAppeals)
+				.addQuestion(questions.linkAppeals)
+				.withCondition(questionHasAnswer(questions.anyOtherAppeals, 'yes')),
+			new Section('Upload documents', 'upload-documents')
+				.addQuestion(questions.uploadOriginalApplicationForm)
+				.addQuestion(questions.uploadChangeOfDescriptionEvidence)
+				.withCondition(questionHasAnswer(questions.updateDevelopmentDescription, 'yes'))
+				.addQuestion(questions.uploadApplicationDecisionLetter)
+				.addQuestion(questions.uploadAppellantStatement)
+				.addQuestion(questions.costApplication)
+				.addQuestion(questions.uploadCostApplication)
+				.withCondition(questionHasAnswer(questions.costApplication, 'yes'))
+		);
+	}
+}
+
+module.exports = { S78AppealFormJourney, baseS78SubmissionUrl, taskListUrl };

--- a/packages/forms-web-app/src/dynamic-forms/s78-appeal-form/journey.test.js
+++ b/packages/forms-web-app/src/dynamic-forms/s78-appeal-form/journey.test.js
@@ -1,0 +1,35 @@
+const { S78AppealFormJourney, baseS78SubmissionUrl } = require('./journey');
+
+const mockResponse = {
+	referenceId: '123',
+	answers: []
+};
+
+describe('HAS Appeal Form Journey class', () => {
+	describe('constructor', () => {
+		it('should error if no response', () => {
+			expect(() => {
+				new S78AppealFormJourney();
+			}).toThrow("Cannot read properties of undefined (reading 'referenceId')");
+		});
+		it('should set baseUrl', () => {
+			const journey = new S78AppealFormJourney(mockResponse);
+			expect(journey.baseUrl).toEqual(expect.stringContaining(baseS78SubmissionUrl));
+			expect(journey.baseUrl).toEqual(expect.stringContaining(mockResponse.referenceId));
+		});
+
+		it('should set taskListUrl', () => {
+			const journey = new S78AppealFormJourney(mockResponse);
+			expect(journey.taskListUrl).toEqual('/appeals/full-planning/appeal-form/your-appeal?id=123');
+		});
+
+		it('should set template', () => {
+			const journey = new S78AppealFormJourney(mockResponse);
+			expect(journey.journeyTemplate).toBe('submission-form-template.njk');
+		});
+		it('should set journeyTitle', () => {
+			const journey = new S78AppealFormJourney(mockResponse);
+			expect(journey.journeyTitle).toBe('Appeal a planning decision');
+		});
+	});
+});

--- a/packages/forms-web-app/src/routes/appeals/index.js
+++ b/packages/forms-web-app/src/routes/appeals/index.js
@@ -13,6 +13,9 @@ router.get('/no-appeals', noAppealsController.get);
 // householder appeals
 router.use('/householder', dynamicSubmission);
 
+// s78 appeals
+router.use('/full-planning', dynamicSubmission);
+
 // todo: leave at end or fix the urls defined in these routes, currently catches anything else as :appealNumber
 router.use('/', selectedAppealRouter);
 


### PR DESCRIPTION
## Ticket Number

https://pins-ds.atlassian.net/browse/AAPD-1724

## Description of change

Two new feature flags (HAS_APPEAL_FORM_V2, S78_APPEAL_FORM_V2) as well as removing defunct APPEAL_FORM_V2.

Add routes for new S78 V2 appeal form submission.

Creates S78 Appeal Journey.

## Checklist

<!-- Put an `x` in all the boxes that apply: -->

- [ ] Requires infrastructure changes
- [ ] I have updated the documentation accordingly
- [ ] My commit history in this PR is linear
- [ ] New features have tests
- [ ] Breaking change (team conversation required)

## Important

Please do not merge from `main` (please only [rebase](https://github.com/Planning-Inspectorate/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
