### PR TITLE
feat(a2-1195): display inquiry details on appeal page for appellants …

### DIFF
--- a/packages/common/src/view-model-maps/events.js
+++ b/packages/common/src/view-model-maps/events.js
@@ -57,22 +57,28 @@ const formatSiteVisits = (events, role) => {
 /**
  * @param {Array<Event>} events
  * @param {string} role
- * @returns {Array<string|null>}
+ * @returns {Array<string|undefined>}
  */
 const formatInquiries = (events, role) => {
 	let inquiries = events.filter((item) => item.type === EVENT_TYPES.INQUIRY);
-	return inquiries.map((inquiry) => {
-		const { formattedTime: formattedStartTime, formattedDate: formattedStartDate } =
-			getFormattedTimeAndDate(inquiry.startDate);
-		const address = formatEventAddress(inquiry);
+	return inquiries
+		.map((inquiry) => {
+			const { formattedTime: formattedStartTime, formattedDate: formattedStartDate } =
+				getFormattedTimeAndDate(inquiry.startDate);
+			const address = formatEventAddress(inquiry);
 
-		if (role === LPA_USER_ROLE) {
-			return `The inquiry will start at ${formattedStartTime} on ${formattedStartDate}. You must attend the inquiry ${
-				address ? `at ${address}` : '- address to be confirmed'
-			}`;
-		}
-		return null;
-	});
+			if (
+				role === LPA_USER_ROLE ||
+				role === APPEAL_USER_ROLES.APPELLANT ||
+				role === APPEAL_USER_ROLES.AGENT
+			) {
+				return `The inquiry will start at ${formattedStartTime} on ${formattedStartDate}. You must attend the inquiry ${
+					address ? `at ${address}` : '- address to be confirmed'
+				}`;
+			}
+			return;
+		})
+		.filter(Boolean);
 };
 
 /**

--- a/packages/common/src/view-model-maps/events.test.js
+++ b/packages/common/src/view-model-maps/events.test.js
@@ -29,23 +29,41 @@ describe('view-model-maps/events', () => {
 	};
 
 	describe('formatInquiries', () => {
-		it('returns null if not an LPA user', () => {
-			const events = [inquiryEvent];
-			const role = APPEAL_USER_ROLES.APPELLANT;
+		it('returns empty array if not a valid user', () => {
+			const events = [siteVisitEvent, inquiryEvent];
+			const role = 'not a valid user';
 
-			expect(formatInquiries(events, role)).toBeNull;
+			expect(formatInquiries(events, role)).toHaveLength(0);
 		});
 
 		it('returns null if no inquiries in events', () => {
 			const events = [siteVisitEvent];
 			const role = LPA_USER_ROLE;
 
-			expect(formatInquiries(events, role)).toBeNull;
+			expect(formatInquiries(events, role)).toHaveLength(0);
 		});
 
-		it('returns correct string array if valid inquiry & user', () => {
+		it('returns correct string array if valid inquiry & LPA user', () => {
 			const events = [siteVisitEvent, inquiryEvent];
 			const role = LPA_USER_ROLE;
+
+			expect(formatInquiries(events, role)).toEqual([
+				'The inquiry will start at 9am on 29 December 2024. You must attend the inquiry at 101 The Street, Flat 2, Town, County, AB1 2CD'
+			]);
+		});
+
+		it('returns correct string array if valid inquiry & appellant user', () => {
+			const events = [siteVisitEvent, inquiryEvent];
+			const role = APPEAL_USER_ROLES.APPELLANT;
+
+			expect(formatInquiries(events, role)).toEqual([
+				'The inquiry will start at 9am on 29 December 2024. You must attend the inquiry at 101 The Street, Flat 2, Town, County, AB1 2CD'
+			]);
+		});
+
+		it('returns correct string array if valid inquiry & agent user', () => {
+			const events = [siteVisitEvent, inquiryEvent];
+			const role = APPEAL_USER_ROLES.AGENT;
 
 			expect(formatInquiries(events, role)).toEqual([
 				'The inquiry will start at 9am on 29 December 2024. You must attend the inquiry at 101 The Street, Flat 2, Town, County, AB1 2CD'


### PR DESCRIPTION
…or agents

## Ticket Number

<!-- Add the number from the Jira board -->

https://pins-ds.atlassian.net/browse/A2-1195

## Description of change

Enable appellant/agent users to see inquiry details on individual appeal page on appellant dashboard.

<!-- Please describe the change -->

## Checklist

<!-- Put an `x` in all the boxes that apply: -->

- [ ] Requires infrastructure changes
- [ ] I have updated the documentation accordingly
- [ ] My commit history in this PR is linear
- [ ] New features have tests
- [ ] Breaking change (team conversation required)

## Important

Please do not merge from `main` (please only [rebase](https://github.com/Planning-Inspectorate/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
