### PR TITLE
fix(A2-234): save data for new journey, refactor unanswered q middleware

### DIFF
--- a/packages/common/src/client/appeals-api-client.js
+++ b/packages/common/src/client/appeals-api-client.js
@@ -389,6 +389,17 @@ class AppealsApiClient {
 	}
 
 	/**
+	 * @param {string} caseReference
+	 * @param {object} data
+	 * @returns {Promise<(LPAStatementSubmission)>}
+	 */
+	async patchLPAStatement(caseReference, data) {
+		const endpoint = `${v2}/appeal-cases/${caseReference}/lpa-statement-submission`;
+		const response = await this.#makePatchRequest(endpoint, data);
+		return response.json();
+	}
+
+	/**
 	 * @param {string} id
 	 * @param {object} data
 	 * @returns {Promise<(AppellantSubmission)>}

--- a/packages/forms-web-app/src/dynamic-forms/question.js
+++ b/packages/forms-web-app/src/dynamic-forms/question.js
@@ -276,6 +276,8 @@ class Question {
 				journeyResponse.referenceId,
 				responseToSave.answers
 			);
+		} else if ([JOURNEY_TYPES.S78_LPA_STATEMENT].includes(journeyType)) {
+			await apiClient.patchLPAStatement(journeyResponse.referenceId, responseToSave.answers);
 		}
 	}
 

--- a/packages/forms-web-app/src/dynamic-forms/s78-lpa-statement/journey.js
+++ b/packages/forms-web-app/src/dynamic-forms/s78-lpa-statement/journey.js
@@ -38,9 +38,7 @@ class S78LpaStatementJourney extends Journey {
 		// const questionsHaveAnswers = questionsHaveAnswersBuilder(response);
 
 		this.sections.push(
-			new Section('Appeal statement', config.dynamicForms.DEFAULT_SECTION).addQuestion(
-				questions.lpaStatement
-			)
+			new Section('', config.dynamicForms.DEFAULT_SECTION).addQuestion(questions.lpaStatement)
 		);
 	}
 }


### PR DESCRIPTION
## Ticket Number

<!-- Add the number from the Jira board -->

https://pins-ds.atlassian.net/browse/A2-234

## Description of change

adds new journey type to saveResponseToDB function and associated api client

## Checklist

<!-- Put an `x` in all the boxes that apply: -->

- [ ] Requires infrastructure changes
- [ ] I have updated the documentation accordingly
- [x] My commit history in this PR is linear
- [ ] New features have tests
- [ ] Breaking change (team conversation required)

## Important

Please do not merge from `main` (please only [rebase](https://github.com/Planning-Inspectorate/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
