### PR TITLE
feat(a2-598): ip decided appeal page

### DIFF
--- a/packages/forms-web-app/src/routes/file-based-router/comment-planning-appeal/appeals/_appealNumber/controller.js
+++ b/packages/forms-web-app/src/routes/file-based-router/comment-planning-appeal/appeals/_appealNumber/controller.js
@@ -1,5 +1,7 @@
 const { getAppealStatus } = require('#utils/appeal-status');
-const { formatCommentDeadlineText } = require('#utils/format-deadline-text');
+const { formatCommentDeadlineText } = require('../../../../../utils/format-deadline-text');
+const { formatCommentDecidedData } = require('../../../../../utils/format-comment-decided-data');
+const { formatCommentHeadlineText } = require('../../../../../utils/format-headline-text');
 const { formatHeadlineData, formatRows } = require('@pins/common');
 const { appealSubmissionRows } = require('./ip-appeal-submission-rows');
 const { applicationRows } = require('./ip-application-rows');
@@ -21,21 +23,29 @@ const selectedAppeal = async (req, res) => {
 
 	const status = getAppealStatus(appeal);
 
+	const headlineText = formatCommentHeadlineText(appealNumber, status);
+
 	const deadlineText = formatCommentDeadlineText(appeal, status);
 
 	const submissionRows = appealSubmissionRows(appeal);
-	const appealSubmission = formatRows(submissionRows, appeal);
+	// For MVP we are only displaying headlines for decided appeals
+	const appealSubmission = status === 'decided' ? [] : formatRows(submissionRows, appeal);
 
 	const originalApplicationRows = applicationRows(appeal);
-	const application = formatRows(originalApplicationRows, appeal);
+	// For MVP we are only displaying headlines for decided appeals
+	const application = status === 'decided' ? [] : formatRows(originalApplicationRows, appeal);
+
+	const decidedData = formatCommentDecidedData(appeal);
 
 	res.render(`comment-planning-appeal/appeals/_appealNumber/index`, {
 		appeal: {
 			...appeal,
 			status,
+			headlineText,
 			deadlineText,
 			appealSubmission,
-			application
+			application,
+			decidedData
 		},
 		headlineData
 	});

--- a/packages/forms-web-app/src/routes/file-based-router/comment-planning-appeal/appeals/_appealNumber/index.njk
+++ b/packages/forms-web-app/src/routes/file-based-router/comment-planning-appeal/appeals/_appealNumber/index.njk
@@ -2,10 +2,11 @@
 
 {% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
 {% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
+{% from "govuk/components/tag/macro.njk" import govukTag %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "pins/components/appeal-sections-block.njk" import appealSectionsBlock %}
 
-{% set title="Appeal " + appeal.status + " for comment - Comment on a planning appeal - GOV.UK" %}
+{% set title=appeal.headlineText + " for comment - Comment on a planning appeal - GOV.UK" %}
 
 {% block pageTitle %}
   {{ title }}
@@ -21,12 +22,28 @@
         }) }}
       {% endif %}
 
-      <h1 class="govuk-heading-l">Appeal {{appeal.status}} for comment</h1>
+      <h1 class="govuk-heading-l">{{appeal.headlineText}}</h1>
+
+			{% if appeal.status === 'decided' %}
+				<h2 class="govuk-heading-2">Appeal decision</h2>
+				{{ govukTag({
+					text: appeal.decidedData.caseDecisionOutcome,
+					classes: "govuk-tag--" + appeal.decidedData.formattedDecisionColour + " govuk-!-margin-bottom-3"
+				}) }}
+				<p class="govuk-body">Decision date: {{appeal.decidedData.formattedCaseDecisionDate}}</p>
+				{% for document in appeal.decidedData.decisionDocuments %}
+				  <p class="govuk-body"><a href="/published-document/{{document.id}}" class="govuk-link">{{document.filename}}</a></p>
+				{% endfor %}
+				<hr class="govuk-section-break govuk-section-break--visible govuk-section-break--m">
+			{% endif %}
 
       {{ govukSummaryList({
         classes: "appeal-headlines govuk-summary-list--no-border",
         rows: headlineData
       }) }}
+
+				{# NOTE - FOR MVP DECIDED APPEALS ONLY SHOW HEADLINES #}
+			{% if appeal.status != 'decided' %}
 
 			<hr class="govuk-section-break govuk-section-break--visible govuk-section-break--l">
 		</div>
@@ -64,6 +81,9 @@
 				classes: "govuk-summary-list long-answers",
 				rows: appeal.application
 			}) }}
+
+	{% endif %}
 		</div>
   </div>
+
 {% endblock %}

--- a/packages/forms-web-app/src/routes/file-based-router/comment-planning-appeal/decided-appeals/index.njk
+++ b/packages/forms-web-app/src/routes/file-based-router/comment-planning-appeal/decided-appeals/index.njk
@@ -20,7 +20,11 @@
       <tbody class="govuk-table__body">
         {% for appeal in decidedAppeals %}
           <tr class="govuk-table__row">
-            <td class="govuk-table__cell">{{ appeal.caseReference }}</td>
+            <td class="govuk-table__cell">
+							<a href="/comment-planning-appeal/appeals/{{appeal.caseReference}}" class="govuk-link">
+                {{ appeal.caseReference }}
+              </a>
+						</td>
             <td class="govuk-table__cell">{{ appeal.formattedAddress }}</td>
             <td class="govuk-table__cell">{{ appeal.formattedCaseDecisionDate }}</td>
             <td class="govuk-table__cell">{{ appeal.appealTypeName }}</td>

--- a/packages/forms-web-app/src/utils/appeal-status.js
+++ b/packages/forms-web-app/src/utils/appeal-status.js
@@ -3,7 +3,14 @@
  * @param {AppealViewModel} appeal
  * @returns {AppealViewModel["status"]}
  */
-exports.getAppealStatus = (appeal) =>
-	appeal.interestedPartyRepsDueDate && new Date(appeal.interestedPartyRepsDueDate) > new Date()
-		? 'open'
-		: 'closed';
+exports.getAppealStatus = (appeal) => {
+	if (appeal.caseDecisionOutcomeDate) {
+		return 'decided';
+	} else if (
+		appeal.interestedPartyRepsDueDate &&
+		new Date(appeal.interestedPartyRepsDueDate) > new Date()
+	) {
+		return 'open';
+	}
+	return 'closed';
+};

--- a/packages/forms-web-app/src/utils/appeals-view.d.ts
+++ b/packages/forms-web-app/src/utils/appeals-view.d.ts
@@ -4,5 +4,5 @@ export interface AppealViewModel extends Api.AppealCaseDetailed {
 	formattedAddress?: string;
 	formattedCaseDecisionDate?: string;
 	formattedDecisionColour?: string;
-	status?: 'open' | 'closed';
+	status?: 'open' | 'closed' | 'decided';
 }

--- a/packages/forms-web-app/src/utils/format-comment-decided-data.js
+++ b/packages/forms-web-app/src/utils/format-comment-decided-data.js
@@ -1,0 +1,31 @@
+const { formatDate } = require('./format-date');
+const { mapDecisionColour } = require('@pins/business-rules/src/utils/decision-outcome');
+const { APPEAL_CASE_DECISION_OUTCOME, APPEAL_DOCUMENT_TYPE } = require('pins-data-model');
+
+/**
+ * @typedef {import("./appeals-view").AppealViewModel} AppealViewModel
+ * @param {AppealViewModel} appeal
+ * @returns {object }
+ */
+exports.formatCommentDecidedData = (appeal) => {
+	if (!appeal.caseDecisionOutcomeDate) return {};
+
+	return {
+		formattedCaseDecisionDate: formatDate(appeal.caseDecisionOutcomeDate),
+		formattedDecisionColour: mapDecisionColour(appeal.caseDecisionOutcome),
+		caseDecisionOutcome:
+			appeal.caseDecisionOutcome in APPEAL_CASE_DECISION_OUTCOME
+				? APPEAL_CASE_DECISION_OUTCOME[appeal.caseDecisionOutcome].name
+				: appeal.caseDecisionOutcome,
+		decisionDocuments: filterDecisionDocuments(appeal.Documents)
+	};
+};
+
+/**
+ * @param {import('appeals-service-api').Api.Document[]} documents
+ * @return {import('appeals-service-api').Api.Document[]}
+ */
+const filterDecisionDocuments = (documents) =>
+	documents.filter(
+		(document) => document.documentType === APPEAL_DOCUMENT_TYPE.CASE_DECISION_LETTER
+	);

--- a/packages/forms-web-app/src/utils/format-headline-text.js
+++ b/packages/forms-web-app/src/utils/format-headline-text.js
@@ -1,0 +1,13 @@
+/**
+ * @param {string} appealNumber
+ * @param {string } status
+ * @returns {string }
+ */
+exports.formatCommentHeadlineText = (appealNumber, status) => {
+	switch (status) {
+		case 'decided':
+			return `Decision for appeal ${appealNumber}`;
+		default:
+			return `Appeal ${status} for comment`;
+	}
+};


### PR DESCRIPTION
## Ticket Number

https://pins-ds.atlassian.net/browse/A2-598

## Description of change

Adds active links for decided appeals on Interested Party views.  At present appeal detail page only shows headlines, not full appeal details.

## Checklist

<!-- Put an `x` in all the boxes that apply: -->

- [ ] Requires infrastructure changes
- [ ] I have updated the documentation accordingly
- [ ] My commit history in this PR is linear
- [ ] New features have tests
- [ ] Breaking change (team conversation required)

## Important

Please do not merge from `main` (please only [rebase](https://github.com/Planning-Inspectorate/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
