### PR TITLE
feat(1769): hide save and continue button on list of documents for v2 routes

### DIFF
--- a/packages/forms-web-app/__tests__/unit/controllers/full-appeal/submit-appeal/list-of-documents.test.js
+++ b/packages/forms-web-app/__tests__/unit/controllers/full-appeal/submit-appeal/list-of-documents.test.js
@@ -55,6 +55,9 @@ describe('controllers/full-appeal/submit-appeal/list-of-documents', () => {
 
 	describe('getListOfDocuments', () => {
 		it('should call the correct template', () => {
+			getDepartmentFromId.mockResolvedValue({ lpaCode: 'testCode' });
+			isFeatureActive.mockResolvedValue(false);
+
 			getListOfDocuments(req, res);
 
 			expect(res.render).toHaveBeenCalledWith(LIST_OF_DOCUMENTS);

--- a/packages/forms-web-app/__tests__/unit/controllers/full-appeal/submit-appeal/list-of-documents.test.js
+++ b/packages/forms-web-app/__tests__/unit/controllers/full-appeal/submit-appeal/list-of-documents.test.js
@@ -54,13 +54,13 @@ describe('controllers/full-appeal/submit-appeal/list-of-documents', () => {
 	});
 
 	describe('getListOfDocuments', () => {
-		it('should call the correct template', () => {
+		it('should call the correct template', async () => {
 			getDepartmentFromId.mockResolvedValue({ lpaCode: 'testCode' });
 			isFeatureActive.mockResolvedValue(false);
 
-			getListOfDocuments(req, res);
+			await getListOfDocuments(req, res);
 
-			expect(res.render).toHaveBeenCalledWith(LIST_OF_DOCUMENTS);
+			expect(res.render).toHaveBeenCalledWith(LIST_OF_DOCUMENTS, { usingV2Form: false });
 		});
 	});
 

--- a/packages/forms-web-app/src/controllers/appeal-householder-decision/list-of-documents.js
+++ b/packages/forms-web-app/src/controllers/appeal-householder-decision/list-of-documents.js
@@ -10,8 +10,14 @@ const {
 	taskListUrl
 } = require('../../dynamic-forms/has-appeal-form/journey');
 
-const getListOfDocuments = (req, res) => {
-	res.render('appeal-householder-decision/list-of-documents');
+const getListOfDocuments = async (req, res) => {
+	const appeal = req.session.appeal;
+
+	const lpa = await getDepartmentFromId(appeal.lpaCode);
+	const lpaCode = lpa.lpaCode ?? (await getLPAById(lpa.id)).lpaCode; // fallback to lookup in case cached lpa doesn't have code
+
+	const usingV2Form = await isFeatureActive(FLAG.HAS_APPEAL_FORM_V2, lpaCode);
+	res.render('appeal-householder-decision/list-of-documents', { usingV2Form });
 };
 
 const postListOfDocuments = async (req, res) => {

--- a/packages/forms-web-app/src/controllers/full-appeal/submit-appeal/list-of-documents.js
+++ b/packages/forms-web-app/src/controllers/full-appeal/submit-appeal/list-of-documents.js
@@ -15,8 +15,15 @@ const {
 	taskListUrl
 } = require('../../../dynamic-forms/s78-appeal-form/journey');
 
-const getListOfDocuments = (_, res) => {
-	res.render(currentPage);
+const getListOfDocuments = async (_, res) => {
+	const appeal = _.session.appeal;
+
+	const lpa = await getDepartmentFromId(appeal.lpaCode);
+	const lpaCode = lpa.lpaCode ?? (await getLPAById(lpa.id)).lpaCode; // fallback to lookup in case cached lpa doesn't have code
+
+	const usingV2Form = await isFeatureActive(FLAG.S78_APPEAL_FORM_V2, lpaCode);
+
+	res.render(currentPage, { usingV2Form });
 };
 
 const postListOfDocuments = async (req, res) => {

--- a/packages/forms-web-app/src/controllers/full-appeal/submit-appeal/list-of-documents.js
+++ b/packages/forms-web-app/src/controllers/full-appeal/submit-appeal/list-of-documents.js
@@ -15,8 +15,8 @@ const {
 	taskListUrl
 } = require('../../../dynamic-forms/s78-appeal-form/journey');
 
-const getListOfDocuments = async (_, res) => {
-	const appeal = _.session.appeal;
+const getListOfDocuments = async (req, res) => {
+	const appeal = req.session.appeal;
 
 	const lpa = await getDepartmentFromId(appeal.lpaCode);
 	const lpaCode = lpa.lpaCode ?? (await getLPAById(lpa.id)).lpaCode; // fallback to lookup in case cached lpa doesn't have code

--- a/packages/forms-web-app/src/views/appeal-householder-decision/list-of-documents.njk
+++ b/packages/forms-web-app/src/views/appeal-householder-decision/list-of-documents.njk
@@ -39,7 +39,9 @@
             type: "submit",
             attributes: { "data-cy":"button-save-and-continue"}
           }) }}
-          {{ saveAndReturnButton () }}
+					{% if usingV2Form == false %}
+          	{{ saveAndReturnButton () }}
+					{% endif %}
         </div>
       </form>
     </div>

--- a/packages/forms-web-app/src/views/full-appeal/submit-appeal/list-of-documents.njk
+++ b/packages/forms-web-app/src/views/full-appeal/submit-appeal/list-of-documents.njk
@@ -38,7 +38,9 @@
             type: "submit",
             attributes: { "data-cy":"button-save-and-continue"}
           }) }}
-          {{ saveAndReturnButton () }}
+          {% if usingV2Form == false %}
+          	{{ saveAndReturnButton () }}
+					{% endif %}
         </div>
       </form>
     </div>


### PR DESCRIPTION

## Ticket Number

https://pins-ds.atlassian.net/browse/AAPD-1769

## Description of change

When showing list of documents page for HAS and s78 Appeals, checks to see if v2 routes active and if so will not show 'Save and Come Back Later' button.

## Checklist

<!-- Put an `x` in all the boxes that apply: -->

- [ ] Requires infrastructure changes
- [ ] I have updated the documentation accordingly
- [ ] My commit history in this PR is linear
- [ ] New features have tests
- [ ] Breaking change (team conversation required)

## Important

Please do not merge from `main` (please only [rebase](https://github.com/Planning-Inspectorate/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
