### PR TITLE
feat(a2-1562): update site access and safety details logic on dashboards

### DIFF
--- a/packages/common/src/lib/format-appeal-details.js
+++ b/packages/common/src/lib/format-appeal-details.js
@@ -52,24 +52,26 @@ exports.formatUserDetails = formatUserDetails;
 
 /**
  * @param {import("../client/appeals-api-client").AppealCaseDetailed} caseData
+ * @returns {string} site access details provided by Appellant
  */
 exports.formatAccessDetails = (caseData) => {
-	if (!caseData.siteAccessDetails) {
+	if (!caseData.siteAccessDetails || !caseData.siteAccessDetails[0]) {
 		return 'No';
 	}
 
-	const details = caseData.siteAccessDetails.join('\n');
+	const details = caseData.siteAccessDetails[0];
 
 	return `Yes \n ${details}`;
 };
 
 /**
  * @param {import("../client/appeals-api-client").AppealCaseDetailed} caseData
+ * @returns {string} safety details provided by Appellant
  */
 exports.formatHealthAndSafety = (caseData) => {
-	if (!caseData.siteSafetyDetails) return 'No';
+	if (!caseData.siteSafetyDetails || !caseData.siteSafetyDetails[0]) return 'No';
 
-	const details = caseData.siteSafetyDetails.map((x) => x).join('\n');
+	const details = caseData.siteSafetyDetails[0];
 
 	return `Yes \n ${details}`;
 };

--- a/packages/common/src/lib/format-appeal-details.test.js
+++ b/packages/common/src/lib/format-appeal-details.test.js
@@ -1,0 +1,44 @@
+const { formatHealthAndSafety, formatAccessDetails } = require('./format-appeal-details');
+
+describe('format-appeal-details', () => {
+	describe('formatHealthAndSafety', () => {
+		it('returns string of "Yes" plus siteSafetyDetails index 0 string', () => {
+			const resultIndex1Empty = formatHealthAndSafety({
+				siteSafetyDetails: ['appellant safety details', '']
+			});
+			const resultAllIndexesPopulated = formatHealthAndSafety({
+				siteSafetyDetails: ['appellant safety details', 'lpa safety details']
+			});
+			expect(resultIndex1Empty).toEqual('Yes \n appellant safety details');
+			expect(resultAllIndexesPopulated).toEqual('Yes \n appellant safety details');
+		});
+		it('returns no if siteSafetyDetails index 0 is empty', () => {
+			const resultIndex0Empty = formatHealthAndSafety({
+				siteSafetyDetails: ['', 'lpa safety details']
+			});
+			const resultAllIndexesEmpty = formatHealthAndSafety({ siteSafetyDetails: ['', ''] });
+			expect(resultIndex0Empty).toEqual('No');
+			expect(resultAllIndexesEmpty).toEqual('No');
+		});
+	});
+	describe('formatAccessDetails', () => {
+		it('returns string of "Yes" plus siteAccessDetails index 0 string', () => {
+			const resultIndex1Empty = formatAccessDetails({
+				siteAccessDetails: ['appellant access details', '']
+			});
+			const resultAllIndexesPopulated = formatAccessDetails({
+				siteAccessDetails: ['appellant access details', 'lpa access details']
+			});
+			expect(resultIndex1Empty).toEqual('Yes \n appellant access details');
+			expect(resultAllIndexesPopulated).toEqual('Yes \n appellant access details');
+		});
+		it('returns no if siteAccessDetails index 0 is empty', () => {
+			const resultIndex0Empty = formatAccessDetails({
+				siteAccessDetails: ['', 'lpa access details']
+			});
+			const resultAllIndexesEmpty = formatAccessDetails({ siteAccessDetails: ['', ''] });
+			expect(resultIndex0Empty).toEqual('No');
+			expect(resultAllIndexesEmpty).toEqual('No');
+		});
+	});
+});

--- a/packages/common/src/lib/format-questionnaire-details.js
+++ b/packages/common/src/lib/format-questionnaire-details.js
@@ -160,23 +160,23 @@ exports.formatDevelopmentDescription = (caseData) => {
 
 /**
  * @param {AppealCaseDetailed} caseData
- * @param {boolean} hasSiteSafetyDetails
- * @returns {string}
+ * @returns {string} safety details provided by LPA User
  */
-exports.formatSiteSafetyRisks = (caseData, hasSiteSafetyDetails) => {
-	if (hasSiteSafetyDetails) {
-		return 'Yes\n' + caseData.siteSafetyDetails?.filter((value) => value.length > 0).join('\n');
-	} else {
-		return 'No';
-	}
+exports.formatSiteSafetyRisks = (caseData) => {
+	if (!caseData.siteSafetyDetails || !caseData.siteSafetyDetails[1]) return 'No';
+
+	const details = caseData.siteSafetyDetails[1];
+
+	return `Yes\n${details}`;
 };
 
 /**
- * @param {Array.<string>} accessDetails
- * @returns {string}
+ * @param {AppealCaseDetailed} caseData
+ * @returns {string} access details provided by LPA User
  */
-exports.formatSiteAccessDetails = (accessDetails) => {
-	return accessDetails.filter((value) => value.length > 0).join('\n');
+exports.formatSiteAccessDetails = (caseData) => {
+	if (!caseData.siteAccessDetails || !caseData.siteAccessDetails[1]) return '';
+	return caseData.siteAccessDetails[1];
 };
 
 /**

--- a/packages/common/src/lib/format-questionnaire-details.test.js
+++ b/packages/common/src/lib/format-questionnaire-details.test.js
@@ -5,30 +5,44 @@ const {
 
 describe('format-questionnaire-details', () => {
 	describe('formatSiteAccessDetails', () => {
-		it('returns array converted to string with newlines', () => {
-			const result = formatSiteAccessDetails(['one', 'two', 'three']);
-			expect(result).toEqual('one\ntwo\nthree');
+		it('returns siteAccessDetails index 1 string if it exists', () => {
+			const resultIndex0Empty = formatSiteAccessDetails({
+				siteAccessDetails: ['', 'lpa access details']
+			});
+			const resultAllIndexesPopulated = formatSiteAccessDetails({
+				siteAccessDetails: ['appellant access details', 'lpa access details']
+			});
+			expect(resultIndex0Empty).toEqual('lpa access details');
+			expect(resultAllIndexesPopulated).toEqual('lpa access details');
 		});
-		it('excludes null values', () => {
-			const result = formatSiteAccessDetails(['', 'two', '']);
-			expect(result).toEqual('two');
+		it('returns empty string if siteAccessDetails index 1 is empty', () => {
+			const resultIndex1Empty = formatSiteAccessDetails({
+				siteAccessDetails: ['appellant access details', '']
+			});
+			const resultAllIndexesEmpty = formatSiteAccessDetails({ siteAccessDetails: ['', ''] });
+			expect(resultIndex1Empty).toEqual('');
+			expect(resultAllIndexesEmpty).toEqual('');
 		});
 	});
 
 	describe('formatSiteSafetyRisks', () => {
-		it('returns array converted to string with Yes and newlines if details present and provided', () => {
-			const result = formatSiteSafetyRisks({ siteSafetyDetails: ['one', 'two', 'three'] }, true);
-			expect(result).toEqual('Yes\none\ntwo\nthree');
+		it('returns string of "Yes" plus siteSafetyDetails index 1 string', () => {
+			const resultIndex0Empty = formatSiteSafetyRisks({
+				siteSafetyDetails: ['', 'lpa safety details']
+			});
+			const resultAllIndexesPopulated = formatSiteSafetyRisks({
+				siteSafetyDetails: ['appellant safety details', 'lpa safety details']
+			});
+			expect(resultIndex0Empty).toEqual('Yes\nlpa safety details');
+			expect(resultAllIndexesPopulated).toEqual('Yes\nlpa safety details');
 		});
-		it('excludes null values', () => {
-			const resultSomeNulls = formatSiteSafetyRisks({ siteSafetyDetails: ['', 'two', ''] }, true);
-			const resultAllNulls = formatSiteSafetyRisks({ siteSafetyDetails: ['', '', ''] }, true);
-			expect(resultSomeNulls).toEqual('Yes\ntwo');
-			expect(resultAllNulls).toEqual('Yes\n');
-		});
-		it('returns no if false param provided', () => {
-			const result = formatSiteSafetyRisks({ siteSafetyDetails: ['one', 'two', 'three'] }, false);
-			expect(result).toEqual('No');
+		it('returns no if siteSafetyDetails index 1 is empty', () => {
+			const resultIndex1Empty = formatSiteSafetyRisks({
+				siteSafetyDetails: ['appellant safety details', '']
+			});
+			const resultAllIndexesEmpty = formatSiteSafetyRisks({ siteSafetyDetails: ['', ''] });
+			expect(resultIndex1Empty).toEqual('No');
+			expect(resultAllIndexesEmpty).toEqual('No');
 		});
 	});
 });

--- a/packages/forms-web-app/src/controllers/selected-appeal/questionnaire-details/site-access-details-rows.js
+++ b/packages/forms-web-app/src/controllers/selected-appeal/questionnaire-details/site-access-details-rows.js
@@ -8,15 +8,7 @@ const { formatNeighbouringAddressWithBreaks } = require('@pins/common/src/lib/fo
 exports.siteAccessRows = (caseData) => {
 	const neighbourAddressesArray = caseData.NeighbouringAddresses || [];
 
-	//todo: siteAccessDetails and siteSafetyRisks logic will need updating when data model updated
-	// to specify which details provided by LPAQ and which provided by appellant
-	const showAccessForInspection = caseData.siteAccessDetails !== undefined;
-	const accessForInspectionBool = !!caseData.siteAccessDetails?.filter((value) => value !== null)
-		.length;
-
-	const showSiteSafetyDetails = caseData.siteSafetyDetails !== undefined;
-	const hasSiteSafetyDetails = !!caseData.siteSafetyDetails?.filter((value) => value !== null)
-		.length;
+	const accessForInspectionBool = !!caseData.siteAccessDetails?.[1];
 
 	const hasNeighbourAddressesField = caseData.NeighbouringAddresses !== undefined;
 	const hasNeighboursText = neighbourAddressesArray.length ? 'Yes' : 'No';
@@ -28,13 +20,11 @@ exports.siteAccessRows = (caseData) => {
 		{
 			keyText: 'Access for inspection',
 			valueText: boolToYesNo(accessForInspectionBool),
-			condition: () => showAccessForInspection
+			condition: () => true
 		},
 		{
 			keyText: 'Reason for Inspector access',
-			valueText: caseData.siteAccessDetails
-				? formatSiteAccessDetails(caseData.siteAccessDetails)
-				: '',
+			valueText: formatSiteAccessDetails(caseData),
 			condition: () => accessForInspectionBool
 		},
 		{
@@ -62,8 +52,8 @@ exports.siteAccessRows = (caseData) => {
 
 	rows.push({
 		keyText: 'Potential safety risks',
-		valueText: formatSiteSafetyRisks(caseData, hasSiteSafetyDetails),
-		condition: () => showSiteSafetyDetails
+		valueText: formatSiteSafetyRisks(caseData),
+		condition: () => true
 	});
 
 	return rows;

--- a/packages/forms-web-app/src/controllers/selected-appeal/questionnaire-details/site-access-details-rows.test.js
+++ b/packages/forms-web-app/src/controllers/selected-appeal/questionnaire-details/site-access-details-rows.test.js
@@ -3,8 +3,8 @@ const { siteAccessRows } = require('./site-access-details-rows');
 describe('siteAccessRows', () => {
 	it('should create rows with correct data if relevant case data fields exist & field values populated', () => {
 		const caseData = {
-			siteAccessDetails: ['some site access details'],
-			siteSafetyDetails: ['some site safety details', 'additional site safety details'],
+			siteAccessDetails: ['appellant access details do not show', 'lpa access details for show'],
+			siteSafetyDetails: ['appellant safety details do not show', 'lpa safety details for show'],
 			neighbouringSiteAccessDetails: 'some neighbouring site access details',
 			NeighbouringAddresses: [
 				{
@@ -32,7 +32,7 @@ describe('siteAccessRows', () => {
 
 		expect(rows[1].condition()).toEqual(true);
 		expect(rows[1].keyText).toEqual('Reason for Inspector access');
-		expect(rows[1].valueText).toEqual('some site access details');
+		expect(rows[1].valueText).toEqual('lpa access details for show');
 
 		expect(rows[2].condition()).toEqual(true);
 		expect(rows[2].keyText).toEqual('Inspector visit to neighbour');
@@ -52,15 +52,32 @@ describe('siteAccessRows', () => {
 
 		expect(rows[6].condition()).toEqual(true);
 		expect(rows[6].keyText).toEqual('Potential safety risks');
-		expect(rows[6].valueText).toEqual(
-			'Yes\nsome site safety details\nadditional site safety details'
-		);
+		expect(rows[6].valueText).toEqual('Yes\nlpa safety details for show');
+	});
+
+	it('should handle site access and site safety rows correctly', () => {
+		const caseData = {
+			siteAccessDetails: ['', 'lpa access details'],
+			siteSafetyDetails: ['', 'lpa safety details']
+		};
+		const rows = siteAccessRows(caseData);
+		expect(rows[0].condition()).toEqual(true);
+		expect(rows[0].keyText).toEqual('Access for inspection');
+		expect(rows[0].valueText).toEqual('Yes');
+
+		expect(rows[1].condition()).toEqual(true);
+		expect(rows[1].keyText).toEqual('Reason for Inspector access');
+		expect(rows[1].valueText).toEqual('lpa access details');
+
+		expect(rows[4].condition()).toEqual(true);
+		expect(rows[4].keyText).toEqual('Potential safety risks');
+		expect(rows[4].valueText).toEqual('Yes\nlpa safety details');
 	});
 
 	it('should handle false values correctly', () => {
 		const caseData = {
-			siteAccessDetails: [],
-			siteSafetyDetails: [],
+			siteAccessDetails: ['', ''],
+			siteSafetyDetails: ['', ''],
 			NeighbouringAddresses: []
 		};
 
@@ -85,14 +102,14 @@ describe('siteAccessRows', () => {
 		expect(rows[4].valueText).toEqual('No');
 	});
 
-	it('should not display if no fields/files exist', () => {
+	it('should set condition correctly if fields do not exist', () => {
 		const rows = siteAccessRows({});
 
 		expect(rows.length).toEqual(5);
-		expect(rows[0].condition()).toEqual(false);
+		expect(rows[0].condition()).toEqual(true);
 		expect(rows[1].condition()).toEqual(false);
 		expect(rows[2].condition()).toEqual(false);
 		expect(rows[3].condition()).toEqual(false);
-		expect(rows[4].condition()).toEqual(false);
+		expect(rows[4].condition()).toEqual(true);
 	});
 });


### PR DESCRIPTION
## Ticket Number

<!-- Add the number from the Jira board -->

https://pins-ds.atlassian.net/browse/A2-1562

## Description of change

* amend logic to display only LPA user-provided site access / site risk details on LPA questionnaire details page, and only appellant-provided site access / site risk details on appeal details page (on dashboards)

<!-- Please describe the change -->

## Checklist

<!-- Put an `x` in all the boxes that apply: -->

- [ ] Requires infrastructure changes
- [ ] I have updated the documentation accordingly
- [ ] My commit history in this PR is linear
- [ ] New features have tests
- [ ] Breaking change (team conversation required)

## Important

Please do not merge from `main` (please only [rebase](https://github.com/Planning-Inspectorate/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
