### PR TITLE
chore(web): add cache control max-age

### DIFF
--- a/packages/forms-web-app/src/app.js
+++ b/packages/forms-web-app/src/app.js
@@ -122,15 +122,22 @@ app.use(cookieParser());
 app.use(removeUnwantedCookiesMiddelware);
 app.use(setLocalslDisplayCookieBannerValue);
 
-app.use('/robots.txt', express.static(path.join(__dirname, 'robots.txt')));
-app.use('/public', express.static(path.join(__dirname, 'public')));
+const staticOptions = {
+	maxAge: config.cacheControl.maxAge
+};
+
+app.use('/robots.txt', express.static(path.join(__dirname, 'robots.txt'), staticOptions));
+app.use('/public', express.static(path.join(__dirname, 'public'), staticOptions));
 app.use(
 	'/assets',
 	// resolve accessible-autocomplete dist folder
-	express.static(path.join(require.resolve('accessible-autocomplete'), '..')),
-	express.static(path.join(govukFrontEndRoot, 'govuk', 'assets'))
+	express.static(path.join(require.resolve('accessible-autocomplete'), '..'), staticOptions),
+	express.static(path.join(govukFrontEndRoot, 'govuk', 'assets'), staticOptions)
 );
-app.use('/assets/govuk/all.js', express.static(path.join(govukFrontEndRoot, 'govuk', 'all.js')));
+app.use(
+	'/assets/govuk/all.js',
+	express.static(path.join(govukFrontEndRoot, 'govuk', 'all.js'), staticOptions)
+);
 
 app.use(fileUpload({ ...config.fileUpload /*useTempFiles: true*/ }));
 app.use(session(sessionConfig()));

--- a/packages/forms-web-app/src/config.js
+++ b/packages/forms-web-app/src/config.js
@@ -26,6 +26,9 @@ module.exports = {
 		timeout: numberWithDefault(process.env.APPEALS_SERVICE_API_TIMEOUT, 10000),
 		url: process.env.APPEALS_SERVICE_API_URL
 	},
+	cacheControl: {
+		maxAge: process.env.CACHE_CONTROL_MAX_AGE || '1d'
+	},
 	db: {
 		session: {
 			uri: process.env.SESSION_MONGODB_URL,


### PR DESCRIPTION
## Description of change

Ensure static assets have a non-zero max-age applied. To be improved in the future with immutable assets and cache-busting techniques.

## Checklist

<!-- Put an `x` in all the boxes that apply: -->

- [ ] Requires infrastructure changes
- [ ] I have updated the documentation accordingly
- [ ] My commit history in this PR is linear
- [ ] New features have tests
- [ ] Breaking change (team conversation required)

## Important

Please do not merge from `main` (please only [rebase](https://github.com/Planning-Inspectorate/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
