### PR TITLE
fix(a2-1616): use public url for web verify check

### DIFF
--- a/azure-pipelines-deploy.yml
+++ b/azure-pipelines-deploy.yml
@@ -217,7 +217,7 @@ extends:
                   repository: appeal-planning-decision/forms-web-app
               - script: |
                     echo "Verifying Web Version (using git hash $(resources.pipeline.build.sourceCommit))..."
-                    bash ./scripts/verify_commit_hash.sh "API" "https://pins-app-appeals-service-appeals-wfe-$(ENVIRONMENT)-$(REGION_SHORT)-001.azurewebsites.net/health" "$(resources.pipeline.build.sourceCommit)" 5
+                    bash ./scripts/verify_commit_hash.sh "API" "$(WEB_URL)/health" "$(resources.pipeline.build.sourceCommit)" 5
                 displayName: Web Verify Version
                 failOnStderr: true
                 continueOnError: false


### PR DESCRIPTION
## Ticket Number

<!-- Add the number from the Jira board -->

https://pins-ds.atlassian.net/browse/A2-1616

## Description of change

- Front end web app has different networking restrictions from other apps, (blocks connections that don't come from front door), this uses the public facing url to route through front door
- variables added to existing group in devops pipeline library

## Checklist

<!-- Put an `x` in all the boxes that apply: -->

- [ ] Requires infrastructure changes
- [ ] I have updated the documentation accordingly
- [ ] My commit history in this PR is linear
- [ ] New features have tests
- [ ] Breaking change (team conversation required)

## Important

Please do not merge from `main` (please only [rebase](https://github.com/Planning-Inspectorate/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
