### PR TITLE
fix: submission updatedAt dates to allow nulls

### DIFF
--- a/packages/database/src/migrations/20240726162321_add_submission_dates/migration.sql
+++ b/packages/database/src/migrations/20240726162321_add_submission_dates/migration.sql
@@ -1,21 +1,14 @@
-/*
-  Warnings:
-
-  - Added the required column `updatedAt` to the `AppellantSubmission` table without a default value. This is not possible if the table is not empty.
-  - Added the required column `updatedAt` to the `LPAQuestionnaireSubmission` table without a default value. This is not possible if the table is not empty.
-
-*/
 BEGIN TRY
 
 BEGIN TRAN;
 
 -- AlterTable
 ALTER TABLE [dbo].[AppellantSubmission] ADD [createdAt] DATETIME2 NOT NULL CONSTRAINT [AppellantSubmission_createdAt_df] DEFAULT CURRENT_TIMESTAMP,
-[updatedAt] DATETIME2 NOT NULL;
+[updatedAt] DATETIME2;
 
 -- AlterTable
 ALTER TABLE [dbo].[LPAQuestionnaireSubmission] ADD [createdAt] DATETIME2 NOT NULL CONSTRAINT [LPAQuestionnaireSubmission_createdAt_df] DEFAULT CURRENT_TIMESTAMP,
-[updatedAt] DATETIME2 NOT NULL;
+[updatedAt] DATETIME2;
 
 COMMIT TRAN;
 

--- a/packages/database/src/schema.prisma
+++ b/packages/database/src/schema.prisma
@@ -627,8 +627,8 @@ model AppellantSubmission {
   appealTypeCode String // type shortcode such as HAS or S78
 
   // dates
-  createdAt DateTime @default(now())
-  updatedAt DateTime @updatedAt
+  createdAt DateTime  @default(now())
+  updatedAt DateTime? @updatedAt
 
   // application
   applicationDecisionDate DateTime?
@@ -733,8 +733,8 @@ model LPAQuestionnaireSubmission {
   AppealCase          AppealCase @relation(fields: [appealCaseReference], references: [caseReference])
 
   // dates
-  createdAt DateTime @default(now())
-  updatedAt DateTime @updatedAt
+  createdAt DateTime  @default(now())
+  updatedAt DateTime? @updatedAt
 
   // state
   submitted Boolean @default(false) /// whether the appeal has been submitted to BO


### PR DESCRIPTION
## Ticket Number

<!-- Add the number from the Jira board -->

## Description of change

updatedAt fields need to be nullable without a default

may require the deletion of the failed migration record in dev db

## Checklist

<!-- Put an `x` in all the boxes that apply: -->

- [ ] Requires infrastructure changes
- [ ] I have updated the documentation accordingly
- [ ] My commit history in this PR is linear
- [ ] New features have tests
- [ ] Breaking change (team conversation required)

## Important

Please do not merge from `main` (please only [rebase](https://github.com/Planning-Inspectorate/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
