### PR TITLE
fix(a2-828): add lpaQuestionnaireSubmittedDate on submission not on c…

### DIFF
--- a/packages/appeals-service-api/src/routes/v2/appeal-cases/_caseReference/lpa-questionnaire-submission/repo.js
+++ b/packages/appeals-service-api/src/routes/v2/appeal-cases/_caseReference/lpa-questionnaire-submission/repo.js
@@ -118,16 +118,27 @@ class LPAQuestionnaireSubmissionRepository {
 	}
 
 	/**
-	 * @param {string} id
+	 * @param {string} caseReference
+	 * @param {string} lpaQuestionnaireSubmittedDate
 	 * @returns {Promise<{id: string}>}
 	 */
-	markLPAQuestionnaireAsSubmitted(id) {
-		return this.dbClient.lPAQuestionnaireSubmission.update({
+	async markLPAQuestionnaireAsSubmitted(caseReference, lpaQuestionnaireSubmittedDate) {
+		return await this.dbClient.lPAQuestionnaireSubmission.update({
 			where: {
-				id: id
+				appealCaseReference: caseReference
 			},
 			data: {
-				submitted: true
+				submitted: true,
+				AppealCase: {
+					update: {
+						where: {
+							caseReference
+						},
+						data: {
+							lpaQuestionnaireSubmittedDate
+						}
+					}
+				}
 			},
 			select: {
 				id: true

--- a/packages/appeals-service-api/src/routes/v2/appeal-cases/_caseReference/lpa-questionnaire-submission/service.js
+++ b/packages/appeals-service-api/src/routes/v2/appeal-cases/_caseReference/lpa-questionnaire-submission/service.js
@@ -58,11 +58,12 @@ async function patchLPAQuestionnaireByAppealId(appealCaseId, data) {
 /**
  * mark questionnaire as submitted to back office
  *
- * @param {string} questionnaireId
+ * @param {string} caseReference
+ * @param {string} lpaQuestionnaireSubmittedDate
  * @return {Promise<{id: string}>}
  */
-function markQuestionnaireAsSubmitted(questionnaireId) {
-	return repo.markLPAQuestionnaireAsSubmitted(questionnaireId);
+function markQuestionnaireAsSubmitted(caseReference, lpaQuestionnaireSubmittedDate) {
+	return repo.markLPAQuestionnaireAsSubmitted(caseReference, lpaQuestionnaireSubmittedDate);
 }
 
 module.exports = {

--- a/packages/appeals-service-api/src/services/back-office-v2/index.js
+++ b/packages/appeals-service-api/src/services/back-office-v2/index.js
@@ -132,10 +132,11 @@ class BackOfficeV2Service {
 			throw new Error("Questionnaire's associated AppealCase has an invalid appealTypeCode");
 
 		let result;
+		let mappedData;
 		// todo: temporary check until integration work for s78 is done
 		if (appealTypeCode === 'HAS') {
 			logger.info(`mapping lpaq ${caseReference} to ${appealTypeCode} schema`);
-			const mappedData = await formatters.questionnaire[appealTypeCodeToAppealId[appealTypeCode]](
+			mappedData = await formatters.questionnaire[appealTypeCodeToAppealId[appealTypeCode]](
 				caseReference,
 				questionnaire
 			);
@@ -156,7 +157,10 @@ class BackOfficeV2Service {
 			result = await forwarders.questionnaire([mappedData]);
 		}
 
-		await markQuestionnaireAsSubmitted(questionnaire.id);
+		await markQuestionnaireAsSubmitted(
+			caseReference,
+			mappedData?.casedata?.lpaQuestionnaireSubmittedDate
+		);
 
 		return result;
 	}


### PR DESCRIPTION
…onf from BO

## Ticket Number

https://pins-ds.atlassian.net/browse/A2-828

## Description of change

At present the lpaQuestionnaireSubmittedDate on the appealCase is set when we receive confirmation from the bo, not on submission, which affects when the appeal moves between tabs on the lpaUser dashboard.  This PR adds the update to the markQuestionnaireAsSubmitted call.

## Checklist

<!-- Put an `x` in all the boxes that apply: -->

- [ ] Requires infrastructure changes
- [ ] I have updated the documentation accordingly
- X My commit history in this PR is linear
- [ ] New features have tests
- [ ] Breaking change (team conversation required)

## Important

Please do not merge from `main` (please only [rebase](https://github.com/Planning-Inspectorate/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
