### PR TITLE
fix(461): add required fields to appeal submission formatter

### DIFF
--- a/packages/appeals-service-api/src/services/back-office-v2/formatters/has/appeal.js
+++ b/packages/appeals-service-api/src/services/back-office-v2/formatters/has/appeal.js
@@ -81,6 +81,7 @@ exports.formatter = async (appellantSubmission) => {
 			siteSafetyDetails: [
 				appellantSubmission.appellantSiteSafety_appellantSiteSafetyDetails
 			].filter(Boolean),
+			isGreenBelt: appellantSubmission.appellantGreenBelt ?? null,
 			siteAreaSquareMetres: Number(appellantSubmission.siteAreaSquareMetres) ?? null,
 			floorSpaceSquareMetres: Number(appellantSubmission.siteAreaSquareMetres) ?? null,
 			ownsAllLand: appellantSubmission.ownsAllLand ?? null,
@@ -95,8 +96,7 @@ exports.formatter = async (appellantSubmission) => {
 				({ caseReference }) => caseReference
 			),
 			neighbouringSiteAddresses: null, // added by the LPA later I believe
-			appellantCostsAppliedFor: appellantSubmission.costApplication ?? null,
-			isGreenBelt: appellantSubmission.appellantGreenBelt
+			appellantCostsAppliedFor: appellantSubmission.costApplication ?? null
 		},
 		documents: await getDocuments(appellantSubmission),
 		users: formatApplicationSubmissionUsers(appellantSubmission)

--- a/packages/appeals-service-api/src/services/back-office-v2/formatters/s78/appeal.js
+++ b/packages/appeals-service-api/src/services/back-office-v2/formatters/s78/appeal.js
@@ -81,6 +81,7 @@ exports.formatter = async (appellantSubmission) => {
 			siteSafetyDetails: [
 				appellantSubmission.appellantSiteSafety_appellantSiteSafetyDetails
 			].filter(Boolean),
+			isGreenBelt: appellantSubmission.appellantGreenBelt ?? null,
 			siteAreaSquareMetres: Number(appellantSubmission.siteAreaSquareMetres) ?? null,
 			floorSpaceSquareMetres: Number(appellantSubmission.siteAreaSquareMetres) ?? null,
 			ownsAllLand: appellantSubmission.ownsAllLand ?? null,


### PR DESCRIPTION
## Ticket Number

https://pins-ds.atlassian.net/browse/AS-461

## Description of change

Adds isGreenBelt fields to appeal submission formatters

## Checklist

<!-- Put an `x` in all the boxes that apply: -->

- [ ] Requires infrastructure changes
- [ ] I have updated the documentation accordingly
- X My commit history in this PR is linear
- [ ] New features have tests
- [ ] Breaking change (team conversation required)

## Important

Please do not merge from `main` (please only [rebase](https://github.com/Planning-Inspectorate/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
