### PR TITLE
fix: specify pdf service platform

### DIFF
--- a/docker-compose.full.yml
+++ b/docker-compose.full.yml
@@ -18,6 +18,8 @@ services:
 
   pdf-service-api:
     profiles: ['all', 'appeals']
+    # platform required to build chromium on Apple Silicon Macs
+    platform: 'linux/amd64' 
     build:
       context: .
       dockerfile: ./packages/pdf-service-api/Dockerfile


### PR DESCRIPTION
## Ticket Number

<!-- Add the number from the Jira board -->
https://pins-ds.atlassian.net/browse/A2-1243

## Description of change

I've explicitly defined the platform for building the pdf service in docker compose - this fixes an issue whereby chromium would not install on m1 macs and prevent docker from building the image.

Before approving this PR, it would be useful if a windows-based dev could remove existing pdf service image from docker and check this still builds correctly for them using this branch. 

It would also be helpful if another mac-based developer could confirm this builds correctly - an example postman request is below:
<img width="699" alt="Screenshot 2024-10-07 at 12 03 12" src="https://github.com/user-attachments/assets/6763344c-5803-46bd-9609-ac25c8267f5b">
 

<!-- Please describe the change -->

## Checklist

<!-- Put an `x` in all the boxes that apply: -->

- [ ] Requires infrastructure changes
- [ ] I have updated the documentation accordingly
- [ ] My commit history in this PR is linear
- [ ] New features have tests
- [ ] Breaking change (team conversation required)

## Important

Please do not merge from `main` (please only [rebase](https://github.com/Planning-Inspectorate/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
