### PR TITLE
fix(a2-1775): check for validation errors at start of save function

### DIFF
--- a/packages/forms-web-app/src/journeys/question-overrides/multi-file-upload.js
+++ b/packages/forms-web-app/src/journeys/question-overrides/multi-file-upload.js
@@ -241,6 +241,12 @@ function removeDocuments(apiClient, journeyId) {
  * @returns {Promise<void>}
  */
 async function saveAction(req, res, journey, section, journeyResponse) {
+	// check for saving validation errors
+	const saveViewModel = this.checkForSavingErrors(req, section, journey);
+	if (saveViewModel) {
+		return this.renderAction(res, saveViewModel);
+	}
+
 	const previouslyUploadedFiles = this.getRelevantUploadedFiles(journeyResponse);
 
 	const { uploadedFiles } = await getDataToSave.call(this, req, journeyResponse);
@@ -278,12 +284,6 @@ async function saveAction(req, res, journey, section, journeyResponse) {
 		};
 	}
 	await this.saveResponseToDB(req.appealsApiClient, journey.response, responseToSave);
-
-	// check for saving errors
-	const saveViewModel = this.checkForSavingErrors(req, section, journey);
-	if (saveViewModel) {
-		return this.renderAction(res, saveViewModel);
-	}
 
 	// move to the next question
 	return this.handleNextQuestion(res, journey, section.segment, this.fieldName);


### PR DESCRIPTION
## Ticket Number

https://pins-ds.atlassian.net/browse/A2-1775

## Description of change

Moves the validation check to the start of the save function to ensure correct error message

## Checklist

<!-- Put an `x` in all the boxes that apply: -->

- [ ] Requires infrastructure changes
- [ ] I have updated the documentation accordingly
- X My commit history in this PR is linear
- [ ] New features have tests
- [ ] Breaking change (team conversation required)

## Important

Please do not merge from `main` (please only [rebase](https://github.com/Planning-Inspectorate/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
