### PR TITLE
fix(a2-1165): correct link url for route to final comments from appea…

### DIFF
--- a/packages/forms-web-app/src/views/selected-appeal/appeal.njk
+++ b/packages/forms-web-app/src/views/selected-appeal/appeal.njk
@@ -66,7 +66,7 @@
 						You can submit final comments by {{appeal.finalCommentDueDate }}
 							<ul>
 								<li>
-									<a href="/final-comments" class="govuk-link">
+									<a href="/manage-appeals/final-comments/{{appeal.appealNumber}}" class="govuk-link">
 										Submit final comments
 									</a>
 								</li>
@@ -87,7 +87,7 @@
 						You can submit final comments by {{appeal.finalCommentDueDate }}
 							<ul>
 								<li>
-									<a href="/final-comments" class="govuk-link">
+									<a href="/appeals/final-comments/{{appeal.appealNumber}}" class="govuk-link">
 										Submit final comments
 									</a>
 								</li>


### PR DESCRIPTION
…l page

## Ticket Number

a2-1165

## Description of change

There are two routes to the final comment journeys - from the dashboard and from an action banner on the appeal page.  This PR updates the url in the action banners.

## Checklist

<!-- Put an `x` in all the boxes that apply: -->

- [ ] Requires infrastructure changes
- [ ] I have updated the documentation accordingly
- [ ] My commit history in this PR is linear
- [ ] New features have tests
- [ ] Breaking change (team conversation required)

## Important

Please do not merge from `main` (please only [rebase](https://github.com/Planning-Inspectorate/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
