### PR TITLE
Feat/a2 1525 ip comments back link

### DIFF
--- a/packages/forms-web-app/src/routes/file-based-router/comment-planning-appeal/appeals/_appealNumber/controller.js
+++ b/packages/forms-web-app/src/routes/file-based-router/comment-planning-appeal/appeals/_appealNumber/controller.js
@@ -12,9 +12,9 @@ const {
 const selectedAppeal = async (req, res) => {
 	const appealNumber = req.params.appealNumber;
 
-	createInterestedPartySession(req, appealNumber);
-
 	const appeal = await req.appealsApiClient.getAppealCaseByCaseRef(appealNumber);
+
+	createInterestedPartySession(req, appealNumber, appeal.siteAddressPostcode);
 
 	const lpa = await getDepartmentFromCode(appeal.LPACode);
 	const headlineData = formatHeadlineData(appeal, lpa.name);

--- a/packages/forms-web-app/src/routes/file-based-router/comment-planning-appeal/appeals/controller.js
+++ b/packages/forms-web-app/src/routes/file-based-router/comment-planning-appeal/appeals/controller.js
@@ -9,7 +9,7 @@ const { SERVICE_USER_TYPE } = require('pins-data-model');
 
 /** @type {import('express').RequestHandler} */
 const appeals = async (req, res) => {
-	const postcode = req.query.search;
+	const postcode = req.query.search || req.session.interestedParty?.searchPostcode;
 	/** @type {import('#utils/appeals-view').AppealViewModel[]} */
 	const postcodeSearchResults = await req.appealsApiClient.getPostcodeSearchResults({
 		postcode,

--- a/packages/forms-web-app/src/routes/file-based-router/comment-planning-appeal/decided-appeals/controller.js
+++ b/packages/forms-web-app/src/routes/file-based-router/comment-planning-appeal/decided-appeals/controller.js
@@ -7,7 +7,7 @@ const { formatDateForDisplay } = require('@pins/common/src/lib/format-date');
 
 /** @type {import('express').RequestHandler} */
 const decidedAppeals = async (req, res) => {
-	const postcode = req.query.search;
+	const postcode = req.query.search || req.session.interestedParty?.searchPostcode;
 	/** @type {import('#utils/appeals-view').AppealViewModel[]} */
 	const decidedAppeals = await req.appealsApiClient.getPostcodeSearchResults({
 		postcode,

--- a/packages/forms-web-app/src/routes/file-based-router/comment-planning-appeal/index.js
+++ b/packages/forms-web-app/src/routes/file-based-router/comment-planning-appeal/index.js
@@ -1,0 +1,8 @@
+const express = require('express');
+
+const router = express.Router();
+
+// To do - consider whether to have designated landing page for interested parties
+router.get('/', (req, res) => res.redirect('./enter-appeal-reference'));
+
+module.exports = { router };

--- a/packages/forms-web-app/src/services/interested-party.service.js
+++ b/packages/forms-web-app/src/services/interested-party.service.js
@@ -1,6 +1,7 @@
 /**
  * @typedef {Object} InterestedParty
  * @property {string} caseReference
+ * @property {string} searchPostcode
  * @property {string} [firstName]
  * @property {string} [lastName]
  * @property {string} [emailAddress]
@@ -17,11 +18,13 @@
  * Adds InterestedParty to req.session
  * @param {import('express').Request} req
  * @param {string} caseReference
+ * @param {string} searchPostcode
  */
-const createInterestedPartySession = (req, caseReference) => {
+const createInterestedPartySession = (req, caseReference, searchPostcode) => {
 	/** @type {InterestedParty} */
 	req.session.interestedParty = {
-		caseReference
+		caseReference,
+		searchPostcode
 	};
 };
 


### PR DESCRIPTION
## Ticket Number

https://pins-ds.atlassian.net/browse/A2-1525

## Description of change

fixes the issue where the back link from a particular appeal for interested parties would not return to the correct page as didn't pass postcode as query param.  Solves this by adding a searchPostcode field to the interestedParty session object.

## Checklist

<!-- Put an `x` in all the boxes that apply: -->

- [ ] Requires infrastructure changes
- [ ] I have updated the documentation accordingly
- X My commit history in this PR is linear
- [ ] New features have tests
- [ ] Breaking change (team conversation required)

## Important

Please do not merge from `main` (please only [rebase](https://github.com/Planning-Inspectorate/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
