### PR TITLE
fix: provide default doc type for lpaq

### DIFF
--- a/packages/appeals-service-api/src/services/back-office-v2/formatters/has/questionnaire.js
+++ b/packages/appeals-service-api/src/services/back-office-v2/formatters/has/questionnaire.js
@@ -7,6 +7,7 @@
  */
 
 const { getDocuments, howYouNotifiedPeople } = require('../utils');
+const { documentTypes } = require('@pins/common/src/document-types');
 
 /**
  * @param {string} caseReference
@@ -50,6 +51,6 @@ exports.formatter = async (caseReference, { ...answers }) => {
 			lpaStatement: '', // not asked
 			lpaCostsAppliedFor: null // not asked
 		},
-		documents: await getDocuments(answers)
+		documents: await getDocuments(answers, documentTypes.planningOfficersReportUpload.dataModelName)
 	};
 };

--- a/packages/appeals-service-api/src/services/back-office-v2/formatters/s78/questionnaire.js
+++ b/packages/appeals-service-api/src/services/back-office-v2/formatters/s78/questionnaire.js
@@ -5,6 +5,7 @@
  */
 
 const { toBool, getDocuments } = require('../utils');
+const { documentTypes } = require('@pins/common/src/document-types');
 
 /**
  * @param {string} caseReference
@@ -57,6 +58,6 @@ exports.formatter = async (caseReference, { AppealCase: { LPACode }, ...answers 
 			supplementaryPlanningDocs: answers.supplementaryPlanningDocs,
 			treePreservationOrder: answers.treePreservationOrder
 		},
-		documents: await getDocuments(answers)
+		documents: await getDocuments(answers, documentTypes.planningOfficersReportUpload.dataModelName)
 	};
 };

--- a/packages/appeals-service-api/src/services/back-office-v2/formatters/utils.js
+++ b/packages/appeals-service-api/src/services/back-office-v2/formatters/utils.js
@@ -43,9 +43,10 @@ exports.toBool = (str) => str === 'yes';
 
 /**
  * @param {{ SubmissionDocumentUpload: import('@prisma/client').SubmissionDocumentUpload[] }} answers
+ * @param {string} [defaultDocType]
  * @returns {Promise<DataModelDocuments>}
  */
-exports.getDocuments = async ({ SubmissionDocumentUpload }) => {
+exports.getDocuments = async ({ SubmissionDocumentUpload }, defaultDocType) => {
 	const uploadedFilesAndBlobMeta = await conjoinedPromises(
 		SubmissionDocumentUpload,
 		(uploadedFile) => getBlobMeta(uploadedFile.location)
@@ -67,7 +68,7 @@ exports.getDocuments = async ({ SubmissionDocumentUpload }) => {
 			mime: mime_type,
 			documentURI: _response.request.url,
 			dateCreated: new Date(createdOn).toISOString(),
-			documentType: getDocType(document_type, 'name').dataModelName
+			documentType: getDocType(document_type, 'name').dataModelName ?? defaultDocType
 		})
 	);
 };


### PR DESCRIPTION
## Description of change

Provides a default doc type in lpaq mapping to data model

## Checklist

<!-- Put an `x` in all the boxes that apply: -->

- [ ] Requires infrastructure changes
- [ ] I have updated the documentation accordingly
- [ ] My commit history in this PR is linear
- [ ] New features have tests
- [ ] Breaking change (team conversation required)

## Important

Please do not merge from `main` (please only [rebase](https://github.com/Planning-Inspectorate/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
