### PR TITLE
fix: correct constant for appeal document type

### DIFF
--- a/packages/forms-web-app/src/controllers/selected-appeal/questionnaire-details/planning-officer-details-rows.js
+++ b/packages/forms-web-app/src/controllers/selected-appeal/questionnaire-details/planning-officer-details-rows.js
@@ -14,15 +14,15 @@ exports.planningOfficerReportRows = (caseData) => {
 	const documents = caseData.Documents || [];
 	return [
 		{
-			keyText: 'Uploaded planning officer’s report',
+			keyText: "Uploaded planning officer's report",
 			valueText: formatDocumentDetails(documents, APPEAL_DOCUMENT_TYPE.PLANNING_OFFICER_REPORT),
 			condition: () => documentExists(documents, APPEAL_DOCUMENT_TYPE.PLANNING_OFFICER_REPORT),
 			isEscaped: true
 		},
 		{
 			keyText: 'Uploaded policies from statutory development plan',
-			valueText: formatDocumentDetails(documents, APPEAL_DOCUMENT_TYPE.developmentPlanPolicies),
-			condition: () => documentExists(documents, APPEAL_DOCUMENT_TYPE.developmentPlanPolicies),
+			valueText: formatDocumentDetails(documents, APPEAL_DOCUMENT_TYPE.DEVELOPMENT_PLAN_POLICIES),
+			condition: () => documentExists(documents, APPEAL_DOCUMENT_TYPE.DEVELOPMENT_PLAN_POLICIES),
 			isEscaped: true
 		},
 		{

--- a/packages/forms-web-app/src/controllers/selected-appeal/questionnaire-details/planning-officer-details-rows.test.js
+++ b/packages/forms-web-app/src/controllers/selected-appeal/questionnaire-details/planning-officer-details-rows.test.js
@@ -7,22 +7,33 @@ describe('planningOfficerReportRows', () => {
 		expect(rows.length).toEqual(12);
 	});
 
-	it('should show a document', () => {
+	it('should show documents', () => {
 		const rows = planningOfficerReportRows({
 			Documents: [
 				{
 					id: 1,
 					documentType: APPEAL_DOCUMENT_TYPE.PLANNING_OFFICER_REPORT,
 					filename: 'test.txt'
+				},
+				{
+					id: 2,
+					documentType: APPEAL_DOCUMENT_TYPE.DEVELOPMENT_PLAN_POLICIES,
+					filename: 'test2.txt'
 				}
 			]
 		});
 
 		expect(rows[0].condition()).toEqual(true);
 		expect(rows[0].isEscaped).toEqual(true);
-		expect(rows[0].keyText).toEqual('Uploaded planning officer’s report');
+		expect(rows[0].keyText).toEqual("Uploaded planning officer's report");
 		expect(rows[0].valueText).toEqual(
 			'<a href="/published-document/1" class="govuk-link">test.txt</a>'
+		);
+		expect(rows[1].condition()).toEqual(true);
+		expect(rows[1].isEscaped).toEqual(true);
+		expect(rows[1].keyText).toEqual('Uploaded policies from statutory development plan');
+		expect(rows[1].valueText).toEqual(
+			'<a href="/published-document/2" class="govuk-link">test2.txt</a>'
 		);
 	});
 });


### PR DESCRIPTION
## Description of change

Fix typo to use correct constant for development plan policies appeal documents.
Update unit test.

## Checklist

<!-- Put an `x` in all the boxes that apply: -->

- [ ] Requires infrastructure changes
- [ ] I have updated the documentation accordingly
- [ ] My commit history in this PR is linear
- [ ] New features have tests
- [ ] Breaking change (team conversation required)

## Important

Please do not merge from `main` (please only [rebase](https://github.com/Planning-Inspectorate/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
