### PR TITLE
fix(A2-757): add planning obligation doc type

### DIFF
--- a/packages/common/src/document-types.js
+++ b/packages/common/src/document-types.js
@@ -544,6 +544,7 @@ const documentTypes = {
 	},
 	uploadPlanningObligation: {
 		name: 'uploadPlanningObligation',
+		dataModelName: APPEAL_DOCUMENT_TYPE.PLANNING_OBLIGATION,
 		multiple: true,
 		displayName: '',
 		involvement: '',


### PR DESCRIPTION
## Ticket Number

<!-- Add the number from the Jira board -->

https://pins-ds.atlassian.net/browse/A2-757

## Description of change

add planning obligation doc type to make file links function

## Checklist

<!-- Put an `x` in all the boxes that apply: -->

- [ ] Requires infrastructure changes
- [ ] I have updated the documentation accordingly
- [x] My commit history in this PR is linear
- [ ] New features have tests
- [ ] Breaking change (team conversation required)

## Important

Please do not merge from `main` (please only [rebase](https://github.com/Planning-Inspectorate/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
