### PR TITLE
fix(asi-135): don't show questionnairre link when submitted

### DIFF
--- a/packages/forms-web-app/src/controllers/selected-appeal/index.js
+++ b/packages/forms-web-app/src/controllers/selected-appeal/index.js
@@ -118,7 +118,7 @@ const formatTitleSuffix = (userType) => {
  */
 const shouldDisplayQuestionnaireDueNotification = (caseData, userType) =>
 	userType === 'LPAUser' &&
-	!caseData.lpaQuestionnaireSubmitted &&
+	!caseData.lpaQuestionnaireSubmittedDate &&
 	!!caseData.lpaQuestionnaireDueDate;
 
 /**


### PR DESCRIPTION
## Ticket Number

<!-- Add the number from the Jira board -->

https://pins-ds.atlassian.net/browse/asi-135

## Description of change

don't show questionnaire link when submitted, use date field, boolean previously used doesn't exist

## Checklist

<!-- Put an `x` in all the boxes that apply: -->

- [ ] Requires infrastructure changes
- [ ] I have updated the documentation accordingly
- [x] My commit history in this PR is linear
- [ ] New features have tests
- [ ] Breaking change (team conversation required)

## Important

Please do not merge from `main` (please only [rebase](https://github.com/Planning-Inspectorate/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
