### PR TITLE
Feat/a2 250 lpa final comment checkbox

### DIFF
--- a/packages/common/src/document-types.js
+++ b/packages/common/src/document-types.js
@@ -622,6 +622,17 @@ const documentTypes = {
 		horizonDocumentType: '', // Does not exist in horizon
 		horizonDocumentGroupType: '' // Does not exist in horizon
 	},
+	uploadLPAFinalCommentDocuments: {
+		name: 'uploadLPAFinalCommentDocuments',
+		dataModelName: '', // To be added once data model confirmed
+		multiple: true,
+		displayName: '',
+		involvement: '',
+		owner: appellantOwner,
+		publiclyAccessible: false,
+		horizonDocumentType: '', // Does not exist in horizon
+		horizonDocumentGroupType: '' // Does not exist in horizon
+	},
 	caseDecisionLetter: {
 		name: 'caseDecisionLetter',
 		dataModelName: APPEAL_DOCUMENT_TYPE.CASE_DECISION_LETTER,

--- a/packages/forms-web-app/src/dynamic-forms/dynamic-components/text-entry/index.njk
+++ b/packages/forms-web-app/src/dynamic-forms/dynamic-components/text-entry/index.njk
@@ -76,6 +76,24 @@
 
                 {% endif %}
 
+								{% if question.textEntryCheckbox %}
+										<div class="govuk-form-group">
+											{{ govukCheckboxes({
+    										name: "text-entry-checkbox",
+												classes: "govuk-checkboxes checkboxes-long-text",
+    										items: [
+    	  									{
+    	    									value: "yes",
+    	    									text: question.textEntryCheckbox.text
+    	  									}
+    										],
+    										errorMessage: errors['text-entry-checkbox'] and {
+    	  									text: errors['text-entry-checkbox'].msg
+    										}
+      								}) }}
+										</div>
+								{% endif %}
+
                 {{ govukButton({
                     text: "Continue",
                     type: "submit",

--- a/packages/forms-web-app/src/dynamic-forms/dynamic-components/text-entry/index.njk
+++ b/packages/forms-web-app/src/dynamic-forms/dynamic-components/text-entry/index.njk
@@ -78,9 +78,9 @@
                 {% endif %}
 
 								{% if question.textEntryCheckbox %}
-										<h1 class="govuk-heading-m">
+										<h2 class="govuk-heading-m">
                         {{question.textEntryCheckbox.header}}
-                    </h1>
+                    </h2>
 										<div class="govuk-form-group">
 											{{ govukCheckboxes({
     										name: question.textEntryCheckbox.name,

--- a/packages/forms-web-app/src/dynamic-forms/dynamic-components/text-entry/index.njk
+++ b/packages/forms-web-app/src/dynamic-forms/dynamic-components/text-entry/index.njk
@@ -4,6 +4,7 @@
 {% from "govuk/components/textarea/macro.njk" import govukTextarea %}
 {% from "govuk/components/label/macro.njk" import govukLabel %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
+{% from "govuk/components/checkboxes/macro.njk" import govukCheckboxes %}
 
 {% set title = question.pageTitle + " - " + journeyTitle + " - GOV.UK" %}
 {% block pageTitle %}{{ "Error: " + title if errors else title }}{% endblock %}
@@ -77,9 +78,12 @@
                 {% endif %}
 
 								{% if question.textEntryCheckbox %}
+										<h1 class="govuk-heading-m">
+                        {{question.textEntryCheckbox.header}}
+                    </h1>
 										<div class="govuk-form-group">
 											{{ govukCheckboxes({
-    										name: "text-entry-checkbox",
+    										name: question.textEntryCheckbox.name,
 												classes: "govuk-checkboxes checkboxes-long-text",
     										items: [
     	  									{
@@ -87,8 +91,8 @@
     	    									text: question.textEntryCheckbox.text
     	  									}
     										],
-    										errorMessage: errors['text-entry-checkbox'] and {
-    	  									text: errors['text-entry-checkbox'].msg
+    										errorMessage: errors[question.textEntryCheckbox.name] and {
+    	  									text: errors[question.textEntryCheckbox.name].msg
     										}
       								}) }}
 										</div>

--- a/packages/forms-web-app/src/dynamic-forms/dynamic-components/text-entry/question.js
+++ b/packages/forms-web-app/src/dynamic-forms/dynamic-components/text-entry/question.js
@@ -8,6 +8,12 @@ const Question = require('../../question');
  */
 
 /**
+ * @typedef {Object} TextEntryCheckbox
+ * @property {string} text
+ * @property {string} [errorMessage]
+ */
+
+/**
  * @class
  */
 class TextEntryQuestion extends Question {
@@ -19,10 +25,21 @@ class TextEntryQuestion extends Question {
 	 * @param {string} [params.url]
 	 * @param {string} [params.html]
 	 * @param {string} [params.hint]
+	 * @param {TextEntryCheckbox} [params.textEntryCheckbox]
 	 * @param {string|undefined} [params.label] if defined this show as a label for the input and the question will just be a standard h1
 	 * @param {Array.<import('../../validator/base-validator')>} [params.validators]
 	 */
-	constructor({ title, question, fieldName, url, hint, validators, html, label }) {
+	constructor({
+		title,
+		question,
+		fieldName,
+		url,
+		hint,
+		validators,
+		html,
+		textEntryCheckbox,
+		label
+	}) {
 		super({
 			title,
 			viewFolder: 'text-entry',
@@ -34,12 +51,14 @@ class TextEntryQuestion extends Question {
 			html
 		});
 
+		this.textEntryCheckbox = textEntryCheckbox;
 		this.label = label;
 	}
 
 	prepQuestionForRendering(section, journey, customViewData, payload) {
 		let viewModel = super.prepQuestionForRendering(section, journey, customViewData);
 		viewModel.question.label = this.label;
+		viewModel.question.textEntryCheckbox = this.textEntryCheckbox;
 		viewModel.question.value = payload
 			? payload[viewModel.question.fieldName]
 			: viewModel.question.value;

--- a/packages/forms-web-app/src/dynamic-forms/dynamic-components/text-entry/question.js
+++ b/packages/forms-web-app/src/dynamic-forms/dynamic-components/text-entry/question.js
@@ -9,7 +9,9 @@ const Question = require('../../question');
 
 /**
  * @typedef {Object} TextEntryCheckbox
+ * @property {string} header
  * @property {string} text
+ * @property {string} name
  * @property {string} [errorMessage]
  */
 

--- a/packages/forms-web-app/src/dynamic-forms/questions.js
+++ b/packages/forms-web-app/src/dynamic-forms/questions.js
@@ -2060,7 +2060,7 @@ exports.questions = {
 		title: 'Do you want to submit any final comments?',
 		question: 'Do you want to submit any final comments?',
 		fieldName: 'appellantFinalComment',
-		url: 'submit-final-comment',
+		url: 'submit-final-comments',
 		validators: [new RequiredValidator('Select yes if you want to submit any final comments')]
 	}),
 	appellantFinalCommentDetails: new TextEntryQuestion({

--- a/packages/forms-web-app/src/dynamic-forms/questions.js
+++ b/packages/forms-web-app/src/dynamic-forms/questions.js
@@ -58,6 +58,7 @@ const NumericValidator = require('./validator/numeric-validator');
 const SiteAddressQuestion = require('./dynamic-components/site-address/question');
 const MultiFieldInputValidator = require('./validator/multi-field-input-validator');
 const UnitOptionEntryQuestion = require('./dynamic-components/unit-option-entry/question');
+const ConfirmationCheckboxValidator = require('./validator/confirmation-checkbox-validator');
 
 inputMaxCharacters = Math.min(Number(inputMaxCharacters), 1000);
 
@@ -2069,6 +2070,8 @@ exports.questions = {
 		html: 'resources/appellant-final-comments/content.html',
 		fieldName: 'appellantFinalCommentDetails',
 		textEntryCheckbox: {
+			header: 'Your comments',
+			name: 'sensitiveInformationCheckbox',
 			text: 'I confirm that I have not included any sensitive information in my final comments'
 		},
 		validators: [
@@ -2078,6 +2081,11 @@ exports.questions = {
 					maxLength: appealFormV2.textInputMaxLength,
 					maxLengthMessage: `Your final comments must be ${appealFormV2.textInputMaxLength} characters or less`
 				}
+			}),
+			new ConfirmationCheckboxValidator({
+				checkboxName: 'sensitiveInformationCheckbox',
+				errorMessage:
+					'You must confirm that you have not included any sensitive information in your final comments'
 			})
 		]
 	}),
@@ -2118,6 +2126,8 @@ exports.questions = {
 		html: 'resources/lpa-final-comments/content.html',
 		fieldName: 'lpaFinalCommentDetails',
 		textEntryCheckbox: {
+			header: 'Your comments',
+			name: 'sensitiveInformationCheckbox',
 			text: 'I confirm that I have not included any sensitive information in my final comments'
 		},
 		validators: [
@@ -2127,6 +2137,11 @@ exports.questions = {
 					maxLength: appealFormV2.textInputMaxLength,
 					maxLengthMessage: `Your final comments must be ${appealFormV2.textInputMaxLength} characters or less`
 				}
+			}),
+			new ConfirmationCheckboxValidator({
+				checkboxName: 'sensitiveInformationCheckbox',
+				errorMessage:
+					'You must confirm that you have not included any sensitive information in your final comments'
 			})
 		]
 	}),
@@ -2141,5 +2156,16 @@ exports.questions = {
 				'Select yes if you have additional documents to support your final comments'
 			)
 		]
+	}),
+	uploadLPAFinalCommentDocuments: new MultiFileUploadQuestion({
+		title: 'Upload your new supporting documents',
+		question: 'Upload your new supporting documents',
+		fieldName: 'uploadLPAFinalCommentDocuments',
+		url: 'upload-supporting-documents',
+		validators: [
+			new RequiredFileUploadValidator('Select your new supporting documents'),
+			new MultifileUploadValidator()
+		],
+		documentType: documentTypes.uploadLPAFinalCommentDocuments
 	})
 };

--- a/packages/forms-web-app/src/dynamic-forms/questions.js
+++ b/packages/forms-web-app/src/dynamic-forms/questions.js
@@ -2068,6 +2068,9 @@ exports.questions = {
 		url: 'final-comments',
 		html: 'resources/appellant-final-comments/content.html',
 		fieldName: 'appellantFinalCommentDetails',
+		textEntryCheckbox: {
+			text: 'I confirm that I have not included any sensitive information in my final comments'
+		},
 		validators: [
 			new RequiredValidator('Enter your final comments'),
 			new StringValidator({
@@ -2107,6 +2110,25 @@ exports.questions = {
 		fieldName: 'lpaFinalComment',
 		url: 'submit-final-comments',
 		validators: [new RequiredValidator('Select yes if you want to submit any final comments')]
+	}),
+	lpaFinalCommentDetails: new TextEntryQuestion({
+		title: 'Add your final comments',
+		question: 'Add your final comments',
+		url: 'final-comments',
+		html: 'resources/lpa-final-comments/content.html',
+		fieldName: 'lpaFinalCommentDetails',
+		textEntryCheckbox: {
+			text: 'I confirm that I have not included any sensitive information in my final comments'
+		},
+		validators: [
+			new RequiredValidator('Enter your final comments'),
+			new StringValidator({
+				maxLength: {
+					maxLength: appealFormV2.textInputMaxLength,
+					maxLengthMessage: `Your final comments must be ${appealFormV2.textInputMaxLength} characters or less`
+				}
+			})
+		]
 	}),
 	lpaFinalCommentDocuments: new BooleanQuestion({
 		title: 'Do you have additional documents to support your final comments?',

--- a/packages/forms-web-app/src/dynamic-forms/s78-lpa-final-comments/journey.js
+++ b/packages/forms-web-app/src/dynamic-forms/s78-lpa-final-comments/journey.js
@@ -2,7 +2,7 @@ const { questions } = require('../questions');
 const { Section } = require('../section');
 const config = require('../../config');
 const { JOURNEY_TYPES } = require('@pins/common/src/dynamic-forms/journey-types');
-// const { questionHasAnswer } = require('../dynamic-components/utils/question-has-answer');
+const { questionHasAnswer } = require('../dynamic-components/utils/question-has-answer');
 
 /**
  * @typedef {import('../journey-response').JourneyResponse} JourneyResponse
@@ -14,10 +14,15 @@ const { JOURNEY_TYPES } = require('@pins/common/src/dynamic-forms/journey-types'
  * @returns {Section[]}
  */
 const sections = [
-	
 	new Section('', config.dynamicForms.DEFAULT_SECTION)
-	.addQuestion(questions.lpaFinalComment)
-	.addQuestion(questions.lpaFinalCommentDocuments)
+		.addQuestion(questions.lpaFinalComment)
+		.addQuestion(questions.lpaFinalCommentDetails)
+		.withCondition((response) => questionHasAnswer(response, questions.lpaFinalComment, 'yes'))
+		.addQuestion(questions.lpaFinalCommentDocuments)
+		.addQuestion(questions.uploadLPAFinalCommentDocuments)
+		.withCondition((response) =>
+			questionHasAnswer(response, questions.uploadLPAFinalCommentDocuments, 'yes')
+		)
 ];
 
 const baseS78LPAFinalCommentsUrl = '/manage-appeals/final-comments';

--- a/packages/forms-web-app/src/dynamic-forms/s78-lpa-final-comments/journey.js
+++ b/packages/forms-web-app/src/dynamic-forms/s78-lpa-final-comments/journey.js
@@ -21,7 +21,7 @@ const sections = [
 		.addQuestion(questions.lpaFinalCommentDocuments)
 		.addQuestion(questions.uploadLPAFinalCommentDocuments)
 		.withCondition((response) =>
-			questionHasAnswer(response, questions.uploadLPAFinalCommentDocuments, 'yes')
+			questionHasAnswer(response, questions.lpaFinalCommentDocuments, 'yes')
 		)
 ];
 

--- a/packages/forms-web-app/src/dynamic-forms/validator/confirmation-checkbox-validator.js
+++ b/packages/forms-web-app/src/dynamic-forms/validator/confirmation-checkbox-validator.js
@@ -1,0 +1,39 @@
+const { body } = require('express-validator');
+const BaseValidator = require('./base-validator.js');
+
+/**
+ * @typedef {import('../question.js')} Question
+ */
+
+/**
+ * enforces a confirmation checkbox is checked before proceeding
+ * @class
+ */
+class ConfirmationCheckboxValidator extends BaseValidator {
+	/**
+	 * @type {string} error message to display to user
+	 */
+	errorMessage = 'Please check the checkbox';
+
+	/**
+	 * creates an instance of a ConditionalRequiredValidator
+	 * @param {Object} params
+	 * @param {string} params.checkboxName
+	 * @param {string} params.errorMessage - custom error message to show on validation failure
+	 */
+	constructor({ checkboxName, errorMessage }) {
+		super();
+
+		this.checkboxName = checkboxName;
+		this.errorMessage = errorMessage;
+	}
+
+	/**
+	 * validates the response body, checking the checkbox name
+	 */
+	validate() {
+		return body(this.checkboxName).notEmpty().withMessage(this.errorMessage);
+	}
+}
+
+module.exports = ConfirmationCheckboxValidator;

--- a/packages/forms-web-app/src/dynamic-forms/validator/confirmation-checkbox-validator.test.js
+++ b/packages/forms-web-app/src/dynamic-forms/validator/confirmation-checkbox-validator.test.js
@@ -1,0 +1,33 @@
+const ConfirmationCheckboxValidator = require('./confirmation-checkbox-validator');
+describe('./src/dynamic-forms/validator/confirmation-checkbox-validator.js', () => {
+	it('should return an error if the checkbox has not been checked', () => {
+		const validator = new ConfirmationCheckboxValidator({
+			checkboxName: 'testBox',
+			errorMessage: 'test error message'
+		});
+		const rule = validator.validate({}).builder.build();
+		expect(rule.locations[0]).toEqual('body');
+		expect(rule.stack[0].message).toEqual(validator.errorMessage);
+		expect(rule.stack[0].validator.name).toEqual('isEmpty');
+	});
+
+	it('should not return an error message if the checkbox has been checked', async () => {
+		const req = {
+			body: {
+				testBox: 'yes'
+			}
+		};
+		const question = {
+			textEntryCheckbox: {
+				name: 'testBox'
+			}
+		};
+
+		const validator = new ConfirmationCheckboxValidator({
+			checkboxName: 'testBox',
+			errorMessage: 'test error message'
+		});
+		const validationResult = await validator.validate(question).run(req);
+		expect(validationResult.errors.length).toEqual(0);
+	});
+});

--- a/packages/forms-web-app/src/public/resources/lpa-final-comments/comment-details.html
+++ b/packages/forms-web-app/src/public/resources/lpa-final-comments/comment-details.html
@@ -1,0 +1,34 @@
+<p class="govuk-body">Only respond to any comments from interested parties. Do not include any new evidence.</p>
+<p class="govuk-body">You can upload documents to support your final comments.</p>
+<h2 class="govuk-heading">Sensitive information</h1>
+<p class="govuk-body">Do not include any sensitive information in your final comments. It will delay your appeal.</p>
+<details class="govuk-details">
+	<summary class="govuk-details__summary">
+		<span class="govuk-details__summary-text">
+			What is sensitive information?
+		</span>
+	</summary>
+	<div class="govuk-details__text">
+		<p class="govuk-body">Sensitive information refers to:</p>
+		<ul class="govuk-list govuk-list--bullet">
+			<li>comments from children</li>
+			<li>information relating to children</li>
+			<li>information relating to health</li>
+			<li>information relating to crime</li>
+		</ul>
+
+		<p class="govuk-body">It also includes any information relating to an individual’s:</p>
+
+		<ul class="govuk-list govuk-list--bullet">
+			<li>race</li>
+			<li>ethnic origin</li>
+			<li>politics</li>
+			<li>religion</li>
+			<li>trade union membership</li>
+			<li>genetics</li>
+			<li>physical characteristics</li>
+			<li>sex life</li>
+			<li>sexual orientation</li>
+		</ul>
+	 </div>
+</details>

--- a/packages/forms-web-app/src/routes/lpa-dashboard/final-comments.js
+++ b/packages/forms-web-app/src/routes/lpa-dashboard/final-comments.js
@@ -93,7 +93,7 @@ router.get(
 
 // question
 router.get(
-	'/final-comments:referenceId/:question',
+	'/final-comments/:referenceId/:question',
 	setDefaultSection(),
 	getJourneyResponse(),
 	getJourney(journeys),


### PR DESCRIPTION
## Ticket Number

https://pins-ds.atlassian.net/browse/A2-250

## Description of change

- Adds optional confirmation checkbox option to text input questions
- Adds confirmation checkbox validator and test
- Uses this option in appellant and lpa final comment pages
- Adds uploadLPAFinalComment docs question

## Checklist

<!-- Put an `x` in all the boxes that apply: -->

- [ ] Requires infrastructure changes
- [ ] I have updated the documentation accordingly
- X My commit history in this PR is linear
- X New features have tests
- [ ] Breaking change (team conversation required)

## Important

Please do not merge from `main` (please only [rebase](https://github.com/Planning-Inspectorate/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
