### PR TITLE
fix(A2-754): increase date accuracy for filtering decided appeals

### DIFF
--- a/packages/forms-web-app/__tests__/unit/lib/filter-decided-appeal.test.js
+++ b/packages/forms-web-app/__tests__/unit/lib/filter-decided-appeal.test.js
@@ -1,5 +1,5 @@
 const { filterAppealsWithinGivenDate } = require('../../../src/lib/filter-decided-appeals');
-const { subYears } = require('date-fns');
+const { subYears, addDays } = require('date-fns');
 
 describe('filterAppealsByGivenDate', () => {
 	const FIVE_YEARS_IN_MILLISECONDS = 5 * 365 * 24 * 60 * 60 * 1000;
@@ -10,6 +10,7 @@ describe('filterAppealsByGivenDate', () => {
 	const fourYearsAgo = subYears(new Date(), 4);
 	const sixYearsAgo = subYears(new Date(), 6);
 	const sevenYearsAgo = subYears(new Date(), 7);
+	const fiveYearsTwoDaysBeforeCutoff = addDays(subYears(new Date(), 5), 2);
 
 	it('should include appeals within the specified time frame (5 years)', () => {
 		const recentAppeal = {
@@ -93,5 +94,18 @@ describe('filterAppealsByGivenDate', () => {
 				FIVE_YEARS_IN_MILLISECONDS
 			)
 		).toBe(false);
+	});
+	it('should include appeals that are 2 days less than 5 years old', () => {
+		const appealWithDifferentDate = {
+			caseWithdrawnDate: fiveYearsTwoDaysBeforeCutoff
+		};
+
+		expect(
+			filterAppealsWithinGivenDate(
+				appealWithDifferentDate,
+				'caseWithdrawnDate',
+				FIVE_YEARS_IN_MILLISECONDS
+			)
+		).toBe(true);
 	});
 });

--- a/packages/forms-web-app/src/lib/filter-decided-appeals.js
+++ b/packages/forms-web-app/src/lib/filter-decided-appeals.js
@@ -1,3 +1,5 @@
+const { subYears } = require('date-fns');
+
 /**
  * @param {import('./dashboard-functions').DashboardDisplayData} appeal
  * @param {string} dateToFilterBy
@@ -5,14 +7,19 @@
  * @returns {boolean}
  */
 exports.filterAppealsWithinGivenDate = (appeal, dateToFilterBy, timeInMiliseconds) => {
+	const millisecondsPerYear = 365 * 24 * 60 * 60 * 1000;
 	const appealDate = appeal[dateToFilterBy];
 
 	if (!appealDate) {
 		return false;
 	}
 
-	const now = new Date().getTime();
-	const decisionDate = new Date(appealDate).getTime();
+	const now = new Date();
 
-	return decisionDate > now - timeInMiliseconds;
+	const decisionDate = new Date(appealDate);
+
+	const timeLimitDate = subYears(now, timeInMiliseconds / millisecondsPerYear);
+	timeLimitDate.setHours(23, 59, 59);
+
+	return decisionDate > timeLimitDate;
 };


### PR DESCRIPTION
## Ticket Number

<!-- Add the number from the Jira board -->

https://pins-ds.atlassian.net/browse/A2-754
https://pins-ds.atlassian.net/browse/A2-755

## Description of change

fix filtering out decided appeals that are still a few days within the time frame

## Checklist

<!-- Put an `x` in all the boxes that apply: -->

- [ ] Requires infrastructure changes
- [ ] I have updated the documentation accordingly
- [x] My commit history in this PR is linear
- [x] New features have tests
- [ ] Breaking change (team conversation required)

## Important

Please do not merge from `main` (please only [rebase](https://github.com/Planning-Inspectorate/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
