### PR TITLE
fix(a2-1085): fix send email to rule 6 on proofs submission

### DIFF
--- a/packages/appeals-service-api/src/lib/notify.js
+++ b/packages/appeals-service-api/src/lib/notify.js
@@ -542,14 +542,12 @@ const sendAppellantProofEvidenceSubmissionEmailToAppellantV2 = async (
 };
 
 /**
- * @param { Rule6ProofOfEvidenceSubmission } appellantProofEvidenceSubmission
+ * @param { Rule6ProofOfEvidenceSubmission } rule6ProofEvidenceSubmission
  * @param {string} emailAddress
- * @param {string} appellantName
  */
 const sendRule6ProofEvidenceSubmissionEmailToRule6PartyV2 = async (
-	appellantProofEvidenceSubmission,
-	emailAddress,
-	appellantName
+	rule6ProofEvidenceSubmission,
+	emailAddress
 ) => {
 	try {
 		const {
@@ -561,9 +559,9 @@ const sendRule6ProofEvidenceSubmissionEmailToRule6PartyV2 = async (
 			siteAddressCounty,
 			siteAddressPostcode,
 			proofsOfEvidenceDueDate
-		} = appellantProofEvidenceSubmission.AppealCase;
+		} = rule6ProofEvidenceSubmission.AppealCase;
 
-		const caseReference = appellantProofEvidenceSubmission.caseReference;
+		const caseReference = rule6ProofEvidenceSubmission.caseReference;
 
 		const formattedAddress = formatSubmissionAddress({
 			addressLine1: siteAddressLine1,
@@ -573,17 +571,16 @@ const sendRule6ProofEvidenceSubmissionEmailToRule6PartyV2 = async (
 			postcode: siteAddressPostcode
 		});
 
-		const reference = appellantProofEvidenceSubmission.id;
+		const reference = rule6ProofEvidenceSubmission.id;
 
 		let variables = {
 			appeal_reference_number: caseReference,
-			'appellant name': appellantName,
 			site_address: formattedAddress,
 			lpa_reference: applicationReference,
 			'deadline date': formatInTimeZone(proofsOfEvidenceDueDate, 'Europe/London', 'dd MMMM yyyy')
 		};
 
-		logger.debug({ variables }, 'Sending proof of evidence email to appellant');
+		logger.debug({ variables }, 'Sending proof of evidence email to rule 6 party');
 
 		await NotifyBuilder.reset()
 			.setTemplateId(
@@ -599,7 +596,7 @@ const sendRule6ProofEvidenceSubmissionEmailToRule6PartyV2 = async (
 				config.services.notify.apiKey
 			);
 	} catch (err) {
-		logger.error({ err }, 'Unable to send proof of evidence submission email to appellant');
+		logger.error({ err }, 'Unable to send proof of evidence submission email to rule 6 party');
 	}
 };
 

--- a/packages/appeals-service-api/src/routes/v2/appeal-cases/_caseReference/rule-6-proof-evidence-submission/repo.js
+++ b/packages/appeals-service-api/src/routes/v2/appeal-cases/_caseReference/rule-6-proof-evidence-submission/repo.js
@@ -44,7 +44,8 @@ class Rule6ProofOfEvidenceSubmissionRepository {
 							siteAddressTown: true,
 							siteAddressCounty: true,
 							siteAddressPostcode: true,
-							applicationReference: true
+							applicationReference: true,
+							proofsOfEvidenceDueDate: true
 						}
 					},
 					SubmissionDocumentUpload: true

--- a/packages/appeals-service-api/src/services/back-office-v2/index.js
+++ b/packages/appeals-service-api/src/services/back-office-v2/index.js
@@ -402,24 +402,7 @@ class BackOfficeV2Service {
 			caseReference
 		);
 
-		const { email, serviceUserId } = await getUserById(userId);
-
-		let appellantName;
-
-		if (serviceUserId) {
-			const serviceUserDetails = await getServiceUserByIdAndCaseReference(
-				serviceUserId,
-				caseReference
-			);
-
-			if (serviceUserDetails?.firstName && serviceUserDetails?.lastName) {
-				appellantName = serviceUserDetails.firstName + ' ' + serviceUserDetails.lastName;
-			} else {
-				appellantName = 'Rule 6 Party';
-			}
-		} else {
-			appellantName = 'Rule 6 Party';
-		}
+		const { email } = await getUserById(userId);
 
 		logger.info(
 			`forwarding rule 6 party proof of evidence submission for ${caseReference} to service bus`
@@ -431,8 +414,7 @@ class BackOfficeV2Service {
 		try {
 			await sendRule6ProofEvidenceSubmissionEmailToRule6PartyV2(
 				rule6ProofOfEvidenceSubmission,
-				email,
-				appellantName
+				email
 			);
 		} catch (err) {
 			logger.error({ err }, 'failed to sendRule6ProofOfEvidenceSubmissionEmailToRule6PartyV2');

--- a/packages/appeals-service-api/src/spec/api-types.d.ts
+++ b/packages/appeals-service-api/src/spec/api-types.d.ts
@@ -1309,6 +1309,8 @@ export interface Rule6ProofOfEvidenceSubmission {
 		siteAddressCounty?: string;
 		siteAddressPostcode?: string;
 		applicationReference?: string;
+		/** @format date-time */
+		proofsOfEvidenceDueDate?: string;
 	};
 	userId?: string;
 	/** @format date-time */

--- a/packages/appeals-service-api/src/spec/rule-6-proof-of-evidence-submission.yaml
+++ b/packages/appeals-service-api/src/spec/rule-6-proof-of-evidence-submission.yaml
@@ -37,6 +37,9 @@ components:
               type: string
             applicationReference:
               type: string
+            proofsOfEvidenceDueDate:
+              type: string
+              format: date-time
         userId:
           type: string
         createdAt:


### PR DESCRIPTION
## Ticket Number

https://pins-ds.atlassian.net/browse/A2-1085

## Description of change

Fixes the sending of notify email to rule 6 on submission of proofs:
- gets correct proofsDueDate on repo call
- removes unused variables

## Checklist

<!-- Put an `x` in all the boxes that apply: -->

- [ ] Requires infrastructure changes
- [ ] I have updated the documentation accordingly
- X My commit history in this PR is linear
- [ ] New features have tests
- [ ] Breaking change (team conversation required)

## Important

Please do not merge from `main` (please only [rebase](https://github.com/Planning-Inspectorate/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
