### PR TITLE
fix(a2-852): remove lastAccessedTime from user on logout to avoid log…

### DIFF
--- a/packages/forms-web-app/__tests__/unit/services/user.service.test.js
+++ b/packages/forms-web-app/__tests__/unit/services/user.service.test.js
@@ -1,7 +1,8 @@
 const {
 	createLPAUserSession,
 	getUserFromSession,
-	setLPAUserStatus
+	setLPAUserStatus,
+	logoutUser
 } = require('../../../src/services/user.service');
 const { getLPA } = require('#lib/appeals-api-wrapper');
 const { STATUS_CONSTANTS } = require('@pins/common/src/constants');
@@ -68,6 +69,33 @@ describe('services/user.service', () => {
 		it('should not set the user status to unknownstatus', async () => {
 			await setLPAUserStatus(req, 1, 'unknownstatus');
 			expect(req.appealsApiClient.setLPAUserStatus).toHaveBeenCalledTimes(0);
+		});
+	});
+
+	describe('logoutUser', () => {
+		it('should remove user from session ', async () => {
+			const mockReq = {
+				session: {
+					user: {},
+					lastAccessedTime: new Date()
+				}
+			};
+
+			logoutUser(mockReq);
+
+			expect(mockReq.session.user).toEqual(null);
+			expect(mockReq.session.lastAccessedTime).toEqual(null);
+		});
+
+		it('should not error if user not in session ', async () => {
+			const mockReq = {
+				session: {}
+			};
+
+			logoutUser(mockReq);
+
+			expect(mockReq.session.user).toEqual(null);
+			expect(mockReq.session.lastAccessedTime).toEqual(null);
 		});
 	});
 });

--- a/packages/forms-web-app/src/services/user.service.js
+++ b/packages/forms-web-app/src/services/user.service.js
@@ -85,6 +85,7 @@ const getLPAUser = async (req, userId) => {
  */
 const logoutUser = (req) => {
 	req.session.user = null;
+	req.session.lastAccessedTime = null;
 };
 
 /**


### PR DESCRIPTION
…in loop

## Ticket Number

<!-- Add the number from the Jira board -->

https://pins-ds.atlassian.net/browse/a2-852

## Description of change

lastAccessedTime reset during new login

## Checklist

<!-- Put an `x` in all the boxes that apply: -->

- [ ] Requires infrastructure changes
- [ ] I have updated the documentation accordingly
- [x] My commit history in this PR is linear
- [x] New features have tests
- [ ] Breaking change (team conversation required)

## Important

Please do not merge from `main` (please only [rebase](https://github.com/Planning-Inspectorate/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
