### PR TITLE
feat(a2-1179): add submission documents end point

### DIFF
--- a/packages/common/src/client/documents-api-client.js
+++ b/packages/common/src/client/documents-api-client.js
@@ -50,10 +50,11 @@ class DocumentsApiClient {
 	/**
 	 * @param {string} caseRef
 	 * @param {string} caseStage
+	 * @param {string} documentsLocation
 	 * @returns {Promise<Buffer>}
 	 */
-	async getBackOfficeDocumentsByAppealNumberAndCaseStage(caseRef, caseStage) {
-		const endpoint = `${v2}/back-office/${caseRef}/case-stage/${caseStage}`;
+	async getBulkDocumentsDownload(caseRef, caseStage, documentsLocation) {
+		const endpoint = `${v2}/${documentsLocation}/${caseRef}/case-stage/${caseStage}`;
 		const response = await this.#makeGetRequest(endpoint);
 		return response.buffer();
 	}

--- a/packages/document-service-api/src/db/repos/repository.js
+++ b/packages/document-service-api/src/db/repos/repository.js
@@ -34,6 +34,25 @@ class DocumentsRepository {
 	}
 
 	/**
+	 * @param {string} caseRef
+	 * @returns {Promise<import("@prisma/client").SubmissionDocumentUpload>[]} documents
+	 */
+	async getSubmissionDocumentsByCaseRef(caseRef) {
+		return this.dbClient.submissionDocumentUpload.findMany({
+			where: {
+				LPAQuestionnaireSubmission: {
+					appealCaseReference: caseRef
+				}
+			},
+			select: {
+				location: true,
+				type: true,
+				originalFileName: true
+			}
+		});
+	}
+
+	/**
 	 * @param {string} id SubmissionDocumentUpload id
 	 * @return {Promise<import("@prisma/client").SubmissionDocumentUpload>}
 	 */

--- a/packages/document-service-api/src/routes/v2/submission/_caseReference/case_stage/_caseStage/controller.js
+++ b/packages/document-service-api/src/routes/v2/submission/_caseReference/case_stage/_caseStage/controller.js
@@ -1,0 +1,125 @@
+const kebabCase = require('lodash.kebabcase');
+const blobClient = require('#lib/front-office-storage-client');
+const { isFeatureActive } = require('#config/featureFlag');
+const { FLAG } = require('@pins/common/src/feature-flags');
+const archiver = require('archiver');
+const { DocumentsRepository } = require('../../../../../../db/repos/repository');
+const repo = new DocumentsRepository();
+const { storage } = require('#config/config');
+const { APPEAL_CASE_STAGE } = require('pins-data-model');
+
+/**
+ * @param {string} caseStage
+ * @param {string} caseReference *
+ * @returns {Promise[]}
+ */
+async function getBlobCollection(caseStage, caseReference) {
+	let documents;
+	switch (caseStage) {
+		case APPEAL_CASE_STAGE.LPA_QUESTIONNAIRE:
+			documents = await repo.getSubmissionDocumentsByCaseRef(caseReference);
+			break;
+		default:
+			return [];
+	}
+
+	return documents.map((document) => {
+		const { location, originalFileName, type } = document;
+		return {
+			fullName: `${kebabCase(type)}/${originalFileName}`,
+			blobStorageContainer: storage.container,
+			blobStoragePath: originalFileName,
+			documentURI: location
+		};
+	});
+}
+
+/**
+ * Create a blob download stream
+ *
+ * @param {string} blobStorageContainer
+ * @param {string} blobStoragePath
+ * @returns {Promise<Buffer|null>}
+ */
+async function createBlobDownloadStream(blobStorageContainer, blobStoragePath) {
+	const blobName = blobStoragePath.startsWith('/') ? blobStoragePath.slice(1) : blobStoragePath;
+
+	let blobProperties;
+	try {
+		blobProperties = await blobClient.getProperties(blobStorageContainer, blobName);
+
+		if (!blobProperties) {
+			return null;
+		}
+
+		const blobDownloadResponseParsed = await blobClient.downloadBlob(
+			blobStorageContainer,
+			blobName
+		);
+
+		if (!blobDownloadResponseParsed?.readableStreamBody) {
+			return null;
+		}
+
+		// @ts-ignore
+		return blobDownloadResponseParsed.blobDownloadStream;
+	} catch (error) {
+		return null;
+	}
+}
+
+/**
+ * @type {import('express').Handler}
+ */
+async function getDocumentsByCaseReferenceAndCaseStage(req, res) {
+	if (!(await isFeatureActive(FLAG.SERVE_BO_DOCUMENTS))) {
+		res.sendStatus(501);
+		return;
+	}
+
+	const { caseStage, caseReference } = req.params ?? {};
+
+	if (!caseStage || !caseReference) {
+		res.sendStatus(400);
+		return;
+	}
+
+	const blobCollection = await getBlobCollection(caseStage, caseReference);
+
+	const archive = archiver('zip', {
+		zlib: { level: 9 } // Sets the compression level.
+	});
+
+	archive.pipe(res);
+
+	const /** @type {string[]} */ missingFiles = [];
+
+	if (!blobCollection?.length) {
+		missingFiles.push('No documents found in this case');
+	} else {
+		const blobStreams = await Promise.all(
+			blobCollection.map((blobInfo) =>
+				createBlobDownloadStream(blobInfo.blobStorageContainer, blobInfo.blobStoragePath)
+			)
+		);
+
+		blobStreams.forEach((blobStream, index) => {
+			if (blobStream) {
+				archive.append(blobStream, { name: blobCollection[index].fullName });
+			} else {
+				missingFiles.push(blobCollection[index].fullName);
+			}
+		});
+	}
+
+	if (missingFiles.length) {
+		archive.append(Buffer.from(JSON.stringify(missingFiles)), { name: 'missing-files.json' });
+	}
+
+	await archive.finalize();
+	return res.status(200);
+}
+
+module.exports = {
+	getDocumentsByCaseReferenceAndCaseStage
+};

--- a/packages/document-service-api/src/routes/v2/submission/_caseReference/case_stage/_caseStage/controller.test.js
+++ b/packages/document-service-api/src/routes/v2/submission/_caseReference/case_stage/_caseStage/controller.test.js
@@ -1,0 +1,89 @@
+const { mockReq, mockRes } = require('../../../../../../../test/utils/mocks');
+const { getDocumentsByCaseReferenceAndCaseStage } = require('./controller');
+
+const testCaseReference = '1234567890';
+const testCaseStage = 'lpa-questionnaire';
+const testDocumentType = 'doctype';
+const testDocuments = ['document-one.pdf', 'document-two.pdf', 'document-three.pdf'];
+
+jest.mock('../../../../../../configuration/featureFlag', () => ({
+	isFeatureActive: jest.fn().mockResolvedValue(true)
+}));
+
+const mockAppend = jest.fn();
+
+jest.mock('archiver', () =>
+	jest.fn().mockReturnValue({
+		pipe: jest.fn(),
+		append: jest.fn().mockImplementation((...params) => mockAppend(...params)),
+		finalize: jest.fn()
+	})
+);
+
+jest.mock('../../../../../../db/repos/repository', () => ({
+	DocumentsRepository: jest.fn().mockImplementation(() => ({
+		getSubmissionDocumentsByCaseRef: jest.fn().mockImplementation(async (caseReference) =>
+			testDocuments.map((document) => ({
+				location: `${testDocumentType}:${caseReference}/${document}`,
+				originalFileName: `${caseReference}-${document}`,
+				type: testDocumentType
+			}))
+		)
+	}))
+}));
+
+jest.mock('#lib/front-office-storage-client', () => ({
+	getProperties: jest.fn().mockResolvedValue({}),
+	downloadBlob: jest.fn().mockImplementation(async (_, filename) => {
+		return {
+			readableStreamBody: true,
+			blobDownloadStream: { stream: filename }
+		};
+	})
+}));
+
+describe('/v2/back-office/{caseReference}/case_stage/{caseStage}', () => {
+	let res = mockRes();
+
+	let req;
+
+	beforeEach(() => {
+		req = {
+			...mockReq,
+			params: {
+				caseReference: testCaseReference,
+				caseStage: testCaseStage
+			}
+		};
+		res = {
+			...mockRes,
+			sendStatus: jest.fn(),
+			status: jest.fn()
+		};
+	});
+
+	afterEach(() => {
+		jest.clearAllMocks();
+	});
+
+	it('should return status of 200', async () => {
+		await getDocumentsByCaseReferenceAndCaseStage(req, res);
+		expect(res.status).toHaveBeenCalledWith(200);
+	});
+
+	it('should expect 3 blob streams to be appended', async () => {
+		await getDocumentsByCaseReferenceAndCaseStage(req, res);
+
+		// Testing archive append was called correctly 3 times
+		expect(mockAppend).toBeCalledTimes(3);
+
+		testDocuments.map((testDocument, index) => {
+			const document = `${testCaseReference}-${testDocument}`;
+			expect(mockAppend).toHaveBeenNthCalledWith(
+				index + 1,
+				{ stream: document },
+				{ name: `${testDocumentType}/${document}` }
+			);
+		});
+	});
+});

--- a/packages/document-service-api/src/routes/v2/submission/_caseReference/case_stage/_caseStage/index.js
+++ b/packages/document-service-api/src/routes/v2/submission/_caseReference/case_stage/_caseStage/index.js
@@ -1,0 +1,28 @@
+const express = require('express');
+const asyncHandler = require('@pins/common/src/middleware/async-handler');
+const { AUTH } = require('@pins/common/src/constants');
+const config = require('../../../../../../configuration/config');
+const { getDocumentsByCaseReferenceAndCaseStage } = require('./controller');
+const { auth } = require('express-oauth2-jwt-bearer');
+const { validateToken } = require('@pins/common/src/middleware/validate-token');
+
+const router = express.Router({ mergeParams: true });
+
+router.use(
+	auth({
+		issuerBaseURL: `${config.auth.authServerUrl}${AUTH.OIDC_ENDPOINT}`,
+		audience: AUTH.RESOURCE
+	})
+);
+router.use(
+	validateToken({
+		headerName: 'authentication',
+		reqPropertyName: 'id_token',
+		jwksUri: `${config.auth.authServerUrl}${AUTH.JWKS_ENDPOINT}`,
+		enforceToken: false
+	})
+);
+
+router.get('/', asyncHandler(getDocumentsByCaseReferenceAndCaseStage));
+
+module.exports = { router };

--- a/packages/forms-web-app/src/controllers/selected-appeal/downloads/documents.js
+++ b/packages/forms-web-app/src/controllers/selected-appeal/downloads/documents.js
@@ -1,15 +1,9 @@
 const { PassThrough } = require('node:stream');
-
-const buildZipFilename = (appealNumber, appealCaseStage) => {
-	const timestampTokens = new Date().toISOString().split('T');
-	const dateString = timestampTokens[0].replaceAll('-', '');
-	const timeString = timestampTokens[1].split('.')[0].replaceAll(':', '');
-	return `appeal_${appealNumber}_${appealCaseStage}_${dateString}${timeString}.zip`;
-};
+const buildZipFilename = require('#lib/build-zip-filename');
 
 exports.get = () => {
 	return async (req, res) => {
-		const { appealNumber, appealCaseStage } = req.params;
+		const { appealNumber, appealCaseStage, documentsLocation } = req.params;
 
 		if (!appealCaseStage) {
 			return res.status(404);
@@ -24,9 +18,10 @@ exports.get = () => {
 		const bufferStream = new PassThrough();
 
 		bufferStream.end(
-			await req.docsApiClient.getBackOfficeDocumentsByAppealNumberAndCaseStage(
+			await req.docsApiClient.getBulkDocumentsDownload(
 				appealNumber,
-				appealCaseStage
+				appealCaseStage,
+				documentsLocation
 			)
 		);
 

--- a/packages/forms-web-app/src/controllers/selected-appeal/questionnaire-details/index.js
+++ b/packages/forms-web-app/src/controllers/selected-appeal/questionnaire-details/index.js
@@ -45,7 +45,9 @@ exports.get = (layoutTemplate = 'layouts/no-banner-link/main.njk') => {
 		let zipDownloadUrl;
 		if (userType === LPA_USER_ROLE && !isPagePdfDownload) {
 			pdfDownloadUrl = userRouteUrl + '?pdf=true';
-			zipDownloadUrl = userRouteUrl + `/download/documents/${APPEAL_CASE_STAGE.LPA_QUESTIONNAIRE}`;
+			zipDownloadUrl =
+				req.originalUrl.substring(0, req.originalUrl.lastIndexOf('/')) +
+				`/download/back-office/documents/${APPEAL_CASE_STAGE.LPA_QUESTIONNAIRE}`;
 		}
 
 		const lpaUser = getUserFromSession(req);

--- a/packages/forms-web-app/src/controllers/selected-appeal/questionnaire-details/index.test.js
+++ b/packages/forms-web-app/src/controllers/selected-appeal/questionnaire-details/index.test.js
@@ -76,7 +76,7 @@ const expectedViewContext = {
 		appealProcessDetails: 'some formatted row data'
 	},
 	pdfDownloadUrl: 'a/fake/url?pdf=true',
-	zipDownloadUrl: `a/fake/url/download/documents/${APPEAL_CASE_STAGE.LPA_QUESTIONNAIRE}`
+	zipDownloadUrl: `a/fake/download/back-office/documents/${APPEAL_CASE_STAGE.LPA_QUESTIONNAIRE}`
 };
 
 describe('controllers/selected-appeal/questionnaire-details/index', () => {

--- a/packages/forms-web-app/src/dynamic-forms/dynamic-components/submission-screen/lpa.njk
+++ b/packages/forms-web-app/src/dynamic-forms/dynamic-components/submission-screen/lpa.njk
@@ -25,6 +25,12 @@
         We will review your evidence and will contact you if we need any further information.
       </p>
 
+			{% if zipDownloadUrl %}
+				<p class="govuk-body">
+					<a href="{{ zipDownloadUrl }}">Download your documents (ZIP)</a>
+				</p>
+			{% endif %}
+
       <p class="govuk-body">
         <a data-cy="Feedback-Page-Body" href="/manage-appeals/your-appeals" class="govuk-link">View your planning appeals</a>
       </p>

--- a/packages/forms-web-app/src/lib/build-zip-filename.js
+++ b/packages/forms-web-app/src/lib/build-zip-filename.js
@@ -1,0 +1,8 @@
+const buildZipFilename = (appealNumber, appealCaseStage) => {
+	const timestampTokens = new Date().toISOString().split('T');
+	const dateString = timestampTokens[0].replaceAll('-', '');
+	const timeString = timestampTokens[1].split('.')[0].replaceAll(':', '');
+	return `appeal_${appealNumber}_${appealCaseStage}_${dateString}${timeString}.zip`;
+};
+
+module.exports = buildZipFilename;

--- a/packages/forms-web-app/src/routes/lpa-dashboard/questionnaire.js
+++ b/packages/forms-web-app/src/routes/lpa-dashboard/questionnaire.js
@@ -5,7 +5,8 @@ const {
 	save,
 	remove,
 	submit,
-	lpaSubmitted
+	lpaSubmitted,
+	bulkDownloadSubmissionDocuments
 } = require('../../dynamic-forms/controller');
 const validate = require('../../dynamic-forms/validator/validator');
 const {
@@ -115,6 +116,11 @@ router.get(
 	getJourney(journeys),
 	validationErrorHandler,
 	lpaSubmitted
+);
+
+router.get(
+	'/:applicationType/:referenceId/download/:documentsLocation/documents/:appealCaseStage',
+	bulkDownloadSubmissionDocuments
 );
 
 // remove answer - only available for some question types

--- a/packages/forms-web-app/src/routes/lpa-dashboard/selected-appeal.js
+++ b/packages/forms-web-app/src/routes/lpa-dashboard/selected-appeal.js
@@ -20,7 +20,7 @@ router.get(
 	questionnaireDetailsController.get('layouts/lpa-dashboard/main.njk')
 );
 router.get(
-	`/:appealNumber/questionnaire/download/documents/:appealCaseStage`,
+	`/:appealNumber/download/:documentsLocation/documents/:appealCaseStage`,
 	downloadDocumentsController.get()
 );
 router.get(


### PR DESCRIPTION
## Ticket Number

<!-- Add the number from the Jira board -->

https://pins-ds.atlassian.net/browse/A2-1179

## Description of change

document-service-api:
 - Added a new route to the document-service-api to build a zip file for the specified case reference and case stage: 
    - "/v2/submission/{caseReference}/case_stage/{caseStage}" 
 - Updated unit tests to the document-service-api   
 
 forms-web-app:
 - Amended dashboard route to the forms-web-app as a pass-through endpoint to retrieve the zip file via document-service-api
    - "/{appealNumber}/download/back-office/documents/{appealCaseStage}"
 - Added submission route to the forms-web-app as a pass-through endpoint to retrieve the zip file via document-service-api
    - "/{appealNumber}/download/submission/documents/{appealCaseStage}"
 - Updated unit test

<!-- Please describe the change -->

## Checklist

<!-- Put an `x` in all the boxes that apply: -->

- [ ] Requires infrastructure changes
- [ ] I have updated the documentation accordingly
- [x] My commit history in this PR is linear
- [x] New features have tests
- [ ] Breaking change (team conversation required)

## Important

Please do not merge from `main` (please only [rebase](https://github.com/Planning-Inspectorate/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
