### PR TITLE
Feat/a2 745 display has q appellant dashboard

### DIFF
--- a/packages/common/src/lib/format-address.js
+++ b/packages/common/src/lib/format-address.js
@@ -93,7 +93,7 @@ const formatAppealSubmissionAddress = (appealSubmission) => {
  * @param {NeighbouringAddress} neighbourAddress
  * @returns {string}
  */
-const formatNeibouringAddressWithBreaks = (neighbourAddress) => {
+const formatNeighbouringAddressWithBreaks = (neighbourAddress) => {
 	const addressComponents = [
 		neighbourAddress.addressLine1,
 		neighbourAddress.addressLine2,
@@ -142,7 +142,7 @@ function isV2Submission(caseOrSubmission) {
 module.exports = {
 	formatAddress,
 	formatAddressWithBreaks,
-	formatNeibouringAddressWithBreaks,
+	formatNeighbouringAddressWithBreaks,
 	formatSubmissionAddress,
 	isAppealSubmission,
 	isV2Submission

--- a/packages/database/src/seed/data-dev.js
+++ b/packages/database/src/seed/data-dev.js
@@ -421,15 +421,15 @@ const appealCases = [
 		isCorrectAppealType: true,
 		scheduledMonument: false,
 		conservationArea: false,
-		protectedSpecies: false,
-		isGreenBelt: false,
-		areaOutstandingBeauty: false,
-		designatedSites: 'None',
-		treePreservationOrder: false,
-		gypsyTraveller: true,
-		publicRightOfWay: false,
+		protectedSpecies: null,
+		isGreenBelt: true,
+		areaOutstandingBeauty: null,
+		designatedSites: null,
+		treePreservationOrder: null,
+		gypsyTraveller: null,
+		publicRightOfWay: null,
 		// environmental
-		environmentalImpactSchedule: 'no',
+		environmentalImpactSchedule: null,
 		sensitiveArea: false,
 		columnTwoThreshold: false,
 		screeningOpinion: false,
@@ -440,23 +440,25 @@ const appealCases = [
 		consultationResponses: false,
 		otherPartyRepresentations: false,
 		// planning officer reports
-		emergingPlan: false,
-		supplementaryPlanningDocs: false,
-		infrastructureLevy: true,
-		infrastructureLevyAdopted: false,
-		infrastructureLevyExpectedDate: new Date(Date.now()),
+		emergingPlan: true,
+		supplementaryPlanningDocs: true,
+		infrastructureLevy: null,
+		infrastructureLevyAdopted: null,
+		infrastructureLevyExpectedDate: null,
 		// site access
-		lpaSiteAccess: false,
-		neighbouringSiteAccess: false,
-		addNeighbouringSiteAccess: true,
-		lpaSiteSafetyRisks: false,
+		lpaSiteAccess: true,
+		lpaSiteAccessDetails: 'site access details',
+		neighbouringSiteAccess: null,
+		addNeighbouringSiteAccess: null,
+		neighbouringSiteAccessDetails: null,
+		lpaSiteSafetyRisks: true,
+		lpaSiteSafetyRiskDetails: 'generic dangers',
 		// appeal process
-		lpaProcedurePreference: APPEAL_CASE_PROCEDURE.INQUIRY,
-		lpaPreferInquiryDetails: 'Example preference',
-		lpaPreferInquiryDuration: '6',
+		lpaProcedurePreference: null,
+		lpaProcedurePreferenceDetails: null,
+		lpaProcedurePreferenceDuration: null,
 		changedDevelopmentDescription: true,
-		newConditionDetails: 'Example new conditions',
-		ProcedureType: { connect: { key: APPEAL_CASE_PROCEDURE.INQUIRY } }
+		newConditionDetails: 'Example new conditions'
 	},
 	{
 		Appeal: {
@@ -960,6 +962,54 @@ const caseListedBuilding = [
  * @type {import('@prisma/client').Prisma.AppealCaseLpaNotificationMethodCreateInput[]}
  */
 const caseNotificationMethods = [
+	{
+		AppealCase: {
+			connect: {
+				caseReference: caseReferences.caseReferenceOne
+			}
+		},
+		LPANotificationMethod: {
+			connect: {
+				key: 'notice'
+			}
+		}
+	},
+	{
+		AppealCase: {
+			connect: {
+				caseReference: caseReferences.caseReferenceOne
+			}
+		},
+		LPANotificationMethod: {
+			connect: {
+				key: 'notice'
+			}
+		}
+	},
+	{
+		AppealCase: {
+			connect: {
+				caseReference: caseReferences.caseReferenceOne
+			}
+		},
+		LPANotificationMethod: {
+			connect: {
+				key: 'letter'
+			}
+		}
+	},
+	{
+		AppealCase: {
+			connect: {
+				caseReference: caseReferences.caseReferenceOne
+			}
+		},
+		LPANotificationMethod: {
+			connect: {
+				key: 'advert'
+			}
+		}
+	},
 	{
 		AppealCase: {
 			connect: {

--- a/packages/forms-web-app/src/controllers/selected-appeal/appeal-details/appeal-documents-rows.js
+++ b/packages/forms-web-app/src/controllers/selected-appeal/appeal-details/appeal-documents-rows.js
@@ -1,5 +1,5 @@
 const { formatDocumentDetails, formatNewDescription } = require('@pins/common');
-const { APPEAL_USER_ROLES } = require('@pins/common/src/constants');
+const { APPEALS_CASE_DATA, APPEAL_USER_ROLES } = require('@pins/common/src/constants');
 const { APPEAL_DOCUMENT_TYPE } = require('pins-data-model');
 
 /**
@@ -32,7 +32,7 @@ exports.documentsRows = (caseData, userType) => {
 		{
 			keyText: 'Plans, drawings and supporting documents',
 			valueText: formatDocumentDetails(documents, APPEAL_DOCUMENT_TYPE.PLANS_DRAWINGS),
-			condition: () => true,
+			condition: () => caseData.appealTypeCode === APPEALS_CASE_DATA.APPEAL_TYPE_CODE.S78,
 			isEscaped: true
 		},
 		{

--- a/packages/forms-web-app/src/controllers/selected-appeal/appeal-details/appeal-documents-rows.test.js
+++ b/packages/forms-web-app/src/controllers/selected-appeal/appeal-details/appeal-documents-rows.test.js
@@ -1,5 +1,5 @@
 const { documentsRows } = require('./appeal-documents-rows');
-const { APPEAL_USER_ROLES } = require('@pins/common/src/constants');
+const { APPEAL_USER_ROLES, APPEALS_CASE_DATA } = require('@pins/common/src/constants');
 const { APPEAL_DOCUMENT_TYPE } = require('pins-data-model');
 
 describe('appeal-documents-rows', () => {
@@ -29,5 +29,28 @@ describe('appeal-documents-rows', () => {
 		expect(rows[0].valueText).toEqual(
 			'<a href="/published-document/1" class="govuk-link">test.txt</a>'
 		);
+	});
+
+	describe('Plans, drawings and supporting documents', () => {
+		it('should display field if S78', () => {
+			const rows = documentsRows(
+				{ appealTypeCode: APPEALS_CASE_DATA.APPEAL_TYPE_CODE.S78 },
+				APPEAL_USER_ROLES.APPELLANT
+			);
+			expect(rows[2].keyText).toEqual('Plans, drawings and supporting documents');
+			expect(rows[2].valueText).toEqual('No');
+			expect(rows[2].condition()).toEqual(true);
+			expect(rows[2].isEscaped).toEqual(true);
+		});
+		it('should not display field if not S78', () => {
+			const rows = documentsRows(
+				{ appealTypeCode: APPEALS_CASE_DATA.APPEAL_TYPE_CODE.HAS },
+				APPEAL_USER_ROLES.APPELLANT
+			);
+			expect(rows[2].keyText).toEqual('Plans, drawings and supporting documents');
+			expect(rows[2].valueText).toEqual('No');
+			expect(rows[2].condition()).toEqual(false);
+			expect(rows[2].isEscaped).toEqual(true);
+		});
 	});
 });

--- a/packages/forms-web-app/src/controllers/selected-appeal/questionnaire-details/appeal-process-details-rows.js
+++ b/packages/forms-web-app/src/controllers/selected-appeal/questionnaire-details/appeal-process-details-rows.js
@@ -5,6 +5,7 @@ const {
 	formatRelatedAppeals
 } = require('@pins/common');
 const { CASE_RELATION_TYPES } = require('@pins/common/src/database/data-static');
+const { isNotUndefinedOrNull } = require('#lib/is-not-undefined-or-null');
 
 /**
  * @param {import('appeals-service-api').Api.AppealCaseDetailed } caseData
@@ -18,12 +19,12 @@ exports.appealProcessRows = (caseData) => {
 		{
 			keyText: 'Appeal procedure',
 			valueText: formatProcedurePreference(caseData),
-			condition: () => caseData.lpaProcedurePreference
+			condition: () => !!caseData.lpaProcedurePreference
 		},
 		{
 			keyText: 'Appeals near the site',
 			valueText: boolToYesNo(showNearby),
-			condition: () => true
+			condition: () => isNotUndefinedOrNull(caseData.relations)
 		},
 		{
 			keyText: 'Appeal references',
@@ -33,7 +34,7 @@ exports.appealProcessRows = (caseData) => {
 		{
 			keyText: 'Extra conditions',
 			valueText: formatConditions(caseData),
-			condition: () => caseData.changedDevelopmentDescription
+			condition: () => isNotUndefinedOrNull(caseData.changedDevelopmentDescription)
 		}
 	];
 };

--- a/packages/forms-web-app/src/controllers/selected-appeal/questionnaire-details/appeal-process-details.test.js
+++ b/packages/forms-web-app/src/controllers/selected-appeal/questionnaire-details/appeal-process-details.test.js
@@ -1,0 +1,76 @@
+const { APPEAL_CASE_PROCEDURE } = require('pins-data-model');
+const { appealProcessRows } = require('./appeal-process-details-rows');
+const { CASE_RELATION_TYPES } = require('@pins/common/src/database/data-static');
+
+describe('appealProcessRows', () => {
+	it('should create rows with correct data if relevant case data fields exist & field values populated', () => {
+		const caseData = {
+			lpaProcedurePreference: APPEAL_CASE_PROCEDURE.INQUIRY,
+			lpaProcedurePreferenceDetails: 'inquiry preference',
+			lpaProcedurePreferenceDuration: 6,
+			changedDevelopmentDescription: true,
+			newConditionDetails: 'new condition details',
+			relations: [
+				{
+					id: 1,
+					type: CASE_RELATION_TYPES.nearby,
+					caseReference: '0000001',
+					caseReference2: '0000002'
+				}
+			]
+		};
+
+		const rows = appealProcessRows(caseData);
+
+		expect(rows.length).toEqual(4);
+		expect(rows[0].keyText).toEqual('Appeal procedure');
+		expect(rows[0].valueText).toEqual('Inquiry\ninquiry preference\nExpected duration: 6 days');
+		expect(rows[0].condition()).toEqual(true);
+
+		expect(rows[1].keyText).toEqual('Appeals near the site');
+		expect(rows[1].valueText).toEqual('Yes');
+		expect(rows[1].condition()).toEqual(true);
+
+		expect(rows[2].keyText).toEqual('Appeal references');
+		expect(rows[2].valueText).toEqual('0000002');
+		expect(rows[2].condition()).toEqual(true);
+
+		expect(rows[3].keyText).toEqual('Extra conditions');
+		expect(rows[3].valueText).toEqual('Yes\nnew condition details');
+		expect(rows[3].condition()).toEqual(true);
+	});
+
+	it('should handle false values correctly', () => {
+		const caseData = {
+			changedDevelopmentDescription: false,
+			newConditionDetails: false,
+			relations: []
+		};
+
+		const rows = appealProcessRows(caseData);
+
+		expect(rows.length).toEqual(4);
+		expect(rows[0].keyText).toEqual('Appeal procedure');
+		expect(rows[0].condition()).toEqual(false);
+
+		expect(rows[1].keyText).toEqual('Appeals near the site');
+		expect(rows[1].valueText).toEqual('No');
+		expect(rows[1].condition()).toEqual(true);
+		expect(rows[2].keyText).toEqual('Appeal references');
+		expect(rows[2].condition()).toEqual(false);
+
+		expect(rows[3].keyText).toEqual('Extra conditions');
+		expect(rows[3].valueText).toEqual('No');
+		expect(rows[3].condition()).toEqual(true);
+	});
+
+	it('should not display if no fields/files exists', () => {
+		const rows = appealProcessRows({});
+
+		expect(rows.length).toEqual(4);
+		expect(rows[0].condition()).toEqual(false);
+		expect(rows[1].condition()).toEqual(false);
+		expect(rows[2].condition()).toEqual(false);
+		expect(rows[3].condition()).toEqual(false);
+	});
+});

--- a/packages/forms-web-app/src/controllers/selected-appeal/questionnaire-details/constraints-details-rows.js
+++ b/packages/forms-web-app/src/controllers/selected-appeal/questionnaire-details/constraints-details-rows.js
@@ -7,17 +7,11 @@ const {
 const { APPEAL_DOCUMENT_TYPE } = require('pins-data-model');
 
 /**
- * @typedef {import('@pins/common/src/constants').AppealToUserRoles} AppealToUserRoles
- * @typedef {import('@pins/common/src/constants').LpaUserRole} LpaUserRole
- */
-
-/**
  * @param {import('appeals-service-api').Api.AppealCaseDetailed} caseData
- * @param {AppealToUserRoles|LpaUserRole|null} _user
  * @returns {import("@pins/common/src/view-model-maps/rows/def").Rows}
  */
 
-exports.constraintsRows = (caseData, _user) => {
+exports.constraintsRows = (caseData) => {
 	const documents = caseData.Documents || [];
 
 	const affectedListedBuildings = caseData.AffectedListedBuildings;

--- a/packages/forms-web-app/src/controllers/selected-appeal/questionnaire-details/constraints-details-rows.js
+++ b/packages/forms-web-app/src/controllers/selected-appeal/questionnaire-details/constraints-details-rows.js
@@ -6,6 +6,7 @@ const {
 } = require('@pins/common');
 const { APPEALS_CASE_DATA } = require('@pins/common/src/constants');
 const { APPEAL_DOCUMENT_TYPE } = require('pins-data-model');
+const { isNotUndefinedOrNull } = require('#lib/is-not-undefined-or-null');
 
 /**
  * @param {import('appeals-service-api').Api.AppealCaseDetailed} caseData
@@ -14,7 +15,6 @@ const { APPEAL_DOCUMENT_TYPE } = require('pins-data-model');
 
 exports.constraintsRows = (caseData) => {
 	const documents = caseData.Documents || [];
-	const isNotHAS = caseData.appealTypeCode !== APPEALS_CASE_DATA.APPEAL_TYPE_CODE.HAS;
 
 	const affectedListedBuildings = caseData.AffectedListedBuildings;
 	const showAffectedListed = !!(affectedListedBuildings && affectedListedBuildings.length);
@@ -35,12 +35,12 @@ exports.constraintsRows = (caseData) => {
 		{
 			keyText: 'Is this the correct type of appeal',
 			valueText: formatYesOrNo(caseData, 'isCorrectAppealType'),
-			condition: () => conditionYesOrNo(caseData.isCorrectAppealType)
+			condition: () => isNotUndefinedOrNull(caseData.isCorrectAppealType)
 		},
 		{
 			keyText: 'Affects a listed building',
 			valueText: affectedListedBuildingText,
-			condition: () => conditionYesOrNo(caseData.AffectedListedBuildings)
+			condition: () => isNotUndefinedOrNull(caseData.AffectedListedBuildings)
 		},
 		{
 			// todo: bring in listed building details after move of listed building data to sql
@@ -51,12 +51,14 @@ exports.constraintsRows = (caseData) => {
 		{
 			keyText: 'Affects a scheduled monument',
 			valueText: formatYesOrNo(caseData, 'scheduledMonument'),
-			condition: () => isNotHAS && conditionYesOrNo(caseData.scheduledMonument)
+			condition: () =>
+				caseData.appealTypeCode !== APPEALS_CASE_DATA.APPEAL_TYPE_CODE.HAS &&
+				isNotUndefinedOrNull(caseData.scheduledMonument)
 		},
 		{
 			keyText: 'Conservation area',
 			valueText: formatYesOrNo(caseData, 'conservationArea'),
-			condition: () => conditionYesOrNo(caseData.conservationArea)
+			condition: () => isNotUndefinedOrNull(caseData.conservationArea)
 		},
 		{
 			keyText: 'Uploaded conservation area map and guidance',
@@ -69,33 +71,32 @@ exports.constraintsRows = (caseData) => {
 		{
 			keyText: 'Protected species',
 			valueText: formatYesOrNo(caseData, 'protectedSpecies'),
-			condition: () => isNotHAS && conditionYesOrNo(caseData.protectedSpecies)
+			condition: () => isNotUndefinedOrNull(caseData.protectedSpecies)
 		},
 		{
 			keyText: 'Green belt',
 			valueText: formatYesOrNo(caseData, 'isGreenBelt'),
-			condition: () => conditionYesOrNo(caseData.isGreenBelt)
+			condition: () => isNotUndefinedOrNull(caseData.isGreenBelt)
 		},
 		{
 			keyText: 'Area of outstanding natural beauty',
 			valueText: formatYesOrNo(caseData, 'areaOutstandingBeauty'),
-			condition: () => isNotHAS && conditionYesOrNo(caseData.areaOutstandingBeauty)
+			condition: () => isNotUndefinedOrNull(caseData.areaOutstandingBeauty)
 		},
 		{
 			keyText: 'Designated sites',
 			valueText: formatDesignations(caseData),
-			condition: () => isNotHAS && !!formatDesignations(caseData)
+			condition: () => !!formatDesignations(caseData)
 		},
 		{
 			keyText: 'Tree Preservation Order',
 			valueText: formatYesOrNo(caseData, 'treePreservationOrder'),
-			condition: () => isNotHAS && conditionYesOrNo(caseData.treePreservationOrder)
+			condition: () => isNotUndefinedOrNull(caseData.treePreservationOrder)
 		},
 		{
 			keyText: 'Uploaded Tree Preservation Order extent',
 			valueText: formatDocumentDetails(documents, APPEAL_DOCUMENT_TYPE.TREE_PRESERVATION_PLAN),
 			condition: () =>
-				isNotHAS &&
 				!!caseData.treePreservationOrder &&
 				documentExists(documents, APPEAL_DOCUMENT_TYPE.TREE_PRESERVATION_PLAN),
 			isEscaped: true
@@ -103,29 +104,20 @@ exports.constraintsRows = (caseData) => {
 		{
 			keyText: 'Gypsy or Traveller',
 			valueText: formatYesOrNo(caseData, 'gypsyTraveller'),
-			condition: () => isNotHAS && conditionYesOrNo(caseData.gypsyTraveller)
+			condition: () => isNotUndefinedOrNull(caseData.gypsyTraveller)
 		},
 		{
 			keyText: 'Public right of way',
 			valueText: formatYesOrNo(caseData, 'publicRightOfWay'),
-			condition: () => isNotHAS && conditionYesOrNo(caseData.publicRightOfWay)
+			condition: () => isNotUndefinedOrNull(caseData.publicRightOfWay)
 		},
 		{
 			keyText: 'Uploaded definitive map and statement extract',
 			valueText: formatDocumentDetails(documents, APPEAL_DOCUMENT_TYPE.DEFINITIVE_MAP_STATEMENT),
-			condition: () =>
-				isNotHAS && documentExists(documents, APPEAL_DOCUMENT_TYPE.DEFINITIVE_MAP_STATEMENT),
+			condition: () => documentExists(documents, APPEAL_DOCUMENT_TYPE.DEFINITIVE_MAP_STATEMENT),
 			isEscaped: true
 		}
 	];
 
 	return rows;
-};
-
-/**
- * @param {any} input
- * @returns {boolean}
- */
-const conditionYesOrNo = (input) => {
-	return !(input === undefined || input === null);
 };

--- a/packages/forms-web-app/src/controllers/selected-appeal/questionnaire-details/constraints-details-rows.js
+++ b/packages/forms-web-app/src/controllers/selected-appeal/questionnaire-details/constraints-details-rows.js
@@ -4,6 +4,7 @@ const {
 	formatDocumentDetails,
 	documentExists
 } = require('@pins/common');
+const { APPEALS_CASE_DATA } = require('@pins/common/src/constants');
 const { APPEAL_DOCUMENT_TYPE } = require('pins-data-model');
 
 /**
@@ -13,6 +14,7 @@ const { APPEAL_DOCUMENT_TYPE } = require('pins-data-model');
 
 exports.constraintsRows = (caseData) => {
 	const documents = caseData.Documents || [];
+	const isNotHAS = caseData.appealTypeCode !== APPEALS_CASE_DATA.APPEAL_TYPE_CODE.HAS;
 
 	const affectedListedBuildings = caseData.AffectedListedBuildings;
 	const showAffectedListed = !!(affectedListedBuildings && affectedListedBuildings.length);
@@ -49,8 +51,7 @@ exports.constraintsRows = (caseData) => {
 		{
 			keyText: 'Affects a scheduled monument',
 			valueText: formatYesOrNo(caseData, 'scheduledMonument'),
-			condition: () =>
-				caseData.scheduledMonument !== undefined && caseData.scheduledMonument !== null
+			condition: () => isNotHAS && conditionYesOrNo(caseData.scheduledMonument)
 		},
 		{
 			keyText: 'Conservation area',
@@ -68,7 +69,7 @@ exports.constraintsRows = (caseData) => {
 		{
 			keyText: 'Protected species',
 			valueText: formatYesOrNo(caseData, 'protectedSpecies'),
-			condition: () => conditionYesOrNo(caseData.protectedSpecies)
+			condition: () => isNotHAS && conditionYesOrNo(caseData.protectedSpecies)
 		},
 		{
 			keyText: 'Green belt',
@@ -78,22 +79,23 @@ exports.constraintsRows = (caseData) => {
 		{
 			keyText: 'Area of outstanding natural beauty',
 			valueText: formatYesOrNo(caseData, 'areaOutstandingBeauty'),
-			condition: () => conditionYesOrNo(caseData.areaOutstandingBeauty)
+			condition: () => isNotHAS && conditionYesOrNo(caseData.areaOutstandingBeauty)
 		},
 		{
 			keyText: 'Designated sites',
 			valueText: formatDesignations(caseData),
-			condition: () => !!formatDesignations(caseData)
+			condition: () => isNotHAS && !!formatDesignations(caseData)
 		},
 		{
 			keyText: 'Tree Preservation Order',
 			valueText: formatYesOrNo(caseData, 'treePreservationOrder'),
-			condition: () => conditionYesOrNo(caseData.treePreservationOrder)
+			condition: () => isNotHAS && conditionYesOrNo(caseData.treePreservationOrder)
 		},
 		{
 			keyText: 'Uploaded Tree Preservation Order extent',
 			valueText: formatDocumentDetails(documents, APPEAL_DOCUMENT_TYPE.TREE_PRESERVATION_PLAN),
 			condition: () =>
+				isNotHAS &&
 				!!caseData.treePreservationOrder &&
 				documentExists(documents, APPEAL_DOCUMENT_TYPE.TREE_PRESERVATION_PLAN),
 			isEscaped: true
@@ -101,17 +103,18 @@ exports.constraintsRows = (caseData) => {
 		{
 			keyText: 'Gypsy or Traveller',
 			valueText: formatYesOrNo(caseData, 'gypsyTraveller'),
-			condition: () => conditionYesOrNo(caseData.gypsyTraveller)
+			condition: () => isNotHAS && conditionYesOrNo(caseData.gypsyTraveller)
 		},
 		{
 			keyText: 'Public right of way',
 			valueText: formatYesOrNo(caseData, 'publicRightOfWay'),
-			condition: () => conditionYesOrNo(caseData.publicRightOfWay)
+			condition: () => isNotHAS && conditionYesOrNo(caseData.publicRightOfWay)
 		},
 		{
 			keyText: 'Uploaded definitive map and statement extract',
 			valueText: formatDocumentDetails(documents, APPEAL_DOCUMENT_TYPE.DEFINITIVE_MAP_STATEMENT),
-			condition: () => documentExists(documents, APPEAL_DOCUMENT_TYPE.DEFINITIVE_MAP_STATEMENT),
+			condition: () =>
+				isNotHAS && documentExists(documents, APPEAL_DOCUMENT_TYPE.DEFINITIVE_MAP_STATEMENT),
 			isEscaped: true
 		}
 	];

--- a/packages/forms-web-app/src/controllers/selected-appeal/questionnaire-details/constraints-details-rows.js
+++ b/packages/forms-web-app/src/controllers/selected-appeal/questionnaire-details/constraints-details-rows.js
@@ -4,7 +4,6 @@ const {
 	formatDocumentDetails,
 	documentExists
 } = require('@pins/common');
-const { LPA_USER_ROLE } = require('@pins/common/src/constants');
 const { APPEAL_DOCUMENT_TYPE } = require('pins-data-model');
 
 /**
@@ -14,15 +13,16 @@ const { APPEAL_DOCUMENT_TYPE } = require('pins-data-model');
 
 /**
  * @param {import('appeals-service-api').Api.AppealCaseDetailed} caseData
- * @param {AppealToUserRoles|LpaUserRole|null} user
+ * @param {AppealToUserRoles|LpaUserRole|null} _user
  * @returns {import("@pins/common/src/view-model-maps/rows/def").Rows}
  */
 
-exports.constraintsRows = (caseData, user) => {
+exports.constraintsRows = (caseData, _user) => {
 	const documents = caseData.Documents || [];
 
 	const affectedListedBuildings = caseData.AffectedListedBuildings;
 	const showAffectedListed = !!(affectedListedBuildings && affectedListedBuildings.length);
+	const affectedListedBuildingText = showAffectedListed ? 'Yes' : 'No';
 
 	const rows = [
 		// todo: s78 needs a type on relation
@@ -37,72 +37,82 @@ exports.constraintsRows = (caseData, user) => {
 		// 	condition: () => (caseData.changedListedBuildingNumber ? true : undefined)
 		// },
 		{
+			keyText: 'Is this the correct type of appeal',
+			valueText: formatYesOrNo(caseData, 'isCorrectAppealType'),
+			condition: () => conditionYesOrNo(caseData.isCorrectAppealType)
+		},
+		{
 			keyText: 'Affects a listed building',
-			valueText: 'Yes',
-			condition: () => showAffectedListed
+			valueText: affectedListedBuildingText,
+			condition: () => conditionYesOrNo(caseData.AffectedListedBuildings)
 		},
 		{
 			// todo: bring in listed building details after move of listed building data to sql
 			keyText: 'Listed building details',
-			valueText: affectedListedBuildings?.map((x) => x.listedBuildingReference).join('\n'),
+			valueText: affectedListedBuildings?.map((x) => x.listedBuildingReference).join('\n') || '',
 			condition: () => showAffectedListed
 		},
 		{
 			keyText: 'Affects a scheduled monument',
 			valueText: formatYesOrNo(caseData, 'scheduledMonument'),
-			condition: () => caseData.scheduledMonument
+			condition: () =>
+				caseData.scheduledMonument !== undefined && caseData.scheduledMonument !== null
 		},
 		{
 			keyText: 'Conservation area',
 			valueText: formatYesOrNo(caseData, 'conservationArea'),
-			condition: () => caseData.conservationArea
+			condition: () => conditionYesOrNo(caseData.conservationArea)
 		},
 		{
 			keyText: 'Uploaded conservation area map and guidance',
 			valueText: formatDocumentDetails(documents, APPEAL_DOCUMENT_TYPE.CONSERVATION_MAP),
-			condition: () => documentExists(documents, APPEAL_DOCUMENT_TYPE.CONSERVATION_MAP),
+			condition: () =>
+				!!caseData.conservationArea &&
+				documentExists(documents, APPEAL_DOCUMENT_TYPE.CONSERVATION_MAP),
 			isEscaped: true
 		},
 		{
 			keyText: 'Protected species',
 			valueText: formatYesOrNo(caseData, 'protectedSpecies'),
-			condition: () => caseData.protectedSpecies
+			condition: () => conditionYesOrNo(caseData.protectedSpecies)
 		},
 		{
 			keyText: 'Green belt',
 			valueText: formatYesOrNo(caseData, 'isGreenBelt'),
-			condition: () => caseData.isGreenBelt
+			condition: () => conditionYesOrNo(caseData.isGreenBelt)
 		},
 		{
 			keyText: 'Area of outstanding natural beauty',
 			valueText: formatYesOrNo(caseData, 'areaOutstandingBeauty'),
-			condition: () => caseData.areaOutstandingBeauty
+			condition: () => conditionYesOrNo(caseData.areaOutstandingBeauty)
 		},
 		{
 			keyText: 'Designated sites',
 			valueText: formatDesignations(caseData),
-			condition: () => caseData.designatedSites
+			condition: () => !!formatDesignations(caseData)
 		},
 		{
 			keyText: 'Tree Preservation Order',
 			valueText: formatYesOrNo(caseData, 'treePreservationOrder'),
-			condition: () => caseData.treePreservationOrder
+			condition: () => conditionYesOrNo(caseData.treePreservationOrder)
 		},
 		{
 			keyText: 'Uploaded Tree Preservation Order extent',
 			valueText: formatDocumentDetails(documents, APPEAL_DOCUMENT_TYPE.TREE_PRESERVATION_PLAN),
-			condition: () => documentExists(documents, APPEAL_DOCUMENT_TYPE.TREE_PRESERVATION_PLAN),
+			condition: () =>
+				!!caseData.treePreservationOrder &&
+				documentExists(documents, APPEAL_DOCUMENT_TYPE.TREE_PRESERVATION_PLAN),
 			isEscaped: true
 		},
 		{
 			keyText: 'Gypsy or Traveller',
 			valueText: formatYesOrNo(caseData, 'gypsyTraveller'),
-			condition: () => caseData.gypsyTraveller
+			condition: () => conditionYesOrNo(caseData.gypsyTraveller)
 		},
 		{
 			keyText: 'Public right of way',
 			valueText: formatYesOrNo(caseData, 'publicRightOfWay'),
-			condition: () => caseData.publicRightOfWay
+			condition: () => conditionYesOrNo(caseData.publicRightOfWay)
 		},
 		{
 			keyText: 'Uploaded definitive map and statement extract',
@@ -112,13 +122,13 @@ exports.constraintsRows = (caseData, user) => {
 		}
 	];
 
-	if (user === LPA_USER_ROLE) {
-		rows.unshift({
-			keyText: 'Is this the correct type of appeal',
-			valueText: formatYesOrNo(caseData, 'isCorrectAppealType'),
-			condition: () => caseData.isCorrectAppealType
-		});
-	}
-
 	return rows;
+};
+
+/**
+ * @param {any} input
+ * @returns {boolean}
+ */
+const conditionYesOrNo = (input) => {
+	return !(input === undefined || input === null);
 };

--- a/packages/forms-web-app/src/controllers/selected-appeal/questionnaire-details/constraints-details-rows.test.js
+++ b/packages/forms-web-app/src/controllers/selected-appeal/questionnaire-details/constraints-details-rows.test.js
@@ -204,10 +204,7 @@ describe('constraintsRows', () => {
 	});
 
 	it('should create rows with false conditions if fields do not exist', () => {
-		const caseData = {
-			Documents: []
-		};
-		const rows = constraintsRows(caseData);
+		const rows = constraintsRows({ Documents: [] });
 		expect(rows.length).toEqual(15);
 		expect(rows[0].condition()).toEqual(false);
 		expect(rows[1].condition()).toEqual(false);

--- a/packages/forms-web-app/src/controllers/selected-appeal/questionnaire-details/constraints-details-rows.test.js
+++ b/packages/forms-web-app/src/controllers/selected-appeal/questionnaire-details/constraints-details-rows.test.js
@@ -264,4 +264,68 @@ describe('constraintsRows', () => {
 		expect(rows[11].condition()).toEqual(false);
 		expect(rows[11].keyText).toEqual('Uploaded Tree Preservation Order extent');
 	});
+
+	it('should create rows with correct data for HAS appeal', () => {
+		const caseData = {
+			isCorrectAppealType: true,
+			AffectedListedBuildings: [
+				{
+					listedBuildingReference: 'Building 1'
+				},
+				{
+					listedBuildingReference: 'Building 2'
+				}
+			],
+			conservationArea: true,
+			isGreenBelt: true,
+			Documents: [
+				{
+					documentType: APPEAL_DOCUMENT_TYPE.CONSERVATION_MAP,
+					id: '12345',
+					filename: 'conservationmap1.pdf'
+				}
+			]
+		};
+		const rows = constraintsRows(caseData);
+
+		expect(rows.length).toEqual(15);
+		expect(rows[0].condition()).toEqual(true);
+		expect(rows[0].keyText).toEqual('Is this the correct type of appeal');
+		expect(rows[0].valueText).toEqual('Yes');
+
+		expect(rows[1].condition()).toEqual(true);
+		expect(rows[1].keyText).toEqual('Affects a listed building');
+		expect(rows[1].valueText).toEqual('Yes');
+
+		expect(rows[2].condition()).toEqual(true);
+		expect(rows[2].keyText).toEqual('Listed building details');
+		expect(rows[2].valueText).toEqual('Building 1\nBuilding 2');
+
+		expect(rows[3].condition()).toEqual(false);
+
+		expect(rows[4].condition()).toEqual(true);
+		expect(rows[4].keyText).toEqual('Conservation area');
+		expect(rows[4].valueText).toEqual('Yes');
+
+		expect(rows[5].condition()).toEqual(true);
+		expect(rows[5].keyText).toEqual('Uploaded conservation area map and guidance');
+		expect(rows[5].valueText).toEqual(
+			'<a href="/published-document/12345" class="govuk-link">conservationmap1.pdf</a>'
+		);
+		expect(rows[5].isEscaped).toEqual(true);
+
+		expect(rows[6].condition()).toEqual(false);
+
+		expect(rows[7].condition()).toEqual(true);
+		expect(rows[7].keyText).toEqual('Green belt');
+		expect(rows[7].valueText).toEqual('Yes');
+
+		expect(rows[8].condition()).toEqual(false);
+		expect(rows[9].condition()).toEqual(false);
+		expect(rows[10].condition()).toEqual(false);
+		expect(rows[11].condition()).toEqual(false);
+		expect(rows[12].condition()).toEqual(false);
+		expect(rows[13].condition()).toEqual(false);
+		expect(rows[14].condition()).toEqual(false);
+	});
 });

--- a/packages/forms-web-app/src/controllers/selected-appeal/questionnaire-details/constraints-details-rows.test.js
+++ b/packages/forms-web-app/src/controllers/selected-appeal/questionnaire-details/constraints-details-rows.test.js
@@ -3,28 +3,266 @@ const { APPEAL_DOCUMENT_TYPE } = require('pins-data-model');
 const { APPEAL_USER_ROLES } = require('@pins/common/src/constants');
 
 describe('constraintsRows', () => {
-	it('should create rows', () => {
-		const rows = constraintsRows({}, APPEAL_USER_ROLES.AGENT);
-		expect(rows.length).toEqual(14);
-	});
-
-	it('should show a document', () => {
-		const rows = constraintsRows({
+	it('should create rows with correct data if relevant case data fields exist and field values true/files uploaded/otherwise populated', () => {
+		const caseData = {
+			AffectedListedBuildings: [
+				{
+					listedBuildingReference: 'Building 1'
+				},
+				{
+					listedBuildingReference: 'Building 2'
+				}
+			],
+			scheduledMonument: true,
+			isCorrectAppealType: true,
+			conservationArea: true,
+			protectedSpecies: true,
+			isGreenBelt: true,
+			areaOutstandingBeauty: true,
+			designatedSites: 'Yes',
+			treePreservationOrder: true,
+			gypsyTraveller: true,
+			publicRightOfWay: true,
 			Documents: [
 				{
-					id: 1,
 					documentType: APPEAL_DOCUMENT_TYPE.CONSERVATION_MAP,
-					filename: 'test.txt',
+					id: '12345',
+					filename: 'conservationmap1.pdf',
+					redacted: true
+				},
+				{
+					documentType: APPEAL_DOCUMENT_TYPE.CONSERVATION_MAP,
+					id: '12346',
+					filename: 'conservationmap2.pdf',
+					redacted: true
+				},
+				{
+					documentType: APPEAL_DOCUMENT_TYPE.TREE_PRESERVATION_PLAN,
+					id: '12347',
+					filename: 'tree.pdf',
+					redacted: true
+				},
+				{
+					documentType: APPEAL_DOCUMENT_TYPE.DEFINITIVE_MAP_STATEMENT,
+					id: '12348',
+					filename: 'definitive-statement.pdf',
 					redacted: true
 				}
 			]
-		});
+		};
+		const rows = constraintsRows(caseData, APPEAL_USER_ROLES.AGENT);
+		expect(rows.length).toEqual(15);
+		expect(rows[0].condition()).toEqual(true);
+		expect(rows[0].keyText).toEqual('Is this the correct type of appeal');
+		expect(rows[0].valueText).toEqual('Yes');
+
+		expect(rows[1].condition()).toEqual(true);
+		expect(rows[1].keyText).toEqual('Affects a listed building');
+		expect(rows[1].valueText).toEqual('Yes');
+
+		expect(rows[2].condition()).toEqual(true);
+		expect(rows[2].keyText).toEqual('Listed building details');
+		expect(rows[2].valueText).toEqual('Building 1\nBuilding 2');
+
+		expect(rows[3].condition()).toEqual(true);
+		expect(rows[3].keyText).toEqual('Affects a scheduled monument');
+		expect(rows[3].valueText).toEqual('Yes');
 
 		expect(rows[4].condition()).toEqual(true);
-		expect(rows[4].isEscaped).toEqual(true);
-		expect(rows[4].keyText).toEqual('Uploaded conservation area map and guidance');
-		expect(rows[4].valueText).toEqual(
-			'<a href="/published-document/1" class="govuk-link">test.txt</a>'
+		expect(rows[4].keyText).toEqual('Conservation area');
+		expect(rows[4].valueText).toEqual('Yes');
+
+		expect(rows[5].condition()).toEqual(true);
+		expect(rows[5].keyText).toEqual('Uploaded conservation area map and guidance');
+		expect(rows[5].valueText).toEqual(
+			'<a href="/published-document/12345" class="govuk-link">conservationmap1.pdf</a>\n<a href="/published-document/12346" class="govuk-link">conservationmap2.pdf</a>'
 		);
+		expect(rows[5].isEscaped).toEqual(true);
+
+		expect(rows[6].condition()).toEqual(true);
+		expect(rows[6].keyText).toEqual('Protected species');
+		expect(rows[6].valueText).toEqual('Yes');
+
+		expect(rows[7].condition()).toEqual(true);
+		expect(rows[7].keyText).toEqual('Green belt');
+		expect(rows[7].valueText).toEqual('Yes');
+
+		expect(rows[8].condition()).toEqual(true);
+		expect(rows[8].keyText).toEqual('Area of outstanding natural beauty');
+		expect(rows[8].valueText).toEqual('Yes');
+
+		expect(rows[9].condition()).toEqual(true);
+		expect(rows[9].keyText).toEqual('Designated sites');
+		expect(rows[9].valueText).toEqual('Yes');
+
+		expect(rows[10].condition()).toEqual(true);
+		expect(rows[10].keyText).toEqual('Tree Preservation Order');
+		expect(rows[10].valueText).toEqual('Yes');
+
+		expect(rows[11].condition()).toEqual(true);
+		expect(rows[11].keyText).toEqual('Uploaded Tree Preservation Order extent');
+		expect(rows[11].valueText).toEqual(
+			'<a href="/published-document/12347" class="govuk-link">tree.pdf</a>'
+		);
+		expect(rows[11].isEscaped).toEqual(true);
+
+		expect(rows[12].condition()).toEqual(true);
+		expect(rows[12].keyText).toEqual('Gypsy or Traveller');
+		expect(rows[12].valueText).toEqual('Yes');
+
+		expect(rows[13].condition()).toEqual(true);
+		expect(rows[13].keyText).toEqual('Public right of way');
+		expect(rows[13].valueText).toEqual('Yes');
+
+		expect(rows[14].condition()).toEqual(true);
+		expect(rows[14].keyText).toEqual('Uploaded definitive map and statement extract');
+		expect(rows[14].valueText).toEqual(
+			'<a href="/published-document/12348" class="govuk-link">definitive-statement.pdf</a>'
+		);
+		expect(rows[14].isEscaped).toEqual(true);
+	});
+
+	it('should create rows with correct data if relevant case data fields and field values false/no files uploaded/otherwise not populated', () => {
+		const caseData = {
+			AffectedListedBuildings: [],
+			scheduledMonument: false,
+			isCorrectAppealType: false,
+			conservationArea: false,
+			protectedSpecies: false,
+			isGreenBelt: false,
+			areaOutstandingBeauty: false,
+			designatedSites: 'None',
+			treePreservationOrder: false,
+			gypsyTraveller: false,
+			publicRightOfWay: false,
+			Documents: []
+		};
+		const rows = constraintsRows(caseData, APPEAL_USER_ROLES.AGENT);
+		expect(rows.length).toEqual(15);
+		expect(rows[0].condition()).toEqual(true);
+		expect(rows[0].keyText).toEqual('Is this the correct type of appeal');
+		expect(rows[0].valueText).toEqual('No');
+
+		expect(rows[1].condition()).toEqual(true);
+		expect(rows[1].keyText).toEqual('Affects a listed building');
+		expect(rows[1].valueText).toEqual('No');
+
+		expect(rows[2].condition()).toEqual(false);
+		expect(rows[2].keyText).toEqual('Listed building details');
+		expect(rows[2].valueText).toEqual('');
+
+		expect(rows[3].condition()).toEqual(true);
+		expect(rows[3].keyText).toEqual('Affects a scheduled monument');
+		expect(rows[3].valueText).toEqual('No');
+
+		expect(rows[4].condition()).toEqual(true);
+		expect(rows[4].keyText).toEqual('Conservation area');
+		expect(rows[4].valueText).toEqual('No');
+
+		expect(rows[5].condition()).toEqual(false);
+		expect(rows[5].keyText).toEqual('Uploaded conservation area map and guidance');
+		expect(rows[5].valueText).toEqual('No');
+		expect(rows[5].isEscaped).toEqual(true);
+
+		expect(rows[6].condition()).toEqual(true);
+		expect(rows[6].keyText).toEqual('Protected species');
+		expect(rows[6].valueText).toEqual('No');
+
+		expect(rows[7].condition()).toEqual(true);
+		expect(rows[7].keyText).toEqual('Green belt');
+		expect(rows[7].valueText).toEqual('No');
+
+		expect(rows[8].condition()).toEqual(true);
+		expect(rows[8].keyText).toEqual('Area of outstanding natural beauty');
+		expect(rows[8].valueText).toEqual('No');
+
+		expect(rows[9].condition()).toEqual(true);
+		expect(rows[9].keyText).toEqual('Designated sites');
+		expect(rows[9].valueText).toEqual('No');
+
+		expect(rows[10].condition()).toEqual(true);
+		expect(rows[10].keyText).toEqual('Tree Preservation Order');
+		expect(rows[10].valueText).toEqual('No');
+
+		expect(rows[11].condition()).toEqual(false);
+		expect(rows[11].keyText).toEqual('Uploaded Tree Preservation Order extent');
+		expect(rows[11].valueText).toEqual('No');
+		expect(rows[11].isEscaped).toEqual(true);
+
+		expect(rows[12].condition()).toEqual(true);
+		expect(rows[12].keyText).toEqual('Gypsy or Traveller');
+		expect(rows[12].valueText).toEqual('No');
+
+		expect(rows[13].condition()).toEqual(true);
+		expect(rows[13].keyText).toEqual('Public right of way');
+		expect(rows[13].valueText).toEqual('No');
+
+		expect(rows[14].condition()).toEqual(false);
+		expect(rows[14].keyText).toEqual('Uploaded definitive map and statement extract');
+		expect(rows[14].valueText).toEqual('No');
+		expect(rows[14].isEscaped).toEqual(true);
+	});
+
+	it('should create rows with false conditions if fields do not exist', () => {
+		const caseData = {
+			Documents: []
+		};
+		const rows = constraintsRows(caseData, APPEAL_USER_ROLES.AGENT);
+		expect(rows.length).toEqual(15);
+		expect(rows[0].condition()).toEqual(false);
+		expect(rows[1].condition()).toEqual(false);
+		expect(rows[2].condition()).toEqual(false);
+		expect(rows[3].condition()).toEqual(false);
+		expect(rows[4].condition()).toEqual(false);
+		expect(rows[5].condition()).toEqual(false);
+		expect(rows[6].condition()).toEqual(false);
+		expect(rows[7].condition()).toEqual(false);
+		expect(rows[8].condition()).toEqual(false);
+		expect(rows[9].condition()).toEqual(false);
+		expect(rows[10].condition()).toEqual(false);
+		expect(rows[11].condition()).toEqual(false);
+		expect(rows[12].condition()).toEqual(false);
+		expect(rows[13].condition()).toEqual(false);
+		expect(rows[14].condition()).toEqual(false);
+	});
+
+	it('should set conditions as false for uploaded conservation and tree documents if preceding questions not truthy', () => {
+		const caseData = {
+			conservationArea: false,
+			treePreservationOrder: false,
+			Documents: [
+				{
+					documentType: APPEAL_DOCUMENT_TYPE.CONSERVATION_MAP,
+					id: '12345',
+					filename: 'conservationmap1.pdf'
+				},
+				{
+					documentType: APPEAL_DOCUMENT_TYPE.CONSERVATION_MAP,
+					id: '12346',
+					filename: 'conservationmap2.pdf'
+				},
+				{
+					documentType: APPEAL_DOCUMENT_TYPE.TREE_PRESERVATION_PLAN,
+					id: '12347',
+					filename: 'tree.pdf'
+				}
+			]
+		};
+		const rows = constraintsRows(caseData, APPEAL_USER_ROLES.AGENT);
+		expect(rows.length).toEqual(15);
+
+		expect(rows[4].condition()).toEqual(true);
+		expect(rows[4].keyText).toEqual('Conservation area');
+		expect(rows[4].valueText).toEqual('No');
+
+		expect(rows[5].condition()).toEqual(false);
+		expect(rows[5].keyText).toEqual('Uploaded conservation area map and guidance');
+
+		expect(rows[10].condition()).toEqual(true);
+		expect(rows[10].keyText).toEqual('Tree Preservation Order');
+		expect(rows[10].valueText).toEqual('No');
+
+		expect(rows[11].condition()).toEqual(false);
+		expect(rows[11].keyText).toEqual('Uploaded Tree Preservation Order extent');
 	});
 });

--- a/packages/forms-web-app/src/controllers/selected-appeal/questionnaire-details/constraints-details-rows.test.js
+++ b/packages/forms-web-app/src/controllers/selected-appeal/questionnaire-details/constraints-details-rows.test.js
@@ -1,3 +1,4 @@
+const { APPEALS_CASE_DATA } = require('@pins/common/src/constants');
 const { constraintsRows } = require('./constraints-details-rows');
 const { APPEAL_DOCUMENT_TYPE } = require('pins-data-model');
 
@@ -267,6 +268,7 @@ describe('constraintsRows', () => {
 
 	it('should create rows with correct data for HAS appeal', () => {
 		const caseData = {
+			appealTypeCode: APPEALS_CASE_DATA.APPEAL_TYPE_CODE.HAS,
 			isCorrectAppealType: true,
 			AffectedListedBuildings: [
 				{
@@ -277,6 +279,7 @@ describe('constraintsRows', () => {
 				}
 			],
 			conservationArea: true,
+			scheduledMonument: false,
 			isGreenBelt: true,
 			Documents: [
 				{

--- a/packages/forms-web-app/src/controllers/selected-appeal/questionnaire-details/constraints-details-rows.test.js
+++ b/packages/forms-web-app/src/controllers/selected-appeal/questionnaire-details/constraints-details-rows.test.js
@@ -1,6 +1,5 @@
 const { constraintsRows } = require('./constraints-details-rows');
 const { APPEAL_DOCUMENT_TYPE } = require('pins-data-model');
-const { APPEAL_USER_ROLES } = require('@pins/common/src/constants');
 
 describe('constraintsRows', () => {
 	it('should create rows with correct data if relevant case data fields exist and field values true/files uploaded/otherwise populated', () => {
@@ -50,7 +49,7 @@ describe('constraintsRows', () => {
 				}
 			]
 		};
-		const rows = constraintsRows(caseData, APPEAL_USER_ROLES.AGENT);
+		const rows = constraintsRows(caseData);
 		expect(rows.length).toEqual(15);
 		expect(rows[0].condition()).toEqual(true);
 		expect(rows[0].keyText).toEqual('Is this the correct type of appeal');
@@ -137,7 +136,7 @@ describe('constraintsRows', () => {
 			publicRightOfWay: false,
 			Documents: []
 		};
-		const rows = constraintsRows(caseData, APPEAL_USER_ROLES.AGENT);
+		const rows = constraintsRows(caseData);
 		expect(rows.length).toEqual(15);
 		expect(rows[0].condition()).toEqual(true);
 		expect(rows[0].keyText).toEqual('Is this the correct type of appeal');
@@ -207,7 +206,7 @@ describe('constraintsRows', () => {
 		const caseData = {
 			Documents: []
 		};
-		const rows = constraintsRows(caseData, APPEAL_USER_ROLES.AGENT);
+		const rows = constraintsRows(caseData);
 		expect(rows.length).toEqual(15);
 		expect(rows[0].condition()).toEqual(false);
 		expect(rows[1].condition()).toEqual(false);
@@ -248,7 +247,7 @@ describe('constraintsRows', () => {
 				}
 			]
 		};
-		const rows = constraintsRows(caseData, APPEAL_USER_ROLES.AGENT);
+		const rows = constraintsRows(caseData);
 		expect(rows.length).toEqual(15);
 
 		expect(rows[4].condition()).toEqual(true);

--- a/packages/forms-web-app/src/controllers/selected-appeal/questionnaire-details/constraints-details-rows.test.js
+++ b/packages/forms-web-app/src/controllers/selected-appeal/questionnaire-details/constraints-details-rows.test.js
@@ -231,17 +231,20 @@ describe('constraintsRows', () => {
 				{
 					documentType: APPEAL_DOCUMENT_TYPE.CONSERVATION_MAP,
 					id: '12345',
-					filename: 'conservationmap1.pdf'
+					filename: 'conservationmap1.pdf',
+					redacted: true
 				},
 				{
 					documentType: APPEAL_DOCUMENT_TYPE.CONSERVATION_MAP,
 					id: '12346',
-					filename: 'conservationmap2.pdf'
+					filename: 'conservationmap2.pdf',
+					redacted: true
 				},
 				{
 					documentType: APPEAL_DOCUMENT_TYPE.TREE_PRESERVATION_PLAN,
 					id: '12347',
-					filename: 'tree.pdf'
+					filename: 'tree.pdf',
+					redacted: true
 				}
 			]
 		};
@@ -282,7 +285,8 @@ describe('constraintsRows', () => {
 				{
 					documentType: APPEAL_DOCUMENT_TYPE.CONSERVATION_MAP,
 					id: '12345',
-					filename: 'conservationmap1.pdf'
+					filename: 'conservationmap1.pdf',
+					redacted: true
 				}
 			]
 		};

--- a/packages/forms-web-app/src/controllers/selected-appeal/questionnaire-details/index.js
+++ b/packages/forms-web-app/src/controllers/selected-appeal/questionnaire-details/index.js
@@ -68,7 +68,7 @@ exports.get = (layoutTemplate = 'layouts/no-banner-link/main.njk') => {
 		// headline data
 		const headlineData = formatHeadlineData(caseData, lpa.name, userType);
 		// constraints details
-		const constraintsDetailsRows = constraintsRows(caseData, userType);
+		const constraintsDetailsRows = constraintsRows(caseData);
 		const constraintsDetails = formatQuestionnaireRows(constraintsDetailsRows, caseData);
 		// environmental rows
 		const environmentalDetailsRows = environmentalRows(caseData);

--- a/packages/forms-web-app/src/controllers/selected-appeal/questionnaire-details/index.test.js
+++ b/packages/forms-web-app/src/controllers/selected-appeal/questionnaire-details/index.test.js
@@ -117,7 +117,7 @@ describe('controllers/selected-appeal/questionnaire-details/index', () => {
 			});
 			expect(getDepartmentFromCode).toHaveBeenCalledWith('Q9999');
 			expect(formatHeadlineData).toHaveBeenCalledWith(caseData, 'Test LPA', LPA_USER_ROLE);
-			expect(constraintsRows).toHaveBeenCalledWith(caseData, LPA_USER_ROLE);
+			expect(constraintsRows).toHaveBeenCalledWith(caseData);
 			expect(environmentalRows).toHaveBeenCalledWith(caseData);
 			expect(notifiedRows).toHaveBeenCalledWith(caseData);
 			expect(consultationRows).toHaveBeenCalledWith(caseData);
@@ -160,7 +160,7 @@ describe('controllers/selected-appeal/questionnaire-details/index', () => {
 			});
 			expect(getDepartmentFromCode).toHaveBeenCalledWith('Q9999');
 			expect(formatHeadlineData).toHaveBeenCalledWith(caseData, 'Test LPA', LPA_USER_ROLE);
-			expect(constraintsRows).toHaveBeenCalledWith(caseData, LPA_USER_ROLE);
+			expect(constraintsRows).toHaveBeenCalledWith(caseData);
 			expect(environmentalRows).toHaveBeenCalledWith(caseData);
 			expect(notifiedRows).toHaveBeenCalledWith(caseData);
 			expect(consultationRows).toHaveBeenCalledWith(caseData);

--- a/packages/forms-web-app/src/controllers/selected-appeal/questionnaire-details/notified-details-rows.js
+++ b/packages/forms-web-app/src/controllers/selected-appeal/questionnaire-details/notified-details-rows.js
@@ -21,7 +21,7 @@ exports.notifiedRows = (caseData) => {
 		},
 		{
 			keyText: 'Type of Notification',
-			valueText: formatNotificationMethod(caseData),
+			valueText: formatNotificationMethod(caseData) || '',
 			condition: () => hasNotificationMethods(caseData)
 		},
 		{

--- a/packages/forms-web-app/src/controllers/selected-appeal/questionnaire-details/notified-details-rows.test.js
+++ b/packages/forms-web-app/src/controllers/selected-appeal/questionnaire-details/notified-details-rows.test.js
@@ -1,0 +1,90 @@
+const { APPEAL_DOCUMENT_TYPE } = require('pins-data-model');
+const { LPA_NOTIFICATION_METHODS } = require('@pins/common/src/database/data-static');
+const { notifiedRows } = require('./notified-details-rows');
+
+describe('notifiedDetailsRows', () => {
+	it('should create rows with correct data if relevant case data fields exist and files uploaded/field values otherwise populated', () => {
+		const caseData = {
+			AppealCaseLpaNotificationMethod: [
+				{ lPANotificationMethodsKey: LPA_NOTIFICATION_METHODS.notice.key },
+				{ lPANotificationMethodsKey: LPA_NOTIFICATION_METHODS.letter.key },
+				{ lPANotificationMethodsKey: LPA_NOTIFICATION_METHODS.pressAdvert.key }
+			],
+			Documents: [
+				{
+					documentType: APPEAL_DOCUMENT_TYPE.WHO_NOTIFIED,
+					id: '12345',
+					filename: 'whonotified1.pdf'
+				},
+				{
+					documentType: APPEAL_DOCUMENT_TYPE.WHO_NOTIFIED_SITE_NOTICE,
+					id: '12346',
+					filename: 'sitenotice1.pdf'
+				},
+				{
+					documentType: APPEAL_DOCUMENT_TYPE.WHO_NOTIFIED_LETTER_TO_NEIGHBOURS,
+					id: '12347',
+					filename: 'neighbours.pdf'
+				},
+				{
+					documentType: APPEAL_DOCUMENT_TYPE.WHO_NOTIFIED_PRESS_ADVERT,
+					id: '12348',
+					filename: 'press.pdf'
+				}
+			]
+		};
+
+		const rows = notifiedRows(caseData);
+
+		expect(rows.length).toEqual(5);
+		expect(rows[0].condition()).toEqual(true);
+		expect(rows[0].keyText).toEqual('Who was notified');
+		expect(rows[0].valueText).toEqual(
+			'<a href="/published-document/12345" class="govuk-link">whonotified1.pdf</a>'
+		);
+		expect(rows[0].isEscaped).toEqual(true);
+
+		expect(rows[1].condition()).toEqual(true);
+		expect(rows[1].keyText).toEqual('Type of Notification');
+		expect(rows[1].valueText).toEqual(
+			'A site notice\nLetter/email to interested parties\nA press advert'
+		);
+
+		expect(rows[2].condition()).toEqual(true);
+		expect(rows[2].keyText).toEqual('Site notice');
+		expect(rows[2].valueText).toEqual(
+			'<a href="/published-document/12346" class="govuk-link">sitenotice1.pdf</a>'
+		);
+		expect(rows[2].isEscaped).toEqual(true);
+
+		expect(rows[3].condition()).toEqual(true);
+		expect(rows[3].keyText).toEqual('Letters sent to neighbours');
+		expect(rows[3].valueText).toEqual(
+			'<a href="/published-document/12347" class="govuk-link">neighbours.pdf</a>'
+		);
+		expect(rows[3].isEscaped).toEqual(true);
+
+		expect(rows[4].condition()).toEqual(true);
+		expect(rows[4].keyText).toEqual('Press advert');
+		expect(rows[4].valueText).toEqual(
+			'<a href="/published-document/12348" class="govuk-link">press.pdf</a>'
+		);
+		expect(rows[4].isEscaped).toEqual(true);
+	});
+
+	it('should not display if no fields/files exist', () => {
+		const caseData = {
+			AppealCaseLpaNotificationMethod: [],
+			Documents: []
+		};
+
+		const rows = notifiedRows(caseData);
+
+		expect(rows.length).toEqual(5);
+		expect(rows[0].condition()).toEqual(false);
+		expect(rows[1].condition()).toEqual(false);
+		expect(rows[2].condition()).toEqual(false);
+		expect(rows[3].condition()).toEqual(false);
+		expect(rows[4].condition()).toEqual(false);
+	});
+});

--- a/packages/forms-web-app/src/controllers/selected-appeal/questionnaire-details/notified-details-rows.test.js
+++ b/packages/forms-web-app/src/controllers/selected-appeal/questionnaire-details/notified-details-rows.test.js
@@ -14,22 +14,26 @@ describe('notifiedDetailsRows', () => {
 				{
 					documentType: APPEAL_DOCUMENT_TYPE.WHO_NOTIFIED,
 					id: '12345',
-					filename: 'whonotified1.pdf'
+					filename: 'whonotified1.pdf',
+					redacted: true
 				},
 				{
 					documentType: APPEAL_DOCUMENT_TYPE.WHO_NOTIFIED_SITE_NOTICE,
 					id: '12346',
-					filename: 'sitenotice1.pdf'
+					filename: 'sitenotice1.pdf',
+					redacted: true
 				},
 				{
 					documentType: APPEAL_DOCUMENT_TYPE.WHO_NOTIFIED_LETTER_TO_NEIGHBOURS,
 					id: '12347',
-					filename: 'neighbours.pdf'
+					filename: 'neighbours.pdf',
+					redacted: true
 				},
 				{
 					documentType: APPEAL_DOCUMENT_TYPE.WHO_NOTIFIED_PRESS_ADVERT,
 					id: '12348',
-					filename: 'press.pdf'
+					filename: 'press.pdf',
+					redacted: true
 				}
 			]
 		};

--- a/packages/forms-web-app/src/controllers/selected-appeal/questionnaire-details/notified-details-rows.test.js
+++ b/packages/forms-web-app/src/controllers/selected-appeal/questionnaire-details/notified-details-rows.test.js
@@ -73,12 +73,10 @@ describe('notifiedDetailsRows', () => {
 	});
 
 	it('should not display if no fields/files exist', () => {
-		const caseData = {
+		const rows = notifiedRows({
 			AppealCaseLpaNotificationMethod: [],
 			Documents: []
-		};
-
-		const rows = notifiedRows(caseData);
+		});
 
 		expect(rows.length).toEqual(5);
 		expect(rows[0].condition()).toEqual(false);

--- a/packages/forms-web-app/src/controllers/selected-appeal/questionnaire-details/planning-officer-details-rows.js
+++ b/packages/forms-web-app/src/controllers/selected-appeal/questionnaire-details/planning-officer-details-rows.js
@@ -5,6 +5,9 @@ const {
 	formatDate
 } = require('@pins/common');
 const { APPEAL_DOCUMENT_TYPE } = require('pins-data-model');
+const { APPEALS_CASE_DATA } = require('@pins/common/src/constants');
+
+const { isNotUndefinedOrNull } = require('#lib/is-not-undefined-or-null');
 
 /**
  * @param {import('appeals-service-api').Api.AppealCaseDetailed } caseData
@@ -14,13 +17,21 @@ exports.planningOfficerReportRows = (caseData) => {
 	const documents = caseData.Documents || [];
 	return [
 		{
-			keyText: "Uploaded planning officer's report",
+			keyText: "Planning officer's report",
 			valueText: formatDocumentDetails(documents, APPEAL_DOCUMENT_TYPE.PLANNING_OFFICER_REPORT),
 			condition: () => documentExists(documents, APPEAL_DOCUMENT_TYPE.PLANNING_OFFICER_REPORT),
 			isEscaped: true
 		},
 		{
-			keyText: 'Uploaded policies from statutory development plan',
+			keyText: 'Plans, drawings and list of plans',
+			valueText: formatDocumentDetails(documents, APPEAL_DOCUMENT_TYPE.PLANS_DRAWINGS),
+			condition: () =>
+				caseData.appealTypeCode === APPEALS_CASE_DATA.APPEAL_TYPE_CODE.HAS &&
+				documentExists(documents, APPEAL_DOCUMENT_TYPE.PLANS_DRAWINGS),
+			isEscaped: true
+		},
+		{
+			keyText: 'Policies from statutory development plan',
 			valueText: formatDocumentDetails(documents, APPEAL_DOCUMENT_TYPE.DEVELOPMENT_PLAN_POLICIES),
 			condition: () => documentExists(documents, APPEAL_DOCUMENT_TYPE.DEVELOPMENT_PLAN_POLICIES),
 			isEscaped: true
@@ -28,7 +39,7 @@ exports.planningOfficerReportRows = (caseData) => {
 		{
 			keyText: 'Emerging plan',
 			valueText: formatYesOrNo(caseData, 'emergingPlan'),
-			condition: () => caseData.emergingPlan
+			condition: () => isNotUndefinedOrNull(caseData.emergingPlan)
 		},
 		{
 			keyText: 'Uploaded emerging plan and supporting information',
@@ -45,7 +56,7 @@ exports.planningOfficerReportRows = (caseData) => {
 		{
 			keyText: 'Supplementary planning documents',
 			valueText: formatYesOrNo(caseData, 'supplementaryPlanningDocs'),
-			condition: () => caseData.supplementaryPlanningDocs
+			condition: () => isNotUndefinedOrNull(caseData.supplementaryPlanningDocs)
 		},
 		{
 			keyText: 'Uploaded supplementary planning documents',
@@ -56,7 +67,7 @@ exports.planningOfficerReportRows = (caseData) => {
 		{
 			keyText: 'Community infrastructure levy',
 			valueText: formatYesOrNo(caseData, 'infrastructureLevy'),
-			condition: () => caseData.infrastructureLevy
+			condition: () => isNotUndefinedOrNull(caseData.infrastructureLevy)
 		},
 		{
 			keyText: 'Uploaded community infrastructure levy',
@@ -71,17 +82,17 @@ exports.planningOfficerReportRows = (caseData) => {
 		{
 			keyText: 'Community infrastructure levy formally adopted',
 			valueText: formatYesOrNo(caseData, 'infrastructureLevyAdopted'),
-			condition: () => caseData.infrastructureLevyAdopted
+			condition: () => isNotUndefinedOrNull(caseData.infrastructureLevyAdopted)
 		},
 		{
 			keyText: 'Date community infrastructure levy adopted',
 			valueText: formatDate(caseData.infrastructureLevyAdoptedDate),
-			condition: () => caseData.infrastructureLevyAdoptedDate
+			condition: () => !!caseData.infrastructureLevyAdoptedDate
 		},
 		{
 			keyText: 'Date community infrastructure levy expected to be adopted',
 			valueText: formatDate(caseData.infrastructureLevyExpectedDate),
-			condition: () => caseData.infrastructureLevyExpectedDate
+			condition: () => !!caseData.infrastructureLevyExpectedDate
 		}
 	];
 };

--- a/packages/forms-web-app/src/controllers/selected-appeal/questionnaire-details/planning-officer-details-rows.test.js
+++ b/packages/forms-web-app/src/controllers/selected-appeal/questionnaire-details/planning-officer-details-rows.test.js
@@ -167,11 +167,7 @@ describe('planningOfficerReportRows', () => {
 	});
 
 	it('should not display if no fields/files exist', () => {
-		const caseData = {
-			Documents: []
-		};
-
-		const rows = planningOfficerReportRows(caseData);
+		const rows = planningOfficerReportRows({ Documents: [] });
 
 		expect(rows.length).toEqual(13);
 		expect(rows[0].condition()).toEqual(false);

--- a/packages/forms-web-app/src/controllers/selected-appeal/questionnaire-details/planning-officer-details-rows.test.js
+++ b/packages/forms-web-app/src/controllers/selected-appeal/questionnaire-details/planning-officer-details-rows.test.js
@@ -1,41 +1,219 @@
 const { planningOfficerReportRows } = require('./planning-officer-details-rows');
 const { APPEAL_DOCUMENT_TYPE } = require('pins-data-model');
+const { APPEALS_CASE_DATA } = require('@pins/common/src/constants');
+
+const date = new Date('2020-12-17T03:24:00');
+const formattedDate = '17-Dec-2020';
 
 describe('planningOfficerReportRows', () => {
-	it('should create rows', () => {
-		const rows = planningOfficerReportRows({});
-		expect(rows.length).toEqual(12);
-	});
-
-	it('should show documents', () => {
-		const rows = planningOfficerReportRows({
+	it('should create row with correct data if relevant case fields exist and files uploaded/field values otherwise populated', () => {
+		const caseData = {
+			appealTypeCode: APPEALS_CASE_DATA.APPEAL_TYPE_CODE.HAS,
+			emergingPlan: true,
+			supplementaryPlanningDocs: true,
+			infrastructureLevy: true,
+			infrastructureLevyAdopted: true,
+			infrastructureLevyAdoptedDate: date,
+			infrastructureLevyExpectedDate: date,
 			Documents: [
 				{
-					id: 1,
 					documentType: APPEAL_DOCUMENT_TYPE.PLANNING_OFFICER_REPORT,
-					filename: 'test.txt',
+					id: '12345',
+					filename: 'po-report.pdf',
 					redacted: true
 				},
 				{
-					id: 2,
+					documentType: APPEAL_DOCUMENT_TYPE.PLANS_DRAWINGS,
+					id: '12346',
+					filename: 'plans-drawings.pdf',
+					redacted: true
+				},
+				{
 					documentType: APPEAL_DOCUMENT_TYPE.DEVELOPMENT_PLAN_POLICIES,
-					filename: 'test2.txt',
+					id: '12347',
+					filename: 'dev-plan-policies.pdf',
+					redacted: true
+				},
+				{
+					documentType: APPEAL_DOCUMENT_TYPE.EMERGING_PLAN,
+					id: '12348',
+					filename: 'emerging-plan.pdf',
+					redacted: true
+				},
+				{
+					documentType: APPEAL_DOCUMENT_TYPE.OTHER_RELEVANT_POLICIES,
+					id: '12349',
+					filename: 'other-policies.pdf',
+					redacted: true
+				},
+				{
+					documentType: APPEAL_DOCUMENT_TYPE.SUPPLEMENTARY_PLANNING,
+					id: '12350',
+					filename: 'supplementary-planning.pdf',
+					redacted: true
+				},
+				{
+					documentType: APPEAL_DOCUMENT_TYPE.COMMUNITY_INFRASTRUCTURE_LEVY,
+					id: '12351',
+					filename: 'community-infrastructure-levy.pdf',
 					redacted: true
 				}
 			]
-		});
+		};
+
+		const rows = planningOfficerReportRows(caseData);
+		expect(rows.length).toEqual(13);
 
 		expect(rows[0].condition()).toEqual(true);
 		expect(rows[0].isEscaped).toEqual(true);
-		expect(rows[0].keyText).toEqual("Uploaded planning officer's report");
+		expect(rows[0].keyText).toEqual("Planning officer's report");
 		expect(rows[0].valueText).toEqual(
-			'<a href="/published-document/1" class="govuk-link">test.txt</a>'
+			'<a href="/published-document/12345" class="govuk-link">po-report.pdf</a>'
 		);
+
 		expect(rows[1].condition()).toEqual(true);
 		expect(rows[1].isEscaped).toEqual(true);
-		expect(rows[1].keyText).toEqual('Uploaded policies from statutory development plan');
+		expect(rows[1].keyText).toEqual('Plans, drawings and list of plans');
 		expect(rows[1].valueText).toEqual(
-			'<a href="/published-document/2" class="govuk-link">test2.txt</a>'
+			'<a href="/published-document/12346" class="govuk-link">plans-drawings.pdf</a>'
+		);
+
+		expect(rows[2].condition()).toEqual(true);
+		expect(rows[2].isEscaped).toEqual(true);
+		expect(rows[2].keyText).toEqual('Policies from statutory development plan');
+		expect(rows[2].valueText).toEqual(
+			'<a href="/published-document/12347" class="govuk-link">dev-plan-policies.pdf</a>'
+		);
+
+		expect(rows[3].condition()).toEqual(true);
+		expect(rows[3].keyText).toEqual('Emerging plan');
+		expect(rows[3].valueText).toEqual('Yes');
+
+		expect(rows[4].condition()).toEqual(true);
+		expect(rows[4].isEscaped).toEqual(true);
+		expect(rows[4].keyText).toEqual('Uploaded emerging plan and supporting information');
+		expect(rows[4].valueText).toEqual(
+			'<a href="/published-document/12348" class="govuk-link">emerging-plan.pdf</a>'
+		);
+
+		expect(rows[5].condition()).toEqual(true);
+		expect(rows[5].isEscaped).toEqual(true);
+		expect(rows[5].keyText).toEqual('Uploaded other relevant policies');
+		expect(rows[5].valueText).toEqual(
+			'<a href="/published-document/12349" class="govuk-link">other-policies.pdf</a>'
+		);
+
+		expect(rows[6].condition()).toEqual(true);
+		expect(rows[6].keyText).toEqual('Supplementary planning documents');
+		expect(rows[6].valueText).toEqual('Yes');
+
+		expect(rows[7].condition()).toEqual(true);
+		expect(rows[7].isEscaped).toEqual(true);
+		expect(rows[7].keyText).toEqual('Uploaded supplementary planning documents');
+		expect(rows[7].valueText).toEqual(
+			'<a href="/published-document/12350" class="govuk-link">supplementary-planning.pdf</a>'
+		);
+
+		expect(rows[8].condition()).toEqual(true);
+		expect(rows[8].keyText).toEqual('Community infrastructure levy');
+		expect(rows[8].valueText).toEqual('Yes');
+
+		expect(rows[9].condition()).toEqual(true);
+		expect(rows[9].isEscaped).toEqual(true);
+		expect(rows[9].keyText).toEqual('Uploaded community infrastructure levy');
+		expect(rows[9].valueText).toEqual(
+			'<a href="/published-document/12351" class="govuk-link">community-infrastructure-levy.pdf</a>'
+		);
+
+		expect(rows[10].condition()).toEqual(true);
+		expect(rows[10].keyText).toEqual('Community infrastructure levy formally adopted');
+		expect(rows[10].valueText).toEqual('Yes');
+
+		expect(rows[11].condition()).toEqual(true);
+		expect(rows[11].keyText).toEqual('Date community infrastructure levy adopted');
+		expect(rows[11].valueText).toEqual(formattedDate);
+
+		expect(rows[12].condition()).toEqual(true);
+		expect(rows[12].keyText).toEqual('Date community infrastructure levy expected to be adopted');
+		expect(rows[12].valueText).toEqual(formattedDate);
+	});
+	it('should handle false values correctly', () => {
+		const caseData = {
+			appealTypeCode: APPEALS_CASE_DATA.APPEAL_TYPE_CODE.HAS,
+			emergingPlan: false,
+			supplementaryPlanningDocs: false,
+			infrastructureLevy: false,
+			infrastructureLevyAdopted: false,
+			Documents: []
+		};
+
+		const rows = planningOfficerReportRows(caseData);
+
+		expect(rows[3].condition()).toEqual(true);
+		expect(rows[3].keyText).toEqual('Emerging plan');
+		expect(rows[3].valueText).toEqual('No');
+
+		expect(rows[6].condition()).toEqual(true);
+		expect(rows[6].keyText).toEqual('Supplementary planning documents');
+		expect(rows[6].valueText).toEqual('No');
+
+		expect(rows[8].condition()).toEqual(true);
+		expect(rows[8].keyText).toEqual('Community infrastructure levy');
+		expect(rows[8].valueText).toEqual('No');
+
+		expect(rows[10].condition()).toEqual(true);
+		expect(rows[10].keyText).toEqual('Community infrastructure levy formally adopted');
+		expect(rows[10].valueText).toEqual('No');
+	});
+
+	it('should not display if no fields/files exist', () => {
+		const caseData = {
+			Documents: []
+		};
+
+		const rows = planningOfficerReportRows(caseData);
+
+		expect(rows.length).toEqual(13);
+		expect(rows[0].condition()).toEqual(false);
+		expect(rows[1].condition()).toEqual(false);
+		expect(rows[2].condition()).toEqual(false);
+		expect(rows[3].condition()).toEqual(false);
+		expect(rows[4].condition()).toEqual(false);
+		expect(rows[5].condition()).toEqual(false);
+		expect(rows[6].condition()).toEqual(false);
+		expect(rows[7].condition()).toEqual(false);
+		expect(rows[8].condition()).toEqual(false);
+		expect(rows[9].condition()).toEqual(false);
+		expect(rows[10].condition()).toEqual(false);
+		expect(rows[11].condition()).toEqual(false);
+		expect(rows[12].condition()).toEqual(false);
+	});
+
+	it('should set plans, drawings and list of plans condition as false if not HAS appeal type', () => {
+		const caseData = {
+			appealTypeCode: APPEALS_CASE_DATA.APPEAL_TYPE_CODE.S78,
+			emergingPlan: true,
+			supplementaryPlanningDocs: true,
+			infrastructureLevy: true,
+			infrastructureLevyAdopted: true,
+			infrastructureLevyAdoptedDate: date,
+			infrastructureLevyExpectedDate: date,
+			Documents: [
+				{
+					documentType: APPEAL_DOCUMENT_TYPE.PLANS_DRAWINGS,
+					id: '12346',
+					filename: 'plans-drawings.pdf'
+				}
+			]
+		};
+
+		const rows = planningOfficerReportRows(caseData);
+
+		expect(rows[1].condition()).toEqual(false);
+		expect(rows[1].isEscaped).toEqual(true);
+		expect(rows[1].keyText).toEqual('Plans, drawings and list of plans');
+		expect(rows[1].valueText).toEqual(
+			'<a href="/published-document/12346" class="govuk-link">plans-drawings.pdf</a>'
 		);
 	});
 });

--- a/packages/forms-web-app/src/controllers/selected-appeal/questionnaire-details/planning-officer-details-rows.test.js
+++ b/packages/forms-web-app/src/controllers/selected-appeal/questionnaire-details/planning-officer-details-rows.test.js
@@ -198,7 +198,8 @@ describe('planningOfficerReportRows', () => {
 				{
 					documentType: APPEAL_DOCUMENT_TYPE.PLANS_DRAWINGS,
 					id: '12346',
-					filename: 'plans-drawings.pdf'
+					filename: 'plans-drawings.pdf',
+					redacted: true
 				}
 			]
 		};

--- a/packages/forms-web-app/src/controllers/selected-appeal/questionnaire-details/site-access-details-rows.js
+++ b/packages/forms-web-app/src/controllers/selected-appeal/questionnaire-details/site-access-details-rows.js
@@ -1,13 +1,16 @@
 const { formatYesOrNo, formatSiteSafetyRisks } = require('@pins/common');
-const { formatNeibouringAddressWithBreaks } = require('@pins/common/src/lib/format-address');
+const { formatNeighbouringAddressWithBreaks } = require('@pins/common/src/lib/format-address');
+const { isNotUndefinedOrNull } = require('#lib/is-not-undefined-or-null');
 
 /**
  * @param {import('appeals-service-api').Api.AppealCaseDetailed } caseData
  * @returns {import("@pins/common/src/view-model-maps/rows/def").Rows}
  */
 exports.siteAccessRows = (caseData) => {
-	const neighbourAdresses = caseData.NeighbouringAddresses || [];
-	const hasNeighbours = neighbourAdresses.length;
+	const neighbourAddressesArray = caseData.NeighbouringAddresses || [];
+
+	const hasNeighbourAddresses = caseData.NeighbouringAddresses !== undefined;
+	const hasNeighboursText = neighbourAddressesArray.length ? 'Yes' : 'No';
 
 	/**
 	 * @type {import("@pins/common/src/view-model-maps/rows/def").Rows}
@@ -16,7 +19,7 @@ exports.siteAccessRows = (caseData) => {
 		{
 			keyText: 'Access for inspection',
 			valueText: formatYesOrNo(caseData, 'lpaSiteAccess'),
-			condition: () => !!caseData.lpaSiteAccess
+			condition: () => isNotUndefinedOrNull(caseData.lpaSiteAccess)
 		},
 		{
 			keyText: 'Reason for Inspector access',
@@ -25,19 +28,19 @@ exports.siteAccessRows = (caseData) => {
 		},
 		{
 			keyText: 'Inspector visit to neighbour',
-			valueText: 'Yes',
-			condition: () => hasNeighbours
+			valueText: hasNeighboursText,
+			condition: () => hasNeighbourAddresses
 		},
 		{
 			keyText: 'Reason for Inspector visit',
-			valueText: caseData.neighbouringSiteAccessDetails,
+			valueText: caseData.neighbouringSiteAccessDetails || '',
 			condition: () => !!caseData.neighbouringSiteAccessDetails
 		}
 	];
 
-	if (hasNeighbours) {
-		neighbourAdresses.forEach((address, index) => {
-			const formattedAddress = formatNeibouringAddressWithBreaks(address);
+	if (hasNeighbourAddresses && neighbourAddressesArray.length) {
+		neighbourAddressesArray.forEach((address, index) => {
+			const formattedAddress = formatNeighbouringAddressWithBreaks(address);
 			rows.push({
 				keyText: `Neighbouring site ${index + 1}`,
 				valueText: formattedAddress,
@@ -46,12 +49,11 @@ exports.siteAccessRows = (caseData) => {
 		});
 	}
 
-	if (caseData.lpaSiteSafetyRisks) {
-		rows.push({
-			keyText: 'Potential safety risks',
-			valueText: formatSiteSafetyRisks(caseData),
-			condition: () => !!caseData.lpaSiteSafetyRiskDetails
-		});
-	}
+	rows.push({
+		keyText: 'Potential safety risks',
+		valueText: formatSiteSafetyRisks(caseData),
+		condition: () => isNotUndefinedOrNull(caseData.lpaSiteSafetyRisks)
+	});
+
 	return rows;
 };

--- a/packages/forms-web-app/src/controllers/selected-appeal/questionnaire-details/site-access-details-rows.test.js
+++ b/packages/forms-web-app/src/controllers/selected-appeal/questionnaire-details/site-access-details-rows.test.js
@@ -1,0 +1,100 @@
+const { siteAccessRows } = require('./site-access-details-rows');
+
+describe('siteAccessRows', () => {
+	it('should create rows with correct data if relevant case data fields exist & field values populated', () => {
+		const caseData = {
+			lpaSiteAccess: true,
+			lpaSiteAccessDetails: 'some site access details',
+			neighbouringSiteAccessDetails: 'some neighbouring site access details',
+			lpaSiteSafetyRisks: true,
+			lpaSiteSafetyRiskDetails: 'risk description',
+			NeighbouringAddresses: [
+				{
+					addressLine1: 'address 1 l1',
+					addressLine2: 'address 1 l2',
+					townCity: 'town',
+					postcode: 'ab1 2cd'
+				},
+				{
+					addressLine1: 'address 2 l1',
+					addressLine2: 'address 2 l2',
+					townCity: 'another town',
+					postcode: 'ef3 4gh'
+				}
+			]
+		};
+
+		const rows = siteAccessRows(caseData);
+
+		expect(rows.length).toEqual(7);
+
+		expect(rows[0].condition()).toEqual(true);
+		expect(rows[0].keyText).toEqual('Access for inspection');
+		expect(rows[0].valueText).toEqual('Yes');
+
+		expect(rows[1].condition()).toEqual(true);
+		expect(rows[1].keyText).toEqual('Reason for Inspector access');
+		expect(rows[1].valueText).toEqual('some site access details');
+
+		expect(rows[2].condition()).toEqual(true);
+		expect(rows[2].keyText).toEqual('Inspector visit to neighbour');
+		expect(rows[2].valueText).toEqual('Yes');
+
+		expect(rows[3].condition()).toEqual(true);
+		expect(rows[3].keyText).toEqual('Reason for Inspector visit');
+		expect(rows[3].valueText).toEqual('some neighbouring site access details');
+
+		expect(rows[4].condition()).toEqual(true);
+		expect(rows[4].keyText).toEqual('Neighbouring site 1');
+		expect(rows[4].valueText).toEqual('address 1 l1\naddress 1 l2\ntown\nab1 2cd');
+
+		expect(rows[5].condition()).toEqual(true);
+		expect(rows[5].keyText).toEqual('Neighbouring site 2');
+		expect(rows[5].valueText).toEqual('address 2 l1\naddress 2 l2\nanother town\nef3 4gh');
+
+		expect(rows[6].condition()).toEqual(true);
+		expect(rows[6].keyText).toEqual('Potential safety risks');
+		expect(rows[6].valueText).toEqual('Yes\nrisk description');
+	});
+
+	it('should handle false values correctly', () => {
+		const caseData = {
+			lpaSiteAccess: false,
+			lpaSiteSafetyRisks: false,
+			NeighbouringAddresses: []
+		};
+
+		const rows = siteAccessRows(caseData);
+
+		expect(rows.length).toEqual(5);
+
+		expect(rows[0].condition()).toEqual(true);
+		expect(rows[0].keyText).toEqual('Access for inspection');
+		expect(rows[0].valueText).toEqual('No');
+
+		expect(rows[1].condition()).toEqual(false);
+
+		expect(rows[2].condition()).toEqual(true);
+		expect(rows[2].keyText).toEqual('Inspector visit to neighbour');
+		expect(rows[2].valueText).toEqual('No');
+
+		expect(rows[3].condition()).toEqual(false);
+
+		expect(rows[4].condition()).toEqual(true);
+		expect(rows[4].keyText).toEqual('Potential safety risks');
+		expect(rows[4].valueText).toEqual('No');
+	});
+
+	it('should not display if no fields/files exist', () => {
+		const caseData = {};
+
+		const rows = siteAccessRows(caseData);
+
+		expect(rows.length).toEqual(5);
+		expect(rows[0].condition()).toEqual(false);
+		expect(rows[1].condition()).toEqual(false);
+		expect(rows[2].condition()).toEqual(false);
+		expect(rows[3].condition()).toEqual(false);
+		expect(rows[4].condition()).toEqual(false);
+	});
+});

--- a/packages/forms-web-app/src/controllers/selected-appeal/questionnaire-details/site-access-details-rows.test.js
+++ b/packages/forms-web-app/src/controllers/selected-appeal/questionnaire-details/site-access-details-rows.test.js
@@ -86,9 +86,7 @@ describe('siteAccessRows', () => {
 	});
 
 	it('should not display if no fields/files exist', () => {
-		const caseData = {};
-
-		const rows = siteAccessRows(caseData);
+		const rows = siteAccessRows({});
 
 		expect(rows.length).toEqual(5);
 		expect(rows[0].condition()).toEqual(false);

--- a/packages/forms-web-app/src/lib/is-not-undefined-or-null.js
+++ b/packages/forms-web-app/src/lib/is-not-undefined-or-null.js
@@ -1,0 +1,7 @@
+/**
+ * @param {any} input
+ * @returns {boolean}
+ */
+exports.isNotUndefinedOrNull = (input) => {
+	return !(input === undefined || input === null);
+};


### PR DESCRIPTION
## Ticket Number

<!-- Add the number from the Jira board -->

https://pins-ds.atlassian.net/browse/A2-745

(also covers work required for https://pins-ds.atlassian.net/browse/A2-748)

## Description of change

<!-- Please describe the change -->

Ensures required HAS LPAQ fields display correctly on appellant and LPA dashboards:
* fixes issues differentiating between false/falsey values on setting condition - i.e. with 'yes'/'no' questions we want condition to be true if the field value is false, but want condition to be false if field value is undefined or null.
* handles difference between S78 & HAS plans_drawings document type (only required in LPAQ for HAS, displays on appeal details for S78)
* adds unit tests for row generation
* update case ref 1010101 seed data to accurately reflect a HAS questionnaire

## Checklist

<!-- Put an `x` in all the boxes that apply: -->

- [ ] Requires infrastructure changes
- [ ] I have updated the documentation accordingly
- [x] My commit history in this PR is linear
- [x] New features have tests
- [ ] Breaking change (team conversation required)

## Important

Please do not merge from `main` (please only [rebase](https://github.com/Planning-Inspectorate/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
