### PR TITLE
fix(A2-1395): stop doc links being added to nav history

### DIFF
--- a/packages/forms-web-app/__tests__/unit/middleware/navigation-history.test.js
+++ b/packages/forms-web-app/__tests__/unit/middleware/navigation-history.test.js
@@ -210,6 +210,25 @@ describe('middleware/navigation-history', () => {
 				expect(next).toHaveBeenCalled();
 				expect(req.session.navigationHistory).toEqual(['/x/y/z', '/a', '/b']);
 			}
+		},
+		{
+			description: 'should not add published-document links to the navigation history',
+			given: () => ({
+				config: undefined,
+				req: {
+					...mockReq(),
+					session: {
+						...mockReq().session,
+						navigationHistory: ['/previous-page']
+					},
+					baseUrl: '',
+					path: '/published-document/some-document-id'
+				}
+			}),
+			expected: (req, res, next) => {
+				expect(next).toHaveBeenCalled();
+				expect(req.session.navigationHistory).toEqual(['/previous-page']);
+			}
 		}
 	].forEach(({ description, given, expected }) => {
 		it(description, () => {

--- a/packages/forms-web-app/src/middleware/navigation-history.js
+++ b/packages/forms-web-app/src/middleware/navigation-history.js
@@ -32,6 +32,12 @@ module.exports =
 
 		const currentPage = req.baseUrl + req.path;
 
+		// prevent document links being added to nav history
+		if (currentPage.includes('published-document')) {
+			next();
+			return;
+		}
+
 		// going forwards
 		if (currentPage === req.session.navigationHistory[0]) {
 			if (req.session.navigationHistory.length > 1) {


### PR DESCRIPTION
## Ticket Number

<!-- Add the number from the Jira board -->

https://pins-ds.atlassian.net/browse/A2-1395

## Description of change

when a user clicks a doc link it gets added the nav history so breaks the back button working properly.
this stops the doc link being added to the nav history

## Checklist

<!-- Put an `x` in all the boxes that apply: -->

- [ ] Requires infrastructure changes
- [ ] I have updated the documentation accordingly
- [x] My commit history in this PR is linear
- [x] New features have tests
- [ ] Breaking change (team conversation required)

## Important

Please do not merge from `main` (please only [rebase](https://github.com/Planning-Inspectorate/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
