### PR TITLE
fix(A2-1105): remove legacy v1 data from v2 appeal

### DIFF
--- a/packages/appeals-service-api/src/routes/v2/appeals/_id/appeals.spec.js
+++ b/packages/appeals-service-api/src/routes/v2/appeals/_id/appeals.spec.js
@@ -1,0 +1,113 @@
+const supertest = require('supertest');
+const app = require('../../../../app');
+const { createPrismaClient } = require('../../../../db/db-client');
+const { seedStaticData } = require('@pins/database/src/seed/data-static');
+const { APPEAL_USER_ROLES } = require('@pins/common/src/constants');
+const crypto = require('crypto');
+const { isFeatureActive } = require('../../../../configuration/featureFlag');
+/** @type {import('@prisma/client').PrismaClient} */
+let sqlClient;
+/** @type {import('supertest').SuperTest<import('supertest').Test>} */
+let appealsApi;
+let validUser;
+jest.mock('../../../../configuration/featureFlag');
+jest.mock('../../../../../src/services/object-store');
+jest.mock('express-oauth2-jwt-bearer', () => {
+	let currentSub = '';
+	return {
+		auth: jest.fn(() => {
+			return (req, _res, next) => {
+				req.auth = {
+					payload: {
+						sub: currentSub
+					}
+				};
+				next();
+			};
+		}),
+		setCurrentSub: (newSub) => {
+			currentSub = newSub;
+		}
+	};
+});
+jest.setTimeout(30000);
+beforeAll(async () => {
+	///////////////////////////////
+	///// SETUP TEST DATABASE ////
+	/////////////////////////////
+	sqlClient = createPrismaClient();
+	/////////////////////
+	///// SETUP APP ////
+	///////////////////
+	appealsApi = supertest(app);
+	await seedStaticData(sqlClient);
+	const user = await sqlClient.appealUser.create({
+		data: {
+			email: crypto.randomUUID() + '@example.com'
+		}
+	});
+	validUser = user.id;
+});
+beforeEach(async () => {
+	// turn all feature flags on
+	isFeatureActive.mockImplementation(() => {
+		return true;
+	});
+});
+afterEach(async () => {
+	jest.clearAllMocks();
+});
+afterAll(async () => {
+	await sqlClient.$disconnect();
+});
+/**
+ * @returns {Promise<string>}
+ */
+const createAppeal = async () => {
+	const appeal = await sqlClient.appeal.create({
+		data: {
+			legacyAppealSubmissionId: '8d89379a-e7b5-4a03-bdc7-1817f67d5e7b',
+			legacyAppealSubmissionDecisionDate: new Date(),
+			legacyAppealSubmissionState: 'DRAFT',
+			Users: {
+				create: {
+					userId: validUser,
+					role: APPEAL_USER_ROLES.APPELLANT
+				}
+			}
+		}
+	});
+	return appeal.id;
+};
+describe('/api/v2/appeals/{id}', () => {
+	it('should update an appeal with legacy fields set to null', async () => {
+		const appealId = await createAppeal();
+		console.log(appealId);
+		const response = await appealsApi.patch(`/api/v2/appeals/${appealId}`).send({
+			legacyAppealSubmissionId: null,
+			legacyAppealSubmissionDecisionDate: null,
+			legacyAppealSubmissionState: null
+		});
+		expect(response.status).toEqual(200);
+		const updatedAppeal = await sqlClient.appeal.findUnique({
+			where: { id: appealId },
+			select: {
+				legacyAppealSubmissionId: true,
+				legacyAppealSubmissionDecisionDate: true,
+				legacyAppealSubmissionState: true
+			}
+		});
+		expect(updatedAppeal).toMatchObject({
+			legacyAppealSubmissionId: null,
+			legacyAppealSubmissionDecisionDate: null,
+			legacyAppealSubmissionState: null
+		});
+	});
+	it('should return 404 if the appeal does not exist', async () => {
+		const nonExistentId = '00000000-0000-0000-0000-000000000000';
+		const response = await appealsApi.patch(`/api/v2/appeals/${nonExistentId}`).send({
+			legacyAppealSubmissionId: null
+		});
+		expect(response.status).toEqual(404);
+	});
+});

--- a/packages/appeals-service-api/src/routes/v2/appeals/_id/controller.js
+++ b/packages/appeals-service-api/src/routes/v2/appeals/_id/controller.js
@@ -1,0 +1,19 @@
+const ApiError = require('#errors/apiError');
+const { patch } = require('./service');
+
+/**
+ * @type {import('express').Handler}
+ */
+exports.patch = async (req, res) => {
+	const appealId = req.params.id;
+
+	if (!appealId) {
+		throw ApiError.badRequest({ errors: ['Appeal id is required'] });
+	}
+
+	const data = req.body;
+
+	const appeal = await patch({ appealId, data });
+
+	res.send(appeal);
+};

--- a/packages/appeals-service-api/src/routes/v2/appeals/_id/controller.js
+++ b/packages/appeals-service-api/src/routes/v2/appeals/_id/controller.js
@@ -10,10 +10,16 @@ exports.patch = async (req, res) => {
 	if (!appealId) {
 		throw ApiError.badRequest({ errors: ['Appeal id is required'] });
 	}
+	try {
+		const data = req.body;
+		const appeal = await patch({ appealId, data });
 
-	const data = req.body;
+		if (!appeal) {
+			res.status(404).send({ error: 'Appeal not found' });
+		}
 
-	const appeal = await patch({ appealId, data });
-
-	res.send(appeal);
+		res.send(appeal);
+	} catch (error) {
+		res.status(500).send({ error: 'Internal server error' });
+	}
 };

--- a/packages/appeals-service-api/src/routes/v2/appeals/_id/index.js
+++ b/packages/appeals-service-api/src/routes/v2/appeals/_id/index.js
@@ -1,0 +1,19 @@
+const express = require('express');
+const { patch } = require('./controller');
+const { AUTH } = require('@pins/common/src/constants');
+const config = require('../../../../configuration/config');
+const { auth } = require('express-oauth2-jwt-bearer');
+const asyncHandler = require('@pins/common/src/middleware/async-handler');
+const { openApiValidatorMiddleware } = require('../../../../validators/validate-open-api');
+const router = express.Router({ mergeParams: true });
+
+router.use(
+	auth({
+		issuerBaseURL: `${config.auth.authServerUrl}${AUTH.OIDC_ENDPOINT}`,
+		audience: AUTH.RESOURCE
+	})
+);
+
+router.patch('/', openApiValidatorMiddleware(), asyncHandler(patch));
+
+module.exports = { router };

--- a/packages/appeals-service-api/src/routes/v2/appeals/_id/service.js
+++ b/packages/appeals-service-api/src/routes/v2/appeals/_id/service.js
@@ -1,0 +1,20 @@
+const { UserAppealsRepository } = require('../repo');
+const repo = new UserAppealsRepository();
+
+/**
+ * @typedef {import("@prisma/client").Appeal} Appeal
+ */
+
+/**
+ * @param {{ appealId: string, data: Appeal }} params
+ * @return {Promise<Appeal| null>}
+ */
+exports.patch = async ({ appealId, data }) => {
+	const appeal = await repo.patch({ appealId, data });
+
+	if (!appeal) {
+		return null;
+	}
+
+	return appeal;
+};

--- a/packages/appeals-service-api/src/routes/v2/appeals/repo.js
+++ b/packages/appeals-service-api/src/routes/v2/appeals/repo.js
@@ -116,7 +116,7 @@ class UserAppealsRepository {
 			});
 		} catch (e) {
 			if (e instanceof PrismaClientKnownRequestError) {
-				if (e.code === 'P2023') {
+				if (e.code === 'P2023' || e.code === 'P2025') {
 					// probably an invalid ID/GUID
 					return null;
 				}

--- a/packages/appeals-service-api/src/routes/v2/appeals/repo.js
+++ b/packages/appeals-service-api/src/routes/v2/appeals/repo.js
@@ -5,6 +5,7 @@ const { APPEAL_USER_ROLES } = require('@pins/common/src/constants');
 /**
  * @typedef {import("@prisma/client").Prisma.AppealUserGetPayload<{include: {Appeals: {include: {Appeal: { include: {AppealCase: true }}}}}}>} UserWithAppeals
  * @typedef { 'Appellant' | 'Agent' | 'InterestedParty' | 'Rule6Party' } AppealToUserRoles
+ * @typedef {import("@prisma/client").Appeal} Appeal
  */
 
 class UserAppealsRepository {
@@ -87,6 +88,31 @@ class UserAppealsRepository {
 						}
 					}
 				}
+			});
+		} catch (e) {
+			if (e instanceof PrismaClientKnownRequestError) {
+				if (e.code === 'P2023') {
+					// probably an invalid ID/GUID
+					return null;
+				}
+			}
+			throw e;
+		}
+	}
+
+	/**
+	 * Update an appeal
+	 *
+	 * @param {{ appealId: string, data: Appeal }} params
+	 * @returns {Promise<Appeal|null>}
+	 */
+	async patch({ appealId, data }) {
+		try {
+			return await this.dbClient.appeal.update({
+				where: {
+					id: appealId
+				},
+				data: data
 			});
 		} catch (e) {
 			if (e instanceof PrismaClientKnownRequestError) {

--- a/packages/appeals-service-api/src/routes/v2/appeals/spec.yaml
+++ b/packages/appeals-service-api/src/routes/v2/appeals/spec.yaml
@@ -23,6 +23,29 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorBody'
+  /api/v2/appeals/{id}:
+    patch:
+      tags:
+        - appeals
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+          description: Appeal ID
+      description: Update an appeal
+      responses:
+        200:
+          description: Updated appeal
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Appeal'
+        400:
+          description: Bad request
+        404:
+          description: Appeal not found
 
 components:
   parameters:

--- a/packages/appeals-service-api/src/spec/api-types.d.ts
+++ b/packages/appeals-service-api/src/spec/api-types.d.ts
@@ -597,6 +597,19 @@ export interface AppealUser {
 	Rule6StatementSubmission?: object[];
 }
 
+/** A v2 appeal */
+export interface Appeal {
+	/**
+	 * appeal ID
+	 * @format uuid
+	 */
+	id: string;
+	legacyAppealSubmissionId?: string | null;
+	/** @format date-time */
+	legacyAppealSubmissionDecisionDate?: string | null;
+	legacyAppealSubmissionState?: string | null;
+}
+
 /** A final comment submitted by an appellant */
 export interface AppellantFinalCommentSubmission {
 	/** @format uuid */

--- a/packages/appeals-service-api/src/spec/appeal.yaml
+++ b/packages/appeals-service-api/src/spec/appeal.yaml
@@ -1,0 +1,22 @@
+components:
+  schemas:
+    Appeal:
+      description: A v2 appeal
+      type: object
+      required:
+        - id
+      properties:
+        id:
+          type: string
+          format: uuid
+          description: appeal ID
+        legacyAppealSubmissionId:
+          type: string
+          nullable: true
+        legacyAppealSubmissionDecisionDate:
+          type: string
+          format: date-time
+          nullable: true
+        legacyAppealSubmissionState:
+          type: string
+          nullable: true

--- a/packages/common/src/client/appeals-api-client.js
+++ b/packages/common/src/client/appeals-api-client.js
@@ -11,6 +11,7 @@ const trailingSlashRegex = /\/$/;
 
 // Internal API types
 /**
+ * @typedef {import('appeals-service-api').Api.Appeal} Appeal
  * @typedef {import('appeals-service-api').Api.AppealCase} AppealCase
  * @typedef {import('appeals-service-api').Api.AppealCaseDetailed} AppealCaseDetailed
  * @typedef {import('appeals-service-api').Api.AppealSubmission} AppealSubmission
@@ -77,6 +78,17 @@ class AppealsApiClient {
 		this.timeout = timeout;
 		/** @type {string} */
 		this.name = 'Appeals Service API';
+	}
+
+	/**
+	 * @param {string} appealId
+	 * @param {Partial<Appeal>} data
+	 * @returns {Promise<Appeal>}
+	 */
+	async patchAppealById(appealId, data) {
+		const endpoint = `${v2}/appeals/${appealId}`;
+		const response = await this.#makePatchRequest(endpoint, data);
+		return response.json();
 	}
 
 	/**

--- a/packages/forms-web-app/src/dynamic-forms/controller.js
+++ b/packages/forms-web-app/src/dynamic-forms/controller.js
@@ -457,6 +457,12 @@ exports.appellantStartAppeal = async (req, res) => {
 	await deleteAppeal(appeal.id);
 	req.session.appeal = null;
 
+	await req.appealsApiClient.patchAppealById(appeal.appealSqlId, {
+		legacyAppealSubmissionId: null,
+		legacyAppealSubmissionDecisionDate: null,
+		legacyAppealSubmissionState: null
+	});
+
 	return res.redirect(
 		`/appeals/${appealTypeDetails.taskListUrlStub}/appeal-form/your-appeal?id=${appealSubmission.id}`
 	);


### PR DESCRIPTION
## Ticket Number

<!-- Add the number from the Jira board -->

https://pins-ds.atlassian.net/browse/A2-1105

## Description of change

<!-- Please describe the change -->
sets legacy appeal data to null on v2 appeal once v1 appeal deleted at the end of before you start journey

## Checklist

<!-- Put an `x` in all the boxes that apply: -->

- [ ] Requires infrastructure changes
- [ ] I have updated the documentation accordingly
- [x] My commit history in this PR is linear
- [ ] New features have tests
- [ ] Breaking change (team conversation required)

## Important

Please do not merge from `main` (please only [rebase](https://github.com/Planning-Inspectorate/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
