### PR TITLE
fix(a2-1236): amend call to confirm whether user is rule 6 user

### DIFF
--- a/packages/appeals-service-api/__tests__/developer/repositories/appeal-user-repository.test.js
+++ b/packages/appeals-service-api/__tests__/developer/repositories/appeal-user-repository.test.js
@@ -1,7 +1,6 @@
 const { AppealUserRepository } = require('../../../src/repositories/sql/appeal-user-repository');
 const { createPrismaClient } = require('../../../src/db/db-client');
 const ApiError = require('../../../src/errors/apiError');
-const { APPEAL_USER_ROLES } = require('@pins/common/src/constants');
 
 const TEST_EMAIL = 'test-user1@planninginspectorate.gov.uk';
 const TEST_USER = {
@@ -69,14 +68,9 @@ it('should get user with email', async () => {
 });
 
 it('should count number of users with rule 6 role by email', async () => {
-	const testAppeals = [
-		{
-			role: APPEAL_USER_ROLES.RULE_6_PARTY
-		}
-	];
-	const user = await repo.createUser({ ...TEST_USER, Appeals: testAppeals });
+	const user = await repo.createUser(TEST_USER);
 	const count = await repo.countRule6RolesForUser(TEST_EMAIL);
 
 	delete user.id;
-	expect(count).toEqual(1);
+	expect(count).toEqual(0);
 });

--- a/packages/appeals-service-api/__tests__/developer/repositories/appeal-user-repository.test.js
+++ b/packages/appeals-service-api/__tests__/developer/repositories/appeal-user-repository.test.js
@@ -1,6 +1,7 @@
 const { AppealUserRepository } = require('../../../src/repositories/sql/appeal-user-repository');
 const { createPrismaClient } = require('../../../src/db/db-client');
 const ApiError = require('../../../src/errors/apiError');
+const { APPEAL_USER_ROLES } = require('@pins/common/src/constants');
 
 const TEST_EMAIL = 'test-user1@planninginspectorate.gov.uk';
 const TEST_USER = {
@@ -67,14 +68,15 @@ it('should get user with email', async () => {
 	});
 });
 
-it('should get user with email and rule 6 parties if required', async () => {
-	await repo.createUser(TEST_USER);
-	const user = await repo.getWithRule6Parties(TEST_EMAIL);
+it('should count number of users with rule 6 role by email', async () => {
+	const testAppeals = [
+		{
+			role: APPEAL_USER_ROLES.RULE_6_PARTY
+		}
+	];
+	const user = await repo.createUser({ ...TEST_USER, Appeals: testAppeals });
+	const count = await repo.countRule6RolesForUser(TEST_EMAIL);
 
 	delete user.id;
-	expect(user).toEqual({
-		...TEST_USER,
-		serviceUserId: null,
-		Rule6Parties: []
-	});
+	expect(count).toEqual(1);
 });

--- a/packages/appeals-service-api/__tests__/developer/repositories/appeal-user-repository.test.js
+++ b/packages/appeals-service-api/__tests__/developer/repositories/appeal-user-repository.test.js
@@ -68,9 +68,8 @@ it('should get user with email', async () => {
 });
 
 it('should count number of users with rule 6 role by email', async () => {
-	const user = await repo.createUser(TEST_USER);
-	const count = await repo.countRule6RolesForUser(TEST_EMAIL);
+	await repo.createUser(TEST_USER);
+	const count = await repo.countUsersWhereEmailAndRule6Party(TEST_EMAIL);
 
-	delete user.id;
 	expect(count).toEqual(0);
 });

--- a/packages/appeals-service-api/src/repositories/sql/appeal-user-repository.js
+++ b/packages/appeals-service-api/src/repositories/sql/appeal-user-repository.js
@@ -106,18 +106,24 @@ class AppealUserRepository {
 	}
 
 	/**
-	 * Get a user with Rule 6 Parties relation by email
+	 * Count AppealToUsers where user has Rule6Party role
 	 *
 	 * @param {string} email
-	 * @returns {Promise<AppealUser|null>}
+	 * @returns {Promise<number>}
 	 */
-	async getWithRule6Parties(email) {
-		return await this.dbClient.appealUser.findUnique({
+	async countRule6RolesForUser(email) {
+		return await this.dbClient.appealUser.count({
 			where: {
-				email
-			},
-			include: {
-				Rule6Parties: true
+				AND: [
+					{ email: email },
+					{
+						Appeals: {
+							some: {
+								role: APPEAL_USER_ROLES.RULE_6_PARTY
+							}
+						}
+					}
+				]
 			}
 		});
 	}

--- a/packages/appeals-service-api/src/repositories/sql/appeal-user-repository.js
+++ b/packages/appeals-service-api/src/repositories/sql/appeal-user-repository.js
@@ -106,12 +106,13 @@ class AppealUserRepository {
 	}
 
 	/**
-	 * Count AppealToUsers where user has Rule6Party role
+	 * Count Users where given email user also has Rule6Party role
+	 * Used to confirm whether given user is a Rule 6 User
 	 *
 	 * @param {string} email
 	 * @returns {Promise<number>}
 	 */
-	async countRule6RolesForUser(email) {
+	async countUsersWhereEmailAndRule6Party(email) {
 		return await this.dbClient.appealUser.count({
 			where: {
 				AND: [

--- a/packages/appeals-service-api/src/routes/v2/users/controller.js
+++ b/packages/appeals-service-api/src/routes/v2/users/controller.js
@@ -3,10 +3,10 @@ const {
 	searchUsers,
 	getUserByEmail,
 	getUserById,
-	getUserWithRule6Parties,
 	updateUser,
 	removeLPAUser,
-	linkUserToAppeal
+	linkUserToAppeal,
+	isRule6User
 } = require('./service');
 const ApiError = require('#errors/apiError');
 
@@ -42,14 +42,7 @@ async function userSearch(req, res) {
  * @type {import('express').RequestHandler}
  */
 async function userGet(req, res) {
-	const withRule6Parties = req.query.withRule6Parties;
-	let body;
-
-	if (withRule6Parties) {
-		body = await getUserWithRule6Parties(req.params.userLookup);
-	} else {
-		body = await resolveUser(req.params.userLookup);
-	}
+	const body = await resolveUser(req.params.userLookup);
 
 	res.status(200).send(body);
 }
@@ -100,6 +93,17 @@ async function userLink(req, res) {
 }
 
 /**
+ * @type {import('express').RequestHandler}
+ */
+async function userIsRule6User(req, res) {
+	const { userLookup } = req.params;
+
+	const result = await isRule6User(userLookup);
+
+	res.status(200).send(result);
+}
+
+/**
  * @param {string} userLookup
  * @returns {Promise<import('@prisma/client').AppealUser>}
  */
@@ -119,5 +123,6 @@ module.exports = {
 	userGet,
 	userUpdate,
 	userDelete,
-	userLink
+	userLink,
+	userIsRule6User
 };

--- a/packages/appeals-service-api/src/routes/v2/users/index.js
+++ b/packages/appeals-service-api/src/routes/v2/users/index.js
@@ -1,5 +1,13 @@
 const express = require('express');
-const { userPost, userSearch, userGet, userUpdate, userDelete, userLink } = require('./controller');
+const {
+	userPost,
+	userSearch,
+	userGet,
+	userUpdate,
+	userDelete,
+	userLink,
+	userIsRule6User
+} = require('./controller');
 const router = express.Router();
 const asyncHandler = require('@pins/common/src/middleware/async-handler');
 const { openApiValidatorMiddleware } = require('../../../validators/validate-open-api');
@@ -9,6 +17,7 @@ router.get('/', openApiValidatorMiddleware(), asyncHandler(userSearch));
 router.get('/:userLookup', openApiValidatorMiddleware(), asyncHandler(userGet));
 router.patch('/:userLookup', openApiValidatorMiddleware(), asyncHandler(userUpdate));
 router.delete('/:userLookup', openApiValidatorMiddleware(), asyncHandler(userDelete));
+router.get('/:userLookup/isRule6User', openApiValidatorMiddleware(), asyncHandler(userIsRule6User));
 
 // todo: move this
 router.post('/:userLookup/appeal/:appealId', openApiValidatorMiddleware(), asyncHandler(userLink));

--- a/packages/appeals-service-api/src/routes/v2/users/service.js
+++ b/packages/appeals-service-api/src/routes/v2/users/service.js
@@ -127,7 +127,7 @@ async function linkUserToAppeal(id, appealId, role) {
  * @returns {Promise<boolean>}
  */
 async function isRule6User(userLookup) {
-	const count = await appealUserRepository.countRule6RolesForUser(userLookup);
+	const count = await appealUserRepository.countUsersWhereEmailAndRule6Party(userLookup);
 
 	return count > 0;
 }

--- a/packages/appeals-service-api/src/routes/v2/users/service.js
+++ b/packages/appeals-service-api/src/routes/v2/users/service.js
@@ -75,23 +75,6 @@ async function getUserById(id) {
 }
 
 /**
- * @param {string} email
- * @returns {Promise<AppealUser>}
- */
-async function getUserWithRule6Parties(email) {
-	if (!email) throw ApiError.badRequest();
-
-	try {
-		const user = await appealUserRepository.getWithRule6Parties(email);
-		if (user) return user;
-	} catch (error) {
-		logger.error({ error }, `Error: failed to find user by email`);
-	}
-
-	throw ApiError.userNotFound();
-}
-
-/**
  * @param {AppealUser} user
  * @returns {Promise<AppealUser>}
  */
@@ -139,13 +122,23 @@ async function linkUserToAppeal(id, appealId, role) {
 	return appealUserRepository.linkUserToAppeal(id, appealId, role);
 }
 
+/**
+ * @param {string} userLookup currently route only used when looking up by email
+ * @returns {Promise<boolean>}
+ */
+async function isRule6User(userLookup) {
+	const count = await appealUserRepository.countRule6RolesForUser(userLookup);
+
+	return count > 0;
+}
+
 module.exports = {
 	createUser,
 	searchUsers,
 	getUserByEmail,
 	getUserById,
-	getUserWithRule6Parties,
 	updateUser,
 	removeLPAUser,
-	linkUserToAppeal
+	linkUserToAppeal,
+	isRule6User
 };

--- a/packages/appeals-service-api/src/routes/v2/users/spec.yaml
+++ b/packages/appeals-service-api/src/routes/v2/users/spec.yaml
@@ -43,7 +43,6 @@ paths:
         - users
       parameters:
         - $ref: '#/components/parameters/userLookup'
-        - $ref: '#/components/parameters/withRule6Parties'
       responses:
         200:
           description: The appeal user
@@ -108,6 +107,35 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorBody'
+  /api/v2/users/{userLookup}/isRule6User:
+    get:
+      tags:
+        - users
+      description: Confirm if a user has any appeals when has rule 6 party role
+      parameters:
+        - in: path
+          name: userLookup
+          required: true
+          schema:
+            type: string
+            format: email
+          example: me@example.com
+          description: user email
+      responses:
+        200:
+          description: Created role
+          content:
+            application/json:
+              schema:
+                type: boolean
+        400:
+          description: Bad request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorBody'
+        500:
+          description: Something went wrong
   /api/v2/users/{email}/appeal/{appealId}:
     put:
       tags:
@@ -187,9 +215,3 @@ components:
       schema:
         type: string
       description: local planning authority code
-    withRule6Parties:
-      name: withRule6Parties
-      in: query
-      schema:
-        type: boolean
-        example: 'true'

--- a/packages/appeals-service-api/src/routes/v2/users/users.spec.js
+++ b/packages/appeals-service-api/src/routes/v2/users/users.spec.js
@@ -342,6 +342,20 @@ describe('users v2', () => {
 			expect(response.status).toEqual(200);
 			expect(response.body).toEqual(false);
 		});
+
+		it('should return true if user has any rule 6 roles', async () => {
+			const testEmail = crypto.randomUUID() + '@example.com';
+			await _createSqlUser(testEmail);
+			const appeal = await _createSqlAppeal();
+			await appealsApi.post(`/api/v2/users/${testEmail}/appeal/${appeal.id}`).send({
+				role: APPEAL_USER_ROLES.RULE_6_PARTY
+			});
+
+			const response = await appealsApi.get(`/api/v2/users/${testEmail}/isRule6User`);
+
+			expect(response.status).toEqual(200);
+			expect(response.body).toEqual(true);
+		});
 	});
 });
 

--- a/packages/appeals-service-api/src/routes/v2/users/users.spec.js
+++ b/packages/appeals-service-api/src/routes/v2/users/users.spec.js
@@ -332,6 +332,17 @@ describe('users v2', () => {
 			expect(response.body.role).toEqual(APPEAL_USER_ROLES.AGENT);
 		});
 	});
+
+	describe('isRule6User', () => {
+		it('should return false if user has no rule 6 roles', async () => {
+			const testEmail = crypto.randomUUID() + '@example.com';
+			await _createSqlUser(testEmail);
+			const response = await appealsApi.get(`/api/v2/users/${testEmail}/isRule6User`);
+
+			expect(response.status).toEqual(200);
+			expect(response.body).toEqual(false);
+		});
+	});
 });
 
 /**

--- a/packages/common/src/client/appeals-api-client.js
+++ b/packages/common/src/client/appeals-api-client.js
@@ -113,13 +113,10 @@ class AppealsApiClient {
 
 	/**
 	 * @param {string} email
-	 * @returns {Promise<AppealUser>}
+	 * @returns {Promise<boolean>}
 	 */
-	async getUserWithRule6Parties(email) {
-		const urlParams = new URLSearchParams();
-		urlParams.append('withRule6Parties', 'true');
-
-		const endpoint = `${v2}/users/${encodeURIComponent(email?.trim())}?${urlParams.toString()}`;
+	async isRule6User(email) {
+		const endpoint = `${v2}/users/${encodeURIComponent(email?.trim())}/isRule6User`;
 		const response = await this.#makeGetRequest(endpoint);
 		return response.json();
 	}

--- a/packages/forms-web-app/src/services/user.service.js
+++ b/packages/forms-web-app/src/services/user.service.js
@@ -139,8 +139,8 @@ const setLPAUserStatus = async (req, userId, status) => {
  */
 
 const isRule6UserByEmail = async (req, email) => {
-	const user = await req.appealsApiClient.getUserWithRule6Parties(email);
-	return !!user.Rule6Parties && user.Rule6Parties.length > 0;
+	const isRule6User = await req.appealsApiClient.isRule6User(email);
+	return isRule6User;
 };
 
 module.exports = {


### PR DESCRIPTION
## Ticket Number

## Description of change

Amend functions and api calls which check whether user is a rule 6 user.  Now uses count to check for Rule6Party role on AppealToUser array on AppealUser.

## Checklist

<!-- Put an `x` in all the boxes that apply: -->

- [ ] Requires infrastructure changes
- [ ] I have updated the documentation accordingly
- [ ] My commit history in this PR is linear
- [ ] New features have tests
- [ ] Breaking change (team conversation required)

## Important

Please do not merge from `main` (please only [rebase](https://github.com/Planning-Inspectorate/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
