### PR TITLE
fix(1854): correct pdf link url

### DIFF
--- a/packages/appeals-service-api/src/lib/notify.js
+++ b/packages/appeals-service-api/src/lib/notify.js
@@ -91,7 +91,7 @@ const sendSubmissionConfirmationEmailToAppellantV2 = async (appellantSubmission,
 			appeal_reference_number: appellantSubmission.applicationReference,
 			'appeal site address': formattedAddress,
 			'local planning department': lpa.getName(),
-			'link to pdf': `${config.apps.appeals.baseUrl}/document/${appellantSubmission.applicationReference}/${appellantSubmission.submissionPdfId}`
+			'link to pdf': `${config.apps.appeals.baseUrl}/document/${appellantSubmission.id}/${appellantSubmission.submissionPdfId}`
 		};
 
 		const reference = appellantSubmission.id;


### PR DESCRIPTION
## Ticket Number

https://pins-ds.atlassian.net/browse/AAPD-1854

## Description of change

Corrects the pdf link sent to appellants on submission of appeal

## Checklist

<!-- Put an `x` in all the boxes that apply: -->

- [ ] Requires infrastructure changes
- [ ] I have updated the documentation accordingly
- [ ] My commit history in this PR is linear
- [ ] New features have tests
- [ ] Breaking change (team conversation required)

## Important

Please do not merge from `main` (please only [rebase](https://github.com/Planning-Inspectorate/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
