### PR TITLE
feat(a2-1194): add inquiry info to rule 6 party selected appeal page

### DIFF
--- a/packages/common/src/view-model-maps/events.js
+++ b/packages/common/src/view-model-maps/events.js
@@ -70,7 +70,8 @@ const formatInquiries = (events, role) => {
 			if (
 				role === LPA_USER_ROLE ||
 				role === APPEAL_USER_ROLES.APPELLANT ||
-				role === APPEAL_USER_ROLES.AGENT
+				role === APPEAL_USER_ROLES.AGENT ||
+				role === APPEAL_USER_ROLES.RULE_6_PARTY
 			) {
 				return `The inquiry will start at ${formattedStartTime} on ${formattedStartDate}. You must attend the inquiry ${
 					address ? `at ${address}.` : '- address to be confirmed.'

--- a/packages/common/src/view-model-maps/events.test.js
+++ b/packages/common/src/view-model-maps/events.test.js
@@ -31,7 +31,7 @@ describe('view-model-maps/events', () => {
 	describe('formatInquiries', () => {
 		it('returns empty array if not a valid user', () => {
 			const events = [siteVisitEvent, inquiryEvent];
-			const role = APPEAL_USER_ROLES.INTERESTED_PARTY;
+			const role = 'not a valid user';
 
 			expect(formatInquiries(events, role)).toHaveLength(0);
 		});

--- a/packages/common/src/view-model-maps/events.test.js
+++ b/packages/common/src/view-model-maps/events.test.js
@@ -31,7 +31,7 @@ describe('view-model-maps/events', () => {
 	describe('formatInquiries', () => {
 		it('returns empty array if not a valid user', () => {
 			const events = [siteVisitEvent, inquiryEvent];
-			const role = 'not a valid user';
+			const role = APPEAL_USER_ROLES.INTERESTED_PARTY;
 
 			expect(formatInquiries(events, role)).toHaveLength(0);
 		});
@@ -46,6 +46,15 @@ describe('view-model-maps/events', () => {
 		it('returns correct string array if valid inquiry & LPA user', () => {
 			const events = [siteVisitEvent, inquiryEvent];
 			const role = LPA_USER_ROLE;
+
+			expect(formatInquiries(events, role)).toEqual([
+				'The inquiry will start at 9am on 29 December 2024. You must attend the inquiry at 101 The Street, Flat 2, Town, County, AB1 2CD.'
+			]);
+		});
+
+		it('returns correct string array if valid inquiry & rule 6 party user', () => {
+			const events = [siteVisitEvent, inquiryEvent];
+			const role = APPEAL_USER_ROLES.RULE_6_PARTY;
 
 			expect(formatInquiries(events, role)).toEqual([
 				'The inquiry will start at 9am on 29 December 2024. You must attend the inquiry at 101 The Street, Flat 2, Town, County, AB1 2CD.'


### PR DESCRIPTION
## Ticket Number

<!-- Add the number from the Jira board -->

https://pins-ds.atlassian.net/browse/A2-1194

## Description of change

Show inquiry data on rule 6 appeal page if it exists.

<!-- Please describe the change -->

## Checklist

<!-- Put an `x` in all the boxes that apply: -->

- [ ] Requires infrastructure changes
- [ ] I have updated the documentation accordingly
- [ ] My commit history in this PR is linear
- [ ] New features have tests
- [ ] Breaking change (team conversation required)

## Important

Please do not merge from `main` (please only [rebase](https://github.com/Planning-Inspectorate/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
