### PR TITLE
fix(a2-248): amend service name

### DIFF
--- a/packages/forms-web-app/src/dynamic-forms/s78-lpa-final-comments/journey.js
+++ b/packages/forms-web-app/src/dynamic-forms/s78-lpa-final-comments/journey.js
@@ -37,7 +37,7 @@ const makeBaseUrl = (response) =>
 
 const params = {
 	journeyId: JOURNEY_TYPES.S78_LPA_FINAL_COMMENTS,
-	journeyTemplate: 'final-comments-template.njk',
+	journeyTemplate: 'statement-template.njk',
 	listingPageViewPath: 'dynamic-components/task-list/final-comments',
 	journeyTitle: 'Manage your appeals',
 	sections,


### PR DESCRIPTION
## Description of change

Small fix to ensure LPA Final Comments uses right template to display correct service name

## Checklist

<!-- Put an `x` in all the boxes that apply: -->

- [ ] Requires infrastructure changes
- [ ] I have updated the documentation accordingly
- [ ] My commit history in this PR is linear
- [ ] New features have tests
- [ ] Breaking change (team conversation required)

## Important

Please do not merge from `main` (please only [rebase](https://github.com/Planning-Inspectorate/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
