### PR TITLE
fix(a2-633): remove empty error messages from dynamic forms validation

### DIFF
--- a/packages/forms-web-app/src/dynamic-forms/validator/date-validator.js
+++ b/packages/forms-web-app/src/dynamic-forms/validator/date-validator.js
@@ -107,11 +107,15 @@ class DateValidator extends BaseValidator {
 					if (req.body[dayInput]) {
 						return this.noMonthErrorMessage;
 					}
+
+					// empty error message returned
 				}),
 			body(yearInput)
 				.notEmpty()
 				.withMessage((_, { req }) => {
 					if (req.body[dayInput] && req.body[monthInput]) return this.noYearErrorMessage;
+
+					// empty error message returned
 				}),
 
 			// check date values entered are within valid ranges

--- a/packages/forms-web-app/src/dynamic-forms/validator/validation-error-handler.test.js
+++ b/packages/forms-web-app/src/dynamic-forms/validator/validation-error-handler.test.js
@@ -14,10 +14,6 @@ describe('./src/dynamic-forms/validator/validation-error-handler.js', () => {
 
 	it('should call next if no errors', async () => {
 		const req = {
-			params: {
-				section: 1,
-				question: 1
-			},
 			body: {
 				field1: 'bananas'
 			}
@@ -34,12 +30,8 @@ describe('./src/dynamic-forms/validator/validation-error-handler.js', () => {
 		expect(expressValidationErrorsToGovUkErrorList).not.toHaveBeenCalled();
 	});
 
-	it('should map errors if some are returned', async () => {
+	it('should call next if only empty error messages', async () => {
 		const req = {
-			params: {
-				section: 1,
-				question: 1
-			},
 			body: {
 				field1: 'bananas'
 			}
@@ -49,7 +41,28 @@ describe('./src/dynamic-forms/validator/validation-error-handler.js', () => {
 				return false;
 			},
 			mapped: () => {
-				return { test: 'hello' };
+				return { test: { msg: undefined } };
+			}
+		});
+
+		const next = jest.fn();
+		validationErrorHandler(req, {}, next);
+		expect(next).toHaveBeenCalledTimes(1);
+		expect(expressValidationErrorsToGovUkErrorList).not.toHaveBeenCalled();
+	});
+
+	it('should map errors if some are returned', async () => {
+		const req = {
+			body: {
+				field1: 'bananas'
+			}
+		};
+		validationResult.mockReturnValue({
+			isEmpty: () => {
+				return false;
+			},
+			mapped: () => {
+				return { test: { msg: 'hello' } };
 			}
 		});
 


### PR DESCRIPTION
## Ticket Number

<!-- Add the number from the Jira board -->

https://pins-ds.atlassian.net/browse/a2-633

## Description of change

Empty error message is created by date validator
Simple fix here is to remove all errors with no message (they cause accessibility/usability issues)
We could look at some other way to refactor the date validator to handle shared errors between the 3 inputs without creating an empty message, perhaps with a custom rule

## Checklist

<!-- Put an `x` in all the boxes that apply: -->

- [ ] Requires infrastructure changes
- [ ] I have updated the documentation accordingly
- [x] My commit history in this PR is linear
- [x] New features have tests
- [ ] Breaking change (team conversation required)

## Important

Please do not merge from `main` (please only [rebase](https://github.com/Planning-Inspectorate/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
