### PR TITLE
fix(1849): filter uploaded files when removing

### DIFF
--- a/packages/forms-web-app/src/dynamic-forms/dynamic-components/multi-file-upload/question.js
+++ b/packages/forms-web-app/src/dynamic-forms/dynamic-components/multi-file-upload/question.js
@@ -259,8 +259,12 @@ class MultiFileUploadQuestion extends Question {
 			const removedFiles = JSON.parse(body.removedFiles);
 			const currentUploadedFiles = journeyResponse.answers.SubmissionDocumentUpload || [];
 
+			const relevantUploadedFiles = currentUploadedFiles.filter(
+				(upload) => upload.type === this.documentType.name
+			);
+
 			const failedRemovedFiles = await removeFilesV2(
-				currentUploadedFiles,
+				relevantUploadedFiles,
 				removedFiles,
 				journeyResponse.referenceId,
 				`${journeyResponse.journeyId}:${encodedReferenceId}`,


### PR DESCRIPTION
## Ticket Number

https://pins-ds.atlassian.net/browse/AAPD-1849

## Description of change

Fixes a bug - if a user uploaded the same document in respect of multiple questions, when removing from one question there was no consistency regarding which question's version of the document would be removed.  The fix means we filter by relevant question before deleting the document.

## Checklist

<!-- Put an `x` in all the boxes that apply: -->

- [ ] Requires infrastructure changes
- [ ] I have updated the documentation accordingly
- [ ] My commit history in this PR is linear
- [ ] New features have tests
- [ ] Breaking change (team conversation required)

## Important

Please do not merge from `main` (please only [rebase](https://github.com/Planning-Inspectorate/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
