### PR TITLE
feat(a2-1198): add inquiry date to appeal page for interested party

### DIFF
--- a/packages/appeals-service-api/src/spec/api-types.d.ts
+++ b/packages/appeals-service-api/src/spec/api-types.d.ts
@@ -471,7 +471,7 @@ export interface AppealCase {
 	AffectedListedBuildings?: object[];
 	Documents?: object[];
 	NeighbouringAddresses?: object[];
-	Events?: object[];
+	Events?: Event[];
 	AppealCaseLpaNotificationMethod?: object[];
 	/** A final comment submitted by an LPA */
 	LPAFinalCommentSubmission?: LPAFinalCommentSubmission;

--- a/packages/appeals-service-api/src/spec/appeal-case.yaml
+++ b/packages/appeals-service-api/src/spec/appeal-case.yaml
@@ -589,7 +589,7 @@ components:
         Events:
           type: array
           items:
-            type: object
+            $ref: '#/components/schemas/Event'
 
         AppealCaseLpaNotificationMethod:
           type: array

--- a/packages/forms-web-app/src/routes/file-based-router/comment-planning-appeal/appeals/_appealNumber/controller.js
+++ b/packages/forms-web-app/src/routes/file-based-router/comment-planning-appeal/appeals/_appealNumber/controller.js
@@ -2,6 +2,7 @@ const { getAppealStatus } = require('#utils/appeal-status');
 const { formatCommentDeadlineText } = require('../../../../../utils/format-deadline-text');
 const { formatCommentDecidedData } = require('../../../../../utils/format-comment-decided-data');
 const { formatCommentHeadlineText } = require('../../../../../utils/format-headline-text');
+const { formatCommentInquiryText } = require('../../../../../utils/format-comment-inquiry-text');
 const { formatHeadlineData } = require('@pins/common');
 const { getDepartmentFromCode } = require('../../../../../services/department.service');
 const {
@@ -27,13 +28,16 @@ const selectedAppeal = async (req, res) => {
 
 	const decidedData = formatCommentDecidedData(appeal);
 
+	const inquiries = appeal.Events ? formatCommentInquiryText(appeal.Events) : [];
+
 	res.render(`comment-planning-appeal/appeals/_appealNumber/index`, {
 		appeal: {
 			...appeal,
 			status,
 			headlineText,
 			deadlineText,
-			decidedData
+			decidedData,
+			inquiries
 		},
 		headlineData
 	});

--- a/packages/forms-web-app/src/routes/file-based-router/comment-planning-appeal/appeals/_appealNumber/index.njk
+++ b/packages/forms-web-app/src/routes/file-based-router/comment-planning-appeal/appeals/_appealNumber/index.njk
@@ -6,7 +6,7 @@
 {% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "pins/components/appeal-sections-block.njk" import appealSectionsBlock %}
 
-{% set title=appeal.headlineText + " for comment - Comment on a planning appeal - GOV.UK" %}
+{% set title=appeal.headlineText + " - Comment on a planning appeal - GOV.UK" %}
 
 {% block pageTitle %}
   {{ title }}
@@ -64,6 +64,15 @@
 		{% else %}
 		  <p> You cannot add a comment. </p>
 		{% endif %}
+
+		{% for inquiry in appeal.inquiries %}
+				<div class="govuk-inset-text">
+					<p class="govuk-body">
+						{{inquiry}}
+					</p>
+				</div>
+			{% endfor %}
+
 		<hr class="govuk-section-break govuk-section-break--visible govuk-section-break--l">
 	  </div>
     </div>

--- a/packages/forms-web-app/src/utils/format-comment-inquiry-text.js
+++ b/packages/forms-web-app/src/utils/format-comment-inquiry-text.js
@@ -1,0 +1,22 @@
+/**
+ * @typedef {import('appeals-service-api').Api.Event} Event
+ */
+
+const { EVENT_TYPES } = require('@pins/common/src/constants');
+const { format: formatDate } = require('date-fns');
+const { utcToZonedTime } = require('date-fns-tz');
+
+/**
+ * @param {Array<Event>} events
+ * @returns {Array<string>}
+ */
+exports.formatCommentInquiryText = (events) => {
+	const inquiries = events.filter((event) => event.type === EVENT_TYPES.INQUIRY);
+	return inquiries.length
+		? inquiries.map((inquiry) => {
+				const date = inquiry.startDate;
+				const formattedDate = formatDate(utcToZonedTime(date, 'Europe/London'), 'd LLLL yyyy');
+				return `The inquiry will start on ${formattedDate}.`;
+		  })
+		: [];
+};

--- a/packages/forms-web-app/src/utils/format-comment-inquiry-text.test.js
+++ b/packages/forms-web-app/src/utils/format-comment-inquiry-text.test.js
@@ -1,0 +1,31 @@
+const { formatCommentInquiryText } = require('./format-comment-inquiry-text');
+
+describe('formatCommentInquiryText', () => {
+	const siteVisitEvent = {
+		internalId: 'test123',
+		published: true,
+		type: 'siteVisit',
+		subtype: null,
+		startDate: new Date(2024, 11, 29, 9),
+		endDate: new Date(2024, 11, 30, 9)
+	};
+	const inquiryEvent = {
+		internalId: 'test123',
+		published: true,
+		type: 'inquiry',
+		subtype: null,
+		startDate: new Date(2024, 11, 29, 9),
+		endDate: new Date(2024, 11, 30, 9)
+	};
+	it('returns empty array if no inquiries', () => {
+		const events = [siteVisitEvent];
+		expect(formatCommentInquiryText(events)).toHaveLength(0);
+	});
+
+	it('returns correct string if an inquiry event in events array', () => {
+		const events = [siteVisitEvent, inquiryEvent];
+		expect(formatCommentInquiryText(events)).toEqual([
+			'The inquiry will start on 29 December 2024.'
+		]);
+	});
+});


### PR DESCRIPTION
## Ticket Number

<!-- Add the number from the Jira board -->

https://pins-ds.atlassian.net/browse/A2-1198

## Description of change

Adds inquiry date (formatted) on the appeal page for interested parties (if an inquiry event exists for that appeal).
Have updated api spec to reflect that Events related to an appeal case consists of an array of Event types.

Also fixed a small content error in the page title. 

<!-- Please describe the change -->

## Checklist

<!-- Put an `x` in all the boxes that apply: -->

- [ ] Requires infrastructure changes
- [ ] I have updated the documentation accordingly
- [x] My commit history in this PR is linear
- [x] New features have tests
- [ ] Breaking change (team conversation required)

## Important

Please do not merge from `main` (please only [rebase](https://github.com/Planning-Inspectorate/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
