### PR TITLE
feat(a2-1039): add pdf download link to lpa appeal details page

### DIFF
--- a/packages/forms-web-app/__tests__/unit/mocks.js
+++ b/packages/forms-web-app/__tests__/unit/mocks.js
@@ -29,7 +29,9 @@ const mockRes = () => ({
 	locals: jest.fn(),
 	redirect: jest.fn(),
 	render: jest.fn(),
+	send: jest.fn(),
 	sendStatus: jest.fn(),
+	set: jest.fn(),
 	status: jest.fn()
 });
 

--- a/packages/forms-web-app/src/controllers/selected-appeal/appeal-details/index.js
+++ b/packages/forms-web-app/src/controllers/selected-appeal/appeal-details/index.js
@@ -1,17 +1,16 @@
 const { APPEAL_USER_ROLES, LPA_USER_ROLE } = require('@pins/common/src/constants');
 const { formatHeadlineData, formatRows } = require('@pins/common');
 
-const fs = require('fs');
-const path = require('path');
-
 const { VIEW } = require('../../../lib/views');
 const { determineUser } = require('../../../lib/determine-user');
 const { getUserFromSession } = require('../../../services/user.service');
 const { detailsRows } = require('./appeal-details-rows');
 const { documentsRows } = require('./appeal-documents-rows');
 const { getDepartmentFromCode } = require('../../../services/department.service');
-const logger = require('#lib/logger');
 const { generatePDF } = require('../../../lib/pdf-api-wrapper');
+const { default: fetch } = require('node-fetch');
+const config = require('../../../config');
+const logger = require('../../../lib/logger');
 
 /**
  * Shared controller for /appeals/:caseRef/appeal-details, manage-appeals/:caseRef/appeal-details rule-6-appeals/:caseRef/appeal-details
@@ -36,10 +35,8 @@ exports.get = (layoutTemplate = 'layouts/no-banner-link/main.njk') => {
 		const isPagePdfDownload = req.query.pdf === 'true' && userType === LPA_USER_ROLE;
 		let cssOverride;
 		if (isPagePdfDownload) {
-			cssOverride = fs.readFileSync(
-				path.resolve(__dirname, '../../../public/stylesheets/main.css'),
-				'utf8'
-			);
+			const response = await fetch(`${config.server.host}/public/stylesheets/main.css`);
+			cssOverride = await response.text();
 		}
 
 		let pdfDownloadUrl;

--- a/packages/forms-web-app/src/controllers/selected-appeal/appeal-details/index.test.js
+++ b/packages/forms-web-app/src/controllers/selected-appeal/appeal-details/index.test.js
@@ -1,0 +1,160 @@
+const indexController = require('./index');
+
+const { mockRes } = require('../../../../__tests__/unit/mocks');
+const { determineUser } = require('../../../lib/determine-user');
+const { LPA_USER_ROLE } = require('@pins/common/src/constants');
+const { getUserFromSession } = require('../../../services/user.service');
+const { getDepartmentFromCode } = require('../../../services/department.service');
+const { detailsRows } = require('./appeal-details-rows');
+const { documentsRows } = require('./appeal-documents-rows');
+const { formatRows, formatHeadlineData } = require('@pins/common');
+const { VIEW } = require('../../../lib/views');
+const { generatePDF } = require('../../../lib/pdf-api-wrapper');
+const fs = require('fs');
+const path = require('path');
+
+jest.mock('../../../lib/determine-user');
+jest.mock('../../../services/user.service');
+jest.mock('../../../services/department.service');
+jest.mock('./appeal-details-rows');
+jest.mock('./appeal-documents-rows');
+jest.mock('@pins/common');
+jest.mock('../../../lib/pdf-api-wrapper');
+
+const css = fs.readFileSync(
+	path.resolve(__dirname, '../../../public/stylesheets/main.css'),
+	'utf8'
+);
+const date = new Date();
+const caseData = { LPACode: 'Q9999', caseValidDate: date };
+
+const mockReq = () => {
+	return {
+		originalUrl: 'a/fake/url',
+		params: { appealNumber: 123456 },
+		query: { pdf: '' },
+		appealsApiClient: {
+			getUserByEmailV2: jest.fn(),
+			getUsersAppealCase: jest.fn()
+		},
+		app: { render: jest.fn() }
+	};
+};
+
+let res = mockRes();
+let req = mockReq();
+
+const expectedViewContext = {
+	layoutTemplate: 'layouts/no-banner-link/main.njk',
+	titleSuffix: 'Manage your appeals',
+	appealDetailsSuffix: "Appellant's",
+	appeal: {
+		appealNumber: 123456,
+		headlineData: 'formatted headline data',
+		appealDetails: 'some formatted row data',
+		appealDocuments: 'some formatted row data'
+	},
+	cssOverride: undefined,
+	pdfDownloadUrl: 'a/fake/url?pdf=true'
+};
+
+describe('controllers/selected-appeal/appeal-details/index', () => {
+	beforeEach(() => {
+		res = mockRes();
+		req = mockReq();
+		getUserFromSession.mockReturnValue({ email: 'test@example.com' });
+		getDepartmentFromCode.mockReturnValue({ name: 'Test LPA' });
+		documentsRows.mockReturnValue('returned document rows');
+		detailsRows.mockReturnValue('returned details rows');
+		formatRows.mockReturnValue('some formatted row data');
+		formatHeadlineData.mockReturnValue('formatted headline data');
+		req.appealsApiClient.getUserByEmailV2.mockReturnValue({ id: '123' });
+		req.appealsApiClient.getUsersAppealCase.mockReturnValue(caseData);
+		req.app.render.mockImplementation(async (view, locals, callback) => {
+			/* eslint-disable-next-line no-undef */
+			callback((err = null), (html = '<h1>Test Html</h1>'));
+		});
+	});
+	afterEach(() => {
+		jest.resetAllMocks();
+	});
+
+	describe('LPA User', () => {
+		beforeEach(() => {
+			determineUser.mockReturnValue(LPA_USER_ROLE);
+		});
+
+		it('renders page if URL does not have PDF query', async () => {
+			req.appealsApiClient.getUserByEmailV2.mockReturnValue({ id: '123' });
+			req.appealsApiClient.getUsersAppealCase.mockReturnValue(caseData);
+
+			const indexGetController = indexController.get();
+			await indexGetController(req, res);
+
+			expect(determineUser).toHaveBeenCalledWith('a/fake/url');
+			expect(getUserFromSession).toHaveBeenCalledWith(req);
+			expect(req.appealsApiClient.getUserByEmailV2).toHaveBeenCalledWith('test@example.com');
+			expect(req.appealsApiClient.getUsersAppealCase).toHaveBeenCalledWith({
+				caseReference: 123456,
+				role: LPA_USER_ROLE,
+				userId: '123'
+			});
+			expect(getDepartmentFromCode).toHaveBeenCalledWith('Q9999');
+			expect(detailsRows).toHaveBeenCalledWith(caseData, LPA_USER_ROLE);
+			expect(documentsRows).toHaveBeenCalledWith(caseData, LPA_USER_ROLE);
+			expect(formatRows).toHaveBeenCalledWith('returned details rows', caseData);
+			expect(formatHeadlineData).toHaveBeenCalledWith(caseData, 'Test LPA', LPA_USER_ROLE);
+			expect(req.app.render).toHaveBeenCalledWith(
+				VIEW.SELECTED_APPEAL.APPEAL_DETAILS,
+				expectedViewContext,
+				expect.any(Function)
+			);
+
+			expect(res.send).toHaveBeenCalledWith('<h1>Test Html</h1>');
+		});
+
+		it('Generates and downloads PDF and does not render HTML if URL has ?pdf=true query', async () => {
+			req.query.pdf = 'true';
+
+			const testBuffer = Buffer.from('<h1>Test Html</h1>');
+			generatePDF.mockReturnValue(testBuffer);
+
+			const pdfExpectedViewContext = {
+				...expectedViewContext,
+				cssOverride: css,
+				pdfDownloadUrl: undefined
+			};
+
+			const indexGetController = indexController.get();
+			await indexGetController(req, res);
+
+			expect(determineUser).toHaveBeenCalledWith('a/fake/url');
+			expect(getUserFromSession).toHaveBeenCalledWith(req);
+			expect(req.appealsApiClient.getUserByEmailV2).toHaveBeenCalledWith('test@example.com');
+			expect(req.appealsApiClient.getUsersAppealCase).toHaveBeenCalledWith({
+				caseReference: 123456,
+				role: LPA_USER_ROLE,
+				userId: '123'
+			});
+			expect(getDepartmentFromCode).toHaveBeenCalledWith('Q9999');
+			expect(detailsRows).toHaveBeenCalledWith(caseData, LPA_USER_ROLE);
+			expect(documentsRows).toHaveBeenCalledWith(caseData, LPA_USER_ROLE);
+			expect(formatRows).toHaveBeenCalledWith('returned details rows', caseData);
+			expect(formatHeadlineData).toHaveBeenCalledWith(caseData, 'Test LPA', LPA_USER_ROLE);
+			expect(req.app.render).toHaveBeenCalledWith(
+				VIEW.SELECTED_APPEAL.APPEAL_DETAILS,
+				pdfExpectedViewContext,
+				expect.any(Function)
+			);
+
+			expect(res.set).toHaveBeenNthCalledWith(
+				1,
+				'Content-disposition',
+				'attachment; filename="Appeal 123456.pdf"'
+			);
+			expect(res.set).toHaveBeenNthCalledWith(2, 'Content-type', 'application/pdf');
+			expect(res.send).toHaveBeenCalledWith(testBuffer);
+			expect(generatePDF).toHaveBeenCalledWith('<h1>Test Html</h1>');
+		});
+	});
+});

--- a/packages/forms-web-app/src/views/selected-appeal/appeal-details.njk
+++ b/packages/forms-web-app/src/views/selected-appeal/appeal-details.njk
@@ -3,9 +3,19 @@
 {% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
 {% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
 {% from "govuk/components/tag/macro.njk" import govukTag %}
+{% from "govuk/components/inset-text/macro.njk" import govukInsetText %}
 {% from "pins/components/appeal-sections-block.njk" import appealSectionsBlock %}
 
 {% set title="Appeal details " + appeal.appealNumber + " - " + titleSuffix + " - GOV.UK" %}
+
+	{% block head %}
+		{% if cssOverride %}
+			<style {% if cspNonce %}nonce={{ cspNonce }}{% endif %}>{{ cssOverride | safe }}</style>
+			<style {% if cspNonce %}nonce={{ cspNonce }}{% endif %}>.govuk-template { background-color: #FFFFFF; }</style>
+		{% else %}
+			{{ super () }}
+		{% endif %}
+	{% endblock %}
 
 {% block pageTitle %}
 	{{ title }}
@@ -14,15 +24,21 @@
 {% block content %}
 	<div class="govuk-grid-row">
 		<div class="govuk-grid-column-full">
-      {% if errorSummary %}
-        {{ govukErrorSummary({
-          titleText: "There is a problem",
-          errorList: errorSummary
-        }) }}
+			{% if errorSummary %}
+				{{ govukErrorSummary({
+				titleText: "There is a problem",
+				errorList: errorSummary
+				}) }}
 			{% endif %}
 
-      <span class="govuk-caption-xl">Appeal {{appeal.appealNumber}}</span>
+			<span class="govuk-caption-xl">Appeal {{appeal.appealNumber}}</span>
 			<h1 class="govuk-heading-xl">Appeal details</h1>
+
+			{% if pdfDownloadUrl %}
+				{{ govukInsetText({
+					html: "<a href='" + pdfDownloadUrl + "'download'>Download appeal details.</a>"
+				}) }}
+			{% endif %}
 
 			{{ govukSummaryList({
 				classes: "appeal-headlines govuk-summary-list--no-border",


### PR DESCRIPTION
## Ticket Number

https://pins-ds.atlassian.net.mcas.ms/jira/software/c/projects/A2/boards/264?selectedIssue=A2-1039

## Description of change

* add a download link to appeals details page when user is LPA User
* generate PDF from current page html and return it to user when download link clicked

## Checklist

<!-- Put an `x` in all the boxes that apply: -->

- [ ] Requires infrastructure changes
- [ ] I have updated the documentation accordingly
- [x] My commit history in this PR is linear
- [x] New features have tests
- [ ] Breaking change (team conversation required)

## Important

Please do not merge from `main` (please only [rebase](https://github.com/Planning-Inspectorate/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
