### PR TITLE
feat(aapd-1137): add nav to and display lpa final comments on selecte…

### DIFF
--- a/packages/appeals-service-api/src/spec/api-types.d.ts
+++ b/packages/appeals-service-api/src/spec/api-types.d.ts
@@ -73,6 +73,7 @@ export interface AppealCase {
 	appellantProofEvidenceSubmitted?: boolean;
 	appellantProofEvidencePublished?: boolean;
 	appellantFinalCommentsSubmitted?: boolean;
+	appellantFinalCommentDetails?: string;
 	appellantFirstName?: string;
 	appellantLastName?: string;
 	siteAddressLine1: string;
@@ -586,10 +587,10 @@ export interface AppellantSubmission {
 	appellantPreferHearingDetails?: string;
 	appellantPreferInquiryDetails?: string;
 	siteAreaSquareMetres?: number;
-	tenantAgriculturalHolding?: boolean;
 	appellantPreferInquiryDuration?: number;
 	appellantPreferInquiryWitnesses?: number;
 	siteArea?: number;
+	tenantAgriculturalHolding?: boolean;
 	appellantLinkedCaseAdd?: boolean;
 	appellantLinkedCase?: boolean;
 	SubmissionLinkedCase?: object[];

--- a/packages/appeals-service-api/src/spec/appeal-case.yaml
+++ b/packages/appeals-service-api/src/spec/appeal-case.yaml
@@ -79,6 +79,8 @@ components:
           type: boolean
         appellantFinalCommentsSubmitted:
           type: boolean
+        appellantFinalCommentDetails:
+          type: string
         appellantFirstName:
           type: string
         appellantLastName:

--- a/packages/database/src/migrations/20240701131320_add_appellant_final_comment_details_to_appeal_case/migration.sql
+++ b/packages/database/src/migrations/20240701131320_add_appellant_final_comment_details_to_appeal_case/migration.sql
@@ -1,0 +1,19 @@
+BEGIN TRY
+
+BEGIN TRAN;
+
+-- AlterTable
+ALTER TABLE [dbo].[AppealCase] ADD [appellantFinalCommentDetails] NVARCHAR(1000);
+
+COMMIT TRAN;
+
+END TRY
+BEGIN CATCH
+
+IF @@TRANCOUNT > 0
+BEGIN
+    ROLLBACK TRAN;
+END;
+THROW
+
+END CATCH

--- a/packages/database/src/schema.prisma
+++ b/packages/database/src/schema.prisma
@@ -185,6 +185,7 @@ model AppealCase {
   appellantProofEvidenceSubmitted Boolean  @default(false)
   appellantProofEvidencePublished Boolean  @default(false)
   appellantFinalCommentsSubmitted Boolean  @default(false)
+  appellantFinalCommentDetails    String?
 
   appellantFirstName String @default("")
   appellantLastName  String @default("")

--- a/packages/database/src/seed/data-dev.js
+++ b/packages/database/src/seed/data-dev.js
@@ -456,6 +456,8 @@ const appealCases = [
 		lpaFinalCommentsPublished: true,
 		lpaFinalCommentDetails:
 			'gravida neque convallis a cras semper auctor neque vitae tempus quam pellentesque nec nam aliquam sem et tortor consequat id porta nibh venenatis cras sed',
+		appellantFinalCommentDetails:
+			'I am the appellant and this is my final comment. felis eget velit aliquet sagittis id consectetur purus ut faucibus pulvinar elementum integer enim neque volutpat ac tincidunt',
 		appellantFinalCommentsSubmitted: true
 	},
 	{

--- a/packages/database/src/seed/data-dev.js
+++ b/packages/database/src/seed/data-dev.js
@@ -454,6 +454,8 @@ const appealCases = [
 		caseValidDate: new Date(),
 		interestedPartyCommentsPublished: true,
 		lpaFinalCommentsPublished: true,
+		lpaFinalCommentDetails:
+			'gravida neque convallis a cras semper auctor neque vitae tempus quam pellentesque nec nam aliquam sem et tortor consequat id porta nibh venenatis cras sed',
 		appellantFinalCommentsSubmitted: true
 	},
 	{

--- a/packages/forms-web-app/src/controllers/selected-appeal/final-comments-details/index.js
+++ b/packages/forms-web-app/src/controllers/selected-appeal/final-comments-details/index.js
@@ -2,12 +2,17 @@ const { formatHeadlineData } = require('@pins/common');
 
 const { VIEW } = require('../../../lib/views');
 const { apiClient } = require('../../../lib/appeals-api-client');
-const { formatTitleSuffix } = require('../../../lib/selected-appeal-page-setup');
+const {
+	formatTitleSuffix,
+	formatFinalCommentsHeadingPrefix,
+	isAppellantComments,
+	getFinalComments
+} = require('../../../lib/selected-appeal-page-setup');
 const { determineUser } = require('../../../lib/determine-user');
 const { getUserFromSession } = require('../../../services/user.service');
 
 /**
- * Shared controller for /appeals/:caseRef/appeal-details, manage-appeals/:caseRef/appeal-details rule-6-appeals/:caseRef/appeal-details
+ * Shared controller for /manage-appeals/:caseRef/appellant-final-comments, manage-appeals/:caseRef/final-comments
  * @param {string} layoutTemplate - njk template to extend
  * @returns {import('express').RequestHandler}
  */
@@ -40,11 +45,13 @@ exports.get = (layoutTemplate = 'layouts/no-banner-link/main.njk') => {
 		});
 
 		const headlineData = formatHeadlineData(caseData, userType);
-		const finalComments = caseData.lpaFinalCommentDetails ?? null;
+		const isAppellantCommentsResult = isAppellantComments(userRouteUrl, userType);
+		const finalComments = getFinalComments(caseData, isAppellantCommentsResult);
 
 		const viewContext = {
 			layoutTemplate,
 			titleSuffix: formatTitleSuffix(userType),
+			headingPrefix: formatFinalCommentsHeadingPrefix(userRouteUrl),
 
 			appeal: {
 				appealNumber,

--- a/packages/forms-web-app/src/controllers/selected-appeal/final-comments-details/index.js
+++ b/packages/forms-web-app/src/controllers/selected-appeal/final-comments-details/index.js
@@ -1,0 +1,58 @@
+const { formatHeadlineData } = require('@pins/common');
+
+const { VIEW } = require('../../../lib/views');
+const { apiClient } = require('../../../lib/appeals-api-client');
+const { formatTitleSuffix } = require('../../../lib/selected-appeal-page-setup');
+const { determineUser } = require('../../../lib/determine-user');
+const { getUserFromSession } = require('../../../services/user.service');
+
+/**
+ * Shared controller for /appeals/:caseRef/appeal-details, manage-appeals/:caseRef/appeal-details rule-6-appeals/:caseRef/appeal-details
+ * @param {string} layoutTemplate - njk template to extend
+ * @returns {import('express').RequestHandler}
+ */
+exports.get = (layoutTemplate = 'layouts/no-banner-link/main.njk') => {
+	return async (req, res) => {
+		const appealNumber = req.params.appealNumber;
+		const userRouteUrl = req.originalUrl;
+
+		// determine user based on route to selected appeal
+		// i.e '/appeals/' = appellant | agent
+		// todo: use oauth token
+		const userType = determineUser(userRouteUrl);
+
+		if (userType === null) {
+			throw new Error('Unknown role');
+		}
+
+		const userEmail = getUserFromSession(req).email;
+
+		if (!userEmail) {
+			throw new Error('no session email');
+		}
+
+		const user = await apiClient.getUserByEmailV2(userEmail);
+
+		const caseData = await apiClient.getUsersAppealCase({
+			caseReference: appealNumber,
+			role: userType,
+			userId: user.id
+		});
+
+		const headlineData = formatHeadlineData(caseData, userType);
+		const finalComments = caseData.lpaFinalCommentDetails ?? null;
+
+		const viewContext = {
+			layoutTemplate,
+			titleSuffix: formatTitleSuffix(userType),
+
+			appeal: {
+				appealNumber,
+				headlineData,
+				finalComments
+			}
+		};
+
+		res.render(VIEW.SELECTED_APPEAL.APPEAL_FINAL_COMMENTS, viewContext);
+	};
+};

--- a/packages/forms-web-app/src/controllers/selected-appeal/lpa-user-sections.js
+++ b/packages/forms-web-app/src/controllers/selected-appeal/lpa-user-sections.js
@@ -52,12 +52,12 @@ exports.sections = [
 		heading: 'Final comments',
 		links: [
 			{
-				url: '/lpa-final-comments',
+				url: '/final-comments',
 				text: 'View your final comments',
 				condition: (appealCase) => appealCase.lpaFinalCommentsPublished
 			},
 			{
-				url: '/final-comments',
+				url: '/appellant-final-comments',
 				text: 'View appellant final comments',
 				condition: (appealCase) => appealCase.appellantFinalCommentsSubmitted
 			}

--- a/packages/forms-web-app/src/lib/selected-appeal-page-setup.js
+++ b/packages/forms-web-app/src/lib/selected-appeal-page-setup.js
@@ -53,8 +53,9 @@ const isAppellantComments = (url, userType) => {
  * @param {boolean} isAppellantComments
  */
 const getFinalComments = (caseData, isAppellantComments) => {
-	//appellantFinalCommentDetails to be added to Prisma
-	return isAppellantComments ? '' : caseData.lpaFinalCommentDetails;
+	return isAppellantComments
+		? caseData.appellantFinalCommentDetails
+		: caseData.lpaFinalCommentDetails;
 };
 
 module.exports = {

--- a/packages/forms-web-app/src/lib/selected-appeal-page-setup.js
+++ b/packages/forms-web-app/src/lib/selected-appeal-page-setup.js
@@ -20,7 +20,47 @@ const formatQuestionnaireHeading = (userType) => {
 	return 'Local planning authority questionnaire';
 };
 
+//Final Comments
+/**
+ * @param {string} url
+ * @returns {string}
+ */
+const formatFinalCommentsHeadingPrefix = (url) => {
+	switch (true) {
+		case url.includes('/lpa-final-comments'):
+			return 'Local planning authority';
+		case url.includes('/appellant-final-comments'):
+			return `Appellant's`;
+		default:
+			return 'Your';
+	}
+};
+
+/**
+ * @param {string} url
+ * @param {string} userType
+ * @returns {boolean}
+ */
+const isAppellantComments = (url, userType) => {
+	return (
+		url.includes('/appellant-final-comments') ||
+		(url.includes('/final-comments') && userType !== LPA_USER_ROLE)
+	);
+};
+
+/**
+ * @param {import('appeals-service-api').Api.AppealCaseWithRule6Parties} caseData
+ * @param {boolean} isAppellantComments
+ */
+const getFinalComments = (caseData, isAppellantComments) => {
+	//appellantFinalCommentDetails to be added to Prisma
+	return isAppellantComments ? '' : caseData.lpaFinalCommentDetails;
+};
+
 module.exports = {
 	formatTitleSuffix,
-	formatQuestionnaireHeading
+	formatQuestionnaireHeading,
+	formatFinalCommentsHeadingPrefix,
+	isAppellantComments,
+	getFinalComments
 };

--- a/packages/forms-web-app/src/lib/views.js
+++ b/packages/forms-web-app/src/lib/views.js
@@ -213,7 +213,8 @@ const VIEW = {
 	SELECTED_APPEAL: {
 		APPEAL: 'selected-appeal/appeal',
 		APPEAL_DETAILS: 'selected-appeal/appeal-details',
-		APPEAL_QUESTIONNAIRE: 'selected-appeal/questionnaire-details'
+		APPEAL_QUESTIONNAIRE: 'selected-appeal/questionnaire-details',
+		APPEAL_FINAL_COMMENTS: 'selected-appeal/final-comments-details'
 	},
 
 	SUBMIT_APPEAL: {

--- a/packages/forms-web-app/src/routes/lpa-dashboard/selected-appeal.js
+++ b/packages/forms-web-app/src/routes/lpa-dashboard/selected-appeal.js
@@ -4,6 +4,7 @@ const router = express.Router({ mergeParams: true });
 const selectedAppealController = require('../../controllers/selected-appeal');
 const appealDetailsController = require('../../controllers/selected-appeal/appeal-details');
 const questionnaireDetailsController = require('../../controllers/selected-appeal/questionnaire-details');
+const finalCommentsController = require('../../controllers/selected-appeal/final-comments-details');
 
 router.get('/:appealNumber', selectedAppealController.get('layouts/lpa-dashboard/main.njk'));
 router.get(
@@ -13,6 +14,10 @@ router.get(
 router.get(
 	'/:appealNumber/questionnaire',
 	questionnaireDetailsController.get('layouts/lpa-dashboard/main.njk')
+);
+router.get(
+	'/:appealNumber/final-comments',
+	finalCommentsController.get('layouts/lpa-dashboard/main.njk')
 );
 
 module.exports = router;

--- a/packages/forms-web-app/src/routes/lpa-dashboard/selected-appeal.js
+++ b/packages/forms-web-app/src/routes/lpa-dashboard/selected-appeal.js
@@ -19,5 +19,9 @@ router.get(
 	'/:appealNumber/final-comments',
 	finalCommentsController.get('layouts/lpa-dashboard/main.njk')
 );
+router.get(
+	'/:appealNumber/appellant-final-comments',
+	finalCommentsController.get('layouts/lpa-dashboard/main.njk')
+);
 
 module.exports = router;

--- a/packages/forms-web-app/src/views/selected-appeal/final-comments-details.njk
+++ b/packages/forms-web-app/src/views/selected-appeal/final-comments-details.njk
@@ -1,0 +1,49 @@
+{% extends layoutTemplate %}
+
+{% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
+{% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
+{% from "govuk/components/tag/macro.njk" import govukTag %}
+{% from "pins/components/appeal-sections-block.njk" import appealSectionsBlock %}
+
+{% set title="Appeal details - " + titleSuffix + " - GOV.UK" %}
+
+{% block pageTitle %}
+	{{ title }}
+{% endblock %}
+
+{% block content %}
+	<div class="govuk-grid-row">
+		<div class="govuk-grid-column-full">
+            {% if errorSummary %}
+                {{ govukErrorSummary({
+                    titleText: "There is a problem",
+                    errorList: errorSummary
+                }) }}
+			{% endif %}
+
+            <span class="govuk-caption-xl">Appeal {{appeal.appealNumber}}</span>
+			<h1 class="govuk-heading-xl">Your final comments</h1>
+
+			{{ govukSummaryList({
+				classes: "appeal-headlines govuk-summary-list--no-border",
+				rows: appeal.headlineData
+			}) }}
+
+			<hr class="govuk-section-break govuk-section-break--visible govuk-section-break--m">
+
+			{{ govukSummaryList({
+				classes: "govuk-summary-list long-answers",
+				rows: [
+                        {
+                        key: {
+                            text: "Final comments"
+                        },
+                        value: {
+                            text: appeal.finalComments
+                        }
+                    }
+                ]
+			}) }}
+		</div>
+	</div>
+{% endblock %}

--- a/packages/forms-web-app/src/views/selected-appeal/final-comments-details.njk
+++ b/packages/forms-web-app/src/views/selected-appeal/final-comments-details.njk
@@ -22,7 +22,7 @@
 			{% endif %}
 
             <span class="govuk-caption-xl">Appeal {{appeal.appealNumber}}</span>
-			<h1 class="govuk-heading-xl">Your final comments</h1>
+			<h1 class="govuk-heading-xl">{{headingPrefix}} final comments</h1>
 
 			{{ govukSummaryList({
 				classes: "appeal-headlines govuk-summary-list--no-border",


### PR DESCRIPTION
…d appeal

## Ticket Number

<!-- Add the number from the Jira board -->

https://pins-ds.atlassian.net/browse/AAPD-1137
https://pins-ds.atlassian.net/browse/AAPD-1097
https://pins-ds.atlassian.net/browse/AAPD-1136
https://pins-ds.atlassian.net/browse/AAPD-1094

## Description of change

adds navigation to lpa final comments and appellant final comments page on selected appeal and displays lpa/ appellant final comments


## Checklist

<!-- Put an `x` in all the boxes that apply: -->

- [ ] Requires infrastructure changes
- [ ] I have updated the documentation accordingly
- [x] My commit history in this PR is linear
- [ ] New features have tests
- [ ] Breaking change (team conversation required)

## Important

Please do not merge from `main` (please only [rebase](https://github.com/Planning-Inspectorate/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
