### PR TITLE
fix: option question condition handles array and joined string

### DIFF
--- a/packages/forms-web-app/src/dynamic-forms/dynamic-components/checkbox/question.js
+++ b/packages/forms-web-app/src/dynamic-forms/dynamic-components/checkbox/question.js
@@ -1,6 +1,8 @@
 const OptionsQuestion = require('../../options-question');
 const questionUtils = require('../utils/question-utils');
 
+const defaultOptionJoinString = ',';
+
 /**
  * @typedef {import('../../journey').Journey} Journey
  */
@@ -36,6 +38,8 @@ class CheckboxQuestion extends OptionsQuestion {
 			options,
 			validators
 		});
+
+		this.optionJoinString = defaultOptionJoinString;
 	}
 
 	/**
@@ -64,7 +68,7 @@ class CheckboxQuestion extends OptionsQuestion {
 		}
 
 		// answer is a string
-		const answerArray = answer.split(',');
+		const answerArray = answer.split(this.optionJoinString);
 
 		const formattedAnswer = this.options
 			.filter((option) => answerArray.includes(option.value))

--- a/packages/forms-web-app/src/dynamic-forms/dynamic-components/unit-option-entry/question.js
+++ b/packages/forms-web-app/src/dynamic-forms/dynamic-components/unit-option-entry/question.js
@@ -1,6 +1,8 @@
 const nunjucks = require('nunjucks');
 const Question = require('../../question');
 
+const defaultOptionJoinString = ',';
+
 /**
  * @typedef {import('../../question').QuestionViewModel} QuestionViewModel
  * @typedef {import('../../journey').Journey} Journey
@@ -84,6 +86,7 @@ class UnitOptionEntryQuestion extends Question {
 		this.options = options;
 		this.html = html;
 		this.label = label;
+		this.optionJoinString = defaultOptionJoinString;
 	}
 
 	/**
@@ -166,7 +169,7 @@ class UnitOptionEntryQuestion extends Question {
 				`User submitted option(s) did not correlate with valid answers to ${this.fieldName} question`
 			);
 
-		responseToSave.answers[this.fieldName] = fieldValues.join(',');
+		responseToSave.answers[this.fieldName] = fieldValues.join(this.optionJoinString);
 		journeyResponse.answers[this.fieldName] = fieldValues;
 
 		this.options.forEach((option) => {

--- a/packages/forms-web-app/src/dynamic-forms/dynamic-components/utils/question-has-answer.js
+++ b/packages/forms-web-app/src/dynamic-forms/dynamic-components/utils/question-has-answer.js
@@ -11,6 +11,11 @@ const questionHasAnswerBuilder = (response) => (question, expectedValue) => {
 
 	if (Array.isArray(answerField)) {
 		return answerField.includes(expectedValue);
+	} else if (question.optionJoinString) {
+		// todo: answers from options questions sometimes are array sometimes string, why?
+		if (!answerField) return false;
+		const answers = answerField.split(question.optionJoinString);
+		return answers.includes(expectedValue);
 	} else {
 		return answerField === expectedValue;
 	}

--- a/packages/forms-web-app/src/dynamic-forms/dynamic-components/utils/question-has-answer.test.js
+++ b/packages/forms-web-app/src/dynamic-forms/dynamic-components/utils/question-has-answer.test.js
@@ -12,32 +12,101 @@ const testResponse = {
 };
 const testQuestions = {
 	aTestQuestion: { fieldName: 'aTestQuestion' },
-	anotherTestQuestion: { fieldName: 'anotherTestQuestion' }
+	anotherTestQuestion: { fieldName: 'anotherTestQuestion' },
+	optionQuestion: { fieldName: 'optionQuestion', optionJoinString: ',' }
 };
-describe('questionHasAnswer', () => {
-	it('should return true when parameters do match', () => {
-		const questionHasAnswerFunction = questionHasAnswerBuilder(testResponse);
 
-		const result = questionHasAnswerFunction(
-			testQuestions.aTestQuestion,
-			aTestQuestionExpectedResult
-		);
+describe('question-has-answer', () => {
+	describe('questionHasAnswer', () => {
+		it('should return true when parameters do match', () => {
+			const questionHasAnswerFunction = questionHasAnswerBuilder(testResponse);
 
-		expect(result).toBe(true);
+			const result = questionHasAnswerFunction(
+				testQuestions.aTestQuestion,
+				aTestQuestionExpectedResult
+			);
+
+			expect(result).toBe(true);
+		});
+
+		it('should return false when parameters do not match', () => {
+			const questionHasAnswerFunction = questionHasAnswerBuilder(testResponse);
+
+			const result = questionHasAnswerFunction(testQuestions.aTestQuestion);
+
+			expect(result).toBe(false);
+		});
+
+		it('should return false for options question without answer', () => {
+			const questionHasAnswerFunction = questionHasAnswerBuilder(testResponse);
+			const result = questionHasAnswerFunction(testQuestions.optionQuestion, 'option-a');
+			expect(result).toBe(false);
+		});
+
+		it('should return false for options question with null answer', () => {
+			const questionHasAnswerFunction = questionHasAnswerBuilder({
+				answers: {
+					optionQuestion: null
+				}
+			});
+			const result = questionHasAnswerFunction(testQuestions.optionQuestion, 'option-a');
+			expect(result).toBe(false);
+		});
+
+		it('should return true for options question with string', () => {
+			const questionHasAnswerFunction = questionHasAnswerBuilder({
+				answers: {
+					optionQuestion: 'option-a'
+				}
+			});
+			const result = questionHasAnswerFunction(testQuestions.optionQuestion, 'option-a');
+			expect(result).toBe(true);
+		});
+
+		it('should return true for options question with joined string', () => {
+			const questionHasAnswerFunction = questionHasAnswerBuilder({
+				answers: {
+					optionQuestion: `option-a${testQuestions.optionQuestion.optionJoinString}option-b`
+				}
+			});
+			const result = questionHasAnswerFunction(testQuestions.optionQuestion, 'option-a');
+			expect(result).toBe(true);
+		});
+
+		it('should return false for options missing from string', () => {
+			const questionHasAnswerFunction = questionHasAnswerBuilder({
+				answers: {
+					optionQuestion: `option-a${testQuestions.optionQuestion.optionJoinString}option-b`
+				}
+			});
+			const result = questionHasAnswerFunction(testQuestions.optionQuestion, 'option-c');
+			expect(result).toBe(false);
+		});
+
+		it('should return true for options question with array', () => {
+			const questionHasAnswerFunction = questionHasAnswerBuilder({
+				answers: {
+					optionQuestion: ['option-a', 'option-b']
+				}
+			});
+			const result = questionHasAnswerFunction(testQuestions.optionQuestion, 'option-a');
+			expect(result).toBe(true);
+		});
+
+		it('should return false for options missing from array', () => {
+			const questionHasAnswerFunction = questionHasAnswerBuilder({
+				answers: {
+					optionQuestion: ['option-a', 'option-b']
+				}
+			});
+			const result = questionHasAnswerFunction(testQuestions.optionQuestion, 'option-c');
+			expect(result).toBe(false);
+		});
 	});
 
-	it('should return false when parameters do not match', () => {
-		const questionHasAnswerFunction = questionHasAnswerBuilder(testResponse);
-
-		const result = questionHasAnswerFunction(testQuestions.aTestQuestion);
-
-		expect(result).toBe(false);
-	});
-});
-
-describe('questionsHaveAnswer', () => {
-	// prettier-ignore
-	it.each([
+	describe('questionsHaveAnswer', () => {
+		// prettier-ignore
+		it.each([
 		[[[testQuestions.aTestQuestion, aTestQuestionExpectedResult], [testQuestions.anotherTestQuestion, anotherTestQuestionExpectedResult]], 'and', true],
 		[[[testQuestions.aTestQuestion, aTestQuestionExpectedResult], [testQuestions.anotherTestQuestion, anotherTestQuestionUnexpectedResult]], 'and', false],
 		[[[testQuestions.aTestQuestion, aTestQuestionUnexpectedResult], [testQuestions.anotherTestQuestion, anotherTestQuestionUnexpectedResult]], 'and', false],
@@ -57,4 +126,5 @@ describe('questionsHaveAnswer', () => {
 			expect(result).toBe(expectedResult);
 		}
 	);
+	});
 });

--- a/packages/forms-web-app/src/dynamic-forms/options-question.js
+++ b/packages/forms-web-app/src/dynamic-forms/options-question.js
@@ -4,6 +4,8 @@ const Question = require('./question');
 const ValidOptionValidator = require('./validator/valid-option-validator');
 const { getConditionalFieldName } = require('./dynamic-components/utils/question-utils');
 
+const defaultOptionJoinString = ',';
+
 /**
  * @typedef {import('./question').QuestionViewModel} QuestionViewModel
  * @typedef {import('./journey').Journey} Journey
@@ -87,6 +89,7 @@ class OptionsQuestion extends Question {
 		});
 		this.hint = hint;
 		this.options = options;
+		this.optionJoinString = defaultOptionJoinString;
 	}
 
 	/**
@@ -173,7 +176,7 @@ class OptionsQuestion extends Question {
 				`User submitted option(s) did not correlate with valid answers to ${this.fieldName} question`
 			);
 
-		responseToSave.answers[this.fieldName] = fieldValues.join(',');
+		responseToSave.answers[this.fieldName] = fieldValues.join(this.optionJoinString);
 		journeyResponse.answers[this.fieldName] = fieldValues;
 
 		this.options.forEach((option) => {


### PR DESCRIPTION
## Ticket Number

https://pins-ds.atlassian.net/browse/A2-240

## Description of change

Options question used in a journey condition seems to sometimes come through as a joined string and sometimes an array
Have handled both scenarios here, but haven't looked into why this happens

## Checklist

<!-- Put an `x` in all the boxes that apply: -->

- [ ] Requires infrastructure changes
- [ ] I have updated the documentation accordingly
- [ ] My commit history in this PR is linear
- [ ] New features have tests
- [ ] Breaking change (team conversation required)

## Important

Please do not merge from `main` (please only [rebase](https://github.com/Planning-Inspectorate/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
