### PR TITLE
fix: show case headline on new appeals, block access via direct url n…

### DIFF
--- a/packages/common/src/view-model-maps/appeal-headline.js
+++ b/packages/common/src/view-model-maps/appeal-headline.js
@@ -76,20 +76,12 @@ const formatHeadlineData = (caseData, lpaName, userType = APPEAL_USER_ROLES.INTE
 };
 
 /**
- * @param {AppealCaseDetailed} caseData
+ * should this ever be false?
+ * @param {AppealCaseDetailed} _caseData
  * @param {AppealToUserRoles|LpaUserRole|null} userType
  */
-const shouldFormatHeadlines = (
-	{ caseValidDate, lpaQuestionnaireSubmittedDate, lpaQuestionnairePublishedDate },
-	userType
-) => {
-	if (userType === APPEAL_USER_ROLES.APPELLANT) {
-		return lpaQuestionnairePublishedDate;
-	} else if (userType === LPA_USER_ROLE) {
-		return caseValidDate && lpaQuestionnaireSubmittedDate;
-	}
-	return false;
-};
+const shouldFormatHeadlines = (_caseData, userType) =>
+	userType === APPEAL_USER_ROLES.APPELLANT || userType === LPA_USER_ROLE;
 
 /**
  * @param {AppealCaseDetailed} caseData

--- a/packages/forms-web-app/src/controllers/selected-appeal/appeal-details/index.js
+++ b/packages/forms-web-app/src/controllers/selected-appeal/appeal-details/index.js
@@ -43,6 +43,10 @@ exports.get = (layoutTemplate = 'layouts/no-banner-link/main.njk') => {
 			userId: user.id
 		});
 
+		if (!caseData.caseValidDate && userType !== APPEAL_USER_ROLES.APPELLANT) {
+			throw new Error("can't show an unvalidated appeal");
+		}
+
 		logger.debug({ caseData }, 'caseData');
 
 		const lpa = await getDepartmentFromCode(caseData.LPACode);

--- a/packages/forms-web-app/src/controllers/selected-appeal/index.js
+++ b/packages/forms-web-app/src/controllers/selected-appeal/index.js
@@ -14,6 +14,7 @@ const { sections: rule6Sections } = require('./rule-6-sections');
 const { getUserFromSession } = require('../../services/user.service');
 const { format: formatDate } = require('date-fns');
 const { getDepartmentFromCode } = require('../../services/department.service');
+const logger = require('#lib/logger');
 
 /** @type {import('@pins/common/src/view-model-maps/sections/def').UserSectionsDict} */
 const userSectionsDict = {
@@ -85,6 +86,8 @@ exports.get = (layoutTemplate = 'layouts/no-banner-link/main.njk') => {
 			}
 		};
 
+		logger.debug({ viewContext }, 'viewContext');
+
 		res.render(VIEW.SELECTED_APPEAL.APPEAL, viewContext);
 	};
 };
@@ -104,7 +107,9 @@ const formatTitleSuffix = (userType) => {
  * @returns {boolean}
  */
 const shouldDisplayQuestionnaireDueNotification = (caseData, userType) =>
-	userType === 'LPAUser' && !caseData.lpaQuestionnaireSubmitted;
+	userType === 'LPAUser' &&
+	!caseData.lpaQuestionnaireSubmitted &&
+	!!caseData.lpaQuestionnaireDueDate;
 
 /**
  *

--- a/packages/forms-web-app/src/controllers/selected-appeal/questionnaire-details/index.js
+++ b/packages/forms-web-app/src/controllers/selected-appeal/questionnaire-details/index.js
@@ -52,6 +52,10 @@ exports.get = (layoutTemplate = 'layouts/no-banner-link/main.njk') => {
 		});
 		const lpa = await getDepartmentFromCode(caseData.LPACode);
 
+		if (!caseData.lpaQuestionnairePublishedDate && userType !== LPA_USER_ROLE) {
+			throw new Error("can't show an unpublished lpaq");
+		}
+
 		// headline data
 		const headlineData = formatHeadlineData(caseData, lpa.name, userType);
 		// constraints details


### PR DESCRIPTION
…avigation

https://pins-ds.atlassian.net/browse/AAPD-

## Description of change

- hid lpaq banner when no due date
- show lpa case headline on new appeals
- block access to case/lpaq details before they have been validated/published

## Checklist

<!-- Put an `x` in all the boxes that apply: -->

- [ ] Requires infrastructure changes
- [ ] I have updated the documentation accordingly
- [x] My commit history in this PR is linear
- [ ] New features have tests
- [ ] Breaking change (team conversation required)

## Important

Please do not merge from `main` (please only [rebase](https://github.com/Planning-Inspectorate/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
