### PR TITLE
feat: link appeal to initial submission

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,8 @@
 			],
 			"dependencies": {
 				"applicationinsights": "^2.9.0",
-				"patch-package": "^6.5.1"
+				"patch-package": "^6.5.1",
+				"pins-data-model": "github:Planning-Inspectorate/data-model#1.7.3"
 			},
 			"devDependencies": {
 				"@commitlint/cli": "^17.0.0",
@@ -28182,8 +28183,8 @@
 			"integrity": "sha512-EqX4pwDPrt3MuOAAUBMU0Tk5kR/YcCM5fNPEzgCO2zJ5HfX0vbiH9HbJglnyeQsN96Kznae6MWD47pZB5avTrg=="
 		},
 		"node_modules/pins-data-model": {
-			"version": "1.7.2",
-			"resolved": "git+ssh://git@github.com/Planning-Inspectorate/data-model.git#ed01a77cd9423c8d17c159e1ae9f1ebc64ae274a",
+			"version": "1.7.3",
+			"resolved": "git+ssh://git@github.com/Planning-Inspectorate/data-model.git#d8e7287a57e193270d566237ca81d758d4c3d2dd",
 			"dependencies": {
 				"jsonc-parser": "^3.2.0"
 			}
@@ -33355,7 +33356,6 @@
 				"node-cron": "^3.0.2",
 				"pino": "^9.2.0",
 				"pino-http": "^10.1.0",
-				"pins-data-model": "github:Planning-Inspectorate/data-model#1.7.2",
 				"prettier": "^2.8.8",
 				"rhea": "^1.0.24",
 				"secure-pin": "^1.0.14",
@@ -34596,7 +34596,6 @@
 			"dependencies": {
 				"date-fns": "^2.28.0",
 				"date-fns-tz": "^2.0.0",
-				"pins-data-model": "github:Planning-Inspectorate/data-model#1.7.2",
 				"yup": "^0.32.9"
 			},
 			"devDependencies": {
@@ -34677,8 +34676,7 @@
 				"jose": "^5.2.3",
 				"notifications-node-client": "^5.1.1",
 				"openid-client": "^5.6.4",
-				"pino": "^6.14.0",
-				"pins-data-model": "github:Planning-Inspectorate/data-model#1.7.2"
+				"pino": "^6.14.0"
 			},
 			"devDependencies": {
 				"eslint": "^8.17.0",
@@ -34736,8 +34734,7 @@
 			"license": "ISC",
 			"dependencies": {
 				"@pins/business-rules": "file:../business-rules",
-				"@pins/common": "file:../common",
-				"pins-data-model": "github:Planning-Inspectorate/data-model#1.7.2"
+				"@pins/common": "file:../common"
 			},
 			"devDependencies": {
 				"@prisma/client": "^5.11.0",
@@ -35053,7 +35050,6 @@
 				"nunjucks-date-filter": "^0.1.1",
 				"pino": "^9.2.0",
 				"pino-http": "^10.1.0",
-				"pins-data-model": "github:Planning-Inspectorate/data-model#1.7.2",
 				"sass": "^1.49.0",
 				"uuid": "^8.3.1"
 			},
@@ -35218,7 +35214,6 @@
 				"@azure/storage-blob": "^12.17.0",
 				"@pins/common": "file:../common",
 				"got": "^11.8.5",
-				"pins-data-model": "github:Planning-Inspectorate/data-model#1.7.2",
 				"stream-json": "^1.8.0"
 			},
 			"devDependencies": {
@@ -35657,6 +35652,9 @@
 					"optional": true
 				}
 			}
+		},
+		"packages/web-comment": {
+			"extraneous": true
 		},
 		"test-packages/platform-feature-tests": {
 			"version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -128,6 +128,7 @@
 	},
 	"dependencies": {
 		"applicationinsights": "^2.9.0",
-		"patch-package": "^6.5.1"
+		"patch-package": "^6.5.1",
+		"pins-data-model": "github:Planning-Inspectorate/data-model#1.7.3"
 	}
 }

--- a/packages/appeals-service-api/package.json
+++ b/packages/appeals-service-api/package.json
@@ -55,7 +55,6 @@
 		"node-cron": "^3.0.2",
 		"pino": "^9.2.0",
 		"pino-http": "^10.1.0",
-		"pins-data-model": "github:Planning-Inspectorate/data-model#1.7.2",
 		"prettier": "^2.8.8",
 		"rhea": "^1.0.24",
 		"secure-pin": "^1.0.14",

--- a/packages/appeals-service-api/src/routes/v2/appeal-cases/appeal-cases.spec.js
+++ b/packages/appeals-service-api/src/routes/v2/appeal-cases/appeal-cases.spec.js
@@ -401,6 +401,24 @@ describe('appeal-cases', () => {
 			expect(appealRelations.length).toBe(5); // nearbyCaseReferences (linked bi-directional) + leadCaseReference (one-directional)
 		});
 
+		it('links to initial submission', async () => {
+			const appeal = await sqlClient.appeal.create({});
+
+			example.caseReference = 'link-to-submission';
+			example.submissionId = appeal.id;
+
+			await appealsApi.put(`/api/v2/appeal-cases/` + example.caseReference).send(example);
+
+			const appealCase = await sqlClient.appealCase.findFirst({
+				where: { caseReference: example.caseReference },
+				select: {
+					appealId: true
+				}
+			});
+
+			expect(appealCase?.appealId).toBe(appeal.id);
+		});
+
 		it(`returns 400 for bad requests`, async () => {
 			const badData = {
 				caseType: 'D'

--- a/packages/appeals-service-api/src/routes/v2/appeal-cases/repo.js
+++ b/packages/appeals-service-api/src/routes/v2/appeal-cases/repo.js
@@ -77,7 +77,7 @@ const DocumentsArgsPublishedOnly = {
 /**
  * @param {String} caseProcessCode
  * @param {AppealHASCase} dataModel
- * @returns {AppealCaseCreateWithoutAppealInput}
+ * @returns {AppealCaseCreate}
  */
 const mapHASDataModelToAppealCase = (
 	caseProcessCode,
@@ -89,6 +89,7 @@ const mapHASDataModelToAppealCase = (
 		nearbyCaseReferences: _nearbyCaseReferences,
 		neighbouringSiteAddresses: _neighbouringSiteAddresses,
 		affectedListedBuildingNumbers: _affectedListedBuildingNumbers,
+		submissionId: _submissionId,
 		caseStatus,
 		caseDecisionOutcome,
 		caseValidationOutcome,
@@ -190,7 +191,10 @@ class AppealCaseRepository {
 		const mappedData = mapHASDataModelToAppealCase(caseProcessCode, data);
 
 		const appealCase = await this.dbClient.appealCase.upsert({
-			create: { ...mappedData, Appeal: { create: {} } },
+			create: {
+				...mappedData,
+				Appeal: data.submissionId ? { connect: { id: data.submissionId } } : { create: {} }
+			},
 			update: mappedData,
 			where: {
 				caseReference

--- a/packages/appeals-service-api/src/routes/v2/appellant-submissions/_id/submit/index.test.js
+++ b/packages/appeals-service-api/src/routes/v2/appellant-submissions/_id/submit/index.test.js
@@ -23,6 +23,7 @@ jest.mock('../service', () => ({
 		switch (appellantSubmissionId) {
 			case '001':
 				return {
+					appealId: 'f70dd26f-3776-4685-a79c-a81dbe8790b6',
 					LPACode: 'LPA_001',
 					appealTypeCode: 'HAS',
 					applicationDecisionDate: new Date('2024-01-01'),
@@ -95,6 +96,7 @@ jest.mock('../service', () => ({
 				};
 			case '002':
 				return {
+					appealId: '29eee0be-d395-4039-a277-7435e7ab0b66',
 					LPACode: 'LPA_002',
 					appealTypeCode: 'HAS',
 					applicationDecisionDate: new Date('2024-01-01'),
@@ -222,6 +224,7 @@ jest.mock('express-oauth2-jwt-bearer');
 /** @type {import('pins-data-model/src/schemas').AppellantSubmissionCommand} */
 const formattedHAS1 = {
 	casedata: {
+		submissionId: 'f70dd26f-3776-4685-a79c-a81dbe8790b6',
 		advertisedAppeal: null,
 		appellantCostsAppliedFor: false,
 		applicationDate: '2024-01-01T00:00:00.000Z',
@@ -282,6 +285,7 @@ const formattedHAS1 = {
 /** @type {import('pins-data-model/src/schemas').AppellantSubmissionCommand} */
 const formattedHAS2 = {
 	casedata: {
+		submissionId: '29eee0be-d395-4039-a277-7435e7ab0b66',
 		advertisedAppeal: null,
 		appellantCostsAppliedFor: false,
 		applicationDate: '2024-01-01T00:00:00.000Z',

--- a/packages/appeals-service-api/src/services/back-office-v2/formatters/has/appeal.js
+++ b/packages/appeals-service-api/src/services/back-office-v2/formatters/has/appeal.js
@@ -56,6 +56,7 @@ exports.formatter = async (appellantSubmission) => {
 
 	return {
 		casedata: {
+			submissionId: appellantSubmission.appealId,
 			caseType: 'D',
 			caseProcedure: 'written',
 			lpaCode: lpa.getLpaCode(),

--- a/packages/appeals-service-api/src/services/back-office-v2/formatters/s78/appeal.js
+++ b/packages/appeals-service-api/src/services/back-office-v2/formatters/s78/appeal.js
@@ -56,6 +56,7 @@ exports.formatter = async (appellantSubmission) => {
 
 	return {
 		casedata: {
+			submissionId: appellantSubmission.appealId,
 			caseType: 'D',
 			caseProcedure: 'written',
 			lpaCode: lpa.getLpaCode(),

--- a/packages/business-rules/package.json
+++ b/packages/business-rules/package.json
@@ -20,7 +20,6 @@
 	"dependencies": {
 		"date-fns": "^2.28.0",
 		"date-fns-tz": "^2.0.0",
-		"pins-data-model": "github:Planning-Inspectorate/data-model#1.7.2",
 		"yup": "^0.32.9"
 	},
 	"devDependencies": {

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -26,8 +26,7 @@
 		"jose": "^5.2.3",
 		"notifications-node-client": "^5.1.1",
 		"openid-client": "^5.6.4",
-		"pino": "^6.14.0",
-		"pins-data-model": "github:Planning-Inspectorate/data-model#1.7.2"
+		"pino": "^6.14.0"
 	},
 	"devDependencies": {
 		"eslint": "^8.17.0",

--- a/packages/database/package.json
+++ b/packages/database/package.json
@@ -23,8 +23,7 @@
 	"license": "ISC",
 	"dependencies": {
 		"@pins/business-rules": "file:../business-rules",
-		"@pins/common": "file:../common",
-		"pins-data-model": "github:Planning-Inspectorate/data-model#1.7.2"
+		"@pins/common": "file:../common"
 	},
 	"devDependencies": {
 		"@prisma/client": "^5.11.0",

--- a/packages/forms-web-app/package.json
+++ b/packages/forms-web-app/package.json
@@ -56,7 +56,6 @@
 		"nunjucks-date-filter": "^0.1.1",
 		"pino": "^9.2.0",
 		"pino-http": "^10.1.0",
-		"pins-data-model": "github:Planning-Inspectorate/data-model#1.7.2",
 		"sass": "^1.49.0",
 		"uuid": "^8.3.1"
 	},

--- a/packages/integration-functions/package.json
+++ b/packages/integration-functions/package.json
@@ -29,7 +29,6 @@
 		"@azure/storage-blob": "^12.17.0",
 		"@pins/common": "file:../common",
 		"got": "^11.8.5",
-		"pins-data-model": "github:Planning-Inspectorate/data-model#1.7.2",
 		"stream-json": "^1.8.0"
 	}
 }


### PR DESCRIPTION
## Ticket Number

## Description of change

- links an appeal case retrieved from back office to the initial appellant submission

## Checklist

<!-- Put an `x` in all the boxes that apply: -->

- [ ] Requires infrastructure changes
- [ ] I have updated the documentation accordingly
- [x] My commit history in this PR is linear
- [x] New features have tests
- [ ] Breaking change (team conversation required)

## Important

Please do not merge from `main` (please only [rebase](https://github.com/Planning-Inspectorate/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
