### PR TITLE
chore: sql select for appellant dashboard

### DIFF
--- a/packages/appeals-service-api/src/routes/v2/appeals/repo.js
+++ b/packages/appeals-service-api/src/routes/v2/appeals/repo.js
@@ -17,21 +17,49 @@ class UserAppealsRepository {
 	 *
 	 * @param {string} userId
 	 * @returns {Promise<UserWithAppeals|null>}
-	 */ // todo: select only needed fields
+	 */
 	async listAppealsForUser(userId) {
 		try {
 			return await this.dbClient.appealUser.findUnique({
 				where: {
 					id: userId
 				},
-				include: {
+				select: {
+					id: true,
 					Appeals: {
-						include: {
+						select: {
+							appealId: true,
 							Appeal: {
-								include: {
-									AppealCase: true,
+								select: {
+									id: true,
+									legacyAppealSubmissionId: true,
+									legacyAppealSubmissionDecisionDate: true,
+									legacyAppealSubmissionState: true,
+									AppealCase: {
+										select: {
+											id: true,
+											appealTypeCode: true,
+											caseDecisionOutcomeDate: true,
+											caseDecisionOutcome: true,
+											caseReference: true,
+											appellantCommentsSubmitted: true,
+											appellantsProofsSubmitted: true,
+											finalCommentsDueDate: true,
+											proofsOfEvidenceDueDate: true,
+											caseWithdrawnDate: true,
+											caseStatus: true,
+											siteAddressLine1: true,
+											siteAddressLine2: true,
+											siteAddressTown: true,
+											siteAddressPostcode: true
+										}
+									},
 									AppellantSubmission: {
-										include: {
+										select: {
+											id: true,
+											submitted: true,
+											appealTypeCode: true,
+											applicationDecisionDate: true,
 											SubmissionAddress: true
 										}
 									}

--- a/packages/forms-web-app/src/controllers/appeals/your-appeals.js
+++ b/packages/forms-web-app/src/controllers/appeals/your-appeals.js
@@ -22,6 +22,7 @@ exports.get = async (req, res) => {
 		const undecidedAppeals = appeals
 			.filter(isNotWithdrawn)
 			.map(mapToAppellantDashboardDisplayData)
+			.filter(Boolean)
 			.filter((appeal) => !appeal.appealDecision);
 
 		logger.debug({ undecidedAppeals }, 'undecided appeals');

--- a/packages/forms-web-app/src/controllers/appeals/your-appeals/decided-appeals.js
+++ b/packages/forms-web-app/src/controllers/appeals/your-appeals/decided-appeals.js
@@ -10,6 +10,7 @@ exports.get = async (req, res) => {
 		if (appeals?.length > 0) {
 			const decidedAppeals = appeals
 				.map(mapToAppellantDashboardDisplayData)
+				.filter(Boolean)
 				.filter((appeal) => appeal.appealDecision);
 			decidedAppeals.sort(sortByDateFieldDesc('caseDecisionOutcomeDate'));
 			viewContext = { decidedAppeals };

--- a/packages/forms-web-app/src/lib/dashboard-functions.js
+++ b/packages/forms-web-app/src/lib/dashboard-functions.js
@@ -10,6 +10,8 @@ const {
 } = require('@pins/common/src/lib/format-address');
 const { formatDate } = require('#utils/format-date');
 const { caseTypeNameWithDefault } = require('@pins/common/src/lib/format-case-type');
+const logger = require('#lib/logger');
+
 /**
  * @typedef {import('appeals-service-api').Api.AppealCaseDetailed} AppealCaseDetailed
  * @typedef {import('appeals-service-api').Api.AppealSubmission} AppealSubmission
@@ -73,28 +75,39 @@ const mapToLPADashboardDisplayData = (appealCaseData) => ({
 
 /**
  * @param {AppealSubmission | AppealCaseDetailed} appealData
- * @returns {DashboardDisplayData}
+ * @returns {DashboardDisplayData|null}
  */
-const mapToAppellantDashboardDisplayData = (appealData) => ({
-	appealId: isAppealSubmission(appealData) ? appealData._id : appealData.id,
-	appealNumber:
-		isAppealSubmission(appealData) || isV2Submission(appealData) ? '' : appealData.caseReference,
-	address: formatAddress(appealData),
-	appealType: getAppealType(appealData),
-	nextDocumentDue: determineDocumentToDisplayAppellantDashboard(appealData),
-	isDraft: isAppealSubmission(appealData) || isV2Submission(appealData),
-	appealDecision: isAppealSubmission(appealData)
-		? null
-		: mapDecisionLabel(appealData.caseDecisionOutcome),
-	appealDecisionColor:
-		isAppealSubmission(appealData) || isV2Submission(appealData)
-			? null
-			: mapDecisionColour(appealData.caseDecisionOutcome),
-	caseDecisionOutcomeDate:
-		isAppealSubmission(appealData) || isV2Submission(appealData)
-			? null
-			: appealData.caseDecisionOutcomeDate
-});
+const mapToAppellantDashboardDisplayData = (appealData) => {
+	const id = isAppealSubmission(appealData) ? appealData._id : appealData.id;
+	try {
+		return {
+			appealId: id,
+			appealNumber:
+				isAppealSubmission(appealData) || isV2Submission(appealData)
+					? ''
+					: appealData.caseReference,
+			address: formatAddress(appealData),
+			appealType: getAppealType(appealData),
+			nextDocumentDue: determineDocumentToDisplayAppellantDashboard(appealData),
+			isDraft: isAppealSubmission(appealData) || isV2Submission(appealData),
+			appealDecision: isAppealSubmission(appealData)
+				? null
+				: mapDecisionLabel(appealData.caseDecisionOutcome),
+			appealDecisionColor:
+				isAppealSubmission(appealData) || isV2Submission(appealData)
+					? null
+					: mapDecisionColour(appealData.caseDecisionOutcome),
+			caseDecisionOutcomeDate:
+				isAppealSubmission(appealData) || isV2Submission(appealData)
+					? null
+					: appealData.caseDecisionOutcomeDate
+		};
+	} catch (err) {
+		logger.error({ err }, `failed to mapToAppellantDashboardDisplayData ${id}`);
+	}
+
+	return null;
+};
 
 // LPADashboard - ToDo or WaitingToReview FUNCTIONS
 


### PR DESCRIPTION
## Ticket Number

## Description of change

- Reduces the amount of data retrieved for appellant dashboard for efficiency
- stops dashboard breaking if one appeal cannot be mapped
  this was occurring in dev/test due to [AppellantSubmission] records without an applicationDecisionDate set (old data, have fixed data in dev/test)

## Checklist

<!-- Put an `x` in all the boxes that apply: -->

- [ ] Requires infrastructure changes
- [ ] I have updated the documentation accordingly
- [x] My commit history in this PR is linear
- [ ] New features have tests
- [ ] Breaking change (team conversation required)

## Important

Please do not merge from `main` (please only [rebase](https://github.com/Planning-Inspectorate/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
