### PR TITLE
fix(asi-141): use schema validator instead of openapi middleware to v…

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
 			"dependencies": {
 				"applicationinsights": "^2.9.0",
 				"patch-package": "^6.5.1",
-				"pins-data-model": "github:Planning-Inspectorate/data-model#1.8.0"
+				"pins-data-model": "github:Planning-Inspectorate/data-model#1.8.2"
 			},
 			"devDependencies": {
 				"@commitlint/cli": "^17.0.0",
@@ -28204,8 +28204,8 @@
 			"integrity": "sha512-EqX4pwDPrt3MuOAAUBMU0Tk5kR/YcCM5fNPEzgCO2zJ5HfX0vbiH9HbJglnyeQsN96Kznae6MWD47pZB5avTrg=="
 		},
 		"node_modules/pins-data-model": {
-			"version": "1.8.0",
-			"resolved": "git+ssh://git@github.com/Planning-Inspectorate/data-model.git#eeac61e903bcf2a706058bd4b20b4054c58245cb",
+			"version": "1.8.2",
+			"resolved": "git+ssh://git@github.com/Planning-Inspectorate/data-model.git#e48c5bc30da58a8d249fa3d78f25e587e1557506",
 			"dependencies": {
 				"jsonc-parser": "^3.2.0"
 			}

--- a/package.json
+++ b/package.json
@@ -129,6 +129,6 @@
 	"dependencies": {
 		"applicationinsights": "^2.9.0",
 		"patch-package": "^6.5.1",
-		"pins-data-model": "github:Planning-Inspectorate/data-model#1.8.0"
+		"pins-data-model": "github:Planning-Inspectorate/data-model#1.8.2"
 	}
 }

--- a/packages/appeals-service-api/src/routes/v2/appeal-cases/_caseReference/lpa-questionnaire-submission/submit/index.test.js
+++ b/packages/appeals-service-api/src/routes/v2/appeal-cases/_caseReference/lpa-questionnaire-submission/submit/index.test.js
@@ -287,12 +287,7 @@ const formattedHAS = [
 // };
 
 describe('/api/v2/appeal-cases/:caseReference/submit', () => {
-	beforeAll(async () => {
-		// Give the schemas a moment to load from disk
-		await new Promise((res) => {
-			setTimeout(res, 2000);
-		});
-	});
+	beforeAll(async () => {});
 	it.each([
 		['HAS', '001', formattedHAS]
 		// ['S78', '002', formattedS78]

--- a/packages/appeals-service-api/src/routes/v2/appeal-cases/index.js
+++ b/packages/appeals-service-api/src/routes/v2/appeal-cases/index.js
@@ -27,6 +27,6 @@ router.use(
 router.get('/', asyncHandler(list));
 router.get('/count', asyncHandler(getCount));
 router.get('/:caseReference', openApiValidatorMiddleware(), asyncHandler(getByCaseReference));
-router.put('/:caseReference', openApiValidatorMiddleware(), asyncHandler(putByCaseReference));
+router.put('/:caseReference', asyncHandler(putByCaseReference));
 
 module.exports = { router };

--- a/packages/appeals-service-api/src/routes/v2/appeal-cases/service.js
+++ b/packages/appeals-service-api/src/routes/v2/appeal-cases/service.js
@@ -81,7 +81,6 @@ async function putCase(caseReference, data) {
 
 		switch (data.caseType) {
 			case CASE_TYPES.HAS.key:
-				// todo: openApiValidatorMiddleware not working?
 				if (!hasValidator(data)) {
 					throw ApiError.badRequest('Payload was invalid');
 				}

--- a/packages/appeals-service-api/src/routes/v2/appellant-submissions/_id/submit/index.test.js
+++ b/packages/appeals-service-api/src/routes/v2/appellant-submissions/_id/submit/index.test.js
@@ -357,10 +357,6 @@ beforeAll(async () => {
 		data: { email: crypto.randomUUID() + '@example.com' }
 	});
 	validUser = user.id;
-	// Give the schemas a moment to load from disk
-	await new Promise((res) => {
-		setTimeout(res, 2000);
-	});
 });
 
 describe('/api/v2/appeal-cases/:caseReference/submit', () => {

--- a/packages/appeals-service-api/src/routes/v2/documents/index.js
+++ b/packages/appeals-service-api/src/routes/v2/documents/index.js
@@ -4,7 +4,6 @@ const { auth } = require('express-oauth2-jwt-bearer');
 const asyncHandler = require('@pins/common/src/middleware/async-handler');
 const { AUTH } = require('@pins/common/src/constants');
 const controller = require('./controller');
-const { openApiValidatorMiddleware } = require('../../../validators/validate-open-api');
 const config = require('../../../configuration/config');
 
 router.use(
@@ -14,7 +13,7 @@ router.use(
 	})
 );
 
-router.put('/', openApiValidatorMiddleware(), asyncHandler(controller.put));
-router.delete('/:id', openApiValidatorMiddleware(), asyncHandler(controller.delete));
+router.put('/', asyncHandler(controller.put));
+router.delete('/:id', asyncHandler(controller.delete));
 
 module.exports = { router };

--- a/packages/appeals-service-api/src/routes/v2/documents/index.spec.js
+++ b/packages/appeals-service-api/src/routes/v2/documents/index.spec.js
@@ -68,13 +68,13 @@ afterAll(async () => {
 
 describe('documents v2', () => {
 	describe('create document', () => {
-		it('should return 500 if unknown field supplied', async () => {
+		it('should return 400 if unknown field supplied', async () => {
 			const response = await appealsApi.put('/api/v2/documents').send({
 				id: 'doc_001',
 				unknownField: '123'
 			});
 
-			expect(response.status).toBe(500);
+			expect(response.status).toBe(400);
 		});
 
 		it('should create a document', async () => {

--- a/packages/appeals-service-api/src/routes/v2/documents/service.js
+++ b/packages/appeals-service-api/src/routes/v2/documents/service.js
@@ -1,12 +1,19 @@
+const ApiError = require('#errors/apiError');
 const Repo = require('./repo');
-
 const repo = new Repo();
+const { SchemaValidator } = require('../../../services/back-office-v2/validate');
+const { getValidator } = new SchemaValidator();
 
 /**
  * @param {import('pins-data-model/src/schemas').AppealDocument} data
  * @returns {Promise<import('@prisma/client').Document>}
  */
 exports.put = (data) => {
+	const documentValidator = getValidator('appeal-document');
+	if (!documentValidator(data)) {
+		throw ApiError.badRequest('Document payload was invalid');
+	}
+
 	return repo.put(data);
 };
 

--- a/packages/appeals-service-api/src/routes/v2/documents/spec.yaml
+++ b/packages/appeals-service-api/src/routes/v2/documents/spec.yaml
@@ -23,3 +23,24 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorBody'
+  /api/v2/documents/{id}:
+    delete:
+      tags:
+        - documents
+      description: delete a document
+      parameters:
+        - in: path
+          name: id
+          schema:
+            type: string
+          required: true
+          description: document id
+      responses:
+        200:
+          description: deleted document
+        400:
+          description: Bad request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorBody'

--- a/packages/appeals-service-api/src/routes/v2/events/index.js
+++ b/packages/appeals-service-api/src/routes/v2/events/index.js
@@ -4,7 +4,6 @@ const { auth } = require('express-oauth2-jwt-bearer');
 const asyncHandler = require('@pins/common/src/middleware/async-handler');
 const { AUTH } = require('@pins/common/src/constants');
 const { put } = require('./controller');
-const { openApiValidatorMiddleware } = require('../../../validators/validate-open-api');
 const config = require('../../../configuration/config');
 
 router.use(
@@ -14,6 +13,6 @@ router.use(
 	})
 );
 
-router.put('/', openApiValidatorMiddleware(), asyncHandler(put));
+router.put('/', asyncHandler(put));
 
 module.exports = { router };

--- a/packages/appeals-service-api/src/routes/v2/events/index.spec.js
+++ b/packages/appeals-service-api/src/routes/v2/events/index.spec.js
@@ -68,13 +68,13 @@ afterAll(async () => {
 
 describe('events v2', () => {
 	describe('create event', () => {
-		it('should return 500 if unknown field supplied', async () => {
+		it('should return 400 if unknown field supplied', async () => {
 			const response = await appealsApi.put('/api/v2/events').send({
 				id: 'doc_001',
 				unknownField: '123'
 			});
 
-			expect(response.status).toBe(500);
+			expect(response.status).toBe(400);
 		});
 
 		it('should create an event', async () => {

--- a/packages/appeals-service-api/src/routes/v2/events/service.js
+++ b/packages/appeals-service-api/src/routes/v2/events/service.js
@@ -1,11 +1,18 @@
+const ApiError = require('#errors/apiError');
 const Repo = require('./repo');
-
 const repo = new Repo();
+const { SchemaValidator } = require('../../../services/back-office-v2/validate');
+const { getValidator } = new SchemaValidator();
 
 /**
  * @param {import('pins-data-model/src/schemas').AppealEvent} data
  * @returns {Promise<import('@prisma/client').Event>}
  */
 exports.put = (data) => {
+	const eventValidator = getValidator('appeal-event');
+	if (!eventValidator(data)) {
+		throw ApiError.badRequest('Event payload was invalid');
+	}
+
 	return repo.put(data);
 };

--- a/packages/appeals-service-api/src/services/back-office-v2/validate.js
+++ b/packages/appeals-service-api/src/services/back-office-v2/validate.js
@@ -1,7 +1,6 @@
 const Ajv = require('ajv').default;
 const addFormats = require('ajv-formats').default;
-const loadAllSchemas = () =>
-	import('pins-data-model').then(({ loadAllSchemas }) => loadAllSchemas());
+const { loadAllSchemasSync } = require('pins-data-model');
 const logger = require('../../lib/logger');
 
 /**
@@ -39,14 +38,11 @@ class SchemaValidator {
 
 	/**
 	 * plops the schemas into this.schemas
-	 * This just avoids async gunge
-	 * @returns {Promise<void>}
+	 * @returns {void}
 	 */
 	preloadSchemas() {
-		return new Promise((resolve, reject) => {
-			loadAllSchemas().then(this.setSchemas, reject);
-			resolve();
-		});
+		const schemas = loadAllSchemasSync();
+		this.setSchemas(schemas);
 	}
 
 	/**


### PR DESCRIPTION
…alidate data model

## Ticket Number

<!-- Add the number from the Jira board -->

https://pins-ds.atlassian.net/browse/ASI-141

## Description of change

Some discrepancies between the manually managed openapi schema and the data model schema
This removes the openapi validation and replaces with a check against the data model
Also sync loading is now possible so have removed the async preload and delays for it in integration tests

## Checklist

<!-- Put an `x` in all the boxes that apply: -->

- [ ] Requires infrastructure changes
- [ ] I have updated the documentation accordingly
- [x] My commit history in this PR is linear
- [ ] New features have tests
- [ ] Breaking change (team conversation required)

## Important

Please do not merge from `main` (please only [rebase](https://github.com/Planning-Inspectorate/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
