### PR TITLE
fix(A2-469): correct displaying of appellant final comments for lpa view

### DIFF
--- a/packages/forms-web-app/__tests__/unit/lib/selected-appeal-page-setup.test.js
+++ b/packages/forms-web-app/__tests__/unit/lib/selected-appeal-page-setup.test.js
@@ -55,6 +55,13 @@ describe('Content setup functions for selected appeal page', () => {
 			const result = getFinalCommentUserGroup(url, user, userType);
 			expect(result).toBe(LPA_USER_ROLE);
 		});
+		it('should return Appellant when the url includes appellant-final-comments', () => {
+			const url = '/appeals/1234/appellant-final-comments';
+			const user = { lpaCode: 'LPA123' };
+			const userType = '';
+			const result = getFinalCommentUserGroup(url, user, userType);
+			expect(result).toBe(APPEAL_USER_ROLES.APPELLANT);
+		});
 		it('should return LPAUser when the user has an lpaCode and the url includes final-comments', () => {
 			const url = '/appeals/1234/final-comments';
 			const user = { lpaCode: 'LPA123' };

--- a/packages/forms-web-app/src/lib/selected-appeal-page-setup.js
+++ b/packages/forms-web-app/src/lib/selected-appeal-page-setup.js
@@ -52,6 +52,8 @@ const getFinalCommentUserGroup = (url, user, userType) => {
 		return APPEAL_USER_ROLES.RULE_6_PARTY;
 	} else if (url.includes('lpa-final-comments')) {
 		return LPA_USER_ROLE;
+	} else if (url.includes('appellant-final-comments')) {
+		return APPEAL_USER_ROLES.APPELLANT;
 	} else if (user.lpaCode && url.includes('final-comments')) {
 		return LPA_USER_ROLE;
 	} else if (


### PR DESCRIPTION
## Ticket Number

<!-- Add the number from the Jira board -->

https://pins-ds.atlassian.net/browse/A2-469

## Description of change

display appellant final comment when trying to view from lpa view

## Checklist

<!-- Put an `x` in all the boxes that apply: -->

- [ ] Requires infrastructure changes
- [ ] I have updated the documentation accordingly
- [x] My commit history in this PR is linear
- [x] New features have tests
- [ ] Breaking change (team conversation required)

## Important

Please do not merge from `main` (please only [rebase](https://github.com/Planning-Inspectorate/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
