### PR TITLE
fix(a2-1179): correctly convert stored blob storage uri

### DIFF
--- a/packages/common/src/client/blob-storage-client.js
+++ b/packages/common/src/client/blob-storage-client.js
@@ -7,6 +7,7 @@ const {
 } = require('@azure/storage-blob');
 const logger = require('../lib/logger');
 const BlobStorageError = require('./blob-storage-error');
+const getAzureBlobPathFromUri = require('../lib/getAzureBlobPathFromUri');
 
 const trailingSlashRegex = /\/$/;
 
@@ -62,8 +63,7 @@ class BlobStorageClient {
 		const NOW = new Date();
 		const startsOn = new Date(NOW.valueOf() - TEN_MINUTES);
 
-		blobName = blobName.replace(`${this.host}/${containerName}/`, ''); // remove host + container if provided
-		blobName = blobName.replace(`${this.host}/`, ''); // remove host if no container on url
+		blobName = getAzureBlobPathFromUri(blobName, this.host, containerName);
 
 		if (!expiresOn) {
 			expiresOn = new Date(NOW.valueOf() + TEN_MINUTES);

--- a/packages/common/src/lib/getAzureBlobPathFromUri.js
+++ b/packages/common/src/lib/getAzureBlobPathFromUri.js
@@ -1,0 +1,5 @@
+const getAzureBlobPathFromUri = (documentURI, blobHost, blobContainer) => {
+	return documentURI.replace(`${blobHost}/${blobContainer}/`, '').replace(`${blobHost}/`, ''); // remove host if no container on url
+};
+
+module.exports = getAzureBlobPathFromUri;

--- a/packages/document-service-api/src/routes/v2/back-office/_caseReference/case_stage/_caseStage/controller.test.js
+++ b/packages/document-service-api/src/routes/v2/back-office/_caseReference/case_stage/_caseStage/controller.test.js
@@ -23,13 +23,14 @@ jest.mock('archiver', () =>
 	})
 );
 
+const documentURI = 'https://some-url.com/document.pdf';
+
 jest.mock('../../../../../../db/repos/repository', () => ({
 	DocumentsRepository: jest.fn().mockImplementation(() => ({
 		getDocuments: jest.fn().mockImplementation(async ({ documentType }) => [
 			{
-				documentURI: `https://some-url.com/document-one.pdf`,
+				documentURI,
 				documentType,
-				originalFilename: `${documentType}-document.pdf`,
 				filename: 'document.pdf'
 			}
 		])
@@ -84,7 +85,7 @@ describe('/v2/back-office/{caseReference}/case_stage/{caseStage}', () => {
 		testDocumentTypes.map((documentType, index) => {
 			expect(mockAppend).toHaveBeenNthCalledWith(
 				index + 1,
-				{ stream: `${documentType}-document.pdf` },
+				{ stream: documentURI },
 				{ name: `${documentType}/document.pdf` }
 			);
 		});

--- a/packages/document-service-api/src/routes/v2/submission/_caseReference/case_stage/_caseStage/controller.js
+++ b/packages/document-service-api/src/routes/v2/submission/_caseReference/case_stage/_caseStage/controller.js
@@ -7,6 +7,7 @@ const { DocumentsRepository } = require('../../../../../../db/repos/repository')
 const repo = new DocumentsRepository();
 const { storage } = require('#config/config');
 const { APPEAL_CASE_STAGE } = require('pins-data-model');
+const getAzureBlobPathFromUri = require('@pins/common/src/lib/getAzureBlobPathFromUri');
 
 /**
  * @param {string} caseStage
@@ -28,7 +29,7 @@ async function getBlobCollection(caseStage, caseReference) {
 		return {
 			fullName: `${kebabCase(type)}/${originalFileName}`,
 			blobStorageContainer: storage.container,
-			blobStoragePath: originalFileName,
+			blobStoragePath: getAzureBlobPathFromUri(location, storage.host, storage.container),
 			documentURI: location
 		};
 	});

--- a/packages/document-service-api/src/routes/v2/submission/_caseReference/case_stage/_caseStage/controller.test.js
+++ b/packages/document-service-api/src/routes/v2/submission/_caseReference/case_stage/_caseStage/controller.test.js
@@ -22,10 +22,10 @@ jest.mock('archiver', () =>
 
 jest.mock('../../../../../../db/repos/repository', () => ({
 	DocumentsRepository: jest.fn().mockImplementation(() => ({
-		getSubmissionDocumentsByCaseRef: jest.fn().mockImplementation(async (caseReference) =>
+		getSubmissionDocumentsByCaseRef: jest.fn().mockImplementation(async () =>
 			testDocuments.map((document) => ({
-				location: `${testDocumentType}:${caseReference}/${document}`,
-				originalFileName: `${caseReference}-${document}`,
+				location: `${testCaseReference}-${document}`,
+				originalFileName: `${testCaseReference}-${document}`,
 				type: testDocumentType
 			}))
 		)
@@ -42,7 +42,7 @@ jest.mock('#lib/front-office-storage-client', () => ({
 	})
 }));
 
-describe('/v2/back-office/{caseReference}/case_stage/{caseStage}', () => {
+describe('/v2/submission/{caseReference}/case_stage/{caseStage}', () => {
 	let res = mockRes();
 
 	let req;


### PR DESCRIPTION
## Ticket Number

<!-- Add the number from the Jira board -->

https://pins-ds.atlassian.net/browse/A2-1179

## Description of change

document-service-api:
 - Created a reusable function to correctly convert the blob uri supplied by back-office to the correct blob uri for download
 - Updated unit tests to the document-service-api   
 - Tested manually via front office web
<!-- Please describe the change -->

## Checklist

<!-- Put an `x` in all the boxes that apply: -->

- [ ] Requires infrastructure changes
- [ ] I have updated the documentation accordingly
- [x] My commit history in this PR is linear
- [x] New features have tests
- [ ] Breaking change (team conversation required)

## Important

Please do not merge from `main` (please only [rebase](https://github.com/Planning-Inspectorate/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
