### PR TITLE
fix(1772): avoid null displaying on appeal details page

### DIFF
--- a/packages/forms-web-app/src/controllers/selected-appeal/appeal-details/appeal-details-rows.js
+++ b/packages/forms-web-app/src/controllers/selected-appeal/appeal-details/appeal-details-rows.js
@@ -41,7 +41,7 @@ exports.detailsRows = (caseData, userType) => {
 		{
 			keyText: 'Contact details',
 			valueText: formatContactDetails(caseData),
-			condition: () => true
+			condition: (caseData) => caseData.contactFirstName && caseData.contactLastName
 		},
 		{
 			keyText: 'Phone number',


### PR DESCRIPTION
## Ticket Number

https://pins-ds.atlassian.net/browse/AAPD-1772

## Description of change

If no contact details have been entered the the appeal details page currently displays 'null null'.  This fix prevents the contact details row being shown if there are not entries for contactFirstName and contactLastName.

An alternative approach would be to set default empty string values, but this would result in a blank column in the Contact Details row. 

## Checklist

<!-- Put an `x` in all the boxes that apply: -->

- [ ] Requires infrastructure changes
- [ ] I have updated the documentation accordingly
- X My commit history in this PR is linear
- [ ] New features have tests
- [ ] Breaking change (team conversation required)

## Important

Please do not merge from `main` (please only [rebase](https://github.com/Planning-Inspectorate/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
