### PR TITLE
fix: don't display expired draft appeals on waiting for review page

### DIFF
--- a/packages/forms-web-app/src/controllers/appeals/your-appeals.js
+++ b/packages/forms-web-app/src/controllers/appeals/your-appeals.js
@@ -31,7 +31,8 @@ exports.get = async (req, res) => {
 			(acc, appeal) => {
 				if (isToDoAppellantDashboard(appeal)) {
 					acc.toDoAppeals.push(appeal);
-				} else {
+				} else if (appeal.appealNumber) {
+					// don't add draft appeals to waiting for review
 					acc.waitingForReviewAppeals.push(appeal);
 				}
 				return acc;

--- a/packages/forms-web-app/src/controllers/common/enter-code.js
+++ b/packages/forms-web-app/src/controllers/common/enter-code.js
@@ -77,6 +77,11 @@ const getEnterCode = (views, { isGeneralLogin = true }) => {
 
 		const isSqlUsersActive = await isFeatureActive(FLAG.SQL_USERS);
 
+		logger.info(
+			{ isGeneralLogin, isAppealConfirmation, isReturningFromEmail, isSqlUsersActive, action },
+			`getEnterCode`
+		);
+
 		if (isGeneralLogin) {
 			const email = getSessionEmail(req.session, false);
 
@@ -215,6 +220,18 @@ const postEnterCode = (views, { isGeneralLogin = true }) => {
 				sessionEmail
 			);
 		}
+
+		logger.info(
+			{
+				isV2DocRequest,
+				isGeneralLogin,
+				isAppealConfirmation,
+				isReturningFromEmail,
+				sqlUsersFlag,
+				action
+			},
+			`postEnterCode`
+		);
 
 		if (isV2DocRequest) {
 			return handleCustomRedirect();


### PR DESCRIPTION
## Ticket Number

<!-- Add the number from the Jira board -->

## Description of change

Draft appeals that have passed their deadline are displaying in the waiting for review section of your appeals

## Checklist

<!-- Put an `x` in all the boxes that apply: -->

- [ ] Requires infrastructure changes
- [ ] I have updated the documentation accordingly
- [x] My commit history in this PR is linear
- [ ] New features have tests
- [ ] Breaking change (team conversation required)

## Important

Please do not merge from `main` (please only [rebase](https://github.com/Planning-Inspectorate/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
