### PR TITLE
fix(a2-1790): amend check on removed files to prevent api error

### DIFF
--- a/packages/forms-web-app/src/journeys/question-overrides/multi-file-upload.js
+++ b/packages/forms-web-app/src/journeys/question-overrides/multi-file-upload.js
@@ -250,6 +250,7 @@ async function saveAction(req, res, journey, section, journeyResponse) {
 	const previouslyUploadedFiles = this.getRelevantUploadedFiles(journeyResponse);
 
 	const { uploadedFiles } = await getDataToSave.call(this, req, journeyResponse);
+
 	await Promise.all(
 		uploadedFiles.map((file) => {
 			if (!file) return;
@@ -269,8 +270,10 @@ async function saveAction(req, res, journey, section, journeyResponse) {
 	);
 	const allUploadedFiles = [...previouslyUploadedFiles, ...uploadedFiles].filter(Boolean);
 	const isQuestionAnswered = allUploadedFiles.length > 0;
+	const removedAllPreviousFiles = req.body.removedFiles?.length === previouslyUploadedFiles.length;
+
 	let responseToSave;
-	if (req.body.removedFiles && uploadedFiles.length === 0) {
+	if (removedAllPreviousFiles && uploadedFiles.length === 0) {
 		responseToSave = {
 			answers: {
 				[this.fieldName]: null
@@ -283,6 +286,7 @@ async function saveAction(req, res, journey, section, journeyResponse) {
 			}
 		};
 	}
+
 	await this.saveResponseToDB(req.appealsApiClient, journey.response, responseToSave);
 
 	// move to the next question


### PR DESCRIPTION
## Ticket Number

https://pins-ds.atlassian.net/browse/A2-1790

## Description of change

Amends the check when removing files - now makes sure that not all files removed rather than just one (potentially of many)

## Checklist

<!-- Put an `x` in all the boxes that apply: -->

- [ ] Requires infrastructure changes
- [ ] I have updated the documentation accordingly
- X My commit history in this PR is linear
- [ ] New features have tests
- [ ] Breaking change (team conversation required)

## Important

Please do not merge from `main` (please only [rebase](https://github.com/Planning-Inspectorate/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
