### PR TITLE
fix(1768): convert h2 to p for Appeal incomplete

### DIFF
--- a/packages/forms-web-app/src/dynamic-forms/dynamic-components/task-list/submission.njk
+++ b/packages/forms-web-app/src/dynamic-forms/dynamic-components/task-list/submission.njk
@@ -28,7 +28,7 @@
 
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-three-quarters-from-desktop">
-      <h2 class="govuk-heading-s">Appeal incomplete</h2>
+      <p class="govuk-body govuk-!-font-weight-bold">Appeal incomplete</p>
       <p class="govuk-!-margin-bottom-7">You have completed {{summaryListData.completedSectionCount}} of {{summaryListData.sections.length + 1}} sections.</p>
     </div>
   </div>


### PR DESCRIPTION
## Ticket Number

https://pins-ds.atlassian.net/browse/AAPD-1768

## Description of change

Change 'Appeal incomplete' into a bold paragraph rather than h2

## Checklist

<!-- Put an `x` in all the boxes that apply: -->

- [ ] Requires infrastructure changes
- [ ] I have updated the documentation accordingly
- [ ] My commit history in this PR is linear
- [ ] New features have tests
- [ ] Breaking change (team conversation required)

## Important

Please do not merge from `main` (please only [rebase](https://github.com/Planning-Inspectorate/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
