### PR TITLE
fix(1809): add second error message above radios

### DIFF
--- a/packages/forms-web-app/src/dynamic-forms/dynamic-components/unit-option-entry/index.njk
+++ b/packages/forms-web-app/src/dynamic-forms/dynamic-components/unit-option-entry/index.njk
@@ -37,8 +37,8 @@
           classes: "govuk-radios",
           idPrefix: question.fieldName,
           name: question.fieldName,
-          errorMessage: errors[question.fieldName] and {
-            text: errors[question.fieldName].msg
+          errorMessage: errorSummary and {
+            text: errorSummary[0].text
           },
           fieldset: {
             legend: {

--- a/packages/forms-web-app/src/dynamic-forms/question.js
+++ b/packages/forms-web-app/src/dynamic-forms/question.js
@@ -213,11 +213,6 @@ class Question {
 		const { body } = req;
 		const { errors = {}, errorSummary = [] } = body;
 
-		console.log('ohohohohoho');
-		console.log(errors);
-		console.log('popopo');
-		console.log(errorSummary);
-
 		if (Object.keys(errors).length > 0) {
 			return this.prepQuestionForRendering(
 				sectionObj,

--- a/packages/forms-web-app/src/dynamic-forms/question.js
+++ b/packages/forms-web-app/src/dynamic-forms/question.js
@@ -213,6 +213,11 @@ class Question {
 		const { body } = req;
 		const { errors = {}, errorSummary = [] } = body;
 
+		console.log('ohohohohoho');
+		console.log(errors);
+		console.log('popopo');
+		console.log(errorSummary);
+
 		if (Object.keys(errors).length > 0) {
 			return this.prepQuestionForRendering(
 				sectionObj,


### PR DESCRIPTION
## Ticket Number

https://pins-ds.atlassian.net/browse/AAPD-1809

## Description of change

Corrects errorMessage option being passed to njks component to ensure that error message appears above radio buttons as well as at top of page.  Due to complexity of field name options in this dynamic component the second display uses the errorSummary object rather than the errors object - the errorSummary always contains the correct error for this component.

## Checklist

<!-- Put an `x` in all the boxes that apply: -->

- [ ] Requires infrastructure changes
- [ ] I have updated the documentation accordingly
- X My commit history in this PR is linear
- [ ] New features have tests
- [ ] Breaking change (team conversation required)

## Important

Please do not merge from `main` (please only [rebase](https://github.com/Planning-Inspectorate/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
