### PR TITLE
fix(a2-273): retrieve appellant name via service user

### DIFF
--- a/packages/appeals-service-api/src/lib/notify.js
+++ b/packages/appeals-service-api/src/lib/notify.js
@@ -349,10 +349,12 @@ const sendLPAFinalCommentSubmissionEmailToLPAV2 = async (lpaFinalCommentSubmissi
 /**
  * @param { AppellantFinalCommentSubmission } appellantFinalCommentSubmission
  * @param {string} emailAddress
+ * @param {string} appellantName
  */
 const sendAppellantFinalCommentSubmissionEmailToAppellantV2 = async (
 	appellantFinalCommentSubmission,
-	emailAddress
+	emailAddress,
+	appellantName
 ) => {
 	try {
 		const {
@@ -379,12 +381,12 @@ const sendAppellantFinalCommentSubmissionEmailToAppellantV2 = async (
 
 		let variables = {
 			appeal_reference_number: caseReference,
-			// 'appellant name'
+			'appellant name': appellantName,
 			'appeal site address': formattedAddress,
 			'deadline date': format(finalCommentsDueDate, 'dd MMMM yyyy')
 		};
 
-		logger.debug({ variables }, 'Sending email to Interested Party');
+		logger.debug({ variables }, 'Sending final comment email to appellant');
 
 		await NotifyBuilder.reset()
 			.setTemplateId(

--- a/packages/appeals-service-api/src/repositories/sql/service-user-repository.js
+++ b/packages/appeals-service-api/src/repositories/sql/service-user-repository.js
@@ -27,6 +27,26 @@ class ServiceUserRepository {
 	}
 
 	/**
+	 * Get service user by id
+	 *
+	 * @param {string} serviceUserId
+	 * @param {string} caseReference
+	 * @returns {Promise<ServiceUser|null>}
+	 */
+	getServiceUserByIdAndCaseReference(serviceUserId, caseReference) {
+		return this.dbClient.serviceUser.findFirst({
+			where: {
+				id: serviceUserId,
+				caseReference
+			},
+			select: {
+				firstName: true,
+				lastName: true
+			}
+		});
+	}
+
+	/**
 	 * Get service user(s) by case reference and type
 	 *
 	 * @param {string} caseReference

--- a/packages/appeals-service-api/src/repositories/sql/service-user-repository.js
+++ b/packages/appeals-service-api/src/repositories/sql/service-user-repository.js
@@ -36,8 +36,10 @@ class ServiceUserRepository {
 	getServiceUserByIdAndCaseReference(serviceUserId, caseReference) {
 		return this.dbClient.serviceUser.findFirst({
 			where: {
-				id: serviceUserId,
-				caseReference
+				AND: {
+					id: serviceUserId,
+					caseReference
+				}
 			},
 			select: {
 				firstName: true,

--- a/packages/appeals-service-api/src/routes/v2/service-users/service.js
+++ b/packages/appeals-service-api/src/routes/v2/service-users/service.js
@@ -9,3 +9,12 @@ const serviceUserRepository = new ServiceUserRepository();
 exports.put = (data) => {
 	return serviceUserRepository.put(data);
 };
+
+/**
+ * @param {string} serviceUserId
+ * @param {string} caseReference
+ * @returns {import('pins-data-model/src/schemas').ServiceUser}
+ */
+exports.getServiceUserByIdAndCaseReference = (serviceUserId, caseReference) => {
+	return serviceUserRepository.getServiceUserByIdAndCaseReference(serviceUserId, caseReference);
+};

--- a/packages/database/src/seed/data-dev.js
+++ b/packages/database/src/seed/data-dev.js
@@ -29,7 +29,7 @@ const appellants = {
 	appellantOne: {
 		id: '29670d0f-c4b4-4047-8ee0-d62b93e91a11',
 		email: 'appellant1@planninginspectorate.gov.uk',
-		serviceUserId: '123451'
+		serviceUserId: '123475'
 	},
 	appellantTwo: {
 		id: '29670d0f-c4b4-4047-8ee0-d62b93e91a12',
@@ -807,6 +807,14 @@ const serviceUsers = [
 		caseReference: caseReferences.caseReferenceNine,
 		firstName: 'Agent',
 		lastName: 'Nine'
+	},
+	{
+		internalId: 'f53d3c7a-9fff-47d7-ab5b-a39f0e3cfc47',
+		id: '123475',
+		serviceUserType: 'Appellant',
+		caseReference: '6666666',
+		firstName: 'Appellant',
+		lastName: 'One'
 	}
 ];
 

--- a/packages/database/src/seed/data-dev.js
+++ b/packages/database/src/seed/data-dev.js
@@ -28,7 +28,8 @@ const getFutureDate = (daysToAdd, hour = 12) => {
 const appellants = {
 	appellantOne: {
 		id: '29670d0f-c4b4-4047-8ee0-d62b93e91a11',
-		email: 'appellant1@planninginspectorate.gov.uk'
+		email: 'appellant1@planninginspectorate.gov.uk',
+		serviceUserId: '123451'
 	},
 	appellantTwo: {
 		id: '29670d0f-c4b4-4047-8ee0-d62b93e91a12',

--- a/packages/database/src/seed/lpa-appeal-case-data-dev.js
+++ b/packages/database/src/seed/lpa-appeal-case-data-dev.js
@@ -30,7 +30,8 @@ const lpaAppealIds = {
 	appeal22: '7c8312e0-c724-4969-b7d4-441c60c6843b',
 	appeal23: '7c8312e0-c724-4969-b7d4-441c60c6844b',
 	appeal24: '7c8312e0-c724-4969-b7d4-441c60c6845b',
-	appeal25: '7c8312e0-c724-4969-b7d4-441c60c6846b'
+	appeal25: '7c8312e0-c724-4969-b7d4-441c60c6846b',
+	appeal75: '7b8312e0-c724-4969-b7d4-441c60c6741b'
 };
 
 /**
@@ -61,7 +62,8 @@ const lpaAppeals = [
 	{ id: lpaAppealIds.appeal22 },
 	{ id: lpaAppealIds.appeal23 },
 	{ id: lpaAppealIds.appeal24 },
-	{ id: lpaAppealIds.appeal25 }
+	{ id: lpaAppealIds.appeal25 },
+	{ id: lpaAppealIds.appeal75 }
 ];
 
 const commonAppealCaseDataProperties = {
@@ -766,6 +768,32 @@ const lpaAppealCaseData = [
 		},
 		...commonAppealCaseDataProperties,
 		caseReference: '0066666',
+		siteAddressLine1: 'Questionnaire and statement submitted',
+		siteAddressLine2: null,
+		siteAddressTown: 'Comments due',
+		siteAddressCounty: 'Countyshire',
+		siteAddressPostcode: 'BS1 6PN',
+		developmentDescription: 'test description',
+		lpaQuestionnaireDueDate: pickRandom(datesNMonthsAgo(1)),
+		lpaQuestionnaireSubmittedDate: pickRandom(datesNMonthsAgo(1)),
+		lpaQuestionnaireCreatedDate: pickRandom(datesNMonthsAgo(1)),
+		statementDueDate: pickRandom(datesNMonthsAgo(1)),
+		LPAStatementSubmitted: pickRandom(datesNMonthsAgo(1)),
+		finalCommentsDueDate: pickRandom(datesNMonthsAhead(1)),
+		interestedPartyRepsDueDate: pickRandom(datesNMonthsAgo(1)),
+		ProcedureType: { connect: { key: APPEAL_CASE_PROCEDURE.INQUIRY } },
+		CaseType: { connect: { processCode: 'S78' } },
+		CaseStatus: {
+			connect: { key: APPEAL_CASE_STATUS.FINAL_COMMENTS }
+		},
+		caseSubmittedDate: pickRandom(datesNMonthsAgo(3))
+	},
+	{
+		Appeal: {
+			connect: { id: lpaAppealIds.appeal75 }
+		},
+		...commonAppealCaseDataProperties,
+		caseReference: '6666666',
 		siteAddressLine1: 'Questionnaire and statement submitted',
 		siteAddressLine2: null,
 		siteAddressTown: 'Comments due',


### PR DESCRIPTION
## Ticket Number

https://pins-ds.atlassian.net/browse/A2-273

## Description of change

Uses the serviceUserId to retrieve appellant name details and set them in notify email

## Checklist

<!-- Put an `x` in all the boxes that apply: -->

- [ ] Requires infrastructure changes
- [ ] I have updated the documentation accordingly
- [ ] My commit history in this PR is linear
- [ ] New features have tests
- [ ] Breaking change (team conversation required)

## Important

Please do not merge from `main` (please only [rebase](https://github.com/Planning-Inspectorate/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
