### PR TITLE
fix: specify alpine version due to breaking change in latest

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,7 @@ version: '3.7'
 services:
   auth-server:
     profiles: ['all', 'api', 'appeals', 'comment', 'documents']
-    image: node:20-alpine
+    image: node:20-alpine3.20
     environment:
       # Logging
       LOGGER_LEVEL: 'debug'
@@ -70,7 +70,7 @@ services:
 
   appeals-service-api:
     profiles: ['all', 'api', 'appeals', 'comment']
-    image: node:20-alpine
+    image: node:20-alpine3.20
     environment:
       APP_APPEALS_BASE_URL: http://forms-web-app:9003
       APP_LPA_QUESTIONNAIRE_BASE_URL: http://lpa-questionnaire-web-app:9001
@@ -138,7 +138,7 @@ services:
 
   document-service-api: &document-service
     profiles: ['all', 'api', 'appeals', 'documents']
-    image: node:20-alpine
+    image: node:20-alpine3.20
     environment:
       AUTH_BASE_URL: http://auth-server:3000
       BO_STORAGE_CONTAINER_HOST: http://localhost:4004/devstoreaccount1/
@@ -184,7 +184,7 @@ services:
 
   forms-web-app:
     profiles: ['all', 'appeals']
-    image: node:20-alpine
+    image: node:20-alpine3.20
     environment:
       ALLOW_TESTING_OVERRIDES: 'true'
       APPEALS_SERVICE_API_URL: http://appeals-service-api:3000

--- a/packages/appeals-service-api/Dockerfile
+++ b/packages/appeals-service-api/Dockerfile
@@ -1,5 +1,5 @@
 # Stage 1/2: Build
-FROM node:20-alpine AS build
+FROM node:20-alpine3.20 AS build
 
 WORKDIR /opt/packages/appeals-service-api
 

--- a/packages/auth-server/Dockerfile
+++ b/packages/auth-server/Dockerfile
@@ -1,5 +1,5 @@
 # Stage 1/2: Build
-FROM node:20-alpine AS build
+FROM node:20-alpine3.20 AS build
 
 WORKDIR /opt/packages/auth-server
 

--- a/packages/document-service-api/Dockerfile
+++ b/packages/document-service-api/Dockerfile
@@ -1,5 +1,5 @@
 # Stage 1/2: Build
-FROM node:20-alpine AS build
+FROM node:20-alpine3.20 AS build
 
 WORKDIR /opt/packages/document-service-api
 

--- a/packages/forms-web-app/Dockerfile
+++ b/packages/forms-web-app/Dockerfile
@@ -1,5 +1,5 @@
 # Stage 1/2: Build
-FROM node:20-alpine AS build
+FROM node:20-alpine3.20 AS build
 
 WORKDIR /opt/packages/forms-web-app
 


### PR DESCRIPTION
## Ticket Number

<!-- Add the number from the Jira board -->

## Description of change

- Node alpine released a breaking change that has impacted prisma - (unable to find an ssl library, believe the path has changed)
- Specifying the last working version of alpine in the dockerfile
- Intended as a temporary measure until either alpine reverts the change or prisma updates how it searches for the sll lib 

## Checklist

<!-- Put an `x` in all the boxes that apply: -->

- [ ] Requires infrastructure changes
- [ ] I have updated the documentation accordingly
- [ ] My commit history in this PR is linear
- [ ] New features have tests
- [ ] Breaking change (team conversation required)

## Important

Please do not merge from `main` (please only [rebase](https://github.com/Planning-Inspectorate/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
