### PR TITLE
fix(a2-1268): fix unit conversion issue - sql decimals are returned a…

### DIFF
--- a/packages/forms-web-app/src/dynamic-forms/dynamic-components/unit-option-entry/question.js
+++ b/packages/forms-web-app/src/dynamic-forms/dynamic-components/unit-option-entry/question.js
@@ -202,10 +202,8 @@ class UnitOptionEntryQuestion extends Question {
 			1;
 		const unconvertedAnswer = journey.response.answers[this.conditionalFieldName];
 
-		if (typeof unconvertedAnswer !== 'number')
-			throw new Error('Conditional answer had an unexpected type');
-
-		const answerQuantity = unconvertedAnswer / conversionFactor;
+		const answerQuantity = Number(unconvertedAnswer) / conversionFactor;
+		if (isNaN(answerQuantity)) throw new Error('Conditional answer had an unexpected type');
 
 		const formattedAnswer = `${answerQuantity} ${answer}`;
 		return super.formatAnswerForSummary(sectionSegment, journey, formattedAnswer, false);

--- a/packages/forms-web-app/src/dynamic-forms/dynamic-components/unit-option-entry/question.test.js
+++ b/packages/forms-web-app/src/dynamic-forms/dynamic-components/unit-option-entry/question.test.js
@@ -27,19 +27,19 @@ const OPTIONS = [
 	}
 ];
 
+const unitOptionEntryQuestion = new UnitOptionEntryQuestion({
+	title: TITLE,
+	question: QUESTION,
+	description: DESCRIPTION,
+	fieldName: FIELDNAME,
+	conditionalFieldName: CONDITIONAL_FIELDNAME,
+	html: HTML,
+	label: LABEL,
+	options: OPTIONS
+});
+
 describe('./src/dynamic-forms/dynamic-components/unit-option-entry/question.js', () => {
 	it('should create', () => {
-		const unitOptionEntryQuestion = new UnitOptionEntryQuestion({
-			title: TITLE,
-			question: QUESTION,
-			description: DESCRIPTION,
-			fieldName: FIELDNAME,
-			conditionalFieldName: CONDITIONAL_FIELDNAME,
-			html: HTML,
-			label: LABEL,
-			options: OPTIONS
-		});
-
 		expect(unitOptionEntryQuestion.title).toEqual(TITLE);
 		expect(unitOptionEntryQuestion.question).toEqual(QUESTION);
 		expect(unitOptionEntryQuestion.description).toEqual(DESCRIPTION);
@@ -49,5 +49,47 @@ describe('./src/dynamic-forms/dynamic-components/unit-option-entry/question.js',
 		expect(unitOptionEntryQuestion.html).toEqual(HTML);
 		expect(unitOptionEntryQuestion.label).toEqual(LABEL);
 		expect(unitOptionEntryQuestion.options).toEqual(OPTIONS);
+	});
+
+	it('should handle decimal string formatting conversion', () => {
+		const journey = {
+			response: {
+				answers: {
+					[CONDITIONAL_FIELDNAME]: '1.123456789'
+				}
+			},
+			getCurrentQuestionUrl: jest.fn()
+		};
+
+		const result = unitOptionEntryQuestion.formatAnswerForSummary('test', journey, 'ha');
+		expect(result[0].value).toEqual('1.123456789 ha');
+	});
+
+	it('should handle int string formatting conversion', () => {
+		const journey = {
+			response: {
+				answers: {
+					[CONDITIONAL_FIELDNAME]: '1'
+				}
+			},
+			getCurrentQuestionUrl: jest.fn()
+		};
+		const result = unitOptionEntryQuestion.formatAnswerForSummary('test', journey, 'ha');
+		expect(result[0].value).toEqual('1 ha');
+	});
+
+	it('should error for NaN formatting conversion', () => {
+		const journey = {
+			response: {
+				answers: {
+					[CONDITIONAL_FIELDNAME]: 'hello'
+				}
+			},
+			getCurrentQuestionUrl: jest.fn()
+		};
+
+		expect(() => {
+			unitOptionEntryQuestion.formatAnswerForSummary('test', journey, 'ha');
+		}).toThrow(new Error('Conditional answer had an unexpected type'));
 	});
 });


### PR DESCRIPTION
…s strings

## Ticket Number

<!-- Add the number from the Jira board -->

https://pins-ds.atlassian.net/browse/A2-1628

## Description of change

Prisma returns sql decimals as a decimal.js object, which become strings when JSON stringified

## Checklist

<!-- Put an `x` in all the boxes that apply: -->

- [ ] Requires infrastructure changes
- [ ] I have updated the documentation accordingly
- [x] My commit history in this PR is linear
- [x] New features have tests
- [ ] Breaking change (team conversation required)

## Important

Please do not merge from `main` (please only [rebase](https://github.com/Planning-Inspectorate/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
