### PR TITLE
feat: change primary key to uuid for appeal-user relation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -35,6 +35,7 @@
 				"eslint-plugin-jest": "^26.5.3",
 				"husky": "^8.0.0",
 				"jest": "^29.4.0",
+				"jest-mock-extended": "^3.0.7",
 				"lint-staged": "^10.5.0",
 				"multi-semantic-release": "^3.0.2",
 				"nock": "^13.3.3",
@@ -16933,6 +16934,19 @@
 				"node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
 			}
 		},
+		"node_modules/jest-mock-extended": {
+			"version": "3.0.7",
+			"resolved": "https://registry.npmjs.org/jest-mock-extended/-/jest-mock-extended-3.0.7.tgz",
+			"integrity": "sha512-7lsKdLFcW9B9l5NzZ66S/yTQ9k8rFtnwYdCNuRU/81fqDWicNDVhitTSPnrGmNeNm0xyw0JHexEOShrIKRCIRQ==",
+			"dev": true,
+			"dependencies": {
+				"ts-essentials": "^10.0.0"
+			},
+			"peerDependencies": {
+				"jest": "^24.0.0 || ^25.0.0 || ^26.0.0 || ^27.0.0 || ^28.0.0 || ^29.0.0",
+				"typescript": "^3.0.0 || ^4.0.0 || ^5.0.0"
+			}
+		},
 		"node_modules/jest-mock/node_modules/@jest/schemas": {
 			"version": "28.1.3",
 			"resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-28.1.3.tgz",
@@ -32909,6 +32923,20 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">=8"
+			}
+		},
+		"node_modules/ts-essentials": {
+			"version": "10.0.2",
+			"resolved": "https://registry.npmjs.org/ts-essentials/-/ts-essentials-10.0.2.tgz",
+			"integrity": "sha512-Xwag0TULqriaugXqVdDiGZ5wuZpqABZlpwQ2Ho4GDyiu/R2Xjkp/9+zcFxL7uzeLl/QCPrflnvpVYyS3ouT7Zw==",
+			"dev": true,
+			"peerDependencies": {
+				"typescript": ">=4.5.0"
+			},
+			"peerDependenciesMeta": {
+				"typescript": {
+					"optional": true
+				}
 			}
 		},
 		"node_modules/ts-node": {

--- a/package.json
+++ b/package.json
@@ -89,6 +89,7 @@
 		"eslint-plugin-jest": "^26.5.3",
 		"husky": "^8.0.0",
 		"jest": "^29.4.0",
+		"jest-mock-extended": "^3.0.7",
 		"lint-staged": "^10.5.0",
 		"multi-semantic-release": "^3.0.2",
 		"nock": "^13.3.3",

--- a/packages/appeals-service-api/__tests__/developer/appeals.test.js
+++ b/packages/appeals-service-api/__tests__/developer/appeals.test.js
@@ -179,9 +179,7 @@ describe('Appeals', () => {
 		const householderAppeal = AppealFixtures.newHouseholderAppeal();
 		householderAppeal.aboutYouSection.yourDetails.isOriginalApplicant = true;
 
-		const { appealResponse: savedAppealResponse, userResponse: user } = await _createAppeal(
-			householderAppeal
-		);
+		const { appealResponse: savedAppealResponse } = await _createAppeal(householderAppeal);
 
 		if (!savedAppealResponse.ok) {
 			throw new Error('failed to create appeal');
@@ -190,6 +188,7 @@ describe('Appeals', () => {
 		let savedAppeal = savedAppealResponse.body;
 
 		const dataToSend = {
+			id: savedAppeal.id,
 			aboutYouSection: {
 				yourDetails: {
 					isOriginalApplicant: false
@@ -204,12 +203,16 @@ describe('Appeals', () => {
 
 		expect(patchedAppealResponse.body.aboutYouSection.yourDetails.isOriginalApplicant).toBe(false);
 
-		const userLink = await sqlClient.appealToUser.findFirst({
+		const appeal = await sqlClient.appeal.findFirst({
 			where: {
-				userId: user.id
+				legacyAppealSubmissionId: savedAppeal.id
+			},
+			include: {
+				Users: true
 			}
 		});
-		expect(userLink?.role).toBe(APPEAL_USER_ROLES.AGENT);
+		expect(appeal.Users.length).toBe(1);
+		expect(appeal.Users[0].role).toBe(APPEAL_USER_ROLES.AGENT);
 
 		// And: no external systems should be interacted with
 		expectedNotifyInteractions = [];
@@ -220,9 +223,7 @@ describe('Appeals', () => {
 		const fullAppeal = AppealFixtures.newFullAppeal();
 		fullAppeal.contactDetailsSection.isOriginalApplicant = true;
 
-		const { appealResponse: savedAppealResponse, userResponse: user } = await _createAppeal(
-			fullAppeal
-		);
+		const { appealResponse: savedAppealResponse } = await _createAppeal(fullAppeal);
 
 		if (!savedAppealResponse.ok) {
 			throw new Error('failed to create appeal');
@@ -231,6 +232,7 @@ describe('Appeals', () => {
 		let savedAppeal = savedAppealResponse.body;
 
 		const dataToSend = {
+			id: savedAppeal.id,
 			aboutYouSection: {
 				yourDetails: {
 					isOriginalApplicant: false
@@ -245,12 +247,16 @@ describe('Appeals', () => {
 
 		expect(patchedAppealResponse.body.aboutYouSection.yourDetails.isOriginalApplicant).toBe(false);
 
-		const userLink = await sqlClient.appealToUser.findFirst({
+		const appeal = await sqlClient.appeal.findFirst({
 			where: {
-				userId: user.id
+				legacyAppealSubmissionId: savedAppeal.id
+			},
+			include: {
+				Users: true
 			}
 		});
-		expect(userLink?.role).toBe(APPEAL_USER_ROLES.AGENT);
+		expect(appeal.Users.length).toBe(1);
+		expect(appeal.Users[0].role).toBe(APPEAL_USER_ROLES.AGENT);
 
 		// And: no external systems should be interacted with
 		expectedNotifyInteractions = [];

--- a/packages/appeals-service-api/__tests__/unit/repositories/sql/appeal-user-repository.test.js
+++ b/packages/appeals-service-api/__tests__/unit/repositories/sql/appeal-user-repository.test.js
@@ -1,0 +1,147 @@
+const { mockDeep, mockReset } = require('jest-mock-extended');
+const { PrismaClient } = require('@prisma/client');
+const { APPEAL_USER_ROLES, STATUS_CONSTANTS } = require('@pins/common/src/constants');
+const { AppealUserRepository } = require('#repositories/sql/appeal-user-repository');
+
+describe('AppealUserRepository', () => {
+	const mockPrismaClient = mockDeep(PrismaClient);
+	const repository = new AppealUserRepository(mockPrismaClient);
+
+	afterEach(() => {
+		jest.clearAllMocks();
+		mockReset(mockPrismaClient);
+	});
+
+	describe('createUser', () => {
+		it('should create a new user', async () => {
+			const user = { email: 'test@example.com', isLpaUser: true };
+			mockPrismaClient.appealUser.create.mockResolvedValue(user);
+
+			const result = await repository.createUser(user);
+
+			expect(mockPrismaClient.appealUser.create).toHaveBeenCalledWith({ data: user });
+			expect(result).toEqual(user);
+		});
+
+		it('should set lpaStatus and isLpaAdmin for LPA users', async () => {
+			const user = { email: 'test@example.com', isLpaUser: true };
+			const expectedUser = { ...user, lpaStatus: STATUS_CONSTANTS.ADDED, isLpaAdmin: false };
+			mockPrismaClient.appealUser.create.mockResolvedValue(expectedUser);
+
+			const result = await repository.createUser(user);
+
+			expect(mockPrismaClient.appealUser.create).toHaveBeenCalledWith({ data: expectedUser });
+			expect(result).toEqual(expectedUser);
+		});
+	});
+
+	describe('updateUser', () => {
+		it('should update an existing user', async () => {
+			const user = { id: '1', email: 'test@example.com' };
+			mockPrismaClient.appealUser.update.mockResolvedValue(user);
+
+			const result = await repository.updateUser(user);
+
+			expect(mockPrismaClient.appealUser.update).toHaveBeenCalledWith({
+				data: user,
+				where: { id: user.id }
+			});
+			expect(result).toEqual(user);
+		});
+	});
+
+	describe('search', () => {
+		it('should search users with given options', async () => {
+			const searchOptions = { email: 'test@example.com' };
+			const users = [{ id: '1', email: 'test@example.com' }];
+			mockPrismaClient.appealUser.findMany.mockResolvedValue(users);
+
+			const result = await repository.search(searchOptions);
+
+			expect(mockPrismaClient.appealUser.findMany).toHaveBeenCalledWith({ where: searchOptions });
+			expect(result).toEqual(users);
+		});
+	});
+
+	describe('getByEmail', () => {
+		it('should get a user by email', async () => {
+			const email = 'test@example.com';
+			const user = { id: '1', email };
+			mockPrismaClient.appealUser.findUnique.mockResolvedValue(user);
+
+			const result = await repository.getByEmail(email);
+
+			expect(mockPrismaClient.appealUser.findUnique).toHaveBeenCalledWith({ where: { email } });
+			expect(result).toEqual(user);
+		});
+	});
+
+	describe('getById', () => {
+		it('should get a user by id', async () => {
+			const id = '1';
+			const user = { id, email: 'test@example.com' };
+			mockPrismaClient.appealUser.findUnique.mockResolvedValue(user);
+
+			const result = await repository.getById(id);
+
+			expect(mockPrismaClient.appealUser.findUnique).toHaveBeenCalledWith({ where: { id } });
+			expect(result).toEqual(user);
+		});
+	});
+
+	describe('countUsersWhereEmailAndRule6Party', () => {
+		it('should count users with given email and Rule 6 Party role', async () => {
+			const email = 'test@example.com';
+			const count = 1;
+			mockPrismaClient.appealUser.count.mockResolvedValue(count);
+
+			const result = await repository.countUsersWhereEmailAndRule6Party(email);
+
+			expect(mockPrismaClient.appealUser.count).toHaveBeenCalledWith({
+				where: {
+					AND: [{ email }, { Appeals: { some: { role: APPEAL_USER_ROLES.RULE_6_PARTY } } }]
+				}
+			});
+			expect(result).toEqual(count);
+		});
+	});
+
+	describe('linkUserToAppeal', () => {
+		it('should link user to appeal with given role', async () => {
+			const userId = '1';
+			const appealId = '1';
+			const role = APPEAL_USER_ROLES.APPELLANT;
+			const link = { appealId, userId, role };
+			mockPrismaClient.appealToUser.findMany.mockResolvedValue([]);
+			mockPrismaClient.appealToUser.create.mockResolvedValue(link);
+
+			const result = await repository.linkUserToAppeal(userId, appealId, role);
+
+			expect(mockPrismaClient.appealToUser.findMany).toHaveBeenCalledWith({
+				where: { appealId, userId }
+			});
+			expect(mockPrismaClient.appealToUser.create).toHaveBeenCalledWith({ data: link });
+			expect(result).toEqual(link);
+		});
+
+		it('should update existing role if different', async () => {
+			const userId = '1';
+			const appealId = '1';
+			const role = APPEAL_USER_ROLES.AGENT;
+			const existingRole = { id: '1', appealId, userId, role: APPEAL_USER_ROLES.APPELLANT };
+			mockPrismaClient.appealToUser.findMany.mockResolvedValue([existingRole]);
+			mockPrismaClient.appealToUser.update.mockResolvedValue({ ...existingRole, role });
+
+			const result = await repository.linkUserToAppeal(userId, appealId, role);
+
+			expect(mockPrismaClient.appealToUser.findMany).toHaveBeenCalledWith({
+				where: { appealId, userId }
+			});
+			expect(mockPrismaClient.appealToUser.update).toHaveBeenCalledWith({
+				where: { id: existingRole.id },
+				data: { role }
+			});
+			expect(result).toEqual({ ...existingRole, role });
+		});
+	});
+});

--- a/packages/appeals-service-api/__tests__/unit/repositories/sql/service-user-repository.test.js
+++ b/packages/appeals-service-api/__tests__/unit/repositories/sql/service-user-repository.test.js
@@ -1,0 +1,188 @@
+const { mockDeep, mockReset } = require('jest-mock-extended');
+const { PrismaClient } = require('@prisma/client');
+const { ServiceUserRepository } = require('#repositories/sql/service-user-repository');
+const { SERVICE_USER_TYPE } = require('pins-data-model');
+jest.mock('#repositories/sql/appeal-user-repository');
+
+describe('ServiceUserRepository', () => {
+	const mockPrismaClient = mockDeep(PrismaClient);
+	const repository = new ServiceUserRepository(mockPrismaClient);
+
+	afterEach(() => {
+		jest.clearAllMocks();
+		mockReset(mockPrismaClient);
+	});
+
+	describe('getServiceUserByIdAndCaseReference', () => {
+		it('should return service user when found', async () => {
+			const serviceUserId = 'user-id';
+			const caseReference = 'case-ref';
+			const expectedUser = { firstName: 'John', lastName: 'Doe' };
+
+			mockPrismaClient.serviceUser.findFirst.mockResolvedValue(expectedUser);
+
+			const result = await repository.getServiceUserByIdAndCaseReference(
+				serviceUserId,
+				caseReference
+			);
+
+			expect(result).toEqual(expectedUser);
+			expect(mockPrismaClient.serviceUser.findFirst).toHaveBeenCalledWith({
+				where: {
+					AND: {
+						id: serviceUserId,
+						caseReference
+					}
+				},
+				select: {
+					firstName: true,
+					lastName: true
+				}
+			});
+		});
+
+		it('should return null when service user not found', async () => {
+			const serviceUserId = 'user-id';
+			const caseReference = 'case-ref';
+
+			mockPrismaClient.serviceUser.findFirst.mockResolvedValue(null);
+
+			const result = await repository.getServiceUserByIdAndCaseReference(
+				serviceUserId,
+				caseReference
+			);
+
+			expect(result).toBeNull();
+			expect(mockPrismaClient.serviceUser.findFirst).toHaveBeenCalledWith({
+				where: {
+					AND: {
+						id: serviceUserId,
+						caseReference
+					}
+				},
+				select: {
+					firstName: true,
+					lastName: true
+				}
+			});
+		});
+	});
+
+	describe('getForCaseAndType', () => {
+		it('should return service users for given case reference and types', async () => {
+			const caseReference = 'case-ref';
+			const serviceUserTypes = [SERVICE_USER_TYPE.APPELLANT, SERVICE_USER_TYPE.AGENT];
+			const expectedUsers = [
+				{
+					firstName: 'John',
+					lastName: 'Doe',
+					emailAddress: 'john@example.com',
+					organisation: 'Org1',
+					telephoneNumber: '1234567890',
+					serviceUserType: SERVICE_USER_TYPE.APPELLANT
+				},
+				{
+					firstName: 'Jane',
+					lastName: 'Smith',
+					emailAddress: 'jane@example.com',
+					organisation: 'Org2',
+					telephoneNumber: '0987654321',
+					serviceUserType: SERVICE_USER_TYPE.AGENT
+				}
+			];
+
+			mockPrismaClient.serviceUser.findMany.mockResolvedValue(expectedUsers);
+
+			const result = await repository.getForCaseAndType(caseReference, serviceUserTypes);
+
+			expect(result).toEqual(expectedUsers);
+			expect(mockPrismaClient.serviceUser.findMany).toHaveBeenCalledWith({
+				where: {
+					OR: serviceUserTypes.map((type) => ({
+						caseReference,
+						serviceUserType: type
+					}))
+				},
+				select: {
+					firstName: true,
+					lastName: true,
+					emailAddress: true,
+					organisation: true,
+					telephoneNumber: true,
+					serviceUserType: true
+				}
+			});
+		});
+
+		it('should return empty array when no service users found', async () => {
+			const caseReference = 'case-ref';
+			const serviceUserTypes = [SERVICE_USER_TYPE.APPELLANT, SERVICE_USER_TYPE.AGENT];
+
+			mockPrismaClient.serviceUser.findMany.mockResolvedValue([]);
+
+			const result = await repository.getForCaseAndType(caseReference, serviceUserTypes);
+
+			expect(result).toEqual([]);
+			expect(mockPrismaClient.serviceUser.findMany).toHaveBeenCalledWith({
+				where: {
+					OR: serviceUserTypes.map((type) => ({
+						caseReference,
+						serviceUserType: type
+					}))
+				},
+				select: {
+					firstName: true,
+					lastName: true,
+					emailAddress: true,
+					organisation: true,
+					telephoneNumber: true,
+					serviceUserType: true
+				}
+			});
+		});
+	});
+
+	describe('put', () => {
+		it('should create a new service user when not found', async () => {
+			const data = {
+				id: 'user-id',
+				caseReference: 'case-ref',
+				emailAddress: 'john@example.com',
+				serviceUserType: SERVICE_USER_TYPE.APPELLANT
+			};
+
+			mockPrismaClient.appealUser.findFirst.mockResolvedValue(null);
+			mockPrismaClient.appealCase.findFirst.mockResolvedValue({ Appeal: { id: 'appeal-id' } });
+			mockPrismaClient.serviceUser.findFirst.mockResolvedValue(null);
+			mockPrismaClient.appealUser.create.mockResolvedValue({ id: 1 });
+			mockPrismaClient.$transaction.mockImplementation(async (fn) => fn(mockPrismaClient));
+
+			await repository.put(data);
+
+			expect(mockPrismaClient.serviceUser.create).toHaveBeenCalledWith({ data });
+		});
+
+		it('should update an existing service user when found', async () => {
+			const data = {
+				id: 'user-id',
+				caseReference: 'case-ref',
+				emailAddress: 'john@example.com',
+				serviceUserType: SERVICE_USER_TYPE.APPELLANT
+			};
+			const existingUser = { internalId: 'internal-id' };
+
+			mockPrismaClient.appealUser.findFirst.mockResolvedValue(null);
+			mockPrismaClient.appealCase.findFirst.mockResolvedValue({ Appeal: { id: 'appeal-id' } });
+			mockPrismaClient.serviceUser.findFirst.mockResolvedValue(existingUser);
+			mockPrismaClient.appealUser.create.mockResolvedValue({ id: 1 });
+			mockPrismaClient.$transaction.mockImplementation(async (fn) => fn(mockPrismaClient));
+
+			await repository.put(data);
+
+			expect(mockPrismaClient.serviceUser.update).toHaveBeenCalledWith({
+				where: { internalId: existingUser.internalId },
+				data
+			});
+		});
+	});
+});

--- a/packages/appeals-service-api/src/routes/v2/events/repo.js
+++ b/packages/appeals-service-api/src/routes/v2/events/repo.js
@@ -1,7 +1,6 @@
 const { createPrismaClient } = require('#db-client');
 const { APPEAL_EVENT_TYPE } = require('pins-data-model');
 const { EVENT_TYPES, EVENT_SUB_TYPES } = require('@pins/common/src/constants');
-EVENT_TYPES.SITE_VISIT;
 
 /**
  * @typedef {import('pins-data-model/src/schemas').AppealEvent} DataModelEvent

--- a/packages/database/src/migrations/20241028153215_update_appeal_user_pk/migration.sql
+++ b/packages/database/src/migrations/20241028153215_update_appeal_user_pk/migration.sql
@@ -1,0 +1,27 @@
+/*
+  Warnings:
+
+  - The primary key for the `AppealToUser` table will be changed. If it partially fails, the table could be left without primary key constraint.
+
+*/
+BEGIN TRY
+
+BEGIN TRAN;
+
+-- AlterTable
+ALTER TABLE [dbo].[AppealToUser] DROP CONSTRAINT [AppealToUser_pkey];
+ALTER TABLE [dbo].[AppealToUser] ADD [id] UNIQUEIDENTIFIER NOT NULL CONSTRAINT [AppealToUser_id_df] DEFAULT newid();
+ALTER TABLE [dbo].[AppealToUser] ADD CONSTRAINT AppealToUser_pkey PRIMARY KEY CLUSTERED ([id]);
+
+COMMIT TRAN;
+
+END TRY
+BEGIN CATCH
+
+IF @@TRANCOUNT > 0
+BEGIN
+    ROLLBACK TRAN;
+END;
+THROW
+
+END CATCH

--- a/packages/database/src/schema.prisma
+++ b/packages/database/src/schema.prisma
@@ -126,6 +126,8 @@ model Appeal {
 /// AppealToUser represents the relationships between AppealUser and Appeal
 /// This is a many-to-many relationship.
 model AppealToUser {
+  id String @id @default(dbgenerated("newid()")) @db.UniqueIdentifier
+
   /// relation to an Appeal
   appealId   String     @db.UniqueIdentifier
   Appeal     Appeal     @relation(fields: [appealId], references: [id])
@@ -137,8 +139,6 @@ model AppealToUser {
   /// must be an AppealToUserRole name value
   role String
   Role AppealToUserRole @relation(fields: [role], references: [name])
-
-  @@id([appealId, userId])
 }
 
 /// AppealToUserRole represents the role a user has in relation to an Appeal


### PR DESCRIPTION
## Ticket Number

https://pins-ds.atlassian.net/browse/A2-1352

## Description of change

- Update the PK of AppealToUser table to a uuid
- Need to allow users to have more than 1 role on an appeal to allow for rule6, (change from what was initially expected)
- Warning was given when trying to add role to the key, due to length, so changed to uuid

## Checklist

<!-- Put an `x` in all the boxes that apply: -->

- [ ] Requires infrastructure changes
- [ ] I have updated the documentation accordingly
- [x] My commit history in this PR is linear
- [x] New features have tests
- [ ] Breaking change (team conversation required)

## Important

Please do not merge from `main` (please only [rebase](https://github.com/Planning-Inspectorate/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
