### PR TITLE
fix(a2-651): prevent duplicate submits in fo

### DIFF
--- a/packages/forms-web-app/__tests__/unit/lib/client-side/prevent-multiple-submit.test.js
+++ b/packages/forms-web-app/__tests__/unit/lib/client-side/prevent-multiple-submit.test.js
@@ -1,0 +1,24 @@
+/**
+ * @jest-environment jsdom
+ */
+const {
+	initialisePreventMultipleSubmit
+} = require('../../../../src/lib/client-side/prevent-multiple-submit');
+
+const mockAddEventListener = jest.fn();
+const mockDocument = {
+	addEventListener: mockAddEventListener
+};
+
+describe('lib/client-side/prevent-multiple-submit', () => {
+	describe('initialisePreventMultipleSubmit', () => {
+		beforeEach(() => {
+			window.wfeconfig = {};
+		});
+
+		test('addEventListener should be called', () => {
+			initialisePreventMultipleSubmit(mockDocument);
+			expect(mockDocument.addEventListener).toHaveBeenCalledWith('submit', expect.any(Function));
+		});
+	});
+});

--- a/packages/forms-web-app/src/lib/client-side/index.js
+++ b/packages/forms-web-app/src/lib/client-side/index.js
@@ -3,7 +3,9 @@
 const { cookieConsentHandler } = require('./cookie/cookie-consent');
 const { initialiseOptionalJavaScripts } = require('./javascript-requiring-consent');
 const { initialiseMultiFileUpload } = require('./components/multi-file-upload.js');
+const { initialisePreventMultipleSubmit } = require('./prevent-multiple-submit');
 
 cookieConsentHandler(document);
 initialiseOptionalJavaScripts(document);
 initialiseMultiFileUpload(document);
+initialisePreventMultipleSubmit(document);

--- a/packages/forms-web-app/src/lib/client-side/prevent-multiple-submit.js
+++ b/packages/forms-web-app/src/lib/client-side/prevent-multiple-submit.js
@@ -1,0 +1,15 @@
+function initialisePreventMultipleSubmit(document) {
+	let hasBeenSubmitted = false;
+
+	document.addEventListener('submit', function (evt) {
+		if (hasBeenSubmitted) {
+			evt.preventDefault();
+		} else {
+			hasBeenSubmitted = true;
+		}
+	});
+}
+
+module.exports = {
+	initialisePreventMultipleSubmit
+};


### PR DESCRIPTION
## Ticket Number

https://pins-ds.atlassian.net/browse/A2-651

## Description of change

Double click on continue button uploads duplicate files for both full and HAS appeals

- Added client-side code to block multiple submit events to prevent duplicate files being uploaded

## Checklist

<!-- Put an `x` in all the boxes that apply: -->

- [ ] Requires infrastructure changes
- [ ] I have updated the documentation accordingly
- [x] My commit history in this PR is linear
- [x] New features have tests
- [ ] Breaking change (team conversation required)

## Important

Please do not merge from `main` (please only [rebase](https://github.com/Planning-Inspectorate/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
