### PR TITLE
Fix - Navigation conditions for Final Comments Journeys

### DIFF
--- a/packages/forms-web-app/src/dynamic-forms/dynamic-components/submission-screen/lpa-final-comment.njk
+++ b/packages/forms-web-app/src/dynamic-forms/dynamic-components/submission-screen/lpa-final-comment.njk
@@ -1,4 +1,4 @@
-{% extends "layouts/full-appeal-banner/main-no-back-link.njk" %}
+{% extends "layouts/lpa-dashboard/main-no-back-link.njk" %}
 {% from "govuk/components/panel/macro.njk" import govukPanel %}
 
 {% block pageTitle %}

--- a/packages/forms-web-app/src/dynamic-forms/middleware/redirect-middleware-conditions.js
+++ b/packages/forms-web-app/src/dynamic-forms/middleware/redirect-middleware-conditions.js
@@ -11,4 +11,42 @@ const skipIfNoAdditionalDocuments = (question, journeyResponse) => {
 	return false;
 };
 
-module.exports = { skipIfNoAdditionalDocuments };
+/**
+ * @param {import('../section').Question} question
+ * @param {import('../journey-response').JourneyResponse} journeyResponse
+ * @returns {boolean}
+ */
+const appellantFinalCommentSkipConditions = (question, journeyResponse) => {
+	if (
+		question.fieldName === 'appellantFinalCommentDetails' ||
+		question.fieldName === 'appellantFinalCommentDocuments'
+	) {
+		return journeyResponse.answers['appellantFinalComment'] !== 'yes';
+	} else if (question.fieldName === 'uploadAppellantFinalCommentDocuments') {
+		return journeyResponse.answers['appellantFinalCommentDocuments'] !== 'yes';
+	}
+	return false;
+};
+
+/**
+ * @param {import('../section').Question} question
+ * @param {import('../journey-response').JourneyResponse} journeyResponse
+ * @returns {boolean}
+ */
+const lpaFinalCommentSkipConditions = (question, journeyResponse) => {
+	if (
+		question.fieldName === 'lpaFinalCommentDetails' ||
+		question.fieldName === 'lpaFinalCommentDocuments'
+	) {
+		return journeyResponse.answers['lpaFinalComment'] !== 'yes';
+	} else if (question.fieldName === 'uploadLPAFinalCommentDocuments') {
+		return journeyResponse.answers['lpaFinalCommentDocuments'] !== 'yes';
+	}
+	return false;
+};
+
+module.exports = {
+	skipIfNoAdditionalDocuments,
+	appellantFinalCommentSkipConditions,
+	lpaFinalCommentSkipConditions
+};

--- a/packages/forms-web-app/src/dynamic-forms/middleware/redirect-middleware-conditions.test.js
+++ b/packages/forms-web-app/src/dynamic-forms/middleware/redirect-middleware-conditions.test.js
@@ -1,0 +1,140 @@
+const { JourneyResponse } = require('../journey-response');
+const {
+	skipIfNoAdditionalDocuments,
+	appellantFinalCommentSkipConditions,
+	lpaFinalCommentSkipConditions
+} = require('./redirect-middleware-conditions');
+
+describe('redirectMiddleWareConditions middleware', () => {
+	describe('skipIfNoAdditionalDocuments', () => {
+		it('returns true if condition met', () => {
+			const journeyResponse = new JourneyResponse(
+				's78-lpa-statement',
+				'0000001',
+				{
+					additionalDocuments: null
+				},
+				'Q9999'
+			);
+			const question = {
+				fieldName: 'uploadLpaStatementDocuments'
+			};
+			expect(skipIfNoAdditionalDocuments(question, journeyResponse)).toBe(true);
+		});
+
+		it('returns false if condition not met', () => {
+			const journeyResponse = new JourneyResponse(
+				's78-lpa-statement',
+				'0000002',
+				{
+					additionalDocuments: 'yes'
+				},
+				'Q9999'
+			);
+			const question = {
+				fieldName: 'uploadLpaStatementDocuments'
+			};
+			expect(skipIfNoAdditionalDocuments(question, journeyResponse)).toBe(false);
+		});
+	});
+
+	describe('appellantFinalCommentSkipConditions', () => {
+		it('returns true if conditions met', () => {
+			const journeyResponse1 = new JourneyResponse(
+				's78-appellant-final-comments',
+				'0000001',
+				{
+					appellantFinalComment: null,
+					appellantFinalCommentDocuments: null
+				},
+				'Q9999'
+			);
+			const question1 = {
+				fieldName: 'appellantFinalCommentDetails'
+			};
+			const question2 = {
+				fieldName: 'appellantFinalCommentDocuments'
+			};
+			const question3 = {
+				fieldName: 'uploadAppellantFinalCommentDocuments'
+			};
+			expect(appellantFinalCommentSkipConditions(question1, journeyResponse1)).toBe(true);
+			expect(appellantFinalCommentSkipConditions(question2, journeyResponse1)).toBe(true);
+			expect(appellantFinalCommentSkipConditions(question3, journeyResponse1)).toBe(true);
+		});
+
+		it('returns false if conditions not met', () => {
+			const journeyResponse2 = new JourneyResponse(
+				's78-appellant-final-comments',
+				'0000002',
+				{
+					appellantFinalComment: 'yes',
+					appellantFinalCommentDocuments: 'yes'
+				},
+				'Q9999'
+			);
+			const question4 = {
+				fieldName: 'appellantFinalCommentDetails'
+			};
+			const question5 = {
+				fieldName: 'appellantFinalCommentDocuments'
+			};
+			const question6 = {
+				fieldName: 'uploadAppellantFinalCommentDocuments'
+			};
+			expect(appellantFinalCommentSkipConditions(question4, journeyResponse2)).toBe(false);
+			expect(appellantFinalCommentSkipConditions(question5, journeyResponse2)).toBe(false);
+			expect(appellantFinalCommentSkipConditions(question6, journeyResponse2)).toBe(false);
+		});
+	});
+
+	describe('lpaFinalCommentSkipConditions', () => {
+		it('returns true if conditions met', () => {
+			const journeyResponse1 = new JourneyResponse(
+				's78-lpa-final-comments',
+				'0000001',
+				{
+					lpaFinalComment: 'no',
+					lpaFinalCommentDocuments: null
+				},
+				'Q9999'
+			);
+			const question1 = {
+				fieldName: 'lpaFinalCommentDetails'
+			};
+			const question2 = {
+				fieldName: 'lpaFinalCommentDocuments'
+			};
+			const question3 = {
+				fieldName: 'uploadLPAFinalCommentDocuments'
+			};
+			expect(lpaFinalCommentSkipConditions(question1, journeyResponse1)).toBe(true);
+			expect(lpaFinalCommentSkipConditions(question2, journeyResponse1)).toBe(true);
+			expect(lpaFinalCommentSkipConditions(question3, journeyResponse1)).toBe(true);
+		});
+
+		it('returns false if conditions not met', () => {
+			const journeyResponse2 = new JourneyResponse(
+				's78-lpa-final-comments',
+				'0000002',
+				{
+					lpaFinalComment: 'yes',
+					lpaFinalCommentDocuments: 'yes'
+				},
+				'Q9999'
+			);
+			const question4 = {
+				fieldName: 'lpaFinalCommentDetails'
+			};
+			const question5 = {
+				fieldName: 'lpaFinalCommentDocuments'
+			};
+			const question6 = {
+				fieldName: 'uploadLPAFinalCommentDocuments'
+			};
+			expect(lpaFinalCommentSkipConditions(question4, journeyResponse2)).toBe(false);
+			expect(lpaFinalCommentSkipConditions(question5, journeyResponse2)).toBe(false);
+			expect(lpaFinalCommentSkipConditions(question6, journeyResponse2)).toBe(false);
+		});
+	});
+});

--- a/packages/forms-web-app/src/routes/appeals/final-comments/index.js
+++ b/packages/forms-web-app/src/routes/appeals/final-comments/index.js
@@ -17,7 +17,7 @@ const { journeys } = require('../../../journeys');
 const setDefaultSection = require('../../../dynamic-forms/middleware/set-default-section');
 const redirectToUnansweredQuestion = require('../../../dynamic-forms/middleware/redirect-to-unanswered-question');
 const {
-	skipIfNoAdditionalDocuments
+	appellantFinalCommentSkipConditions
 } = require('../../../dynamic-forms/middleware/redirect-middleware-conditions');
 const dynamicReqFilesToReqBodyFiles = require('../../../dynamic-forms/middleware/dynamic-req-files-to-req-body-files');
 const checkNotSubmitted = require('../../../dynamic-forms/middleware/check-not-submitted');
@@ -58,7 +58,7 @@ router.get(
 	'/:referenceId',
 	getJourneyResponse(),
 	getJourney(journeys),
-	redirectToUnansweredQuestion([skipIfNoAdditionalDocuments]),
+	redirectToUnansweredQuestion([appellantFinalCommentSkipConditions]),
 	checkNotSubmitted(dashboardUrl),
 	finalCommentsTaskList
 );

--- a/packages/forms-web-app/src/routes/lpa-dashboard/final-comments.js
+++ b/packages/forms-web-app/src/routes/lpa-dashboard/final-comments.js
@@ -17,7 +17,7 @@ const { journeys } = require('../../journeys');
 const setDefaultSection = require('../../dynamic-forms/middleware/set-default-section');
 const redirectToUnansweredQuestion = require('../../dynamic-forms/middleware/redirect-to-unanswered-question');
 const {
-	skipIfNoAdditionalDocuments
+	lpaFinalCommentSkipConditions
 } = require('../../dynamic-forms/middleware/redirect-middleware-conditions');
 const dynamicReqFilesToReqBodyFiles = require('../../dynamic-forms/middleware/dynamic-req-files-to-req-body-files');
 const checkNotSubmitted = require('../../dynamic-forms/middleware/check-not-submitted');
@@ -67,7 +67,7 @@ router.get(
 	'/final-comments/:referenceId',
 	getJourneyResponse(),
 	getJourney(journeys),
-	redirectToUnansweredQuestion([skipIfNoAdditionalDocuments]),
+	redirectToUnansweredQuestion([lpaFinalCommentSkipConditions]),
 	checkNotSubmitted(dashboardUrl),
 	lpaFinalCommentTaskList
 );


### PR DESCRIPTION
## Description of change

Adds the correct conditions for determining whether to skip a question in the journey for Appellant and LPA Final Comments.

The existing conditions in the journey file determine what is shown on the task list / check answers - these conditions are used in the actual journey when we redirect to the next unanswered question

## Checklist

<!-- Put an `x` in all the boxes that apply: -->

- [ ] Requires infrastructure changes
- [ ] I have updated the documentation accordingly
- [ ] My commit history in this PR is linear
- [ ] New features have tests
- [ ] Breaking change (team conversation required)

## Important

Please do not merge from `main` (please only [rebase](https://github.com/Planning-Inspectorate/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
