### PR TITLE
feat(a2-1251): add feedback env var and update layouts/views

### DIFF
--- a/packages/forms-web-app/__tests__/unit/controllers/appeal/new-or-saved-appeal.test.js
+++ b/packages/forms-web-app/__tests__/unit/controllers/appeal/new-or-saved-appeal.test.js
@@ -4,6 +4,7 @@ const { VIEW } = require('../../../../src/lib/views');
 const { mockReq, mockRes } = require('../../mocks');
 
 jest.mock('../../../../src/lib/appeals-api-wrapper');
+const config = require('../../../../src/config');
 
 describe('controllers/appeal/new-or-saved-appeal', () => {
 	let req;
@@ -22,6 +23,7 @@ describe('controllers/appeal/new-or-saved-appeal', () => {
 		await get(req, res);
 
 		expect(res.render).toBeCalledWith(VIEW.APPEAL.NEW_OR_SAVED_APPEAL, {
+			bannerHtmlOverride: config.betaBannerText,
 			newOrSavedAppeal: 'save-new'
 		});
 	});
@@ -35,6 +37,7 @@ describe('controllers/appeal/new-or-saved-appeal', () => {
 		await post(req, res);
 
 		expect(res.render).toBeCalledWith(VIEW.APPEAL.NEW_OR_SAVED_APPEAL, {
+			bannerHtmlOverride: config.betaBannerText,
 			errors: { fieldName: 'an error occured' },
 			errorSummary: ['an error occured'],
 			newOrSavedAppeal: 'save-new'

--- a/packages/forms-web-app/__tests__/unit/controllers/before-you-start/can-use-service.test.js
+++ b/packages/forms-web-app/__tests__/unit/controllers/before-you-start/can-use-service.test.js
@@ -8,6 +8,7 @@ const priorApprovalHASAppeal = require('../../../mockData/prior-approval/prior-a
 const removalOrVariationOfConditionsFPAppeal = require('../../../mockData/removal-or-variation-of-conditions/removal-or-variation-of-conditions-fp-route');
 const removalOrVariationOfConditionsHASAppeal = require('../../../mockData/removal-or-variation-of-conditions/removal-or-variation-of-conditions-has-route');
 const { getDepartmentFromId } = require('../../../../src/services/department.service');
+const config = require('../../../../src/config');
 
 const {
 	VIEW: {
@@ -49,6 +50,7 @@ describe('controllers/before-you-start/can-use-service', () => {
 			await getCanUseService(req, res);
 
 			expect(res.render).toBeCalledWith(canUseServiceRemovalOrVariationOfConditionsHouseholder, {
+				bannerHtmlOverride: config.betaBannerText,
 				appealLPD: 'Bradford',
 				applicationDecision: 'Refused',
 				applicationType: 'Removal Or Variation Of Conditions',
@@ -69,6 +71,7 @@ describe('controllers/before-you-start/can-use-service', () => {
 			await getCanUseService(req, res);
 
 			expect(res.render).toBeCalledWith(canUseServiceHouseholder, {
+				bannerHtmlOverride: config.betaBannerText,
 				appealLPD: 'Bradford',
 				applicationDecision: 'Granted with conditions',
 				applicationType: 'Householder Planning',
@@ -90,6 +93,7 @@ describe('controllers/before-you-start/can-use-service', () => {
 			await getCanUseService(req, res);
 
 			expect(res.render).toBeCalledWith(canUseServiceHouseholder, {
+				bannerHtmlOverride: config.betaBannerText,
 				appealLPD: 'Bradford',
 				applicationDecision: 'No Decision Received',
 				applicationType: 'Householder Planning',
@@ -111,6 +115,7 @@ describe('controllers/before-you-start/can-use-service', () => {
 			await getCanUseService(req, res);
 
 			expect(res.render).toBeCalledWith(canUseServicePriorApprovalFull, {
+				bannerHtmlOverride: config.betaBannerText,
 				appealLPD: 'Bradford',
 				applicationDecision: 'Refused',
 				applicationType: 'Prior Approval',
@@ -129,6 +134,7 @@ describe('controllers/before-you-start/can-use-service', () => {
 			await getCanUseService(req, res);
 
 			expect(res.render).toBeCalledWith(canUseServicePriorApprovalHouseholder, {
+				bannerHtmlOverride: config.betaBannerText,
 				appealLPD: 'Bradford',
 				applicationDecision: 'Refused',
 				applicationType: 'Prior Approval',
@@ -151,6 +157,7 @@ describe('controllers/before-you-start/can-use-service', () => {
 			await getCanUseService(req, res);
 
 			expect(res.render).toBeCalledWith(canUseServiceRemovalOrVariationOfConditionsFullAppeal, {
+				bannerHtmlOverride: config.betaBannerText,
 				appealLPD: 'Bradford',
 				applicationDecision: 'Refused',
 				applicationType: 'Removal Or Variation Of Conditions',
@@ -171,6 +178,7 @@ describe('controllers/before-you-start/can-use-service', () => {
 			await getCanUseService(req, res);
 
 			expect(res.render).toBeCalledWith(canUseServiceFullAppealUrl, {
+				bannerHtmlOverride: config.betaBannerText,
 				appealLPD: 'Bradford',
 				applicationDecision: 'Granted with conditions',
 				applicationType: 'Full Appeal',
@@ -187,6 +195,7 @@ describe('controllers/before-you-start/can-use-service', () => {
 			await getCanUseService(req, res);
 
 			expect(res.render).toBeCalledWith(canUseServiceFullAppealUrl, {
+				bannerHtmlOverride: config.betaBannerText,
 				appealLPD: 'Bradford',
 				applicationDecision: 'Granted with conditions',
 				applicationType: 'Full Appeal',
@@ -206,6 +215,7 @@ describe('controllers/before-you-start/can-use-service', () => {
 			await getCanUseService(req, res);
 
 			expect(res.render).toBeCalledWith(canUseServiceFullAppealUrl, {
+				bannerHtmlOverride: config.betaBannerText,
 				appealLPD: 'Bradford',
 				applicationDecision: 'No Decision Received',
 				applicationType: 'Full Appeal',

--- a/packages/forms-web-app/__tests__/unit/controllers/before-you-start/use-existing-service-development-type.test.js
+++ b/packages/forms-web-app/__tests__/unit/controllers/before-you-start/use-existing-service-development-type.test.js
@@ -3,6 +3,7 @@ const {
 } = require('../../../../src/controllers/before-you-start/use-existing-service-development-type');
 const { VIEW } = require('../../../../src/lib/views');
 const { mockReq, mockRes } = require('../../mocks');
+const config = require('../../../../src/config');
 
 const req = mockReq();
 const res = mockRes();
@@ -15,6 +16,7 @@ describe('controllers/before-you-start/use-existing-service-development-type', (
 			expect(res.render).toHaveBeenCalledWith(
 				VIEW.BEFORE_YOU_START.USE_EXISTING_SERVICE_DEVELOPMENT_TYPE,
 				{
+					bannerHtmlOverride: config.betaBannerText,
 					acpLink: 'https://acp.planninginspectorate.gov.uk/'
 				}
 			);

--- a/packages/forms-web-app/__tests__/unit/controllers/before-you-start/use-existing-service-listed-building.test.js
+++ b/packages/forms-web-app/__tests__/unit/controllers/before-you-start/use-existing-service-listed-building.test.js
@@ -3,6 +3,7 @@ const {
 } = require('../../../../src/controllers/before-you-start/use-existing-service-listed-building');
 const { VIEW } = require('../../../../src/lib/views');
 const { mockReq, mockRes } = require('../../mocks');
+const config = require('../../../../src/config');
 
 const req = mockReq();
 const res = mockRes();
@@ -15,6 +16,7 @@ describe('controllers/before-you-start/use-existing-service-listed-building', ()
 			expect(res.render).toHaveBeenCalledWith(
 				VIEW.BEFORE_YOU_START.USE_EXISTING_SERVICE_LISTED_BUILDING,
 				{
+					bannerHtmlOverride: config.betaBannerText,
 					acpLink: 'https://acp.planninginspectorate.gov.uk/'
 				}
 			);

--- a/packages/forms-web-app/__tests__/unit/controllers/eligibility/appeal-statement.test.js
+++ b/packages/forms-web-app/__tests__/unit/controllers/eligibility/appeal-statement.test.js
@@ -4,6 +4,7 @@ const {
 } = require('../../../../src/controllers/eligibility/appeal-statement');
 const { VIEW } = require('../../../../src/lib/views');
 const { mockReq, mockRes } = require('../../mocks');
+const config = require('../../../../src/config');
 
 const req = mockReq();
 const res = mockRes();
@@ -13,7 +14,9 @@ describe('controllers/eligibility/appeal-statement', () => {
 		it('should call the correct template', () => {
 			getAppealStatement(req, res);
 
-			expect(res.render).toHaveBeenCalledWith(VIEW.ELIGIBILITY.APPEAL_STATEMENT);
+			expect(res.render).toHaveBeenCalledWith(VIEW.ELIGIBILITY.APPEAL_STATEMENT, {
+				bannerHtmlOverride: config.betaBannerText
+			});
 		});
 	});
 

--- a/packages/forms-web-app/__tests__/unit/controllers/eligibility/costs.test.js
+++ b/packages/forms-web-app/__tests__/unit/controllers/eligibility/costs.test.js
@@ -8,6 +8,7 @@ const { createOrUpdateAppeal } = require('../../../../src/lib/appeals-api-wrappe
 const { VIEW } = require('../../../../src/lib/views');
 const logger = require('../../../../src/lib/logger');
 const { mockReq, mockRes } = require('../../mocks');
+const config = require('../../../../src/config');
 
 jest.mock('../../../../src/lib/appeals-api-wrapper');
 jest.mock('../../../../src/services/task.service');
@@ -29,6 +30,7 @@ describe('controllers/appellant-submission/claim-costs', () => {
 			getCosts(req, res);
 
 			expect(res.render).toHaveBeenCalledWith(VIEW.ELIGIBILITY.COSTS, {
+				bannerHtmlOverride: config.betaBannerText,
 				appeal: req.session.appeal
 			});
 		});
@@ -37,7 +39,9 @@ describe('controllers/appellant-submission/claim-costs', () => {
 	describe('getCostsOut', () => {
 		it('should call the correct template', () => {
 			getCostsOut(req, res);
-			expect(res.render).toHaveBeenCalledWith(VIEW.ELIGIBILITY.COSTS_OUT);
+			expect(res.render).toHaveBeenCalledWith(VIEW.ELIGIBILITY.COSTS_OUT, {
+				bannerHtmlOverride: config.betaBannerText
+			});
 		});
 	});
 
@@ -55,6 +59,7 @@ describe('controllers/appellant-submission/claim-costs', () => {
 
 			expect(res.redirect).not.toHaveBeenCalled();
 			expect(res.render).toHaveBeenCalledWith(VIEW.ELIGIBILITY.COSTS, {
+				bannerHtmlOverride: config.betaBannerText,
 				appeal: {
 					...req.session.appeal,
 					eligibility: {
@@ -83,6 +88,7 @@ describe('controllers/appellant-submission/claim-costs', () => {
 			expect(res.redirect).not.toHaveBeenCalled();
 
 			expect(res.render).toHaveBeenCalledWith(VIEW.ELIGIBILITY.COSTS, {
+				bannerHtmlOverride: config.betaBannerText,
 				appeal: req.session.appeal,
 				errors: {},
 				errorSummary: [{ text: error.toString(), href: '#' }]

--- a/packages/forms-web-app/__tests__/unit/controllers/eligibility/decision-date.test.js
+++ b/packages/forms-web-app/__tests__/unit/controllers/eligibility/decision-date.test.js
@@ -13,7 +13,8 @@ jest.mock('../../../../src/config', () => ({
 		limitedRouting: {
 			serviceUrl: 'example-url'
 		}
-	}
+	},
+	betaBannerText: 'some text'
 }));
 
 const decisionDateController = require('../../../../src/controllers/eligibility/decision-date');
@@ -38,6 +39,7 @@ describe('controllers/eligibility/decision-date', () => {
 			decisionDateController.getDecisionDate(req, res);
 
 			expect(res.render).toHaveBeenCalledWith(VIEW.ELIGIBILITY.DECISION_DATE, {
+				bannerHtmlOverride: 'some text',
 				decisionDate: null
 			});
 		});
@@ -51,6 +53,7 @@ describe('controllers/eligibility/decision-date', () => {
 			decisionDateController.getDecisionDate(mockRequest, res);
 
 			expect(res.render).toHaveBeenCalledWith(VIEW.ELIGIBILITY.DECISION_DATE, {
+				bannerHtmlOverride: 'some text',
 				decisionDate: {
 					day: '01',
 					month: '01',
@@ -95,6 +98,7 @@ describe('controllers/eligibility/decision-date', () => {
 			await decisionDateController.postDecisionDate(mockRequest, res);
 
 			expect(res.render).toHaveBeenCalledWith(VIEW.ELIGIBILITY.DECISION_DATE, {
+				bannerHtmlOverride: 'some text',
 				decisionDate: {
 					day: undefined,
 					month: undefined,
@@ -114,6 +118,7 @@ describe('controllers/eligibility/decision-date', () => {
 			await decisionDateController.postDecisionDate(mockRequest, res);
 
 			expect(res.render).toHaveBeenCalledWith(VIEW.ELIGIBILITY.DECISION_DATE, {
+				bannerHtmlOverride: 'some text',
 				decisionDate: {
 					day: '01',
 					month: '01',
@@ -181,6 +186,7 @@ describe('controllers/eligibility/decision-date', () => {
 
 		expect(res.redirect).not.toHaveBeenCalled();
 		expect(res.render).toHaveBeenCalledWith(VIEW.ELIGIBILITY.DECISION_DATE, {
+			bannerHtmlOverride: 'some text',
 			decisionDate: {
 				day: '1',
 				month: '1',
@@ -207,6 +213,7 @@ describe('controllers/eligibility/decision-date', () => {
 		expect(res.redirect).not.toHaveBeenCalled();
 
 		expect(res.render).toHaveBeenCalledWith(VIEW.ELIGIBILITY.DECISION_DATE, {
+			bannerHtmlOverride: 'some text',
 			appeal: req.session.appeal,
 			errors: {},
 			errorSummary: [{ text: error.toString(), href: '#' }]
@@ -220,6 +227,7 @@ describe('controllers/eligibility/decision-date', () => {
 			decisionDateController.getDecisionDatePassed(req, res);
 
 			expect(res.render).toHaveBeenCalledWith(VIEW.ELIGIBILITY.DECISION_DATE_PASSED, {
+				bannerHtmlOverride: 'some text',
 				deadlineDate: null
 			});
 		});
@@ -235,6 +243,7 @@ describe('controllers/eligibility/decision-date', () => {
 			decisionDateController.getDecisionDatePassed(req, res);
 
 			expect(res.render).toHaveBeenCalledWith(VIEW.ELIGIBILITY.DECISION_DATE_PASSED, {
+				bannerHtmlOverride: 'some text',
 				deadlineDate: date
 			});
 		});

--- a/packages/forms-web-app/__tests__/unit/controllers/eligibility/enforcement-notice.test.js
+++ b/packages/forms-web-app/__tests__/unit/controllers/eligibility/enforcement-notice.test.js
@@ -8,6 +8,7 @@ const { createOrUpdateAppeal } = require('../../../../src/lib/appeals-api-wrappe
 const { VIEW } = require('../../../../src/lib/views');
 const logger = require('../../../../src/lib/logger');
 const { mockReq, mockRes } = require('../../mocks');
+const config = require('../../../../src/config');
 
 jest.mock('../../../../src/lib/appeals-api-wrapper');
 jest.mock('../../../../src/lib/logger');
@@ -27,7 +28,9 @@ describe('controllers/eligibility/enforcement-notice', () => {
 		it('calls the correct template', () => {
 			getServiceNotAvailableWhenReceivedEnforcementNotice(req, res);
 
-			expect(res.render).toHaveBeenCalledWith(VIEW.ELIGIBILITY.ENFORCEMENT_NOTICE_OUT);
+			expect(res.render).toHaveBeenCalledWith(VIEW.ELIGIBILITY.ENFORCEMENT_NOTICE_OUT, {
+				bannerHtmlOverride: config.betaBannerText
+			});
 		});
 	});
 
@@ -36,6 +39,7 @@ describe('controllers/eligibility/enforcement-notice', () => {
 			getEnforcementNotice(req, res);
 
 			expect(res.render).toHaveBeenCalledWith(VIEW.ELIGIBILITY.ENFORCEMENT_NOTICE, {
+				bannerHtmlOverride: config.betaBannerText,
 				appeal: req.session.appeal
 			});
 		});
@@ -57,6 +61,7 @@ describe('controllers/eligibility/enforcement-notice', () => {
 
 			expect(res.redirect).not.toHaveBeenCalled();
 			expect(res.render).toHaveBeenCalledWith(VIEW.ELIGIBILITY.ENFORCEMENT_NOTICE, {
+				bannerHtmlOverride: config.betaBannerText,
 				appeal: {
 					...req.session.appeal,
 					eligibility: {
@@ -85,6 +90,7 @@ describe('controllers/eligibility/enforcement-notice', () => {
 			expect(logger.error).toHaveBeenCalledWith(error);
 
 			expect(res.render).toHaveBeenCalledWith(VIEW.ELIGIBILITY.ENFORCEMENT_NOTICE, {
+				bannerHtmlOverride: config.betaBannerText,
 				appeal: req.session.appeal,
 				errors: {},
 				errorSummary: [{ text: error.toString(), href: '#' }]

--- a/packages/forms-web-app/__tests__/unit/controllers/eligibility/granted-or-refused-permission.test.js
+++ b/packages/forms-web-app/__tests__/unit/controllers/eligibility/granted-or-refused-permission.test.js
@@ -10,6 +10,7 @@ const { createOrUpdateAppeal } = require('../../../../src/lib/appeals-api-wrappe
 const { VIEW } = require('../../../../src/lib/views');
 const logger = require('../../../../src/lib/logger');
 const { mockReq, mockRes } = require('../../mocks');
+const config = require('../../../../src/config');
 
 jest.mock('../../../../src/lib/appeals-api-wrapper');
 jest.mock('../../../../src/lib/logger');
@@ -28,7 +29,9 @@ describe('controllers/eligibility/granted-or-refused-permission', () => {
 	describe('getNoDecision', () => {
 		it('should call the correct template', () => {
 			getNoDecision(req, res);
-			expect(res.render).toHaveBeenCalledWith('eligibility/no-decision');
+			expect(res.render).toHaveBeenCalledWith('eligibility/no-decision', {
+				bannerHtmlOverride: config.betaBannerText
+			});
 		});
 	});
 
@@ -37,6 +40,7 @@ describe('controllers/eligibility/granted-or-refused-permission', () => {
 			getGrantedOrRefusedPermission(req, res);
 
 			expect(res.render).toHaveBeenCalledWith(VIEW.ELIGIBILITY.GRANTED_REFUSED_PERMISSION, {
+				bannerHtmlOverride: config.betaBannerText,
 				appeal: req.session.appeal
 			});
 		});
@@ -46,7 +50,9 @@ describe('controllers/eligibility/granted-or-refused-permission', () => {
 		it('should call the permission out template', () => {
 			getGrantedOrRefusedPermissionOut(req, res);
 
-			expect(res.render).toHaveBeenCalledWith(VIEW.ELIGIBILITY.GRANTED_REFUSED_PERMISSION_OUT);
+			expect(res.render).toHaveBeenCalledWith(VIEW.ELIGIBILITY.GRANTED_REFUSED_PERMISSION_OUT, {
+				bannerHtmlOverride: config.betaBannerText
+			});
 		});
 	});
 
@@ -99,6 +105,7 @@ describe('controllers/eligibility/granted-or-refused-permission', () => {
 			expect(res.redirect).not.toHaveBeenCalled();
 
 			expect(res.render).toHaveBeenCalledWith(VIEW.ELIGIBILITY.GRANTED_REFUSED_PERMISSION, {
+				bannerHtmlOverride: config.betaBannerText,
 				appeal: {
 					...req.session.appeal,
 					eligibility: {
@@ -127,6 +134,7 @@ describe('controllers/eligibility/granted-or-refused-permission', () => {
 			expect(logger.error).toHaveBeenCalledWith(error);
 
 			expect(res.render).toHaveBeenCalledWith(VIEW.ELIGIBILITY.GRANTED_REFUSED_PERMISSION, {
+				bannerHtmlOverride: config.betaBannerText,
 				appeal: req.session.appeal,
 				errors: {},
 				errorSummary: [{ text: error.toString(), href: '#' }]

--- a/packages/forms-web-app/__tests__/unit/controllers/eligibility/householder-planning-permission.test.js
+++ b/packages/forms-web-app/__tests__/unit/controllers/eligibility/householder-planning-permission.test.js
@@ -8,6 +8,7 @@ const { createOrUpdateAppeal } = require('../../../../src/lib/appeals-api-wrappe
 const { VIEW } = require('../../../../src/lib/views');
 const logger = require('../../../../src/lib/logger');
 const { mockReq, mockRes } = require('../../mocks');
+const config = require('../../../../src/config');
 
 jest.mock('../../../../src/lib/appeals-api-wrapper');
 jest.mock('../../../../src/lib/logger');
@@ -27,7 +28,10 @@ describe('controllers/eligibility/householder-planning-permission', () => {
 		it('calls the correct template', () => {
 			getServiceOnlyForHouseholderPlanningPermission(req, res);
 
-			expect(res.render).toHaveBeenCalledWith(VIEW.ELIGIBILITY.HOUSEHOLDER_PLANNING_PERMISSION_OUT);
+			expect(res.render).toHaveBeenCalledWith(
+				VIEW.ELIGIBILITY.HOUSEHOLDER_PLANNING_PERMISSION_OUT,
+				{ bannerHtmlOverride: config.betaBannerText }
+			);
 		});
 	});
 
@@ -36,6 +40,7 @@ describe('controllers/eligibility/householder-planning-permission', () => {
 			getHouseholderPlanningPermission(req, res);
 
 			expect(res.render).toHaveBeenCalledWith(VIEW.ELIGIBILITY.HOUSEHOLDER_PLANNING_PERMISSION, {
+				bannerHtmlOverride: config.betaBannerText,
 				appeal: req.session.appeal
 			});
 		});
@@ -57,6 +62,7 @@ describe('controllers/eligibility/householder-planning-permission', () => {
 
 			expect(res.redirect).not.toHaveBeenCalled();
 			expect(res.render).toHaveBeenCalledWith(VIEW.ELIGIBILITY.HOUSEHOLDER_PLANNING_PERMISSION, {
+				bannerHtmlOverride: config.betaBannerText,
 				appeal: {
 					...req.session.appeal,
 					eligibility: {
@@ -85,6 +91,7 @@ describe('controllers/eligibility/householder-planning-permission', () => {
 			expect(logger.error).toHaveBeenCalledWith(error);
 
 			expect(res.render).toHaveBeenCalledWith(VIEW.ELIGIBILITY.HOUSEHOLDER_PLANNING_PERMISSION, {
+				bannerHtmlOverride: config.betaBannerText,
 				appeal: req.session.appeal,
 				errors: {},
 				errorSummary: [{ text: error.toString(), href: '#' }]

--- a/packages/forms-web-app/__tests__/unit/controllers/eligibility/listed-building.test.js
+++ b/packages/forms-web-app/__tests__/unit/controllers/eligibility/listed-building.test.js
@@ -7,6 +7,7 @@ const {
 const { createOrUpdateAppeal } = require('../../../../src/lib/appeals-api-wrapper');
 const { VIEW } = require('../../../../src/lib/views');
 const { mockReq, mockRes } = require('../../mocks');
+const config = require('../../../../src/config');
 
 jest.mock('../../../../src/lib/appeals-api-wrapper');
 
@@ -30,7 +31,9 @@ describe('controllers/eligibility/listed-building', () => {
 		it('calls the correct template', () => {
 			getServiceNotAvailableForListedBuildings(req, res);
 
-			expect(res.render).toHaveBeenCalledWith(VIEW.ELIGIBILITY.LISTED_OUT);
+			expect(res.render).toHaveBeenCalledWith(VIEW.ELIGIBILITY.LISTED_OUT, {
+				bannerHtmlOverride: config.betaBannerText
+			});
 		});
 	});
 
@@ -39,6 +42,7 @@ describe('controllers/eligibility/listed-building', () => {
 			getListedBuilding(req, res);
 
 			expect(res.render).toHaveBeenCalledWith(VIEW.ELIGIBILITY.LISTED_BUILDING, {
+				bannerHtmlOverride: config.betaBannerText,
 				appeal: req.session.appeal
 			});
 		});
@@ -60,6 +64,7 @@ describe('controllers/eligibility/listed-building', () => {
 
 			expect(res.redirect).not.toHaveBeenCalled();
 			expect(res.render).toHaveBeenCalledWith(VIEW.ELIGIBILITY.LISTED_BUILDING, {
+				bannerHtmlOverride: config.betaBannerText,
 				appeal: {
 					...req.session.appeal,
 					eligibility: {
@@ -86,6 +91,7 @@ describe('controllers/eligibility/listed-building', () => {
 			expect(res.redirect).not.toHaveBeenCalled();
 
 			expect(res.render).toHaveBeenCalledWith(VIEW.ELIGIBILITY.LISTED_BUILDING, {
+				bannerHtmlOverride: config.betaBannerText,
 				appeal: req.session.appeal,
 				errors: {},
 				errorSummary: [{ text: error.toString(), href: '#' }]

--- a/packages/forms-web-app/__tests__/unit/controllers/eligibility/planning-department.test.js
+++ b/packages/forms-web-app/__tests__/unit/controllers/eligibility/planning-department.test.js
@@ -12,6 +12,7 @@ const logger = require('../../../../src/lib/logger');
 
 const { VIEW } = require('../../../../src/lib/views');
 const { mockReq, mockRes } = require('../../mocks');
+const config = require('../../../../src/config');
 
 jest.mock('../../../../src/services/department.service');
 jest.mock('../../../../src/lib/appeals-api-wrapper');
@@ -64,6 +65,7 @@ describe('controllers/eligibility/planning-department', () => {
 			const { eligibleDepartments, ineligibleDepartments } = departmentsData;
 
 			expect(res.render).toBeCalledWith(VIEW.ELIGIBILITY.PLANNING_DEPARTMENT, {
+				bannerHtmlOverride: config.betaBannerText,
 				appealLPD: '',
 				departments: departmentList,
 				eligibleDepartments,
@@ -81,6 +83,7 @@ describe('controllers/eligibility/planning-department', () => {
 			const { eligibleDepartments, ineligibleDepartments } = departmentsData;
 
 			expect(res.render).toBeCalledWith(VIEW.ELIGIBILITY.PLANNING_DEPARTMENT, {
+				bannerHtmlOverride: config.betaBannerText,
 				appealLPD: '',
 				departments: departmentList,
 				eligibleDepartments,
@@ -98,6 +101,7 @@ describe('controllers/eligibility/planning-department', () => {
 			const { eligibleDepartments, ineligibleDepartments } = departmentsData;
 
 			expect(res.render).toBeCalledWith(VIEW.ELIGIBILITY.PLANNING_DEPARTMENT, {
+				bannerHtmlOverride: config.betaBannerText,
 				appealLPD: 'lpdName',
 				departments: departmentList,
 				eligibleDepartments,
@@ -108,7 +112,9 @@ describe('controllers/eligibility/planning-department', () => {
 		it('Test the getPlanningDepartmentOut method calls the correct template', () => {
 			getPlanningDepartmentOut(req, res);
 
-			expect(res.render).toHaveBeenCalledWith(VIEW.ELIGIBILITY.PLANNING_DEPARTMENT_OUT);
+			expect(res.render).toHaveBeenCalledWith(VIEW.ELIGIBILITY.PLANNING_DEPARTMENT_OUT, {
+				bannerHtmlOverride: config.betaBannerText
+			});
 		});
 
 		it('Test the postPlanningDepartment method call with handled department', async () => {
@@ -161,6 +167,7 @@ describe('controllers/eligibility/planning-department', () => {
 
 			expect(res.redirect).not.toHaveBeenCalled();
 			expect(res.render).toHaveBeenCalledWith(VIEW.ELIGIBILITY.PLANNING_DEPARTMENT, {
+				bannerHtmlOverride: config.betaBannerText,
 				appealLPD: '',
 				departments: departmentList,
 				errors: { 'local-planning-department': { msg: 'Invalid Value' } },
@@ -184,6 +191,7 @@ describe('controllers/eligibility/planning-department', () => {
 			expect(logger.error).toHaveBeenCalledWith(error);
 
 			expect(res.render).toHaveBeenCalledWith(VIEW.ELIGIBILITY.PLANNING_DEPARTMENT, {
+				bannerHtmlOverride: config.betaBannerText,
 				appeal,
 				departments: [
 					departmentList[0],

--- a/packages/forms-web-app/__tests__/unit/controllers/full-appeal/any-of-following.spec.js
+++ b/packages/forms-web-app/__tests__/unit/controllers/full-appeal/any-of-following.spec.js
@@ -11,6 +11,7 @@ const {
 		FULL_APPEAL: { ANY_OF_FOLLOWING }
 	}
 } = require('../../../../src/lib/views');
+const config = require('../../../../src/config');
 
 jest.mock('../../../../src/lib/logger');
 jest.mock('../../../../src/lib/appeals-api-wrapper');
@@ -34,6 +35,7 @@ describe('controllers/full-appeal/any-of-following', () => {
 		getAnyOfFollowing(req, res);
 
 		expect(res.render).toHaveBeenCalledWith(ANY_OF_FOLLOWING, {
+			bannerHtmlOverride: config.betaBannerText,
 			applicationCategories: ['none_of_these'],
 			typeOfPlanningApplication: 'full-appeal'
 		});
@@ -56,6 +58,7 @@ describe('controllers/full-appeal/any-of-following', () => {
 			await postAnyOfFollowing(mockRequest, res);
 
 			expect(res.render).toHaveBeenCalledWith(ANY_OF_FOLLOWING, {
+				bannerHtmlOverride: config.betaBannerText,
 				applicationCategories: undefined,
 				typeOfPlanningApplication: 'full-appeal',
 				errorSummary: [{ text: 'Select if your appeal is about any of the following' }],
@@ -138,6 +141,7 @@ describe('controllers/full-appeal/any-of-following', () => {
 			expect(res.redirect).not.toHaveBeenCalled();
 			expect(res.render).toHaveBeenCalledTimes(1);
 			expect(res.render).toHaveBeenCalledWith(ANY_OF_FOLLOWING, {
+				bannerHtmlOverride: config.betaBannerText,
 				applicationCategories: 'none_of_these',
 				typeOfPlanningApplication: 'full-appeal',
 				errors: {},

--- a/packages/forms-web-app/__tests__/unit/controllers/full-appeal/date-decision-due.test.js
+++ b/packages/forms-web-app/__tests__/unit/controllers/full-appeal/date-decision-due.test.js
@@ -12,7 +12,8 @@ jest.mock('../../../../src/config', () => ({
 		limitedRouting: {
 			serviceUrl: 'example-url'
 		}
-	}
+	},
+	betaBannerText: 'some text'
 }));
 
 const dateDecisionDueController = require('../../../../src/controllers/full-appeal/date-decision-due');
@@ -55,6 +56,7 @@ describe('controllers/full-appeal/date-decision-due', () => {
 			dateDecisionDueController.getDateDecisionDue(req, res);
 
 			expect(res.render).toHaveBeenCalledWith(DATE_DECISION_DUE, {
+				bannerHtmlOverride: 'some text',
 				decisionDate: null
 			});
 		});
@@ -69,6 +71,7 @@ describe('controllers/full-appeal/date-decision-due', () => {
 			dateDecisionDueController.getDateDecisionDue(mockRequest, res);
 
 			expect(res.render).toHaveBeenCalledWith(DATE_DECISION_DUE, {
+				bannerHtmlOverride: 'some text',
 				decisionDate: {
 					day: '01',
 					month: '01',
@@ -115,6 +118,7 @@ describe('controllers/full-appeal/date-decision-due', () => {
 			await dateDecisionDueController.postDateDecisionDue(mockRequest, res);
 
 			expect(res.render).toHaveBeenCalledWith(DATE_DECISION_DUE, {
+				bannerHtmlOverride: 'some text',
 				decisionDate: {
 					day: undefined,
 					month: undefined,
@@ -134,6 +138,7 @@ describe('controllers/full-appeal/date-decision-due', () => {
 			await dateDecisionDueController.postDateDecisionDue(mockRequest, res);
 
 			expect(res.render).toHaveBeenCalledWith(DATE_DECISION_DUE, {
+				bannerHtmlOverride: 'some text',
 				decisionDate: {
 					day: '01',
 					month: '01',
@@ -185,6 +190,7 @@ describe('controllers/full-appeal/date-decision-due', () => {
 			await dateDecisionDueController.postDateDecisionDue(mockRequest, res);
 
 			expect(res.render).toHaveBeenCalledWith(DATE_DECISION_DUE, {
+				bannerHtmlOverride: 'some text',
 				decisionDate: {
 					day: '45',
 					month: '15',
@@ -238,6 +244,7 @@ describe('controllers/full-appeal/date-decision-due', () => {
 			await dateDecisionDueController.postDateDecisionDue(mockRequest, res);
 
 			expect(res.render).toHaveBeenCalledWith(DATE_DECISION_DUE, {
+				bannerHtmlOverride: 'some text',
 				decisionDate: {
 					day: '45',
 					month: '01',
@@ -295,6 +302,7 @@ describe('controllers/full-appeal/date-decision-due', () => {
 			};
 			await dateDecisionDueController.postDateDecisionDue(mockRequest, res);
 			expect(res.render).toHaveBeenCalledWith(DATE_DECISION_DUE, {
+				bannerHtmlOverride: 'some text',
 				decisionDate: {
 					day: 1,
 					month: '',
@@ -395,6 +403,7 @@ describe('controllers/full-appeal/date-decision-due', () => {
 			expect(logger.error).toHaveBeenCalledWith(error);
 
 			expect(res.render).toHaveBeenCalledWith(DATE_DECISION_DUE, {
+				bannerHtmlOverride: 'some text',
 				decisionDate: {
 					day: undefined,
 					month: undefined,

--- a/packages/forms-web-app/__tests__/unit/controllers/full-appeal/decision-date.test.js
+++ b/packages/forms-web-app/__tests__/unit/controllers/full-appeal/decision-date.test.js
@@ -11,7 +11,8 @@ jest.mock('../../../../src/config', () => ({
 		limitedRouting: {
 			serviceUrl: 'example-url'
 		}
-	}
+	},
+	betaBannerText: 'some text'
 }));
 
 const sinon = require('sinon');
@@ -47,6 +48,7 @@ describe('controllers/full-appeal/decision-date', () => {
 			decisionDateController.getDecisionDate(req, res);
 
 			expect(res.render).toHaveBeenCalledWith(DECISION_DATE, {
+				bannerHtmlOverride: 'some text',
 				decisionDate: null
 			});
 		});
@@ -57,6 +59,7 @@ describe('controllers/full-appeal/decision-date', () => {
 			decisionDateController.getDecisionDate(req, res);
 
 			expect(res.render).toHaveBeenCalledWith(DECISION_DATE, {
+				bannerHtmlOverride: 'some text',
 				decisionDate: {
 					day: '04',
 					month: '03',
@@ -121,6 +124,7 @@ describe('controllers/full-appeal/decision-date', () => {
 			await decisionDateController.postDecisionDate(mockRequest, res);
 
 			expect(res.render).toHaveBeenCalledWith(DECISION_DATE, {
+				bannerHtmlOverride: 'some text',
 				decisionDate: {
 					day: undefined,
 					month: undefined,
@@ -153,6 +157,7 @@ describe('controllers/full-appeal/decision-date', () => {
 			expect(res.redirect).not.toHaveBeenCalled();
 
 			expect(res.render).toHaveBeenCalledWith(DECISION_DATE, {
+				bannerHtmlOverride: 'some text',
 				appeal: req.session.appeal,
 				errors: {},
 				errorSummary: [{ text: error.toString(), href: 'decision-date' }]

--- a/packages/forms-web-app/__tests__/unit/controllers/full-appeal/enforcement-notice.test.js
+++ b/packages/forms-web-app/__tests__/unit/controllers/full-appeal/enforcement-notice.test.js
@@ -9,6 +9,7 @@ const {
 		FULL_APPEAL: { ENFORCEMENT_NOTICE }
 	}
 } = require('../../../../src/lib/views');
+const config = require('../../../../src/config');
 
 const navigationPages = {
 	nextPage: '/before-you-start/can-use-service',
@@ -44,6 +45,7 @@ describe('controllers/full-appeal/enforcement-notice', () => {
 			getEnforcementNotice(req, res);
 
 			expect(res.render).toHaveBeenCalledWith(ENFORCEMENT_NOTICE, {
+				bannerHtmlOverride: config.betaBannerText,
 				appeal: req.session.appeal
 			});
 		});
@@ -67,6 +69,7 @@ describe('controllers/full-appeal/enforcement-notice', () => {
 
 			expect(res.redirect).not.toHaveBeenCalled();
 			expect(res.render).toHaveBeenCalledWith(ENFORCEMENT_NOTICE, {
+				bannerHtmlOverride: config.betaBannerText,
 				appeal: {
 					...req.session.appeal,
 					eligibility: {
@@ -97,6 +100,7 @@ describe('controllers/full-appeal/enforcement-notice', () => {
 			expect(logger.error).toHaveBeenCalledWith(error);
 
 			expect(res.render).toHaveBeenCalledWith(ENFORCEMENT_NOTICE, {
+				bannerHtmlOverride: config.betaBannerText,
 				appeal: req.session.appeal,
 				errors: {},
 				errorSummary: [{ text: error.toString(), href: '#' }]

--- a/packages/forms-web-app/__tests__/unit/controllers/full-appeal/granted-or-refused.test.js
+++ b/packages/forms-web-app/__tests__/unit/controllers/full-appeal/granted-or-refused.test.js
@@ -12,6 +12,7 @@ const {
 } = require('../../../../src/lib/views');
 const logger = require('../../../../src/lib/logger');
 const { mockReq, mockRes } = require('../../mocks');
+const config = require('../../../../src/config');
 
 jest.mock('../../../../src/lib/appeals-api-wrapper');
 jest.mock('../../../../src/lib/logger');
@@ -32,6 +33,7 @@ describe('controllers/full-appeal/granted-or-refused', () => {
 			getGrantedOrRefused(req, res);
 
 			expect(res.render).toHaveBeenCalledWith(GRANTED_OR_REFUSED, {
+				bannerHtmlOverride: config.betaBannerText,
 				appeal: req.session.appeal
 			});
 		});
@@ -85,6 +87,7 @@ describe('controllers/full-appeal/granted-or-refused', () => {
 			expect(res.redirect).not.toHaveBeenCalled();
 
 			expect(res.render).toHaveBeenCalledWith(GRANTED_OR_REFUSED, {
+				bannerHtmlOverride: config.betaBannerText,
 				appeal: {
 					...req.session.appeal,
 					eligibility: {
@@ -113,6 +116,7 @@ describe('controllers/full-appeal/granted-or-refused', () => {
 			expect(logger.error).toHaveBeenCalledWith(error);
 
 			expect(res.render).toHaveBeenCalledWith(GRANTED_OR_REFUSED, {
+				bannerHtmlOverride: config.betaBannerText,
 				appeal: req.session.appeal,
 				errors: {},
 				errorSummary: [{ text: error.toString(), href: '#' }]

--- a/packages/forms-web-app/__tests__/unit/controllers/full-appeal/local-planning-department.test.js
+++ b/packages/forms-web-app/__tests__/unit/controllers/full-appeal/local-planning-department.test.js
@@ -14,6 +14,7 @@ const {
 	}
 } = require('../../../../src/lib/views');
 const { mockReq, mockRes } = require('../../mocks');
+const config = require('../../../../src/config');
 
 jest.mock('../../../../src/services/department.service');
 jest.mock('../../../../src/lib/appeals-api-wrapper');
@@ -66,6 +67,7 @@ describe('controllers/full-appeal/local-planning-department', () => {
 			const { eligibleDepartments, ineligibleDepartments } = departmentsData;
 
 			expect(res.render).toBeCalledWith(LOCAL_PLANNING_DEPARTMENT, {
+				bannerHtmlOverride: config.betaBannerText,
 				appealLPD: '',
 				departments: departmentList,
 				eligibleDepartments,
@@ -83,6 +85,7 @@ describe('controllers/full-appeal/local-planning-department', () => {
 			const { eligibleDepartments, ineligibleDepartments } = departmentsData;
 
 			expect(res.render).toBeCalledWith(LOCAL_PLANNING_DEPARTMENT, {
+				bannerHtmlOverride: config.betaBannerText,
 				appealLPD: '',
 				departments: departmentList,
 				eligibleDepartments,
@@ -100,6 +103,7 @@ describe('controllers/full-appeal/local-planning-department', () => {
 			const { eligibleDepartments, ineligibleDepartments } = departmentsData;
 
 			expect(res.render).toBeCalledWith(LOCAL_PLANNING_DEPARTMENT, {
+				bannerHtmlOverride: config.betaBannerText,
 				appealLPD: 'lpdName',
 				departments: departmentList,
 				eligibleDepartments,
@@ -152,6 +156,7 @@ describe('controllers/full-appeal/local-planning-department', () => {
 
 			expect(res.redirect).not.toHaveBeenCalled();
 			expect(res.render).toHaveBeenCalledWith(LOCAL_PLANNING_DEPARTMENT, {
+				bannerHtmlOverride: config.betaBannerText,
 				appealLPD: '',
 				departments: departmentList,
 				errors: { 'local-planning-department': { msg: 'Invalid Value' } },
@@ -175,6 +180,7 @@ describe('controllers/full-appeal/local-planning-department', () => {
 			expect(logger.error).toHaveBeenCalledWith(error);
 
 			expect(res.render).toHaveBeenCalledWith(LOCAL_PLANNING_DEPARTMENT, {
+				bannerHtmlOverride: config.betaBannerText,
 				appeal,
 				departments: [
 					departmentList[0],

--- a/packages/forms-web-app/__tests__/unit/controllers/full-appeal/prior-approval-existing-home.test.js
+++ b/packages/forms-web-app/__tests__/unit/controllers/full-appeal/prior-approval-existing-home.test.js
@@ -14,6 +14,7 @@ const {
 
 jest.mock('../../../../src/lib/appeals-api-wrapper');
 jest.mock('../../../../src/services/task.service');
+const config = require('../../../../src/config');
 
 describe('controllers/full-appeal/submit-appeal/prior-approval-existing-home', () => {
 	let req;
@@ -40,8 +41,8 @@ describe('controllers/full-appeal/submit-appeal/prior-approval-existing-home', (
 		it('should call the correct template', () => {
 			getPriorApprovalExistingHome(req, res);
 
-			expect(res.render).toHaveBeenCalledTimes(1);
 			expect(res.render).toHaveBeenCalledWith(PRIOR_APPROVAL_EXISTING_HOME, {
+				bannerHtmlOverride: config.betaBannerText,
 				hasPriorApprovalForExistingHome: true
 			});
 		});
@@ -61,8 +62,8 @@ describe('controllers/full-appeal/submit-appeal/prior-approval-existing-home', (
 			await postPriorApprovalExistingHome(req, res);
 
 			expect(res.redirect).not.toHaveBeenCalled();
-			expect(res.render).toHaveBeenCalledTimes(1);
 			expect(res.render).toHaveBeenCalledWith(PRIOR_APPROVAL_EXISTING_HOME, {
+				bannerHtmlOverride: config.betaBannerText,
 				errors,
 				errorSummary
 			});
@@ -85,8 +86,8 @@ describe('controllers/full-appeal/submit-appeal/prior-approval-existing-home', (
 			await postPriorApprovalExistingHome(req, res);
 
 			expect(res.redirect).not.toHaveBeenCalled();
-			expect(res.render).toHaveBeenCalledTimes(1);
 			expect(res.render).toHaveBeenCalledWith(PRIOR_APPROVAL_EXISTING_HOME, {
+				bannerHtmlOverride: config.betaBannerText,
 				hasPriorApprovalForExistingHome: true,
 				errors: {},
 				errorSummary: [{ text: error.toString(), href: '#' }]

--- a/packages/forms-web-app/__tests__/unit/controllers/full-appeal/type-of-planning-application.test.js
+++ b/packages/forms-web-app/__tests__/unit/controllers/full-appeal/type-of-planning-application.test.js
@@ -15,6 +15,7 @@ const { mockReq, mockRes } = require('../../mocks');
 const {
 	mapPlanningApplication
 } = require('../../../../src/lib/full-appeal/map-planning-application');
+const config = require('../../../../src/config');
 
 jest.mock('../../../../src/lib/appeals-api-wrapper');
 jest.mock('../../../../src/lib/logger');
@@ -35,6 +36,7 @@ describe('controllers/full-appeal/type-of-planning-application', () => {
 			await getTypeOfPlanningApplication(req, res);
 
 			expect(res.render).toBeCalledWith(TYPE_OF_PLANNING_APPLICATION, {
+				bannerHtmlOverride: config.betaBannerText,
 				typeOfPlanningApplication: 'full-appeal'
 			});
 		});
@@ -186,6 +188,7 @@ describe('controllers/full-appeal/type-of-planning-application', () => {
 			expect(createOrUpdateAppeal).not.toHaveBeenCalled();
 
 			expect(res.render).toBeCalledWith(TYPE_OF_PLANNING_APPLICATION, {
+				bannerHtmlOverride: config.betaBannerText,
 				typeOfPlanningApplication: undefined,
 				errors: {
 					'type-of-planning-application': {
@@ -213,6 +216,7 @@ describe('controllers/full-appeal/type-of-planning-application', () => {
 			expect(logger.error).toHaveBeenCalledWith(error);
 
 			expect(res.render).toHaveBeenCalledWith(TYPE_OF_PLANNING_APPLICATION, {
+				bannerHtmlOverride: config.betaBannerText,
 				typeOfPlanningApplication: 'outline-planning',
 				errors: {},
 				errorSummary: [{ text: error.toString(), href: '#' }]

--- a/packages/forms-web-app/__tests__/unit/controllers/full-appeal/use-a-different-service.test.js
+++ b/packages/forms-web-app/__tests__/unit/controllers/full-appeal/use-a-different-service.test.js
@@ -8,6 +8,7 @@ const {
 	}
 } = require('../../../../src/lib/views');
 const { mockReq, mockRes } = require('../../mocks');
+const config = require('../../../../src/config');
 
 describe('controllers/full-appeal/use-a-different-service', () => {
 	const req = mockReq();
@@ -17,6 +18,7 @@ describe('controllers/full-appeal/use-a-different-service', () => {
 		await getUseADifferentService(req, res);
 
 		expect(res.render).toBeCalledWith(USE_A_DIFFERENT_SERVICE, {
+			bannerHtmlOverride: config.betaBannerText,
 			acpLink: 'https://acp.planninginspectorate.gov.uk/'
 		});
 	});

--- a/packages/forms-web-app/__tests__/unit/controllers/full-appeal/use-existing-service-application-type.test.js
+++ b/packages/forms-web-app/__tests__/unit/controllers/full-appeal/use-existing-service-application-type.test.js
@@ -8,6 +8,7 @@ const {
 	}
 } = require('../../../../src/lib/views');
 const { mockReq, mockRes } = require('../../mocks');
+const config = require('../../../../src/config');
 
 describe('controllers/full-appeal/use-existing-service-application-type', () => {
 	const req = mockReq();
@@ -17,6 +18,7 @@ describe('controllers/full-appeal/use-existing-service-application-type', () => 
 		await getUseExistingServiceApplicationType(req, res);
 
 		expect(res.render).toBeCalledWith(USE_EXISTING_SERVICE_APPLICATION_TYPE, {
+			bannerHtmlOverride: config.betaBannerText,
 			acpLink: 'https://acp.planninginspectorate.gov.uk/'
 		});
 	});

--- a/packages/forms-web-app/__tests__/unit/controllers/full-appeal/use-existing-service-enforcement-notice.test.js
+++ b/packages/forms-web-app/__tests__/unit/controllers/full-appeal/use-existing-service-enforcement-notice.test.js
@@ -9,6 +9,7 @@ const {
 } = require('../../../../src/lib/views');
 
 const { mockReq, mockRes } = require('../../mocks');
+const config = require('../../../../src/config');
 
 describe('controllers/full-appeal/use-existing-service-enforcement-notice', () => {
 	const req = mockReq();
@@ -18,6 +19,7 @@ describe('controllers/full-appeal/use-existing-service-enforcement-notice', () =
 		await getUseExistingServiceEnforcementNotice(req, res);
 
 		expect(res.render).toBeCalledWith(USE_EXISTING_SERVICE_ENFORCEMENT_NOTICE, {
+			bannerHtmlOverride: config.betaBannerText,
 			acpLink: 'https://acp.planninginspectorate.gov.uk/'
 		});
 	});

--- a/packages/forms-web-app/__tests__/unit/controllers/full-appeal/use-existing-service-local-planning-department.test.js
+++ b/packages/forms-web-app/__tests__/unit/controllers/full-appeal/use-existing-service-local-planning-department.test.js
@@ -8,6 +8,7 @@ const {
 	}
 } = require('../../../../src/lib/views');
 const { mockReq, mockRes } = require('../../mocks');
+const config = require('../../../../src/config');
 
 describe('controllers/full-appeal/use-existing-service-local-planning-department', () => {
 	const req = mockReq();
@@ -17,6 +18,7 @@ describe('controllers/full-appeal/use-existing-service-local-planning-department
 		await getUseExistingServiceLocalPlanningDepartment(req, res);
 
 		expect(res.render).toBeCalledWith(USE_EXISTING_SERVICE_LOCAL_PLANNING_DEPARTMENT, {
+			bannerHtmlOverride: config.betaBannerText,
 			acpLink: 'https://acp.planninginspectorate.gov.uk/'
 		});
 	});

--- a/packages/forms-web-app/__tests__/unit/controllers/full-appeal/you-cannot-appeal.spec.js
+++ b/packages/forms-web-app/__tests__/unit/controllers/full-appeal/you-cannot-appeal.spec.js
@@ -4,6 +4,7 @@ const { mockReq, mockRes } = require('../../mocks');
 const {
 	VIEW: { YOU_CANNOT_APPEAL }
 } = require('../../../../src/lib/views');
+const config = require('../../../../src/config');
 
 jest.mock('../../../../src/lib/logger');
 
@@ -35,6 +36,7 @@ describe('controllers/full-appeal/out-of-time-shutter-page', () => {
 			await getYouCannotAppeal(mockRequest, res);
 			expect(mockRequest.session.appeal).toBe(null);
 			expect(res.render).toHaveBeenCalledWith(YOU_CANNOT_APPEAL, {
+				bannerHtmlOverride: config.betaBannerText,
 				appealDeadline,
 				appealPeriodToBeDisplayed,
 				beforeYouStartFirstPage

--- a/packages/forms-web-app/__tests__/unit/controllers/householder-planning/eligibility/claiming-costs-householder.test.js
+++ b/packages/forms-web-app/__tests__/unit/controllers/householder-planning/eligibility/claiming-costs-householder.test.js
@@ -7,6 +7,7 @@ const { createOrUpdateAppeal } = require('../../../../../src/lib/appeals-api-wra
 const { getDepartmentFromId } = require('../../../../../src/services/department.service');
 const { isFeatureActive } = require('../../../../../src/featureFlag');
 const logger = require('../../../../../src/lib/logger');
+const config = require('../../../../../src/config');
 
 const {
 	VIEW: {
@@ -54,6 +55,7 @@ describe('controllers/householder-planning/claiming-costs-householder', () => {
 			await getClaimingCostsHouseholder(req, res);
 
 			expect(res.render).toBeCalledWith(CLAIMING_COSTS, {
+				bannerHtmlOverride: config.betaBannerText,
 				isClaimingCosts: appeal.eligibility.isClaimingCosts
 			});
 		});
@@ -107,6 +109,7 @@ describe('controllers/householder-planning/claiming-costs-householder', () => {
 			expect(createOrUpdateAppeal).not.toHaveBeenCalled();
 
 			expect(res.render).toBeCalledWith(`${CLAIMING_COSTS}`, {
+				bannerHtmlOverride: config.betaBannerText,
 				isClaimingCosts: appeal.eligibility.isClaimingCosts,
 				errors: {
 					'claiming-costs-householder': {
@@ -133,6 +136,7 @@ describe('controllers/householder-planning/claiming-costs-householder', () => {
 			expect(logger.error).toHaveBeenCalledWith(error);
 
 			expect(res.render).toHaveBeenCalledWith(`${CLAIMING_COSTS}`, {
+				bannerHtmlOverride: config.betaBannerText,
 				isClaimingCosts: appeal.eligibility.isClaimingCosts,
 				errors: {},
 				errorSummary: [{ text: error.toString(), href: 'pageId' }]

--- a/packages/forms-web-app/__tests__/unit/controllers/householder-planning/eligibility/conditions-householder-permission.test.js
+++ b/packages/forms-web-app/__tests__/unit/controllers/householder-planning/eligibility/conditions-householder-permission.test.js
@@ -14,6 +14,7 @@ const {
 		}
 	}
 } = require('../../../../../src/lib/views');
+const config = require('../../../../../src/config');
 
 jest.mock('../../../../../src/lib/appeals-api-wrapper');
 jest.mock('../../../../../src/services/task.service');
@@ -41,8 +42,8 @@ describe('controllers/householder-planning/eligibility/conditions-householder-pe
 		it('should call the correct template', () => {
 			getConditionsHouseholderPermission(req, res);
 
-			expect(res.render).toHaveBeenCalledTimes(1);
 			expect(res.render).toHaveBeenCalledWith(CONDITIONS_HOUSEHOLDER_PERMISSION, {
+				bannerHtmlOverride: config.betaBannerText,
 				hasHouseholderPermissionConditions: true
 			});
 		});
@@ -62,8 +63,8 @@ describe('controllers/householder-planning/eligibility/conditions-householder-pe
 			await postConditionsHouseholderPermission(req, res);
 
 			expect(res.redirect).not.toHaveBeenCalled();
-			expect(res.render).toHaveBeenCalledTimes(1);
 			expect(res.render).toHaveBeenCalledWith(CONDITIONS_HOUSEHOLDER_PERMISSION, {
+				bannerHtmlOverride: config.betaBannerText,
 				errors,
 				errorSummary
 			});
@@ -86,8 +87,8 @@ describe('controllers/householder-planning/eligibility/conditions-householder-pe
 			await postConditionsHouseholderPermission(req, res);
 
 			expect(res.redirect).not.toHaveBeenCalled();
-			expect(res.render).toHaveBeenCalledTimes(1);
 			expect(res.render).toHaveBeenCalledWith(CONDITIONS_HOUSEHOLDER_PERMISSION, {
+				bannerHtmlOverride: config.betaBannerText,
 				hasHouseholderPermissionConditions: true,
 				errors: {},
 				errorSummary: [{ text: error.toString(), href: '#' }]

--- a/packages/forms-web-app/__tests__/unit/controllers/householder-planning/eligibility/date-decision-due-householder.test.js
+++ b/packages/forms-web-app/__tests__/unit/controllers/householder-planning/eligibility/date-decision-due-householder.test.js
@@ -11,7 +11,8 @@ jest.mock('../../../../../src/config', () => ({
 		limitedRouting: {
 			serviceUrl: 'example-url'
 		}
-	}
+	},
+	betaBannerText: 'some text'
 }));
 const householderAppeal = require('@pins/business-rules/test/data/householder-appeal');
 const dateDecisionDueHouseholderController = require('../../../../../src/controllers/householder-planning/eligibility/date-decision-due-householder');
@@ -45,6 +46,7 @@ describe('controllers/householder-planning/date-decision-due-householder', () =>
 		it('should call the correct template with no decision date given', () => {
 			dateDecisionDueHouseholderController.getDateDecisionDueHouseholder(req, res);
 			expect(res.render).toHaveBeenCalledWith(DATE_DECISION_DUE_HOUSEHOLDER, {
+				bannerHtmlOverride: 'some text',
 				decisionDate: null
 			});
 		});
@@ -55,6 +57,7 @@ describe('controllers/householder-planning/date-decision-due-householder', () =>
 			dateDecisionDueHouseholderController.getDateDecisionDueHouseholder(req, res);
 
 			expect(res.render).toHaveBeenCalledWith(DATE_DECISION_DUE_HOUSEHOLDER, {
+				bannerHtmlOverride: 'some text',
 				decisionDate: {
 					day: '04',
 					month: '03',
@@ -119,6 +122,7 @@ describe('controllers/householder-planning/date-decision-due-householder', () =>
 			await dateDecisionDueHouseholderController.postDateDecisionDueHouseholder(mockRequest, res);
 
 			expect(res.render).toHaveBeenCalledWith(DATE_DECISION_DUE_HOUSEHOLDER, {
+				bannerHtmlOverride: 'some text',
 				decisionDate: {
 					day: undefined,
 					month: undefined,
@@ -151,6 +155,7 @@ describe('controllers/householder-planning/date-decision-due-householder', () =>
 			expect(res.redirect).not.toHaveBeenCalled();
 
 			expect(res.render).toHaveBeenCalledWith(DATE_DECISION_DUE_HOUSEHOLDER, {
+				bannerHtmlOverride: 'some text',
 				decisionDate: {
 					day: undefined,
 					month: undefined,

--- a/packages/forms-web-app/__tests__/unit/controllers/householder-planning/eligibility/decision-date-householder.test.js
+++ b/packages/forms-web-app/__tests__/unit/controllers/householder-planning/eligibility/decision-date-householder.test.js
@@ -10,7 +10,8 @@ jest.mock('../../../../../src/config', () => ({
 		limitedRouting: {
 			serviceUrl: 'example-url'
 		}
-	}
+	},
+	betaBannerText: 'some text'
 }));
 
 const sinon = require('sinon');
@@ -52,6 +53,7 @@ describe('controllers/householder-planning/eligibility/decision-date-householder
 			decisionDateHouseholderController.getDecisionDateHouseholder(req, res);
 
 			expect(res.render).toHaveBeenCalledWith(DECISION_DATE_HOUSEHOLDER, {
+				bannerHtmlOverride: 'some text',
 				decisionDate: null
 			});
 		});
@@ -62,6 +64,7 @@ describe('controllers/householder-planning/eligibility/decision-date-householder
 			decisionDateHouseholderController.getDecisionDateHouseholder(req, res);
 
 			expect(res.render).toHaveBeenCalledWith(DECISION_DATE_HOUSEHOLDER, {
+				bannerHtmlOverride: 'some text',
 				decisionDate: {
 					day: '04',
 					month: '03',
@@ -167,6 +170,7 @@ describe('controllers/householder-planning/eligibility/decision-date-householder
 			await decisionDateHouseholderController.postDecisionDateHouseholder(mockRequest, res);
 
 			expect(res.render).toHaveBeenCalledWith(DECISION_DATE_HOUSEHOLDER, {
+				bannerHtmlOverride: 'some text',
 				decisionDate: {
 					day: undefined,
 					month: undefined,
@@ -199,6 +203,7 @@ describe('controllers/householder-planning/eligibility/decision-date-householder
 			expect(res.redirect).not.toHaveBeenCalled();
 
 			expect(res.render).toHaveBeenCalledWith(DECISION_DATE_HOUSEHOLDER, {
+				bannerHtmlOverride: 'some text',
 				appeal: req.session.appeal,
 				errors: {},
 				errorSummary: [{ text: error.toString(), href: 'decision-date-householder' }]

--- a/packages/forms-web-app/__tests__/unit/controllers/householder-planning/eligibility/enforcement-notice-householder.test.js
+++ b/packages/forms-web-app/__tests__/unit/controllers/householder-planning/eligibility/enforcement-notice-householder.test.js
@@ -15,6 +15,7 @@ const {
 } = require('../../../../../src/lib/views');
 const logger = require('../../../../../src/lib/logger');
 const { mockReq, mockRes } = require('../../../mocks');
+const config = require('../../../../../src/config');
 
 const navigationPages = {
 	nextPage: '/before-you-start/claiming-costs-householder',
@@ -51,6 +52,7 @@ describe('controllers/householder-planning/eligibility/enforcement-notice-househ
 			getEnforcementNoticeHouseholder(req, res);
 
 			expect(res.render).toHaveBeenCalledWith(ENFORCEMENT_NOTICE_HOUSEHOLDER, {
+				bannerHtmlOverride: config.betaBannerText,
 				enforcementNotice: appeal.eligibility.enforcementNotice,
 				previousPage: navigationPages.previousPage
 			});
@@ -78,6 +80,7 @@ describe('controllers/householder-planning/eligibility/enforcement-notice-househ
 
 			expect(res.redirect).not.toHaveBeenCalled();
 			expect(res.render).toHaveBeenCalledWith(ENFORCEMENT_NOTICE_HOUSEHOLDER, {
+				bannerHtmlOverride: config.betaBannerText,
 				enforcementNotice: appeal.eligibility.enforcementNotice,
 				errorSummary: [{ text: 'There were errors here', href: '#' }],
 				errors: { a: 'b' }
@@ -106,6 +109,7 @@ describe('controllers/householder-planning/eligibility/enforcement-notice-househ
 			expect(logger.error).toHaveBeenCalledWith(error);
 
 			expect(res.render).toHaveBeenCalledWith(ENFORCEMENT_NOTICE_HOUSEHOLDER, {
+				bannerHtmlOverride: config.betaBannerText,
 				enforcementNotice: appeal.eligibility.enforcementNotice,
 				errors: {},
 				errorSummary: [{ text: error.toString(), href: '#' }]

--- a/packages/forms-web-app/__tests__/unit/controllers/householder-planning/eligibility/granted-or-refused-householder.test.js
+++ b/packages/forms-web-app/__tests__/unit/controllers/householder-planning/eligibility/granted-or-refused-householder.test.js
@@ -14,6 +14,7 @@ const {
 } = require('../../../../../src/lib/views');
 const logger = require('../../../../../src/lib/logger');
 const { mockReq, mockRes } = require('../../../mocks');
+const config = require('../../../../../src/config');
 
 jest.mock('../../../../../src/lib/appeals-api-wrapper');
 jest.mock('../../../../../src/lib/logger');
@@ -39,6 +40,7 @@ describe('controllers/householder-planning/eligibility/granted-or-refused-househ
 			getGrantedOrRefusedHouseholder(req, res);
 
 			expect(res.render).toHaveBeenCalledWith(GRANTED_OR_REFUSED_HOUSEHOLDER, {
+				bannerHtmlOverride: config.betaBannerText,
 				appeal: req.session.appeal
 			});
 		});
@@ -61,6 +63,7 @@ describe('controllers/householder-planning/eligibility/granted-or-refused-househ
 			expect(res.redirect).not.toHaveBeenCalled();
 
 			expect(res.render).toHaveBeenCalledWith(GRANTED_OR_REFUSED_HOUSEHOLDER, {
+				bannerHtmlOverride: config.betaBannerText,
 				appeal: req.session.appeal,
 				errorSummary: [{ text: 'There were errors here', href: '#' }],
 				errors: { a: 'b' }
@@ -86,6 +89,7 @@ describe('controllers/householder-planning/eligibility/granted-or-refused-househ
 			expect(logger.error).toHaveBeenCalledWith(error);
 
 			expect(res.render).toHaveBeenCalledWith(GRANTED_OR_REFUSED_HOUSEHOLDER, {
+				bannerHtmlOverride: config.betaBannerText,
 				appeal,
 				errors: {},
 				errorSummary: [{ text: error.toString(), href: '#' }]

--- a/packages/forms-web-app/__tests__/unit/controllers/householder-planning/eligibility/listed-building-householder.test.js
+++ b/packages/forms-web-app/__tests__/unit/controllers/householder-planning/eligibility/listed-building-householder.test.js
@@ -15,6 +15,7 @@ const {
 } = require('../../../../../src/lib/views');
 
 const { mockReq, mockRes } = require('../../../mocks');
+const config = require('../../../../../src/config');
 
 jest.mock('../../../../../src/lib/appeals-api-wrapper');
 jest.mock('../../../../../src/lib/logger');
@@ -35,6 +36,7 @@ describe('controllers/householder-planning/eligibility/listed-building-household
 			await getListedBuildingHouseholder(req, res);
 
 			expect(res.render).toBeCalledWith(LISTED_BUILDING_HOUSEHOLDER, {
+				bannerHtmlOverride: config.betaBannerText,
 				isListedBuilding: appeal.eligibility.isListedBuilding
 			});
 		});
@@ -44,6 +46,7 @@ describe('controllers/householder-planning/eligibility/listed-building-household
 			await getListedBuildingHouseholder(req, res);
 
 			expect(res.render).toBeCalledWith(LISTED_BUILDING_HOUSEHOLDER, {
+				bannerHtmlOverride: config.betaBannerText,
 				isListedBuilding: false
 			});
 		});
@@ -97,6 +100,7 @@ describe('controllers/householder-planning/eligibility/listed-building-household
 			expect(createOrUpdateAppeal).not.toHaveBeenCalled();
 
 			expect(res.render).toBeCalledWith(LISTED_BUILDING_HOUSEHOLDER, {
+				bannerHtmlOverride: config.betaBannerText,
 				isListedBuilding: null,
 				typeOfPlanningApplication: 'householder-planning',
 				errors: {
@@ -124,6 +128,7 @@ describe('controllers/householder-planning/eligibility/listed-building-household
 			expect(logger.error).toHaveBeenCalledWith(error);
 
 			expect(res.render).toHaveBeenCalledWith(LISTED_BUILDING_HOUSEHOLDER, {
+				bannerHtmlOverride: config.betaBannerText,
 				isListedBuilding: appeal.eligibility.isListedBuilding,
 				typeOfPlanningApplication: 'householder-planning',
 				errors: {},

--- a/packages/forms-web-app/__tests__/unit/controllers/householder-planning/eligibility/use-existing-service-costs.test.js
+++ b/packages/forms-web-app/__tests__/unit/controllers/householder-planning/eligibility/use-existing-service-costs.test.js
@@ -1,4 +1,4 @@
-const useExistingServiceCostsController = require('../../../../src/controllers/householder-planning/eligibility/use-existing-service-costs');
+const useExistingServiceCostsController = require('../../../../../src/controllers/householder-planning/eligibility/use-existing-service-costs');
 
 const {
 	VIEW: {
@@ -6,9 +6,10 @@ const {
 			ELIGIBILITY: { USE_EXISTING_SERVICE_COSTS }
 		}
 	}
-} = require('../../../../src/lib/views');
+} = require('../../../../../src/lib/views');
 
-const { mockReq, mockRes } = require('../../mocks');
+const { mockReq, mockRes } = require('../../../mocks');
+const config = require('../../../../../src/config');
 
 describe('getUseExistingServiceCosts', () => {
 	const req = mockReq();
@@ -18,6 +19,7 @@ describe('getUseExistingServiceCosts', () => {
 		await useExistingServiceCostsController.getUseExistingServiceCosts(req, res);
 
 		expect(res.render).toBeCalledWith(USE_EXISTING_SERVICE_COSTS, {
+			bannerHtmlOverride: config.betaBannerText,
 			acpLink: 'https://acp.planninginspectorate.gov.uk/'
 		});
 	});

--- a/packages/forms-web-app/__tests__/unit/controllers/householder-planning/eligibility/use-existing-service-enforcement-notice.test.js
+++ b/packages/forms-web-app/__tests__/unit/controllers/householder-planning/eligibility/use-existing-service-enforcement-notice.test.js
@@ -7,6 +7,7 @@ const {
 } = require('../../../../../src/lib/views');
 
 const { mockReq, mockRes } = require('../../../mocks');
+const config = require('../../../../../src/config');
 
 describe('getUseExistingServiceEnforcementNotice', () => {
 	const req = mockReq();
@@ -16,6 +17,7 @@ describe('getUseExistingServiceEnforcementNotice', () => {
 		await useExistingServiceEnforcementNotice.getUseExistingServiceEnforcementNotice(req, res);
 
 		expect(res.render).toBeCalledWith(USE_EXISTING_SERVICE_ENFORCEMENT_NOTICE, {
+			bannerHtmlOverride: config.betaBannerText,
 			acpLink: 'https://acp.planninginspectorate.gov.uk/'
 		});
 	});

--- a/packages/forms-web-app/src/app.js
+++ b/packages/forms-web-app/src/app.js
@@ -104,6 +104,8 @@ env.addGlobal('fileSizeLimits', config.fileUpload.pins);
 env.addGlobal('googleAnalyticsId', config.server.googleAnalyticsId);
 env.addGlobal('googleTagManagerId', config.server.googleTagManagerId);
 env.addGlobal('featureFlag', config.featureFlag);
+env.addGlobal('feedbackUrl', config.feedbackUrl);
+env.addGlobal('betaBannerFeedback', config.betaBannerText + config.betaBannerFeedbackLink);
 
 if (config.server.useSecureSessionCookie) {
 	app.set('trust proxy', 1); // trust first proxy

--- a/packages/forms-web-app/src/config.js
+++ b/packages/forms-web-app/src/config.js
@@ -15,6 +15,8 @@ function numberWithDefault(value, fallback) {
 const oneGigabyte = 1024 * 1024 * 1024;
 const ninetyMinsInMs = 90 * 60 * 1000;
 const httpPort = numberWithDefault(process.env.PORT, 3000);
+const feedbackUrl =
+	'https://forms.office.com/pages/responsepage.aspx?id=mN94WIhvq0iTIpmM5VcIjYt1ax_BPvtOqhVjfvzyJN5UOUlNRkhaQjNXTDQyNEhSRExNOFVGSkNJTS4u&route=shorturl';
 
 module.exports = {
 	application: {
@@ -183,5 +185,8 @@ module.exports = {
 		baseUrl: process.env.AUTH_BASE_URL,
 		clientID: process.env.CLIENT_ID,
 		clientSecret: process.env.CLIENT_SECRET
-	}
+	},
+	feedbackUrl: feedbackUrl,
+	betaBannerText: 'This is a beta service',
+	betaBannerFeedbackLink: ` – your <a class="govuk-link" data-cy="Feedback" href="${feedbackUrl}">feedback</a> will help us to improve it.`
 };

--- a/packages/forms-web-app/src/controllers/appeal/new-saved-appeal.js
+++ b/packages/forms-web-app/src/controllers/appeal/new-saved-appeal.js
@@ -7,7 +7,10 @@ const {
 
 exports.get = async (req, res) => {
 	const { newOrSavedAppeal } = req.session;
-	res.render(VIEW.APPEAL.NEW_OR_SAVED_APPEAL, { newOrSavedAppeal });
+	res.render(VIEW.APPEAL.NEW_OR_SAVED_APPEAL, {
+		bannerHtmlOverride: config.betaBannerText,
+		newOrSavedAppeal
+	});
 };
 
 exports.post = async (req, res) => {
@@ -16,6 +19,7 @@ exports.post = async (req, res) => {
 
 	if (Object.keys(errors).length > 0) {
 		res.render(VIEW.APPEAL.NEW_OR_SAVED_APPEAL, {
+			bannerHtmlOverride: config.betaBannerText,
 			errors,
 			errorSummary,
 			newOrSavedAppeal: body['new-or-saved-appeal']
@@ -29,6 +33,7 @@ exports.post = async (req, res) => {
 		logger.error(e);
 
 		res.render(VIEW.APPEAL.NEW_OR_SAVED_APPEAL, {
+			bannerHtmlOverride: config.betaBannerText,
 			errors,
 			errorSummary: [{ text: e.toString(), href: 'new-or-saved-appeal' }]
 		});

--- a/packages/forms-web-app/src/controllers/before-you-start/before-you-start.js
+++ b/packages/forms-web-app/src/controllers/before-you-start/before-you-start.js
@@ -1,7 +1,8 @@
+const config = require('../../config');
 const { VIEW } = require('../../lib/views');
 
 exports.getBeforeYouStartFirstPage = async (_, res) => {
-	res.render(VIEW.BEFORE_YOU_START.FIRST_PAGE);
+	res.render(VIEW.BEFORE_YOU_START.FIRST_PAGE, { bannerHtmlOverride: config.betaBannerText });
 };
 
 exports.postBeforeYouStartFirstPage = async (req, res) => {

--- a/packages/forms-web-app/src/controllers/before-you-start/can-use-service.js
+++ b/packages/forms-web-app/src/controllers/before-you-start/can-use-service.js
@@ -18,6 +18,7 @@ const {
 		}
 	}
 } = require('../../lib/views');
+const config = require('../../config');
 
 const canUseServiceHouseholderPlanning = async (req, res) => {
 	const { appeal } = req.session;
@@ -48,6 +49,7 @@ const canUseServiceHouseholderPlanning = async (req, res) => {
 			: null;
 
 	res.render(canUseServiceHouseholder, {
+		bannerHtmlOverride: config.betaBannerText,
 		deadlineDate,
 		appealLPD,
 		applicationType,
@@ -80,6 +82,7 @@ const canUseServiceFullAppeal = async (req, res) => {
 	);
 
 	res.render(canUseServiceFullAppealUrl, {
+		bannerHtmlOverride: config.betaBannerText,
 		deadlineDate,
 		appealLPD,
 		applicationType,
@@ -124,6 +127,7 @@ const canUseServicePriorApproval = async (req, res) => {
 				: null;
 
 		res.render(canUseServicePriorApprovalHouseholder, {
+			bannerHtmlOverride: config.betaBannerText,
 			deadlineDate,
 			appealLPD,
 			applicationType,
@@ -144,6 +148,7 @@ const canUseServicePriorApproval = async (req, res) => {
 		);
 
 		res.render(canUseServicePriorApprovalFull, {
+			bannerHtmlOverride: config.betaBannerText,
 			deadlineDate,
 			appealLPD,
 			applicationType,
@@ -190,6 +195,7 @@ const canUseServiceRemovalOrVariationOfConditions = async (req, res) => {
 				: null;
 
 		res.render(canUseServiceRemovalOrVariationOfConditionsHouseholder, {
+			bannerHtmlOverride: config.betaBannerText,
 			deadlineDate,
 			appealLPD,
 			applicationType,
@@ -210,6 +216,7 @@ const canUseServiceRemovalOrVariationOfConditions = async (req, res) => {
 		);
 
 		res.render(canUseServiceRemovalOrVariationOfConditionsFullAppeal, {
+			bannerHtmlOverride: config.betaBannerText,
 			deadlineDate,
 			appealLPD,
 			applicationType,

--- a/packages/forms-web-app/src/controllers/before-you-start/use-existing-service-development-type.js
+++ b/packages/forms-web-app/src/controllers/before-you-start/use-existing-service-development-type.js
@@ -3,9 +3,11 @@ const {
 		BEFORE_YOU_START: { USE_EXISTING_SERVICE_DEVELOPMENT_TYPE: useExistingServiceDevelopmentType }
 	}
 } = require('../../lib/views');
+const config = require('../../config');
 
 exports.getExistingServiceDevelopmentType = async (_, res) => {
 	res.render(useExistingServiceDevelopmentType, {
+		bannerHtmlOverride: config.betaBannerText,
 		acpLink: 'https://acp.planninginspectorate.gov.uk/'
 	});
 };

--- a/packages/forms-web-app/src/controllers/before-you-start/use-existing-service-listed-building.js
+++ b/packages/forms-web-app/src/controllers/before-you-start/use-existing-service-listed-building.js
@@ -3,9 +3,11 @@ const {
 		BEFORE_YOU_START: { USE_EXISTING_SERVICE_LISTED_BUILDING: useExistingServiceListedBuilding }
 	}
 } = require('../../lib/views');
+const config = require('../../config');
 
 exports.getUseExistingServiceListedBuilding = async (_, res) => {
 	res.render(useExistingServiceListedBuilding, {
+		bannerHtmlOverride: config.betaBannerText,
 		acpLink: 'https://acp.planninginspectorate.gov.uk/'
 	});
 };

--- a/packages/forms-web-app/src/controllers/eligibility/appeal-statement.js
+++ b/packages/forms-web-app/src/controllers/eligibility/appeal-statement.js
@@ -1,7 +1,8 @@
 const { VIEW } = require('../../lib/views');
+const config = require('../../config');
 
 exports.getAppealStatement = (req, res) => {
-	res.render(VIEW.ELIGIBILITY.APPEAL_STATEMENT);
+	res.render(VIEW.ELIGIBILITY.APPEAL_STATEMENT, { bannerHtmlOverride: config.betaBannerText });
 };
 
 exports.postAppealStatement = (req, res) => {

--- a/packages/forms-web-app/src/controllers/eligibility/costs.js
+++ b/packages/forms-web-app/src/controllers/eligibility/costs.js
@@ -2,13 +2,15 @@ const logger = require('../../lib/logger');
 const { createOrUpdateAppeal } = require('../../lib/appeals-api-wrapper');
 const { VIEW } = require('../../lib/views');
 const { validCostsOptions } = require('../../validators/eligibility/costs');
+const config = require('../../config');
 
 exports.getCostsOut = (req, res) => {
-	res.render(VIEW.ELIGIBILITY.COSTS_OUT);
+	res.render(VIEW.ELIGIBILITY.COSTS_OUT, { bannerHtmlOverride: config.betaBannerText });
 };
 
 exports.getCosts = (req, res) => {
 	res.render(VIEW.ELIGIBILITY.COSTS, {
+		bannerHtmlOverride: config.betaBannerText,
 		appeal: req.session.appeal
 	});
 };
@@ -27,6 +29,7 @@ exports.postCosts = async (req, res) => {
 
 	if (Object.keys(errors).length > 0) {
 		res.render(VIEW.ELIGIBILITY.COSTS, {
+			bannerHtmlOverride: config.betaBannerText,
 			appeal,
 			errors,
 			errorSummary
@@ -46,6 +49,7 @@ exports.postCosts = async (req, res) => {
 		logger.error(e);
 
 		res.render(VIEW.ELIGIBILITY.COSTS, {
+			bannerHtmlOverride: config.betaBannerText,
 			appeal,
 			errors,
 			errorSummary: [{ text: e.toString(), href: '#' }]

--- a/packages/forms-web-app/src/controllers/eligibility/decision-date.js
+++ b/packages/forms-web-app/src/controllers/eligibility/decision-date.js
@@ -3,14 +3,17 @@ const { rules, validation } = require('@pins/business-rules');
 const { createOrUpdateAppeal } = require('../../lib/appeals-api-wrapper');
 const logger = require('../../lib/logger');
 const { VIEW } = require('../../lib/views');
+const config = require('../../config');
 
 exports.getDecisionDate = (req, res) => {
+	console.log('here');
 	const { appeal } = req.session;
 
 	const appealDecisionDate = parseISO(appeal.decisionDate);
 	const decisionDate = isValid(appealDecisionDate) ? appealDecisionDate : null;
 
 	res.render(VIEW.ELIGIBILITY.DECISION_DATE, {
+		bannerHtmlOverride: config.betaBannerText,
 		decisionDate: decisionDate && {
 			day: `0${decisionDate.getDate()}`.slice(-2),
 			month: `0${decisionDate.getMonth() + 1}`.slice(-2),
@@ -27,6 +30,7 @@ exports.postDecisionDate = async (req, res) => {
 
 	if (Object.keys(errors).length > 0) {
 		res.render(VIEW.ELIGIBILITY.DECISION_DATE, {
+			bannerHtmlOverride: config.betaBannerText,
 			decisionDate: {
 				day: body['decision-date-day'],
 				month: body['decision-date-month'],
@@ -47,6 +51,7 @@ exports.postDecisionDate = async (req, res) => {
 		logger.error(e);
 
 		res.render(VIEW.ELIGIBILITY.DECISION_DATE, {
+			bannerHtmlOverride: config.betaBannerText,
 			appeal,
 			errors,
 			errorSummary: [{ text: e.toString(), href: '#' }]
@@ -69,6 +74,7 @@ exports.getDecisionDatePassed = (req, res) => {
 	const { appeal } = req.session;
 
 	res.render(VIEW.ELIGIBILITY.DECISION_DATE_PASSED, {
+		bannerHtmlOverride: config.betaBannerText,
 		deadlineDate: appeal.decisionDate && rules.appeal.deadlineDate(parseISO(appeal.decisionDate))
 	});
 };

--- a/packages/forms-web-app/src/controllers/eligibility/enforcement-notice.js
+++ b/packages/forms-web-app/src/controllers/eligibility/enforcement-notice.js
@@ -4,13 +4,17 @@ const { VIEW } = require('../../lib/views');
 const {
 	validEnforcementNoticeOptions
 } = require('../../validators/eligibility/enforcement-notice');
+const config = require('../../config');
 
 exports.getServiceNotAvailableWhenReceivedEnforcementNotice = (req, res) => {
-	res.render(VIEW.ELIGIBILITY.ENFORCEMENT_NOTICE_OUT);
+	res.render(VIEW.ELIGIBILITY.ENFORCEMENT_NOTICE_OUT, {
+		bannerHtmlOverride: config.betaBannerText
+	});
 };
 
 exports.getEnforcementNotice = (req, res) => {
 	res.render(VIEW.ELIGIBILITY.ENFORCEMENT_NOTICE, {
+		bannerHtmlOverride: config.betaBannerText,
 		appeal: req.session.appeal
 	});
 };
@@ -28,6 +32,7 @@ exports.postEnforcementNotice = async (req, res) => {
 
 	if (Object.keys(errors).length > 0) {
 		res.render(VIEW.ELIGIBILITY.ENFORCEMENT_NOTICE, {
+			bannerHtmlOverride: config.betaBannerText,
 			appeal: {
 				...appeal,
 				eligibility: {
@@ -53,6 +58,7 @@ exports.postEnforcementNotice = async (req, res) => {
 		logger.error(e);
 
 		res.render(VIEW.ELIGIBILITY.ENFORCEMENT_NOTICE, {
+			bannerHtmlOverride: config.betaBannerText,
 			appeal,
 			errors,
 			errorSummary: [{ text: e.toString(), href: '#' }]

--- a/packages/forms-web-app/src/controllers/eligibility/granted-or-refused-permission.js
+++ b/packages/forms-web-app/src/controllers/eligibility/granted-or-refused-permission.js
@@ -7,17 +7,21 @@ const { createOrUpdateAppeal } = require('../../lib/appeals-api-wrapper');
 const {
 	validHouseholderPlanningPermissionStatusOptions
 } = require('../../validators/eligibility/granted-or-refused-permission');
+const config = require('../../config');
 
 exports.getNoDecision = async (req, res) => {
-	res.render(VIEW.ELIGIBILITY.NO_DECISION);
+	res.render(VIEW.ELIGIBILITY.NO_DECISION, { bannerHtmlOverride: config.betaBannerText });
 };
 
 exports.getGrantedOrRefusedPermissionOut = async (req, res) => {
-	res.render(VIEW.ELIGIBILITY.GRANTED_REFUSED_PERMISSION_OUT);
+	res.render(VIEW.ELIGIBILITY.GRANTED_REFUSED_PERMISSION_OUT, {
+		bannerHtmlOverride: config.betaBannerText
+	});
 };
 
 exports.getGrantedOrRefusedPermission = async (req, res) => {
 	res.render(VIEW.ELIGIBILITY.GRANTED_REFUSED_PERMISSION, {
+		bannerHtmlOverride: config.betaBannerText,
 		appeal: req.session.appeal
 	});
 };
@@ -49,6 +53,7 @@ exports.postGrantedOrRefusedPermission = async (req, res) => {
 
 	if (Object.keys(errors).length > 0) {
 		res.render(forwardPage('default'), {
+			bannerHtmlOverride: config.betaBannerText,
 			appeal: {
 				...appeal,
 				eligibility: {
@@ -74,6 +79,7 @@ exports.postGrantedOrRefusedPermission = async (req, res) => {
 		logger.error(e);
 
 		res.render(forwardPage('default'), {
+			bannerHtmlOverride: config.betaBannerText,
 			appeal,
 			errors,
 			errorSummary: [{ text: e.toString(), href: '#' }]

--- a/packages/forms-web-app/src/controllers/eligibility/householder-planning-permission.js
+++ b/packages/forms-web-app/src/controllers/eligibility/householder-planning-permission.js
@@ -4,13 +4,17 @@ const { VIEW } = require('../../lib/views');
 const {
 	validHouseholderPlanningPermissionOptions
 } = require('../../validators/eligibility/householder-planning-permission');
+const config = require('../../config');
 
 exports.getServiceOnlyForHouseholderPlanningPermission = (req, res) => {
-	res.render(VIEW.ELIGIBILITY.HOUSEHOLDER_PLANNING_PERMISSION_OUT);
+	res.render(VIEW.ELIGIBILITY.HOUSEHOLDER_PLANNING_PERMISSION_OUT, {
+		bannerHtmlOverride: config.betaBannerText
+	});
 };
 
 exports.getHouseholderPlanningPermission = (req, res) => {
 	res.render(VIEW.ELIGIBILITY.HOUSEHOLDER_PLANNING_PERMISSION, {
+		bannerHtmlOverride: config.betaBannerText,
 		appeal: req.session.appeal
 	});
 };
@@ -31,6 +35,7 @@ exports.postHouseholderPlanningPermission = async (req, res) => {
 
 	if (Object.keys(errors).length > 0) {
 		res.render(VIEW.ELIGIBILITY.HOUSEHOLDER_PLANNING_PERMISSION, {
+			bannerHtmlOverride: config.betaBannerText,
 			appeal: {
 				...appeal,
 				eligibility: {
@@ -56,6 +61,7 @@ exports.postHouseholderPlanningPermission = async (req, res) => {
 		logger.error(e);
 
 		res.render(VIEW.ELIGIBILITY.HOUSEHOLDER_PLANNING_PERMISSION, {
+			bannerHtmlOverride: config.betaBannerText,
 			appeal,
 			errors,
 			errorSummary: [{ text: e.toString(), href: '#' }]

--- a/packages/forms-web-app/src/controllers/eligibility/listed-building.js
+++ b/packages/forms-web-app/src/controllers/eligibility/listed-building.js
@@ -1,13 +1,17 @@
 const { VIEW } = require('../../lib/views');
 const { validIsListedBuildingOptions } = require('../../validators/eligibility/listed-building');
 const { createOrUpdateAppeal } = require('../../lib/appeals-api-wrapper');
+const config = require('../../config');
 
 exports.getServiceNotAvailableForListedBuildings = (req, res) => {
-	res.render(VIEW.ELIGIBILITY.LISTED_OUT);
+	res.render(VIEW.ELIGIBILITY.LISTED_OUT, { bannerHtmlOverride: config.betaBannerText });
 };
 
 exports.getListedBuilding = (req, res) => {
-	res.render(VIEW.ELIGIBILITY.LISTED_BUILDING, { appeal: req.session.appeal });
+	res.render(VIEW.ELIGIBILITY.LISTED_BUILDING, {
+		bannerHtmlOverride: config.betaBannerText,
+		appeal: req.session.appeal
+	});
 };
 
 exports.postListedBuilding = async (req, res) => {
@@ -23,6 +27,7 @@ exports.postListedBuilding = async (req, res) => {
 
 	if (Object.keys(errors).length > 0) {
 		res.render(VIEW.ELIGIBILITY.LISTED_BUILDING, {
+			bannerHtmlOverride: config.betaBannerText,
 			appeal: {
 				...appeal,
 				eligibility: {
@@ -48,6 +53,7 @@ exports.postListedBuilding = async (req, res) => {
 		req.log.error(e);
 
 		res.render(VIEW.ELIGIBILITY.LISTED_BUILDING, {
+			bannerHtmlOverride: config.betaBannerText,
 			appeal,
 			errors,
 			errorSummary: [{ text: e.toString(), href: '#' }]

--- a/packages/forms-web-app/src/controllers/eligibility/planning-department.js
+++ b/packages/forms-web-app/src/controllers/eligibility/planning-department.js
@@ -7,6 +7,7 @@ const {
 } = require('../../lib/planning-departments-to-nunjucks-list-items');
 const { getRefreshedDepartmentData } = require('../../services/department.service');
 const { VIEW } = require('../../lib/views');
+const config = require('../../config');
 
 exports.getPlanningDepartment = async (req, res) => {
 	const { departments, eligibleDepartments, ineligibleDepartments } =
@@ -21,6 +22,7 @@ exports.getPlanningDepartment = async (req, res) => {
 	}
 
 	res.render(VIEW.ELIGIBILITY.PLANNING_DEPARTMENT, {
+		bannerHtmlOverride: config.betaBannerText,
 		appealLPD,
 		departments: departmentsToNunjucksItems(departments, appealLPD),
 		eligibleDepartments,
@@ -39,6 +41,7 @@ exports.postPlanningDepartment = async (req, res) => {
 
 		if (errorMessage !== 'Ineligible Department') {
 			res.render(VIEW.ELIGIBILITY.PLANNING_DEPARTMENT, {
+				bannerHtmlOverride: config.betaBannerText,
 				appealLPD: '',
 				departments: departmentsToNunjucksItems(departments),
 				errors,
@@ -59,6 +62,7 @@ exports.postPlanningDepartment = async (req, res) => {
 		logger.error(e);
 
 		res.render(VIEW.ELIGIBILITY.PLANNING_DEPARTMENT, {
+			bannerHtmlOverride: config.betaBannerText,
 			appeal,
 			departments: departmentsToNunjucksItems(departments, lpaName),
 			errors,
@@ -73,5 +77,7 @@ exports.postPlanningDepartment = async (req, res) => {
 };
 
 exports.getPlanningDepartmentOut = (req, res) => {
-	res.render(VIEW.ELIGIBILITY.PLANNING_DEPARTMENT_OUT);
+	res.render(VIEW.ELIGIBILITY.PLANNING_DEPARTMENT_OUT, {
+		bannerHtmlOverride: config.betaBannerText
+	});
 };

--- a/packages/forms-web-app/src/controllers/full-appeal/any-of-following.js
+++ b/packages/forms-web-app/src/controllers/full-appeal/any-of-following.js
@@ -5,6 +5,7 @@ const {
 } = require('../../lib/views');
 const { createOrUpdateAppeal } = require('../../lib/appeals-api-wrapper');
 const logger = require('../../lib/logger');
+const config = require('../../config');
 
 const sectionName = 'eligibility';
 
@@ -14,6 +15,7 @@ const getAnyOfFollowing = (req, res) => {
 		typeOfPlanningApplication
 	} = req.session.appeal;
 	res.render(ANY_OF_FOLLOWING, {
+		bannerHtmlOverride: config.betaBannerText,
 		applicationCategories,
 		typeOfPlanningApplication
 	});
@@ -31,6 +33,7 @@ const postAnyOfFollowing = async (req, res) => {
 
 	if (Object.keys(errors).length > 0) {
 		return res.render(ANY_OF_FOLLOWING, {
+			bannerHtmlOverride: config.betaBannerText,
 			applicationCategories,
 			typeOfPlanningApplication,
 			errors,
@@ -47,6 +50,7 @@ const postAnyOfFollowing = async (req, res) => {
 		logger.error(err);
 
 		return res.render(ANY_OF_FOLLOWING, {
+			bannerHtmlOverride: config.betaBannerText,
 			applicationCategories,
 			typeOfPlanningApplication,
 			errors,

--- a/packages/forms-web-app/src/controllers/full-appeal/date-decision-due.js
+++ b/packages/forms-web-app/src/controllers/full-appeal/date-decision-due.js
@@ -7,6 +7,7 @@ const {
 		FULL_APPEAL: { DATE_DECISION_DUE: currentPage }
 	}
 } = require('../../lib/views');
+const config = require('../../config');
 
 const navigationPage = {
 	nextPage: '/before-you-start/enforcement-notice',
@@ -20,6 +21,7 @@ exports.getDateDecisionDue = (req, res) => {
 	const decisionDate = isValid(appealDecisionDate) ? appealDecisionDate : null;
 
 	res.render(currentPage, {
+		bannerHtmlOverride: config.betaBannerText,
 		decisionDate: decisionDate && {
 			day: `0${decisionDate?.getDate()}`.slice(-2),
 			month: `0${decisionDate?.getMonth() + 1}`.slice(-2),
@@ -54,6 +56,7 @@ exports.postDateDecisionDue = async (req, res) => {
 
 	if (Object.keys(errors).length > 0) {
 		res.render(currentPage, {
+			bannerHtmlOverride: config.betaBannerText,
 			decisionDate: {
 				day: body['decision-date-day'],
 				month: body['decision-date-month'],
@@ -75,6 +78,7 @@ exports.postDateDecisionDue = async (req, res) => {
 		logger.error(e);
 
 		res.render(currentPage, {
+			bannerHtmlOverride: config.betaBannerText,
 			decisionDate: {
 				day: body['decision-date-day'],
 				month: body['decision-date-month'],

--- a/packages/forms-web-app/src/controllers/full-appeal/decision-date.js
+++ b/packages/forms-web-app/src/controllers/full-appeal/decision-date.js
@@ -1,6 +1,7 @@
 const { isValid, parseISO } = require('date-fns');
 const { rules, validation } = require('@pins/business-rules');
 const logger = require('../../lib/logger');
+const config = require('../../config');
 
 const { createOrUpdateAppeal } = require('../../lib/appeals-api-wrapper');
 const {
@@ -16,6 +17,7 @@ exports.getDecisionDate = async (req, res) => {
 	const decisionDate = isValid(appealDecisionDate) ? appealDecisionDate : null;
 
 	res.render(currentPage, {
+		bannerHtmlOverride: config.betaBannerText,
 		decisionDate: decisionDate && {
 			day: `0${decisionDate?.getDate()}`.slice(-2),
 			month: `0${decisionDate?.getMonth() + 1}`.slice(-2),
@@ -31,6 +33,7 @@ exports.postDecisionDate = async (req, res) => {
 
 	if (Object.keys(errors).length > 0) {
 		return res.render(currentPage, {
+			bannerHtmlOverride: config.betaBannerText,
 			decisionDate: {
 				day: body['decision-date-day'],
 				month: body['decision-date-month'],
@@ -79,6 +82,7 @@ exports.postDecisionDate = async (req, res) => {
 		logger.error(e);
 
 		return res.render(currentPage, {
+			bannerHtmlOverride: config.betaBannerText,
 			appeal,
 			errors,
 			errorSummary: [{ text: e.toString(), href: 'decision-date' }]

--- a/packages/forms-web-app/src/controllers/full-appeal/enforcement-notice.js
+++ b/packages/forms-web-app/src/controllers/full-appeal/enforcement-notice.js
@@ -13,12 +13,12 @@ const navigationPages = {
 	nextPage: '/before-you-start/can-use-service',
 	shutterPage: '/before-you-start/use-existing-service-enforcement-notice'
 };
-
-// /full-appeal/submit-appeal/task-list
+const config = require('../../config');
 
 exports.getEnforcementNotice = (req, res) => {
 	const { appeal } = req.session;
 	res.render(currentPage, {
+		bannerHtmlOverride: config.betaBannerText,
 		appeal
 	});
 };
@@ -35,6 +35,7 @@ exports.postEnforcementNotice = async (req, res) => {
 
 	if (Object.keys(errors).length > 0) {
 		res.render(currentPage, {
+			bannerHtmlOverride: config.betaBannerText,
 			appeal: {
 				...appeal,
 				eligibility: {
@@ -60,6 +61,7 @@ exports.postEnforcementNotice = async (req, res) => {
 		logger.error(e);
 
 		res.render(currentPage, {
+			bannerHtmlOverride: config.betaBannerText,
 			appeal,
 			errors,
 			errorSummary: [{ text: e.toString(), href: '#' }]

--- a/packages/forms-web-app/src/controllers/full-appeal/granted-or-refused.js
+++ b/packages/forms-web-app/src/controllers/full-appeal/granted-or-refused.js
@@ -11,6 +11,7 @@ const { createOrUpdateAppeal } = require('../../lib/appeals-api-wrapper');
 const {
 	validApplicationDecisionOptions
 } = require('../../validators/full-appeal/granted-or-refused');
+const config = require('../../config');
 
 exports.forwardPage = (status) => {
 	const statuses = {
@@ -26,7 +27,8 @@ exports.forwardPage = (status) => {
 
 exports.getGrantedOrRefused = async (req, res) => {
 	res.render(currentPage, {
-		appeal: req.session.appeal,
+		bannerHtmlOverride: config.betaBannerText,
+		appeal: req.session.appeal
 	});
 };
 
@@ -47,6 +49,7 @@ exports.postGrantedOrRefused = async (req, res) => {
 
 	if (Object.keys(errors).length > 0) {
 		res.render(currentPage, {
+			bannerHtmlOverride: config.betaBannerText,
 			appeal,
 			errors,
 			errorSummary
@@ -60,6 +63,7 @@ exports.postGrantedOrRefused = async (req, res) => {
 		logger.error(e);
 
 		res.render(currentPage, {
+			bannerHtmlOverride: config.betaBannerText,
 			appeal,
 			errors,
 			errorSummary: [{ text: e.toString(), href: '#' }]

--- a/packages/forms-web-app/src/controllers/full-appeal/local-planning-department.js
+++ b/packages/forms-web-app/src/controllers/full-appeal/local-planning-department.js
@@ -1,4 +1,5 @@
 const logger = require('../../lib/logger');
+const config = require('../../config');
 const {
 	getDepartmentFromName,
 	getDepartmentFromId,
@@ -23,6 +24,7 @@ exports.getPlanningDepartment = async (req, res) => {
 	}
 
 	res.render(VIEW.FULL_APPEAL.LOCAL_PLANNING_DEPARTMENT, {
+		bannerHtmlOverride: config.betaBannerText,
 		appealLPD,
 		departments: departmentsToNunjucksItems(departments, appealLPD),
 		eligibleDepartments,
@@ -41,6 +43,7 @@ exports.postPlanningDepartment = async (req, res) => {
 
 		if (errorMessage !== 'Ineligible Department') {
 			res.render(VIEW.FULL_APPEAL.LOCAL_PLANNING_DEPARTMENT, {
+				bannerHtmlOverride: config.betaBannerText,
 				appealLPD: '',
 				departments: departmentsToNunjucksItems(departments),
 				errors,
@@ -63,6 +66,7 @@ exports.postPlanningDepartment = async (req, res) => {
 		logger.error(e);
 
 		res.render(VIEW.FULL_APPEAL.LOCAL_PLANNING_DEPARTMENT, {
+			bannerHtmlOverride: config.betaBannerText,
 			appeal,
 			departments: departmentsToNunjucksItems(departments, lpaName),
 			errors,

--- a/packages/forms-web-app/src/controllers/full-appeal/prior-approval-existing-home.js
+++ b/packages/forms-web-app/src/controllers/full-appeal/prior-approval-existing-home.js
@@ -8,6 +8,7 @@ const {
 		FULL_APPEAL: { PRIOR_APPROVAL_EXISTING_HOME }
 	}
 } = require('../../lib/views');
+const config = require('../../config');
 
 const sectionName = 'eligibility';
 
@@ -18,6 +19,7 @@ const getPriorApprovalExistingHome = (req, res) => {
 		}
 	} = req.session;
 	res.render(PRIOR_APPROVAL_EXISTING_HOME, {
+		bannerHtmlOverride: config.betaBannerText,
 		hasPriorApprovalForExistingHome
 	});
 };
@@ -31,6 +33,7 @@ const postPriorApprovalExistingHome = async (req, res) => {
 
 	if (Object.keys(errors).length > 0) {
 		return res.render(PRIOR_APPROVAL_EXISTING_HOME, {
+			bannerHtmlOverride: config.betaBannerText,
 			errors,
 			errorSummary
 		});
@@ -62,6 +65,7 @@ const postPriorApprovalExistingHome = async (req, res) => {
 		logger.error(err);
 
 		return res.render(PRIOR_APPROVAL_EXISTING_HOME, {
+			bannerHtmlOverride: config.betaBannerText,
 			hasPriorApprovalForExistingHome,
 			errors,
 			errorSummary: [{ text: err.toString(), href: '#' }]

--- a/packages/forms-web-app/src/controllers/full-appeal/type-of-planning-application.js
+++ b/packages/forms-web-app/src/controllers/full-appeal/type-of-planning-application.js
@@ -17,11 +17,13 @@ const {
 	}
 } = require('../../lib/views');
 const { mapPlanningApplication } = require('../../lib/full-appeal/map-planning-application');
+const config = require('../../config');
 
 const getTypeOfPlanningApplication = (req, res) => {
 	const { appeal } = req.session;
 
 	res.render(TYPE_OF_PLANNING_APPLICATION, {
+		bannerHtmlOverride: config.betaBannerText,
 		typeOfPlanningApplication: appeal.typeOfPlanningApplication
 	});
 };
@@ -35,6 +37,7 @@ const postTypeOfPlanningApplication = async (req, res) => {
 
 	if (errors['type-of-planning-application']) {
 		return res.render(TYPE_OF_PLANNING_APPLICATION, {
+			bannerHtmlOverride: config.betaBannerText,
 			typeOfPlanningApplication,
 			errors,
 			errorSummary
@@ -48,6 +51,7 @@ const postTypeOfPlanningApplication = async (req, res) => {
 	} catch (err) {
 		logger.error(err);
 		return res.render(TYPE_OF_PLANNING_APPLICATION, {
+			bannerHtmlOverride: config.betaBannerText,
 			typeOfPlanningApplication,
 			errors,
 			errorSummary: [{ text: err.toString(), href: '#' }]

--- a/packages/forms-web-app/src/controllers/full-appeal/use-a-different-service.js
+++ b/packages/forms-web-app/src/controllers/full-appeal/use-a-different-service.js
@@ -1,7 +1,9 @@
 const { VIEW } = require('../../lib/views');
+const config = require('../../config');
 
 exports.getUseADifferentService = async (_, res) => {
 	res.render(VIEW.FULL_APPEAL.USE_A_DIFFERENT_SERVICE, {
+		bannerHtmlOverride: config.betaBannerText,
 		acpLink: 'https://acp.planninginspectorate.gov.uk/'
 	});
 };

--- a/packages/forms-web-app/src/controllers/full-appeal/use-existing-service-application-type.js
+++ b/packages/forms-web-app/src/controllers/full-appeal/use-existing-service-application-type.js
@@ -1,7 +1,9 @@
 const { VIEW } = require('../../lib/views');
+const config = require('../../config');
 
 exports.getUseExistingServiceApplicationType = async (_, res) => {
 	res.render(VIEW.FULL_APPEAL.USE_EXISTING_SERVICE_APPLICATION_TYPE, {
+		bannerHtmlOverride: config.betaBannerText,
 		acpLink: 'https://acp.planninginspectorate.gov.uk/'
 	});
 };

--- a/packages/forms-web-app/src/controllers/full-appeal/use-existing-service-enforcement-notice.js
+++ b/packages/forms-web-app/src/controllers/full-appeal/use-existing-service-enforcement-notice.js
@@ -1,7 +1,9 @@
 const { VIEW } = require('../../lib/views');
+const config = require('../../config');
 
 exports.getUseExistingServiceEnforcementNotice = async (_, res) => {
 	res.render(VIEW.BEFORE_YOU_START.USE_EXISTING_SERVICE_ENFORCEMENT_NOTICE, {
+		bannerHtmlOverride: config.betaBannerText,
 		acpLink: 'https://acp.planninginspectorate.gov.uk/'
 	});
 };

--- a/packages/forms-web-app/src/controllers/full-appeal/use-existing-service-local-planning-department.js
+++ b/packages/forms-web-app/src/controllers/full-appeal/use-existing-service-local-planning-department.js
@@ -1,7 +1,9 @@
 const { VIEW } = require('../../lib/views');
+const config = require('../../config');
 
 exports.getUseExistingServiceLocalPlanningDepartment = async (_, res) => {
 	res.render(VIEW.FULL_APPEAL.USE_EXISTING_SERVICE_LOCAL_PLANNING_DEPARTMENT, {
+		bannerHtmlOverride: config.betaBannerText,
 		acpLink: 'https://acp.planninginspectorate.gov.uk/'
 	});
 };

--- a/packages/forms-web-app/src/controllers/full-appeal/you-cannot-appeal.js
+++ b/packages/forms-web-app/src/controllers/full-appeal/you-cannot-appeal.js
@@ -1,3 +1,4 @@
+const config = require('../../config');
 const { VIEW } = require('../../lib/views');
 
 const getYouCannotAppeal = async (req, res) => {
@@ -10,6 +11,7 @@ const getYouCannotAppeal = async (req, res) => {
 	req.session.appeal = null;
 
 	return res.render(VIEW.YOU_CANNOT_APPEAL, {
+		bannerHtmlOverride: config.betaBannerText,
 		appealDeadline,
 		appealPeriodToBeDisplayed: appealPeriod,
 		beforeYouStartFirstPage

--- a/packages/forms-web-app/src/controllers/householder-planning/eligibility/claiming-costs-householder.js
+++ b/packages/forms-web-app/src/controllers/householder-planning/eligibility/claiming-costs-householder.js
@@ -11,6 +11,7 @@ const {
 		}
 	}
 } = require('../../../lib/views');
+const config = require('../../../config');
 
 const nextPage = `/before-you-start/can-use-service`;
 
@@ -28,6 +29,7 @@ exports.getClaimingCostsHouseholder = async (req, res) => {
 	}
 
 	res.render(claimingCosts, {
+		bannerHtmlOverride: config.betaBannerText,
 		isClaimingCosts: appeal.eligibility.isClaimingCosts
 	});
 };
@@ -50,6 +52,7 @@ exports.postClaimingCostsHouseholder = async (req, res) => {
 
 	if (errors['claiming-costs-householder']) {
 		return res.render(claimingCosts, {
+			bannerHtmlOverride: config.betaBannerText,
 			isClaimingCosts: appeal.eligibility.isClaimingCosts,
 			errors,
 			errorSummary
@@ -68,6 +71,7 @@ exports.postClaimingCostsHouseholder = async (req, res) => {
 		logger.error(e);
 
 		return res.render(claimingCosts, {
+			bannerHtmlOverride: config.betaBannerText,
 			isClaimingCosts: appeal.eligibility.isClaimingCosts,
 			errors,
 			errorSummary: [{ text: e.toString(), href: 'pageId' }]

--- a/packages/forms-web-app/src/controllers/householder-planning/eligibility/conditions-householder-permission.js
+++ b/packages/forms-web-app/src/controllers/householder-planning/eligibility/conditions-householder-permission.js
@@ -10,6 +10,7 @@ const {
 		}
 	}
 } = require('../../../lib/views');
+const config = require('../../../config');
 
 const sectionName = 'eligibility';
 
@@ -20,6 +21,7 @@ const getConditionsHouseholderPermission = (req, res) => {
 		}
 	} = req.session;
 	res.render(CONDITIONS_HOUSEHOLDER_PERMISSION, {
+		bannerHtmlOverride: config.betaBannerText,
 		hasHouseholderPermissionConditions
 	});
 };
@@ -33,6 +35,7 @@ const postConditionsHouseholderPermission = async (req, res) => {
 
 	if (Object.keys(errors).length > 0) {
 		return res.render(CONDITIONS_HOUSEHOLDER_PERMISSION, {
+			bannerHtmlOverride: config.betaBannerText,
 			errors,
 			errorSummary
 		});
@@ -64,6 +67,7 @@ const postConditionsHouseholderPermission = async (req, res) => {
 		logger.error(err);
 
 		return res.render(CONDITIONS_HOUSEHOLDER_PERMISSION, {
+			bannerHtmlOverride: config.betaBannerText,
 			hasHouseholderPermissionConditions,
 			errors,
 			errorSummary: [{ text: err.toString(), href: '#' }]

--- a/packages/forms-web-app/src/controllers/householder-planning/eligibility/date-decision-due-householder.js
+++ b/packages/forms-web-app/src/controllers/householder-planning/eligibility/date-decision-due-householder.js
@@ -9,6 +9,7 @@ const {
 		}
 	}
 } = require('../../../lib/views');
+const config = require('../../../config');
 
 const shutterPage = '/before-you-start/you-cannot-appeal';
 const enforcementNoticeHouseholder = `/before-you-start/enforcement-notice-householder`;
@@ -20,6 +21,7 @@ exports.getDateDecisionDueHouseholder = async (req, res) => {
 	const decisionDate = isValid(appealDecisionDate) ? appealDecisionDate : null;
 
 	res.render(currentPage, {
+		bannerHtmlOverride: config.betaBannerText,
 		decisionDate: decisionDate && {
 			day: `0${decisionDate?.getDate()}`.slice(-2),
 			month: `0${decisionDate?.getMonth() + 1}`.slice(-2),
@@ -35,6 +37,7 @@ exports.postDateDecisionDueHouseholder = async (req, res) => {
 
 	if (Object.keys(errors).length > 0) {
 		return res.render(currentPage, {
+			bannerHtmlOverride: config.betaBannerText,
 			decisionDate: {
 				day: body['date-decision-due-householder-day'],
 				month: body['date-decision-due-householder-month'],
@@ -85,6 +88,7 @@ exports.postDateDecisionDueHouseholder = async (req, res) => {
 		logger.error(e);
 
 		return res.render(currentPage, {
+			bannerHtmlOverride: config.betaBannerText,
 			decisionDate: {
 				day: body['date-decision-due-householder-day'],
 				month: body['date-decision-due-householder-month'],

--- a/packages/forms-web-app/src/controllers/householder-planning/eligibility/decision-date-householder.js
+++ b/packages/forms-web-app/src/controllers/householder-planning/eligibility/decision-date-householder.js
@@ -10,6 +10,7 @@ const {
 		}
 	}
 } = require('../../../lib/views');
+const config = require('../../../config');
 
 const shutter = `/before-you-start/you-cannot-appeal`;
 const enforcementNoticeHouseholder = `/before-you-start/enforcement-notice-householder`;
@@ -21,6 +22,7 @@ exports.getDecisionDateHouseholder = async (req, res) => {
 	const decisionDate = isValid(appealDecisionDate) ? appealDecisionDate : null;
 
 	res.render(currentPage, {
+		bannerHtmlOverride: config.betaBannerText,
 		decisionDate: decisionDate && {
 			day: `0${decisionDate?.getDate()}`.slice(-2),
 			month: `0${decisionDate?.getMonth() + 1}`.slice(-2),
@@ -36,6 +38,7 @@ exports.postDecisionDateHouseholder = async (req, res) => {
 
 	if (Object.keys(errors).length > 0) {
 		return res.render(currentPage, {
+			bannerHtmlOverride: config.betaBannerText,
 			decisionDate: {
 				day: body['decision-date-householder-day'],
 				month: body['decision-date-householder-month'],
@@ -85,6 +88,7 @@ exports.postDecisionDateHouseholder = async (req, res) => {
 		logger.error(e);
 
 		return res.render(currentPage, {
+			bannerHtmlOverride: config.betaBannerText,
 			appeal,
 			errors,
 			errorSummary: [{ text: e.toString(), href: 'decision-date-householder' }]

--- a/packages/forms-web-app/src/controllers/householder-planning/eligibility/enforcement-notice-householder.js
+++ b/packages/forms-web-app/src/controllers/householder-planning/eligibility/enforcement-notice-householder.js
@@ -13,6 +13,7 @@ const {
 const { getDepartmentFromId } = require('../../../services/department.service');
 const { isFeatureActive } = require('../../../featureFlag');
 const { FLAG } = require('@pins/common/src/feature-flags');
+const config = require('../../../config');
 
 const navigationPages = {
 	nextPage: '/before-you-start/claiming-costs-householder',
@@ -24,6 +25,7 @@ exports.getEnforcementNoticeHouseholder = (req, res) => {
 	const { appeal } = req.session;
 
 	res.render(currentPage, {
+		bannerHtmlOverride: config.betaBannerText,
 		enforcementNotice: appeal.eligibility.enforcementNotice
 	});
 };
@@ -40,6 +42,7 @@ exports.postEnforcementNoticeHouseholder = async (req, res) => {
 
 	if (Object.keys(errors).length > 0) {
 		res.render(currentPage, {
+			bannerHtmlOverride: config.betaBannerText,
 			enforcementNotice: appeal.eligibility.enforcementNotice,
 			errors,
 			errorSummary
@@ -54,6 +57,7 @@ exports.postEnforcementNoticeHouseholder = async (req, res) => {
 		logger.error(e);
 
 		res.render(currentPage, {
+			bannerHtmlOverride: config.betaBannerText,
 			enforcementNotice: appeal.eligibility.enforcementNotice,
 			errors,
 			errorSummary: [{ text: e.toString(), href: '#' }]

--- a/packages/forms-web-app/src/controllers/householder-planning/eligibility/granted-or-refused-householder.js
+++ b/packages/forms-web-app/src/controllers/householder-planning/eligibility/granted-or-refused-householder.js
@@ -10,9 +10,11 @@ const {
 	}
 } = require('../../../lib/views');
 const { createOrUpdateAppeal } = require('../../../lib/appeals-api-wrapper');
+const config = require('../../../config');
 
 const getGrantedOrRefusedHouseholder = async (req, res) => {
 	res.render(GRANTED_OR_REFUSED_HOUSEHOLDER, {
+		bannerHtmlOverride: config.betaBannerText,
 		appeal: req.session.appeal
 	});
 };
@@ -26,6 +28,7 @@ const postGrantedOrRefusedHouseholder = async (req, res) => {
 
 	if (Object.keys(errors).length > 0) {
 		return res.render(GRANTED_OR_REFUSED_HOUSEHOLDER, {
+			bannerHtmlOverride: config.betaBannerText,
 			appeal,
 			errors,
 			errorSummary
@@ -43,6 +46,7 @@ const postGrantedOrRefusedHouseholder = async (req, res) => {
 		logger.error(err);
 
 		return res.render(GRANTED_OR_REFUSED_HOUSEHOLDER, {
+			bannerHtmlOverride: config.betaBannerText,
 			appeal,
 			errors,
 			errorSummary: [{ text: err.toString(), href: '#' }]

--- a/packages/forms-web-app/src/controllers/householder-planning/eligibility/listed-building-householder.js
+++ b/packages/forms-web-app/src/controllers/householder-planning/eligibility/listed-building-householder.js
@@ -7,6 +7,7 @@ const {
 		}
 	}
 } = require('../../../lib/views');
+const config = require('../../../config');
 
 const sectionName = 'eligibility';
 
@@ -27,6 +28,7 @@ const getListedBuildingHouseholder = async (req, res) => {
 	}
 
 	res.render(LISTED_BUILDING_HOUSEHOLDER, {
+		bannerHtmlOverride: config.betaBannerText,
 		isListedBuilding
 	});
 };
@@ -49,6 +51,7 @@ const postListedBuildingHouseholder = async (req, res) => {
 
 	if (Object.keys(errors).length > 0) {
 		return res.render(LISTED_BUILDING_HOUSEHOLDER, {
+			bannerHtmlOverride: config.betaBannerText,
 			isListedBuilding,
 			typeOfPlanningApplication,
 			errors,
@@ -63,6 +66,7 @@ const postListedBuildingHouseholder = async (req, res) => {
 		logger.error(err);
 
 		return res.render(LISTED_BUILDING_HOUSEHOLDER, {
+			bannerHtmlOverride: config.betaBannerText,
 			isListedBuilding,
 			typeOfPlanningApplication,
 			errors,

--- a/packages/forms-web-app/src/controllers/householder-planning/eligibility/use-existing-service-costs.js
+++ b/packages/forms-web-app/src/controllers/householder-planning/eligibility/use-existing-service-costs.js
@@ -5,9 +5,11 @@ const {
 		}
 	}
 } = require('../../../lib/views');
+const config = require('../../../config');
 
 exports.getUseExistingServiceCosts = async (_, res) => {
 	res.render(useExistingServiceCosts, {
+		bannerHtmlOverride: config.betaBannerText,
 		acpLink: 'https://acp.planninginspectorate.gov.uk/'
 	});
 };

--- a/packages/forms-web-app/src/controllers/householder-planning/eligibility/use-existing-service-enforcement-notice.js
+++ b/packages/forms-web-app/src/controllers/householder-planning/eligibility/use-existing-service-enforcement-notice.js
@@ -1,7 +1,9 @@
 const { VIEW } = require('../../../lib/views');
+const config = require('../../../config');
 
 exports.getUseExistingServiceEnforcementNotice = async (_, res) => {
 	res.render(VIEW.BEFORE_YOU_START.USE_EXISTING_SERVICE_ENFORCEMENT_NOTICE, {
+		bannerHtmlOverride: config.betaBannerText,
 		acpLink: 'https://acp.planninginspectorate.gov.uk/'
 	});
 };

--- a/packages/forms-web-app/src/dynamic-forms/dynamic-components/submission-screen/appellant-final-comment.njk
+++ b/packages/forms-web-app/src/dynamic-forms/dynamic-components/submission-screen/appellant-final-comment.njk
@@ -19,7 +19,7 @@ content %}
     </p>
 
     <p class="govuk-body">
-      <a data-cy="Feedback-Page-Body" href="https://forms.office.com/pages/responsepage.aspx?id=mN94WIhvq0iTIpmM5VcIjVqzqAxXAi1LghAWTH6Y3OJUOFg4UFdEUThGTlU3S0hFUTlERVYwMVRLTy4u" class="govuk-link">What did you think of this service?</a> (takes 30
+      <a data-cy="Feedback-Page-Body" href="{{feedbackUrl}}" class="govuk-link">What did you think of this service?</a> (takes 30
       seconds)
     </p>
   </div>

--- a/packages/forms-web-app/src/dynamic-forms/dynamic-components/submission-screen/appellant.njk
+++ b/packages/forms-web-app/src/dynamic-forms/dynamic-components/submission-screen/appellant.njk
@@ -32,7 +32,7 @@ content %}
 
 
     <p class="govuk-body">
-      <a data-cy="Feedback-Page-Body" href="https://forms.office.com.mcas.ms/pages/responsepage.aspx?id=mN94WIhvq0iTIpmM5VcIjYt1ax_BPvtOqhVjfvzyJN5UOUlNRkhaQjNXTDQyNEhSRExNOFVGSkNJTS4u&route=shorturl" class="govuk-link">What did you think of this service?</a> (takes 30
+      <a data-cy="Feedback-Page-Body" href="{{feedbackUrl}}" class="govuk-link">What did you think of this service?</a> (takes 30
       seconds)
     </p>
   </div>

--- a/packages/forms-web-app/src/dynamic-forms/dynamic-components/submission-screen/lpa-final-comment.njk
+++ b/packages/forms-web-app/src/dynamic-forms/dynamic-components/submission-screen/lpa-final-comment.njk
@@ -23,7 +23,7 @@
     </p>
 
     <p class="govuk-body">
-      <a data-cy="Feedback-Page-Body" href="https://forms.office.com/pages/responsepage.aspx?id=mN94WIhvq0iTIpmM5VcIjVqzqAxXAi1LghAWTH6Y3OJUOFg4UFdEUThGTlU3S0hFUTlERVYwMVRLTy4u" class="govuk-link">What did you think of this service?</a> (takes 30
+      <a data-cy="Feedback-Page-Body" href="{{feedbackUrl}}" class="govuk-link">What did you think of this service?</a> (takes 30
       seconds)
     </p>
   </div>

--- a/packages/forms-web-app/src/routes/file-based-router/comment-planning-appeal/comment-submitted/index.njk
+++ b/packages/forms-web-app/src/routes/file-based-router/comment-planning-appeal/comment-submitted/index.njk
@@ -23,7 +23,7 @@
     </p>
 
     <p class="govuk-body">
-      <a data-cy="Feedback-Page-Body" href="https://forms.office.com.mcas.ms/pages/responsepage.aspx?id=mN94WIhvq0iTIpmM5VcIjYt1ax_BPvtOqhVjfvzyJN5UQVU3UkdCT0FPVlYwQUsxUDYySDA1V1NXWC4u&route=shorturl" class="govuk-link">What did you think of this service?</a> (takes 30
+      <a data-cy="Feedback-Page-Body" href="{{feedbackUrl}}" class="govuk-link">What did you think of this service?</a> (takes 30
       seconds)
     </p>
   </div>

--- a/packages/forms-web-app/src/views/appellant-submission/confirmation.njk
+++ b/packages/forms-web-app/src/views/appellant-submission/confirmation.njk
@@ -32,8 +32,8 @@
       <p>If you need to contact us include the reference number from your original planning application.</p>
 
       <p class="govuk-body">
-        <a data-cy="Feedback-Page-Body" href="https://forms.office.com/Pages/ResponsePage.aspx?id=mN94WIhvq0iTIpmM5VcIjVqzqAxXAi1LghAWTH6Y3OJUOFg4UFdEUThGTlU3S0hFUTlERVYwMVRLTy4u" class="govuk-link">What did you
-          think of this service?</a> (takes 2 minutes)
+        <a data-cy="Feedback-Page-Body" href="{{ feedbackUrl }}}" class="govuk-link">What did you
+          think of this service?</a> (takes 30 seconds)
       </p>
     </div>
   </div>

--- a/packages/forms-web-app/src/views/full-appeal/submit-appeal/appeal-submitted.njk
+++ b/packages/forms-web-app/src/views/full-appeal/submit-appeal/appeal-submitted.njk
@@ -28,8 +28,8 @@
       </p>
 
       <p class="govuk-body">
-        <a data-cy="Feedback-Page-Body" href="https://forms.office.com/r/kRcwRQF9LQ" class="govuk-link">What did you
-          think of this service?</a> (takes 2 minutes)
+        <a data-cy="Feedback-Page-Body" href="{{feedbackUrl}}" class="govuk-link">What did you
+          think of this service?</a> (takes 30 seconds)
       </p>
     </div>
   </div>

--- a/packages/forms-web-app/src/views/layouts/comment-planning-appeal/main-no-back-link.njk
+++ b/packages/forms-web-app/src/views/layouts/comment-planning-appeal/main-no-back-link.njk
@@ -30,9 +30,7 @@
           tag: {
             text: "beta"
           },
-          html: 'This is a beta service – your <a class="govuk-link"
-          data-cy="Feedback"
-          href="https://forms.office.com/pages/responsepage.aspx?id=mN94WIhvq0iTIpmM5VcIjYt1ax_BPvtOqhVjfvzyJN5UQVU3UkdCT0FPVlYwQUsxUDYySDA1V1NXWC4u&route=shorturl">feedback</a> will help us to improve it.'
+          html: betaBannerFeedback
       }) }}
     {% endblock phaseBanner %}
 

--- a/packages/forms-web-app/src/views/layouts/comment-planning-appeal/main.njk
+++ b/packages/forms-web-app/src/views/layouts/comment-planning-appeal/main.njk
@@ -30,9 +30,7 @@
           tag: {
             text: "beta"
           },
-          html: 'This is a beta service – your <a class="govuk-link"
-          data-cy="Feedback"
-          href="https://forms.office.com/pages/responsepage.aspx?id=mN94WIhvq0iTIpmM5VcIjYt1ax_BPvtOqhVjfvzyJN5UQVU3UkdCT0FPVlYwQUsxUDYySDA1V1NXWC4u&route=shorturl">feedback</a> will help us to improve it.'
+          html: betaBannerFeedback
       }) }}
     {% endblock phaseBanner %}
 

--- a/packages/forms-web-app/src/views/layouts/full-appeal-banner/main-no-back-link.njk
+++ b/packages/forms-web-app/src/views/layouts/full-appeal-banner/main-no-back-link.njk
@@ -25,6 +25,10 @@
 
 {% set mainClasses = mainClasses | default("govuk-main-wrapper--auto-spacing") %}
 
+{% set bannerHtml %}
+  {{ bannerHtmlOverride if bannerHtmlOverride else betaBannerFeedback | safe }}
+{% endset %}
+
 {% block main %}
   <div class="govuk-width-container govuk-body {{ containerClasses }}">
     {% block phaseBanner %}
@@ -32,7 +36,7 @@
         tag: {
           text: "beta"
         },
-        html: 'This is a beta service – your <a class="govuk-link" data-cy="Feedback" href="https://forms.office.com.mcas.ms/pages/responsepage.aspx?id=mN94WIhvq0iTIpmM5VcIjdUN-o-7ZchJstlDoYRZ9U1UQzM3N1g0TE9VQjhSNzZYTUxHU0haWVNNSSQlQCN0PWcu">feedback</a> will help us to improve it.'
+        html: bannerHtml
       }) }}
     {% endblock %}
 

--- a/packages/forms-web-app/src/views/layouts/full-appeal-banner/main.njk
+++ b/packages/forms-web-app/src/views/layouts/full-appeal-banner/main.njk
@@ -26,6 +26,10 @@
 
 {% set mainClasses = mainClasses | default("govuk-main-wrapper--auto-spacing") %}
 
+{% set bannerHtml %}
+  {{ bannerHtmlOverride if bannerHtmlOverride else betaBannerFeedback | safe}}
+{% endset %}
+
 {% block main %}
   <div class="govuk-width-container govuk-body {{ containerClasses }}">
     {% block phaseBanner %}
@@ -33,7 +37,7 @@
         tag: {
           text: "beta"
         },
-        html: 'This is a beta service – your <a class="govuk-link" data-cy="Feedback" href="https://forms.office.com.mcas.ms/pages/responsepage.aspx?id=mN94WIhvq0iTIpmM5VcIjdUN-o-7ZchJstlDoYRZ9U1UQzM3N1g0TE9VQjhSNzZYTUxHU0haWVNNSSQlQCN0PWcu">feedback</a> will help us to improve it.'
+        html: bannerHtml
       }) }}
     {% endblock %}
 

--- a/packages/forms-web-app/src/views/layouts/guidance-page.njk
+++ b/packages/forms-web-app/src/views/layouts/guidance-page.njk
@@ -12,7 +12,7 @@
       tag: {
         text: "beta"
       },
-      html: 'This is a beta service – your <a class="govuk-link" data-cy="Feedback" href="https://forms.office.com/Pages/ResponsePage.aspx?id=mN94WIhvq0iTIpmM5VcIjVqzqAxXAi1LghAWTH6Y3OJUOFg4UFdEUThGTlU3S0hFUTlERVYwMVRLTy4u">feedback</a> will help us to improve it.'
+      html: betaBannerFeedback
     }) }}
 
     {{ govukBreadcrumbs({

--- a/packages/forms-web-app/src/views/layouts/householder-banner/main-no-back-link.njk
+++ b/packages/forms-web-app/src/views/layouts/householder-banner/main-no-back-link.njk
@@ -25,6 +25,10 @@
 
 {% set mainClasses = mainClasses | default("govuk-main-wrapper--auto-spacing") %}
 
+{% set bannerHtml %}
+  {{ bannerHtmlOverride if bannerHtmlOverride else betaBannerFeedback | safe}}
+{% endset %}
+
 {% block main %}
   <div class="govuk-width-container govuk-body {{ containerClasses }}">
     {% block phaseBanner %}
@@ -32,7 +36,7 @@
         tag: {
           text: "beta"
         },
-        html: 'This is a beta service – your <a class="govuk-link" data-cy="Feedback" href="https://forms.office.com.mcas.ms/Pages/ResponsePage.aspx?id=mN94WIhvq0iTIpmM5VcIjVqzqAxXAi1LghAWTH6Y3OJUOFg4UFdEUThGTlU3S0hFUTlERVYwMVRLTy4u">feedback</a> will help us to improve it.'
+        html: bannerHtml
       }) }}
     {% endblock %}
     

--- a/packages/forms-web-app/src/views/layouts/householder-banner/main.njk
+++ b/packages/forms-web-app/src/views/layouts/householder-banner/main.njk
@@ -26,6 +26,10 @@
 
 {% set mainClasses = mainClasses | default("govuk-main-wrapper--auto-spacing") %}
 
+{% set bannerHtml %}
+  {{ bannerHtmlOverride if bannerHtmlOverride else betaBannerFeedback | safe}}
+{% endset %}
+
 {% block main %}
   <div class="govuk-width-container govuk-body {{ containerClasses }}">
     {% block phaseBanner %}
@@ -33,7 +37,7 @@
         tag: {
           text: "beta"
         },
-        html: 'This is a beta service – your <a class="govuk-link" data-cy="Feedback" href="https://forms.office.com.mcas.ms/Pages/ResponsePage.aspx?id=mN94WIhvq0iTIpmM5VcIjVqzqAxXAi1LghAWTH6Y3OJUOFg4UFdEUThGTlU3S0hFUTlERVYwMVRLTy4u">feedback</a> will help us to improve it.'
+        html: bannerHtml
       }) }}
     {% endblock %}
 

--- a/packages/forms-web-app/src/views/layouts/main-no-back-link.njk
+++ b/packages/forms-web-app/src/views/layouts/main-no-back-link.njk
@@ -25,6 +25,10 @@
 
 {% set mainClasses = mainClasses | default("govuk-main-wrapper--auto-spacing") %}
 
+{% set bannerHtml %}
+  {{ bannerHtmlOverride if bannerHtmlOverride else betaBannerFeedback | safe}}
+{% endset %}
+
 {% block main %}
   <div class="govuk-width-container govuk-body {{ containerClasses }}">
     {% block phaseBanner %}
@@ -32,7 +36,7 @@
         tag: {
           text: "beta"
         },
-        html: 'This is a beta service – your <a class="govuk-link" data-cy="Feedback" href="https://forms.office.com/Pages/ResponsePage.aspx?id=mN94WIhvq0iTIpmM5VcIjVqzqAxXAi1LghAWTH6Y3OJUOFg4UFdEUThGTlU3S0hFUTlERVYwMVRLTy4u">feedback</a> will help us to improve it.'
+        html: bannerHtml
       }) }}
     {% endblock %}
     

--- a/packages/forms-web-app/src/views/layouts/main.njk
+++ b/packages/forms-web-app/src/views/layouts/main.njk
@@ -26,6 +26,10 @@
 
 {% set mainClasses = mainClasses | default("govuk-main-wrapper--auto-spacing") %}
 
+{% set bannerHtml %}
+  {{ bannerHtmlOverride if bannerHtmlOverride else betaBannerFeedback | safe}}
+{% endset %}
+
 {% block main %}
   <div class="govuk-width-container govuk-body {{ containerClasses }}">
     {% block phaseBanner %}
@@ -33,7 +37,7 @@
         tag: {
           text: "beta"
         },
-        html: 'This is a beta service – your <a class="govuk-link" data-cy="Feedback" href="https://forms.office.com/Pages/ResponsePage.aspx?id=mN94WIhvq0iTIpmM5VcIjVqzqAxXAi1LghAWTH6Y3OJUOFg4UFdEUThGTlU3S0hFUTlERVYwMVRLTy4u">feedback</a> will help us to improve it.'
+        html: bannerHtml
       }) }}
     {% endblock %}
 

--- a/packages/forms-web-app/src/views/layouts/no-banner-link/main-no-back-link.njk
+++ b/packages/forms-web-app/src/views/layouts/no-banner-link/main-no-back-link.njk
@@ -25,6 +25,10 @@
 
 {% set mainClasses = mainClasses | default("govuk-main-wrapper--auto-spacing") %}
 
+{% set bannerHtml %}
+  {{ bannerHtmlOverride if bannerHtmlOverride else betaBannerFeedback | safe}}
+{% endset %}
+
 {% block main %}
   <div class="govuk-width-container govuk-body {{ containerClasses }}">
     {% block phaseBanner %}
@@ -32,7 +36,7 @@
         tag: {
           text: "beta"
         },
-        html: 'This is a beta service'
+        html: bannerHtml
       }) }}
     {% endblock %}
 

--- a/packages/forms-web-app/src/views/layouts/no-banner-link/main.njk
+++ b/packages/forms-web-app/src/views/layouts/no-banner-link/main.njk
@@ -26,6 +26,10 @@
 
 {% set mainClasses = mainClasses | default("govuk-main-wrapper--auto-spacing") %}
 
+{% set bannerHtml %}
+  {{ bannerHtmlOverride if bannerHtmlOverride else betaBannerFeedback | safe}}
+{% endset %}
+
 {% block main %}
   <div class="govuk-width-container govuk-body {{ containerClasses }}">
     {% block phaseBanner %}
@@ -33,7 +37,7 @@
         tag: {
           text: "beta"
         },
-        html: 'This is a beta service'
+        html: bannerHtml
       }) }}
     {% endblock %}
 


### PR DESCRIPTION
## Ticket Number

https://pins-ds.atlassian.net/browse/A2-1251

## Description of change

* created global nunjucks env vars for feedback URL and beta banner feedback text + link
* replaced existing instances of feedback link in views/layouts with new env vars
* updated layouts for appellant journey to display feedback link by default
* have updated all 'before you start' controllers to override default and not display feedback link (this is the bulk of the PR)

## Checklist

<!-- Put an `x` in all the boxes that apply: -->

- [ ] Requires infrastructure changes
- [ ] I have updated the documentation accordingly
- [ ] My commit history in this PR is linear
- [ ] New features have tests
- [ ] Breaking change (team conversation required)

## Important

Please do not merge from `main` (please only [rebase](https://github.com/Planning-Inspectorate/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
