### PR TITLE
feat(a2-1271): show awaiting review documents on dashboards

### DIFF
--- a/packages/appeals-service-api/src/routes/v2/appeal-cases/_caseReference/appeal-final-comments/repo.js
+++ b/packages/appeals-service-api/src/routes/v2/appeal-cases/_caseReference/appeal-final-comments/repo.js
@@ -15,7 +15,8 @@ const IndirectDocumentsArgsPublishedOnly = {
 				publishedDocumentURI: true,
 				filename: true,
 				documentType: true,
-				datePublished: true
+				datePublished: true,
+				redacted: true
 			}
 		}
 	}

--- a/packages/appeals-service-api/src/routes/v2/appeal-cases/repo.js
+++ b/packages/appeals-service-api/src/routes/v2/appeal-cases/repo.js
@@ -87,7 +87,8 @@ const DocumentsArgsPublishedOnly = {
 		publishedDocumentURI: true,
 		filename: true,
 		documentType: true,
-		datePublished: true
+		datePublished: true,
+		redacted: true
 	}
 };
 

--- a/packages/appeals-service-api/src/routes/v2/documents/repo.js
+++ b/packages/appeals-service-api/src/routes/v2/documents/repo.js
@@ -27,8 +27,10 @@ const mapDataModelToFODBDocument = ({
 	stage: caseStage,
 	published: !!commonFields.datePublished,
 	redacted:
-		redactedStatus === APPEAL_REDACTED_STATUS.REDACTED ||
-		redactedStatus === APPEAL_REDACTED_STATUS.NO_REDACTION_REQUIRED
+		redactedStatus === null
+			? null
+			: redactedStatus === APPEAL_REDACTED_STATUS.REDACTED ||
+			  redactedStatus === APPEAL_REDACTED_STATUS.NO_REDACTION_REQUIRED
 });
 
 module.exports = class Repo {

--- a/packages/common/src/lib/format-appeal-documents.js
+++ b/packages/common/src/lib/format-appeal-documents.js
@@ -65,9 +65,13 @@ exports.formatNotificationMethod = (caseData) => {
  * @returns {string}
  */
 const formatDocumentLink = (document) => {
-	return `<a href="/published-document/${document.id}" class="govuk-link">${escape(
-		document.filename
-	)}</a>`;
+	if (document.redacted) {
+		return `<a href="/published-document/${document.id}" class="govuk-link">${escape(
+			document.filename
+		)}</a>`;
+	}
+
+	return escape(document.filename) + ' - awaiting review';
 };
 
 /**

--- a/packages/common/src/lib/format-appeal-documents.test.js
+++ b/packages/common/src/lib/format-appeal-documents.test.js
@@ -2,7 +2,8 @@ const {
 	documentExists,
 	hasNotificationMethods,
 	formatNotificationMethod,
-	sortDocumentsByDate
+	sortDocumentsByDate,
+	formatDocumentDetails
 } = require('./format-appeal-documents');
 const { LPA_NOTIFICATION_METHODS } = require('../database/data-static');
 
@@ -66,6 +67,22 @@ describe('format-case-type:', () => {
 			).toEqual('A site notice\nLetter/email to interested parties');
 		});
 	});
+
+	describe('formatDocumentLink', () => {
+		it('returns "No" for no documents', () => {
+			expect(formatDocumentDetails([], '')).toEqual('No');
+			expect(formatDocumentDetails([{ documentType: 'a' }], 'b')).toEqual('No');
+		});
+
+		it('returns escaped links for document, or awaiting review for unredacted docs', () => {
+			const doc1 = { documentType: 'a', id: '1', filename: 'test>1', redacted: true };
+			const doc2 = { documentType: 'a', id: '2', filename: 'test>2', redacted: false };
+			expect(formatDocumentDetails([doc1, doc2], 'a')).toEqual(
+				'<a href="/published-document/1" class="govuk-link">test&gt;1</a>\ntest&gt;2 - awaiting review'
+			);
+		});
+	});
+
 	describe('sortDocumentsByDate', () => {
 		it('should sort documents by datePublished in ascending order', () => {
 			const documents = [

--- a/packages/database/src/migrations/20241023174115_allow_null_redaction/migration.sql
+++ b/packages/database/src/migrations/20241023174115_allow_null_redaction/migration.sql
@@ -1,0 +1,20 @@
+BEGIN TRY
+
+BEGIN TRAN;
+
+-- AlterTable
+ALTER TABLE [dbo].[Document] DROP CONSTRAINT [Document_redacted_df];
+ALTER TABLE [dbo].[Document] ALTER COLUMN [redacted] BIT NULL;
+
+COMMIT TRAN;
+
+END TRY
+BEGIN CATCH
+
+IF @@TRANCOUNT > 0
+BEGIN
+    ROLLBACK TRAN;
+END;
+THROW
+
+END CATCH

--- a/packages/database/src/schema.prisma
+++ b/packages/database/src/schema.prisma
@@ -564,8 +564,8 @@ model Document {
 
   // states
   virusCheckStatus String? // nullble?
-  published        Boolean @default(false)
-  redacted         Boolean @default(false)
+  published        Boolean  @default(false)
+  redacted         Boolean?
   version          Int?
   fileMD5          String?
   owner            String?

--- a/packages/database/src/seed/appeal-documents-dev.js
+++ b/packages/database/src/seed/appeal-documents-dev.js
@@ -668,6 +668,40 @@ const appealDocuments = [
 		origin: 'pins',
 		stage: 'decision',
 		AppealCase: {}
+	},
+	{
+		id: '15113775-801a-46fe-ada7-7432e6e1c571',
+		filename: 'example-false-redaction.txt',
+		originalFilename: 'example.txt',
+		size: 16,
+		mime: 'text/plain',
+		documentURI: '',
+		dateCreated: new Date(),
+		published: true,
+		redacted: false,
+		virusCheckStatus: APPEAL_VIRUS_CHECK_STATUS.SCANNED,
+		documentType: APPEAL_DOCUMENT_TYPE.ORIGINAL_APPLICATION_FORM,
+		sourceSystem: 'appeals',
+		origin: 'pins',
+		stage: 'decision',
+		AppealCase: {}
+	},
+	{
+		id: '3332324c-386e-43c9-803f-f94b58a4a562',
+		filename: 'example-null-redaction.txt',
+		originalFilename: 'example.txt',
+		size: 16,
+		mime: 'text/plain',
+		documentURI: '',
+		dateCreated: new Date(),
+		published: true,
+		redacted: null,
+		virusCheckStatus: APPEAL_VIRUS_CHECK_STATUS.SCANNED,
+		documentType: APPEAL_DOCUMENT_TYPE.ORIGINAL_APPLICATION_FORM,
+		sourceSystem: 'appeals',
+		origin: 'pins',
+		stage: 'decision',
+		AppealCase: {}
 	}
 ];
 

--- a/packages/forms-web-app/src/controllers/selected-appeal/appeal-details/appeal-documents-rows.test.js
+++ b/packages/forms-web-app/src/controllers/selected-appeal/appeal-details/appeal-documents-rows.test.js
@@ -15,7 +15,8 @@ describe('appeal-documents-rows', () => {
 					{
 						id: 1,
 						documentType: APPEAL_DOCUMENT_TYPE.ORIGINAL_APPLICATION_FORM,
-						filename: 'test.txt'
+						filename: 'test.txt',
+						redacted: true
 					}
 				]
 			},

--- a/packages/forms-web-app/src/controllers/selected-appeal/planning-obligation-details/planning-obligation-details-rows.test.js
+++ b/packages/forms-web-app/src/controllers/selected-appeal/planning-obligation-details/planning-obligation-details-rows.test.js
@@ -12,7 +12,8 @@ describe('planningObligationRows', () => {
 				{
 					id: 1,
 					documentType: APPEAL_DOCUMENT_TYPE.PLANNING_OBLIGATION,
-					filename: 'test.txt'
+					filename: 'test.txt',
+					redacted: true
 				}
 			]
 		});

--- a/packages/forms-web-app/src/controllers/selected-appeal/questionnaire-details/constraints-details-rows.test.js
+++ b/packages/forms-web-app/src/controllers/selected-appeal/questionnaire-details/constraints-details-rows.test.js
@@ -14,7 +14,8 @@ describe('constraintsRows', () => {
 				{
 					id: 1,
 					documentType: APPEAL_DOCUMENT_TYPE.CONSERVATION_MAP,
-					filename: 'test.txt'
+					filename: 'test.txt',
+					redacted: true
 				}
 			]
 		});

--- a/packages/forms-web-app/src/controllers/selected-appeal/questionnaire-details/consultation-details-rows.test.js
+++ b/packages/forms-web-app/src/controllers/selected-appeal/questionnaire-details/consultation-details-rows.test.js
@@ -14,7 +14,8 @@ describe('consultationRows', () => {
 				{
 					id: 1,
 					documentType: APPEAL_DOCUMENT_TYPE.CONSULTATION_RESPONSES,
-					filename: 'test.txt'
+					filename: 'test.txt',
+					redacted: true
 				}
 			]
 		});

--- a/packages/forms-web-app/src/controllers/selected-appeal/questionnaire-details/environmental-details-rows.test.js
+++ b/packages/forms-web-app/src/controllers/selected-appeal/questionnaire-details/environmental-details-rows.test.js
@@ -13,7 +13,8 @@ describe('environmentalRows', () => {
 				{
 					id: 1,
 					documentType: APPEAL_DOCUMENT_TYPE.EIA_SCREENING_DIRECTION,
-					filename: 'test.txt'
+					filename: 'test.txt',
+					redacted: true
 				}
 			]
 		});

--- a/packages/forms-web-app/src/controllers/selected-appeal/questionnaire-details/planning-officer-details-rows.test.js
+++ b/packages/forms-web-app/src/controllers/selected-appeal/questionnaire-details/planning-officer-details-rows.test.js
@@ -13,12 +13,14 @@ describe('planningOfficerReportRows', () => {
 				{
 					id: 1,
 					documentType: APPEAL_DOCUMENT_TYPE.PLANNING_OFFICER_REPORT,
-					filename: 'test.txt'
+					filename: 'test.txt',
+					redacted: true
 				},
 				{
 					id: 2,
 					documentType: APPEAL_DOCUMENT_TYPE.DEVELOPMENT_PLAN_POLICIES,
-					filename: 'test2.txt'
+					filename: 'test2.txt',
+					redacted: true
 				}
 			]
 		});

--- a/packages/integration-functions/src/functions/appeal-document.js
+++ b/packages/integration-functions/src/functions/appeal-document.js
@@ -8,13 +8,9 @@
  */
 
 const { app } = require('@azure/functions');
-const { APPEAL_VIRUS_CHECK_STATUS, APPEAL_REDACTED_STATUS } = require('pins-data-model');
+const { APPEAL_VIRUS_CHECK_STATUS } = require('pins-data-model');
 
 const VALID_SCAN_STATUSES = [APPEAL_VIRUS_CHECK_STATUS.SCANNED];
-const VALID_REDACTED_STATUSES = [
-	APPEAL_REDACTED_STATUS.REDACTED,
-	APPEAL_REDACTED_STATUS.NO_REDACTION_REQUIRED
-];
 const createApiClient = require('../common/api-client');
 
 /**
@@ -61,30 +57,16 @@ async function processDocumentMetadata(context, documentMessage) {
  * @throws {Error} message schema is invalid
  */
 function checkMessageIsValid(documentMessage, context) {
-	let isValid = false;
+	context.log('documentMessage.virusCheckStatus ', documentMessage);
 
-	context.log('documentMessage.virusCheckStatus ', documentMessage.virusCheckStatus);
-	context.log('documentMessage.datePublished ', documentMessage.datePublished);
-	context.log('documentMessage.redactedStatus ', documentMessage.redactedStatus);
-	context.log('documentMessage.documentId ', documentMessage.documentId);
-
-	if (
-		!documentMessage.virusCheckStatus ||
-		!documentMessage.datePublished ||
-		!documentMessage.redactedStatus ||
-		!documentMessage.documentId
-	) {
+	if (!documentMessage.virusCheckStatus || !documentMessage.documentId) {
 		throw new Error('Invalid message schema');
 	}
 
-	if (
-		VALID_SCAN_STATUSES.includes(documentMessage.virusCheckStatus) &&
-		VALID_REDACTED_STATUSES.includes(documentMessage.redactedStatus)
-	) {
-		isValid = true;
-	}
-
-	return isValid;
+	return (
+		!!documentMessage.datePublished &&
+		VALID_SCAN_STATUSES.includes(documentMessage.virusCheckStatus)
+	);
 }
 
 /**


### PR DESCRIPTION
## Ticket Number

<!-- Add the number from the Jira board -->

https://pins-ds.atlassian.net/browse/a2-1271

## Description of change

- Makes redacted nullable
- Allows through null/not redacted statuses from service bus
- Displays awaiting review next to documents if they are not redacted yet

## Checklist

<!-- Put an `x` in all the boxes that apply: -->

- [ ] Requires infrastructure changes
- [ ] I have updated the documentation accordingly
- [x] My commit history in this PR is linear
- [x] New features have tests
- [ ] Breaking change (team conversation required)

## Important

Please do not merge from `main` (please only [rebase](https://github.com/Planning-Inspectorate/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
