### PR TITLE
fix(a2-489): send appeal ref to appellant after being generated by BO

### DIFF
--- a/packages/appeals-service-api/src/configuration/config.js
+++ b/packages/appeals-service-api/src/configuration/config.js
@@ -116,6 +116,11 @@ let config = {
 					appealNotificationEmailToLpa:
 						process.env.SRV_NOTIFY_FULL_APPEAL_RECEIVED_NOTIFICATION_EMAIL_TO_LPA_TEMPLATE_ID
 				},
+				V2_COMMON: {
+					appealSubmissionReceivedEmailToAppellant:
+						process.env
+							.SRV_NOTIFY_APPEAL_SUBMISSION_CONFIRMATION_EMAIL_TO_APPELLANT_TEMPLATE_ID_V1_1
+				},
 				SAVE_AND_RETURN: {
 					continueWithAppealEmailToAppellant:
 						process.env.SRV_NOTIFY_SAVE_AND_RETURN_CONTINUE_WITH_APPEAL_TEMPLATE_ID,

--- a/packages/appeals-service-api/src/services/back-office-v2/index.js
+++ b/packages/appeals-service-api/src/services/back-office-v2/index.js
@@ -15,7 +15,7 @@ const {
 const ApiError = require('#errors/apiError');
 const { APPEAL_ID } = require('@pins/business-rules/src/constants');
 const {
-	sendSubmissionConfirmationEmailToAppellantV2,
+	sendSubmissionReceivedEmailToAppellantV2,
 	sendSubmissionReceivedEmailToLpaV2,
 	sendCommentSubmissionConfirmationEmailToIp
 } = require('#lib/notify');
@@ -104,9 +104,9 @@ class BackOfficeV2Service {
 
 		let emailFailed = false;
 		try {
-			await sendSubmissionConfirmationEmailToAppellantV2(appellantSubmission, email);
+			await sendSubmissionReceivedEmailToAppellantV2(appellantSubmission, email);
 		} catch (err) {
-			logger.error({ err }, 'failed to sendSubmissionConfirmationEmailToAppellantV2');
+			logger.error({ err }, 'failed to sendSubmissionReceivedEmailToAppellantV2');
 			emailFailed = true;
 		}
 

--- a/packages/forms-web-app/src/dynamic-forms/dynamic-components/submission-screen/appellant.njk
+++ b/packages/forms-web-app/src/dynamic-forms/dynamic-components/submission-screen/appellant.njk
@@ -4,6 +4,9 @@ Appeal Submitted - Appeal a planning decision - GOV.UK {% endblock %} {% block
 content %}
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
+
+    TODO: FIX THIS
+    
     {{ govukPanel({ titleText: "Appeal submitted", html: "Appeal reference
     number<br /><strong>" + caseReference + "</strong>" }) }}
 


### PR DESCRIPTION
## Ticket Number

<!-- Add the number from the Jira board -->

https://pins-ds.atlassian.net/browse/AAPD-

## Description of change

todo:
- lookup appellant email
- fix submission page, can't display appeal ref before its generated

## Checklist

<!-- Put an `x` in all the boxes that apply: -->

- [ ] Requires infrastructure changes
- [ ] I have updated the documentation accordingly
- [ ] My commit history in this PR is linear
- [ ] New features have tests
- [ ] Breaking change (team conversation required)

## Important

Please do not merge from `main` (please only [rebase](https://github.com/Planning-Inspectorate/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
