### PR TITLE
ci: trigger pr pipeline for merge-queue branches

### DIFF
--- a/azure-pipelines-pr.yml
+++ b/azure-pipelines-pr.yml
@@ -1,4 +1,8 @@
-trigger: none
+trigger:
+  branches:
+    include:
+      # trigger for merge queue branches
+      - gh-readonly-queue/*
 
 pr:
   branches:


### PR DESCRIPTION
## Description of change

Trigger the PR pipeline for merge-queue branches.
See [triggering-merge-group-checks-with-third-party-ci-providers)](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/managing-a-merge-queue#triggering-merge-group-checks-with-third-party-ci-providers)

## Checklist

<!-- Put an `x` in all the boxes that apply: -->

- [ ] Requires infrastructure changes
- [ ] I have updated the documentation accordingly
- [ ] My commit history in this PR is linear
- [ ] New features have tests
- [ ] Breaking change (team conversation required)

## Important

Please do not merge from `main` (please only [rebase](https://github.com/Planning-Inspectorate/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
