### PR TITLE
feat(1808): add s78 appeal formatter

### DIFF
--- a/packages/appeals-service-api/src/configuration/config.js
+++ b/packages/appeals-service-api/src/configuration/config.js
@@ -106,8 +106,13 @@ let config = {
 					appealSubmissionConfirmationEmailToAppellant:
 						process.env
 							.SRV_NOTIFY_APPEAL_SUBMISSION_CONFIRMATION_EMAIL_TO_APPELLANT_TEMPLATE_ID_V1_1,
+					appealSubmissionConfirmationEmailToAppellantV2:
+						process.env
+							.SRV_NOTIFY_HAS_APPEAL_SUBMISSION_CONFIRMATION_EMAIL_TO_APPELLANT_TEMPLATE_ID,
 					appealSubmissionReceivedEmailToAppellant:
 						process.env.SRV_NOTIFY_APPEAL_RECEIVED_NOTIFICATION_EMAIL_TO_APPELLANT_TEMPLATE_ID,
+					appealNotificationEmailToLpaV2:
+						process.env.SRV_NOTIFY_HAS_APPEAL_SUBMISSION_NOTIFICATION_EMAIL_TO_LPA_TEMPLATE_ID,
 					appealNotificationEmailToLpa:
 						process.env.SRV_NOTIFY_FULL_APPEAL_RECEIVED_NOTIFICATION_EMAIL_TO_LPA_TEMPLATE_ID
 				},

--- a/packages/appeals-service-api/src/services/back-office-v2/formatters/s78/appeal.js
+++ b/packages/appeals-service-api/src/services/back-office-v2/formatters/s78/appeal.js
@@ -1,0 +1,104 @@
+const LpaService = require('../../../lpa.service');
+const lpaService = new LpaService();
+const ApiError = require('../../../../errors/apiError');
+const {
+	// getDocuments,
+	formatApplicationSubmissionUsers,
+	formatApplicationDecision,
+	formatYesNoSomeAnswer
+} = require('../utils');
+const deadlineDate = require('@pins/business-rules/src/rules/appeal/deadline-date');
+const { APPEAL_ID } = require('@pins/business-rules/src/constants');
+
+/**
+ * @typedef {import ('pins-data-model').Schemas.AppellantSubmissionCommand} AppellantSubmissionCommand
+ * @typedef {import('@prisma/client').Prisma.AppellantSubmissionGetPayload<{
+ *   include: {
+ *     SubmissionDocumentUpload: true,
+ *     SubmissionAddress: true,
+ *     SubmissionLinkedCase: true,
+ * 		 SubmissionListedBuilding: true,
+ *		 Appeal: {
+ *       include: {
+ *			   Users: {
+ *           include: {
+ *             AppealUser: true
+ *           }
+ *         }
+ *		   }
+ *     }
+ *   }
+ * }>} AppellantSubmission
+ */
+
+/**
+ * @param {AppellantSubmission} appellantSubmission
+ * @returns {Promise<AppellantSubmissionCommand>}
+ */
+exports.formatter = async (appellantSubmission) => {
+	if (!appellantSubmission) throw new Error(`Appeal submission could not be formatted`);
+
+	let lpa;
+
+	try {
+		lpa = await lpaService.getLpaByCode(appellantSubmission.LPACode);
+	} catch (err) {
+		lpa = await lpaService.getLpaById(appellantSubmission.LPACode);
+	}
+
+	if (!lpa) {
+		throw ApiError.lpaNotFound();
+	}
+
+	const address = appellantSubmission.SubmissionAddress?.find(
+		(address) => address.fieldName === 'siteAddress'
+	);
+
+	return {
+		casedata: {
+			caseType: 'D',
+			caseProcedure: 'written',
+			lpaCode: lpa.getLpaCode(),
+			caseSubmittedDate: new Date().toISOString(),
+			enforcementNotice: false, // this will eventually come from before you start
+			applicationReference: appellantSubmission.applicationReference ?? '',
+			applicationDate: appellantSubmission.onApplicationDate?.toISOString() ?? null,
+			applicationDecision: formatApplicationDecision(appellantSubmission.applicationDecision),
+			applicationDecisionDate: appellantSubmission.applicationDecisionDate?.toISOString() ?? null,
+			caseSubmissionDueDate: deadlineDate(
+				appellantSubmission.applicationDecisionDate,
+				APPEAL_ID.PLANNING_SECTION_78,
+				appellantSubmission.applicationDecision
+			).toISOString(),
+			siteAddressLine1: address.addressLine1 ?? '',
+			siteAddressLine2: address.addressLine2 ?? '',
+			siteAddressTown: address.townCity ?? '',
+			siteAddressCounty: address.county ?? '',
+			siteAddressPostcode: address.postcode ?? '',
+			siteAccessDetails: [
+				appellantSubmission.appellantSiteAccess_appellantSiteAccessDetails
+			].filter(Boolean),
+			siteSafetyDetails: [
+				appellantSubmission.appellantSiteSafety_appellantSiteSafetyDetails
+			].filter(Boolean),
+			siteAreaSquareMetres: Number(appellantSubmission.siteAreaSquareMetres) ?? null,
+			floorSpaceSquareMetres: Number(appellantSubmission.siteAreaSquareMetres) ?? null,
+			ownsAllLand: appellantSubmission.ownsAllLand ?? null,
+			ownsSomeLand: appellantSubmission.ownsSomeLand ?? null,
+			knowsOtherOwners: formatYesNoSomeAnswer(appellantSubmission.knowsOtherOwners),
+			knowsAllOwners: formatYesNoSomeAnswer(appellantSubmission.knowsAllOwners),
+			advertisedAppeal: appellantSubmission.advertisedAppeal ?? null,
+			ownersInformed: appellantSubmission.informedOwners ?? null,
+			originalDevelopmentDescription: appellantSubmission.developmentDescriptionOriginal ?? null,
+			changedDevelopmentDescription: appellantSubmission.updateDevelopmentDescription ?? null,
+			nearbyCaseReferences: appellantSubmission.SubmissionLinkedCase?.map(
+				({ caseReference }) => caseReference
+			),
+			neighbouringSiteAddresses: null, // added by the LPA later I believe
+			appellantCostsAppliedFor: appellantSubmission.costApplication ?? null
+		},
+		documents: [],
+		// documents: await getDocuments(appellantSubmission),
+		users: formatApplicationSubmissionUsers(appellantSubmission)
+	};
+};

--- a/packages/appeals-service-api/src/services/back-office-v2/index.js
+++ b/packages/appeals-service-api/src/services/back-office-v2/index.js
@@ -80,7 +80,7 @@ class BackOfficeV2Service {
 		const validator = getValidator('appellant-submission');
 		if (!validator(mappedData)) {
 			throw new Error(
-				`Payload was invalid wen checked against appellant submission command schema`
+				`Payload was invalid when checked against appellant submission command schema`
 			);
 		}
 


### PR DESCRIPTION
## Ticket Number

https://pins-ds.atlassian.net/browse/AAPD-1808

## Description of change

Creates a placeholder s78 appeal formatter function in order to allow submission of s78 appeal v2.

The formatter will be expanded once the data model is finalised.

## Checklist

<!-- Put an `x` in all the boxes that apply: -->

- [ ] Requires infrastructure changes
- [ ] I have updated the documentation accordingly
- X My commit history in this PR is linear
- [ ] New features have tests
- [ ] Breaking change (team conversation required)

## Important

Please do not merge from `main` (please only [rebase](https://github.com/Planning-Inspectorate/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
