### PR TITLE
fix: handle agent on appeal-details page

### DIFF
--- a/packages/forms-web-app/src/controllers/selected-appeal/appeal-details/appeal-details-rows.js
+++ b/packages/forms-web-app/src/controllers/selected-appeal/appeal-details/appeal-details-rows.js
@@ -29,7 +29,7 @@ exports.detailsRows = (caseData, userType) => {
 
 	const agent = caseData.users?.find((x) => x.serviceUserType === APPEAL_USER_ROLES.AGENT);
 	const appellant = caseData.users?.find((x) => x.serviceUserType === APPEAL_USER_ROLES.APPELLANT);
-	const contactIsAppellant = !!agent; // if no agent than appellant made their own appeal
+	const contactIsAppellant = !agent; // if no agent than appellant made their own appeal
 	const contact = contactIsAppellant ? appellant : agent;
 
 	const linkedAppeals = formatRelatedAppeals(caseData, CASE_RELATION_TYPES.linked);
@@ -47,7 +47,7 @@ exports.detailsRows = (caseData, userType) => {
 		{
 			keyText: "Applicant's name",
 			valueText: formatUserDetails(appellant),
-			condition: () => !!agent
+			condition: () => !contactIsAppellant
 		},
 		{
 			keyText: 'Contact details',

--- a/packages/forms-web-app/src/controllers/selected-appeal/appeal-details/appeal-details-rows.test.js
+++ b/packages/forms-web-app/src/controllers/selected-appeal/appeal-details/appeal-details-rows.test.js
@@ -1,0 +1,59 @@
+const { detailsRows } = require('./appeal-details-rows');
+const { APPEAL_USER_ROLES, LPA_USER_ROLE } = require('@pins/common/src/constants');
+
+describe('appeal-details-rows', () => {
+	const appellant = {
+		serviceUserType: APPEAL_USER_ROLES.APPELLANT,
+		firstName: 'Appellant',
+		lastName: 'Test'
+	};
+	const agent = { serviceUserType: APPEAL_USER_ROLES.AGENT, firstName: 'Agent', lastName: 'Test' };
+	const caseWithAgent = { users: [agent, appellant] };
+	const caseWithAppellant = { users: [appellant] };
+
+	describe('in your name?', () => {
+		const inYourNameIndex = 0;
+
+		it('should display application in your name, if appellant/agent', () => {
+			const rows = detailsRows(caseWithAppellant, APPEAL_USER_ROLES.APPELLANT);
+			const rows2 = detailsRows(caseWithAppellant, APPEAL_USER_ROLES.AGENT);
+			expect(rows[inYourNameIndex].keyText).toEqual('Was the application made in your name?');
+			expect(rows[inYourNameIndex].valueText).toEqual('Yes');
+			expect(rows2[inYourNameIndex].keyText).toEqual('Was the application made in your name?');
+			expect(rows2[inYourNameIndex].valueText).toEqual('Yes');
+		});
+
+		it("should display application in appellant's name, if lpa", () => {
+			const rows = detailsRows(caseWithAppellant, LPA_USER_ROLE);
+			expect(rows[inYourNameIndex].keyText).toEqual(
+				"Was the application made in the appellant's name"
+			);
+			expect(rows[inYourNameIndex].valueText).toEqual('Yes');
+		});
+
+		it('should display display No if agent', () => {
+			const rows = detailsRows(caseWithAgent, APPEAL_USER_ROLES.APPELLANT);
+			const rows2 = detailsRows(caseWithAgent, LPA_USER_ROLE);
+			expect(rows[inYourNameIndex].valueText).toEqual('No');
+			expect(rows2[inYourNameIndex].valueText).toEqual('No');
+		});
+	});
+
+	describe("Applicant's name", () => {
+		const nameIndex = 1;
+		const contactIndex = 2;
+
+		it("should display Applicant's and Agent name if agent on case", () => {
+			const rows = detailsRows(caseWithAgent, APPEAL_USER_ROLES.APPELLANT);
+			expect(rows[nameIndex].condition()).toEqual(true);
+			expect(rows[nameIndex].valueText).toEqual('Appellant Test');
+			expect(rows[contactIndex].valueText).toEqual('Agent Test');
+		});
+
+		it("should display only Applicant's name if no agent on case", () => {
+			const rows = detailsRows(caseWithAppellant, APPEAL_USER_ROLES.APPELLANT);
+			expect(rows[nameIndex].condition()).toEqual(false);
+			expect(rows[contactIndex].valueText).toEqual('Appellant Test');
+		});
+	});
+});


### PR DESCRIPTION
## Ticket Number

<!-- Add the number from the Jira board -->

## Description of change

The check for displaying agent details was backwards
- have inverted check
- added some initial tests for the appeal-details-rows.js

## Checklist

<!-- Put an `x` in all the boxes that apply: -->

- [ ] Requires infrastructure changes
- [ ] I have updated the documentation accordingly
- [x] My commit history in this PR is linear
- [x] New features have tests
- [ ] Breaking change (team conversation required)

## Important

Please do not merge from `main` (please only [rebase](https://github.com/Planning-Inspectorate/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
