### PR TITLE
Feat/a2 1477 display agent details

### DIFF
--- a/packages/appeals-service-api/src/lib/notify.js
+++ b/packages/appeals-service-api/src/lib/notify.js
@@ -491,7 +491,7 @@ const sendLPAHASQuestionnaireSubmittedEmailV2 = async (
 	const lpaName = lpa.getName();
 
 	const formattedAddress = formatAddress(appealCase);
-	const formattedDate = format(caseStartedDate, 'dd MMMM yyyy');
+	const formattedDate = caseStartedDate ? format(caseStartedDate, 'dd MMMM yyyy') : '';
 
 	const url = `${config.apps.appeals.baseUrl}/lpa-questionnaire-document/${caseReference}`;
 

--- a/packages/common/src/lib/format-appeal-details.js
+++ b/packages/common/src/lib/format-appeal-details.js
@@ -24,20 +24,6 @@ exports.formatContactDetails = (caseData) => {
 };
 
 /**
- * @param {import("../client/appeals-api-client").AppealCaseDetailed} caseData
- * @returns {string}
- */
-exports.formatApplicantDetails = (caseData) => {
-	const contact = caseData.users?.find((x) => {
-		x.role === APPEAL_USER_ROLES.APPELLANT;
-	});
-
-	if (!contact) return '';
-
-	return formatUserDetails(contact);
-};
-
-/**
  * @param {import('appeals-service-api').Api.ServiceUser} [contact]
  * @returns {string}
  */

--- a/packages/common/src/lib/format-applicant.js
+++ b/packages/common/src/lib/format-applicant.js
@@ -1,19 +1,58 @@
 /**
  * @typedef {import("appeals-service-api").Api.ServiceUser} ServiceUser
+ * @typedef {import('@pins/common/src/constants').AppealToUserRoles} AppealToUserRoles
+ * @typedef {import('@pins/common/src/constants').LpaUserRole} LpaUserRole
  */
 
-const { APPEAL_USER_ROLES } = require('../constants');
+/**
+ * @typedef {Object} formattedApplicant
+ * @property {object} key
+ * @property {object} value
+ */
+
+const { APPEAL_USER_ROLES, LPA_USER_ROLE } = require('../constants');
 
 /**
  * @param {ServiceUser[]} [users]
+ * @param {AppealToUserRoles|LpaUserRole|null} userType
+ * @returns {formattedApplicant}
+ */
+const formatApplicant = (users, userType = APPEAL_USER_ROLES.INTERESTED_PARTY) => {
+	const appellant = users?.find((user) => user.serviceUserType === APPEAL_USER_ROLES.APPELLANT);
+
+	if (userType === LPA_USER_ROLE) {
+		const agent = users?.find((user) => user.serviceUserType === APPEAL_USER_ROLES.AGENT);
+		if (agent) {
+			return {
+				key: { text: 'Agent contact details' },
+				value: { html: formatContactDetails(agent) }
+			};
+		}
+		if (appellant) {
+			return {
+				key: { text: 'Appellant contact details' },
+				value: { html: formatContactDetails(appellant) }
+			};
+		}
+	}
+
+	if (appellant)
+		return {
+			key: { text: 'Applicant' },
+			value: { text: `${appellant.firstName} ${appellant.lastName}` }
+		};
+
+	return { key: { text: 'Applicant' }, value: { text: '' } };
+};
+
+/**
+ * @param {ServiceUser} [user]
  * @returns {string}
  */
-const formatApplicant = (users) => {
-	const appellant = users?.find((x) => x.serviceUserType === APPEAL_USER_ROLES.APPELLANT);
-
-	if (!appellant) return '';
-
-	return `${appellant.firstName} ${appellant.lastName}`;
+const formatContactDetails = (user) => {
+	return [`${user?.firstName} ${user?.lastName}`, user?.emailAddress, user?.telephoneNumber]
+		.filter(Boolean)
+		.join('<br>');
 };
 
 module.exports = {

--- a/packages/common/src/lib/format-applicant.js
+++ b/packages/common/src/lib/format-applicant.js
@@ -41,7 +41,7 @@ const formatApplicant = (users, userType = APPEAL_USER_ROLES.INTERESTED_PARTY) =
 	if (appellant)
 		return {
 			key: { text: 'Applicant' },
-			value: { text: `${appellant.firstName} ${appellant.lastName}` }
+			value: { text: escape(`${appellant.firstName} ${appellant.lastName}`) }
 		};
 
 	return { key: { text: 'Applicant' }, value: { text: '' } };

--- a/packages/common/src/lib/format-applicant.js
+++ b/packages/common/src/lib/format-applicant.js
@@ -52,10 +52,12 @@ const formatApplicant = (users, userType = APPEAL_USER_ROLES.INTERESTED_PARTY) =
  * @returns {string}
  */
 const formatContactDetails = (user) => {
-	const name = escape(`${user?.firstName} ${user?.lastName}`);
-	const email = escape(user?.emailAddress);
-	const telephone = escape(user?.telephoneNumber);
-	return [name, email, telephone].filter(Boolean).join('<br>');
+	const contactDetailLines = [
+		`${user?.firstName} ${user?.lastName}`,
+		user?.emailAddress,
+		user?.telephoneNumber
+	].filter(Boolean);
+	return contactDetailLines.map((item) => escape(item)).join('<br>');
 };
 
 module.exports = {

--- a/packages/common/src/lib/format-applicant.js
+++ b/packages/common/src/lib/format-applicant.js
@@ -1,3 +1,5 @@
+const escape = require('escape-html');
+
 /**
  * @typedef {import("appeals-service-api").Api.ServiceUser} ServiceUser
  * @typedef {import('@pins/common/src/constants').AppealToUserRoles} AppealToUserRoles
@@ -50,9 +52,10 @@ const formatApplicant = (users, userType = APPEAL_USER_ROLES.INTERESTED_PARTY) =
  * @returns {string}
  */
 const formatContactDetails = (user) => {
-	return [`${user?.firstName} ${user?.lastName}`, user?.emailAddress, user?.telephoneNumber]
-		.filter(Boolean)
-		.join('<br>');
+	const name = escape(`${user?.firstName} ${user?.lastName}`);
+	const email = escape(user?.emailAddress);
+	const telephone = escape(user?.telephoneNumber);
+	return [name, email, telephone].filter(Boolean).join('<br>');
 };
 
 module.exports = {

--- a/packages/common/src/lib/format-applicant.test.js
+++ b/packages/common/src/lib/format-applicant.test.js
@@ -90,5 +90,22 @@ describe('format-applicant', () => {
 				value: { html: 'Firstname2 Lastname2<br>test@example.com<br>123456' }
 			});
 		});
+		it('escapes user inputs when generating html value', () => {
+			const users = [
+				{
+					firstName: "'<em>ily'",
+					lastName: '<br>own',
+					emailAddress: '"test@example.com',
+					telephoneNumber: '&123456',
+					serviceUserType: APPEAL_USER_ROLES.APPELLANT
+				}
+			];
+			expect(formatApplicant(users, LPA_USER_ROLE)).toEqual({
+				key: { text: 'Appellant contact details' },
+				value: {
+					html: '&#39;&lt;em&gt;ily&#39; &lt;br&gt;own<br>&quot;test@example.com<br>&amp;123456'
+				}
+			});
+		});
 	});
 });

--- a/packages/common/src/lib/format-applicant.test.js
+++ b/packages/common/src/lib/format-applicant.test.js
@@ -107,5 +107,21 @@ describe('format-applicant', () => {
 				}
 			});
 		});
+		it('filters non-existant values when generating html value', () => {
+			const users = [
+				{
+					firstName: 'fname',
+					lastName: 'lname',
+					emailAddress: 'test@example.com',
+					serviceUserType: APPEAL_USER_ROLES.APPELLANT
+				}
+			];
+			expect(formatApplicant(users, LPA_USER_ROLE)).toEqual({
+				key: { text: 'Appellant contact details' },
+				value: {
+					html: 'fname lname<br>test@example.com'
+				}
+			});
+		});
 	});
 });

--- a/packages/common/src/lib/format-applicant.test.js
+++ b/packages/common/src/lib/format-applicant.test.js
@@ -1,28 +1,94 @@
-const { APPEAL_USER_ROLES } = require('../constants');
+const { APPEAL_USER_ROLES, LPA_USER_ROLE } = require('../constants');
 const { formatApplicant } = require('./format-applicant');
 
 describe('format-applicant', () => {
-	it('formats applicant name when provided with valid user', () => {
-		const users = [
-			{
-				firstName: 'Firstname',
-				lastName: 'Lastname',
-				serviceUserType: APPEAL_USER_ROLES.APPELLANT
-			},
-			{ firstName: 'Invalid', lastName: 'Invalid', serviceUserType: APPEAL_USER_ROLES.AGENT }
-		];
-		expect(formatApplicant(users)).toEqual('Firstname Lastname');
+	describe('when not LPA user', () => {
+		it('returns Applicant key and applicant name value with no contact details when valid ServiceUser attached to appeal', () => {
+			const users = [
+				{
+					firstName: 'Firstname',
+					lastName: 'Lastname',
+					emailAddress: 'test@example.com',
+					telephoneNumber: '123456',
+					serviceUserType: APPEAL_USER_ROLES.APPELLANT
+				},
+				{
+					firstName: 'Invalid',
+					lastName: 'Invalid',
+					emailAddress: 'test2@example.com',
+					telephoneNumber: '123450',
+					serviceUserType: APPEAL_USER_ROLES.AGENT
+				}
+			];
+			expect(formatApplicant(users)).toEqual({
+				key: { text: 'Applicant' },
+				value: { text: 'Firstname Lastname' }
+			});
+		});
+
+		it('returns Applicant key and empty value if no valid ServiceUser attached to appeal', () => {
+			const users = [
+				{
+					firstName: 'Firstname1',
+					lastName: 'Lastname1',
+					emailAddress: 'test3@example.com',
+					telephoneNumber: '123457',
+					serviceUserType: APPEAL_USER_ROLES.INTERESTED_PARTY
+				},
+				{
+					firstName: 'Firstname2',
+					lastName: 'Lastname2',
+					emailAddress: 'test@example.com',
+					telephoneNumber: '123456',
+					serviceUserType: APPEAL_USER_ROLES.AGENT
+				}
+			];
+			expect(formatApplicant(users)).toEqual({ key: { text: 'Applicant' }, value: { text: '' } });
+		});
 	});
 
-	it('returns empty string if no valid user provided', () => {
-		const users = [
-			{
-				firstName: 'Firstname1',
-				lastName: 'Lastname1',
-				serviceUserType: APPEAL_USER_ROLES.INTERESTED_PARTY
-			},
-			{ firstName: 'Firstname2', lastName: 'Lastname2', serviceUserType: APPEAL_USER_ROLES.AGENT }
-		];
-		expect(formatApplicant(users)).toEqual('');
+	describe('when LPA user', () => {
+		it('returns Appellant key and appellant name value with contact details when no agent ServiceUser attached to appeal', () => {
+			const users = [
+				{
+					firstName: 'Firstname1',
+					lastName: 'Lastname1',
+					serviceUserType: APPEAL_USER_ROLES.INTERESTED_PARTY
+				},
+				{
+					firstName: 'Firstname2',
+					lastName: 'Lastname2',
+					emailAddress: 'test@example.com',
+					telephoneNumber: '123456',
+					serviceUserType: APPEAL_USER_ROLES.APPELLANT
+				}
+			];
+			expect(formatApplicant(users, LPA_USER_ROLE)).toEqual({
+				key: { text: 'Appellant contact details' },
+				value: { html: 'Firstname2 Lastname2<br>test@example.com<br>123456' }
+			});
+		});
+		it('returns Agent key and agent name value with contact details when agent ServiceUser attached to appeal', () => {
+			const users = [
+				{
+					firstName: 'Firstname1',
+					lastName: 'Lastname1',
+					emailAddress: 'test@example.com',
+					telephoneNumber: '123456',
+					serviceUserType: APPEAL_USER_ROLES.INTERESTED_PARTY
+				},
+				{
+					firstName: 'Firstname2',
+					lastName: 'Lastname2',
+					emailAddress: 'test@example.com',
+					telephoneNumber: '123456',
+					serviceUserType: APPEAL_USER_ROLES.AGENT
+				}
+			];
+			expect(formatApplicant(users, LPA_USER_ROLE)).toEqual({
+				key: { text: 'Agent contact details' },
+				value: { html: 'Firstname2 Lastname2<br>test@example.com<br>123456' }
+			});
+		});
 	});
 });

--- a/packages/common/src/view-model-maps/appeal-headline.js
+++ b/packages/common/src/view-model-maps/appeal-headline.js
@@ -13,13 +13,13 @@ const { caseTypeNameWithDefault } = require('../lib/format-case-type');
 /**
  * @param {AppealCaseDetailed} caseData
  * @param {string} lpaName
- * @param {AppealToUserRoles|LpaUserRole|null} userType
+ * @param {AppealToUserRoles|LpaUserRole|null} role
  */
-const formatHeadlineData = (caseData, lpaName, userType = APPEAL_USER_ROLES.INTERESTED_PARTY) => {
+const formatHeadlineData = (caseData, lpaName, role = APPEAL_USER_ROLES.INTERESTED_PARTY) => {
 	const { caseReference, appealTypeCode, caseProcedure, users, applicationReference } = caseData;
 
 	const address = formatAddress(caseData);
-	const applicant = formatApplicant(users);
+	const applicant = formatApplicant(users, role);
 
 	const headlines = [
 		{
@@ -40,8 +40,8 @@ const formatHeadlineData = (caseData, lpaName, userType = APPEAL_USER_ROLES.INTE
 			value: { text: address }
 		},
 		{
-			key: { text: 'Applicant' },
-			value: { text: applicant }
+			key: applicant.key,
+			value: applicant.value
 		},
 		{
 			key: { text: 'Local planning authority' },
@@ -53,7 +53,7 @@ const formatHeadlineData = (caseData, lpaName, userType = APPEAL_USER_ROLES.INTE
 		}
 	];
 
-	if (userType === APPEAL_USER_ROLES.INTERESTED_PARTY) {
+	if (role === APPEAL_USER_ROLES.INTERESTED_PARTY) {
 		headlines.unshift({
 			key: { text: 'Appeal reference' },
 			value: { text: caseReference }

--- a/packages/database/src/seed/data-dev.js
+++ b/packages/database/src/seed/data-dev.js
@@ -760,7 +760,9 @@ const serviceUsers = [
 		serviceUserType: 'Appellant',
 		caseReference: caseReferences.caseReferenceTwo,
 		firstName: 'Appellant',
-		lastName: 'Two'
+		lastName: 'Two',
+		emailAddress: 'test2@example.com',
+		telephoneNumber: '21234567890'
 	},
 	{
 		internalId: '19d01551-e0cb-414f-95d9-fd71422c9a83',
@@ -816,7 +818,9 @@ const serviceUsers = [
 		serviceUserType: 'Agent',
 		caseReference: caseReferences.caseReferenceOne,
 		firstName: 'Agent',
-		lastName: 'One'
+		lastName: 'One',
+		emailAddress: 'test@example.com',
+		telephoneNumber: '01234567890'
 	},
 	{
 		internalId: '1c543b78-0fd6-4e86-abc3-28bea670d3c9',

--- a/packages/database/src/seed/data-dev.js
+++ b/packages/database/src/seed/data-dev.js
@@ -841,6 +841,22 @@ const serviceUsers = [
 		caseReference: '6666666',
 		firstName: 'Appellant',
 		lastName: 'One'
+	},
+	{
+		internalId: 'f53d3c7a-9fff-47d7-ab5b-a39f0e3cfc46',
+		id: '123480',
+		serviceUserType: 'Agent',
+		caseReference: '0000001',
+		firstName: 'Agent',
+		lastName: 'Lastname1'
+	},
+	{
+		internalId: 'f53d3c7a-9fff-47d7-ab5b-a39f0e3cfc45',
+		id: '123481',
+		serviceUserType: 'Appellant',
+		caseReference: '0000002',
+		firstName: 'Appellant',
+		lastName: 'Lastname2'
 	}
 ];
 

--- a/packages/database/src/seed/data-dev.js
+++ b/packages/database/src/seed/data-dev.js
@@ -845,22 +845,6 @@ const serviceUsers = [
 		caseReference: '6666666',
 		firstName: 'Appellant',
 		lastName: 'One'
-	},
-	{
-		internalId: 'f53d3c7a-9fff-47d7-ab5b-a39f0e3cfc46',
-		id: '123480',
-		serviceUserType: 'Agent',
-		caseReference: '0000001',
-		firstName: 'Agent',
-		lastName: 'Lastname1'
-	},
-	{
-		internalId: 'f53d3c7a-9fff-47d7-ab5b-a39f0e3cfc45',
-		id: '123481',
-		serviceUserType: 'Appellant',
-		caseReference: '0000002',
-		firstName: 'Appellant',
-		lastName: 'Lastname2'
 	}
 ];
 

--- a/packages/forms-web-app/src/dynamic-forms/controller.js
+++ b/packages/forms-web-app/src/dynamic-forms/controller.js
@@ -394,7 +394,10 @@ exports.lpaQuestionnaireSubmissionInformation = async (req, res) => {
 
 	const summaryListData = buildSummaryListData(journey, journeyResponse);
 	const submissionDate = formatDateForDisplay(new Date(), { format: 'd MMMM yyyy' });
-	const appealInformationSection = formatQuestionnaireAppealInformationSection(appealData);
+	const appealInformationSection = formatQuestionnaireAppealInformationSection(
+		appealData,
+		LPA_USER_ROLE
+	);
 	summaryListData.sections.unshift(appealInformationSection);
 
 	const informationPageType = 'Questionnaire';

--- a/packages/forms-web-app/src/dynamic-forms/dynamic-components/utils/submission-information-utils.js
+++ b/packages/forms-web-app/src/dynamic-forms/dynamic-components/utils/submission-information-utils.js
@@ -67,14 +67,15 @@ exports.formatBeforeYouStartSection = async (appellantSubmission) => {
 /**
  *
  * @param {import('appeals-service-api').Api.AppealCaseDetailed} appeal
+ * @param {import('@pins/common/src/constants').LpaUserRole|null}role
  * @returns
  */
 
-exports.formatQuestionnaireAppealInformationSection = (appeal) => {
+exports.formatQuestionnaireAppealInformationSection = (appeal, role) => {
 	const { appealTypeCode } = appeal;
 	const appealType = typeCodeToSubmissionInformationString[appealTypeCode];
 	const address = formatAddress(appeal);
-	const applicantName = formatApplicant(appeal.users);
+	const applicant = formatApplicant(appeal.users, role);
 
 	return {
 		list: {
@@ -99,12 +100,10 @@ exports.formatQuestionnaireAppealInformationSection = (appeal) => {
 				},
 				{
 					key: {
-						text: 'Applicant',
+						...applicant.key,
 						classes: 'govuk-!-width-one-half'
 					},
-					value: {
-						html: applicantName
-					}
+					value: applicant.value
 				},
 				{
 					key: {

--- a/packages/forms-web-app/src/dynamic-forms/dynamic-components/utils/submission-information-utils.test.js
+++ b/packages/forms-web-app/src/dynamic-forms/dynamic-components/utils/submission-information-utils.test.js
@@ -3,7 +3,11 @@ const {
 	formatQuestionnaireAppealInformationSection
 } = require('./submission-information-utils');
 const { getLPA, getLPAById } = require('../../../lib/appeals-api-wrapper');
-const { APPEALS_CASE_DATA, APPEAL_USER_ROLES } = require('@pins/common/src/constants');
+const {
+	APPEALS_CASE_DATA,
+	APPEAL_USER_ROLES,
+	LPA_USER_ROLE
+} = require('@pins/common/src/constants');
 
 jest.mock('../../../lib/appeals-api-wrapper');
 
@@ -118,7 +122,7 @@ describe('formatQuestionnaireAppealInformationSection', () => {
 					},
 					{
 						key: {
-							text: 'Applicant',
+							text: 'Appellant contact details',
 							classes: 'govuk-!-width-one-half'
 						},
 						value: {
@@ -138,6 +142,8 @@ describe('formatQuestionnaireAppealInformationSection', () => {
 			}
 		};
 
-		expect(formatQuestionnaireAppealInformationSection(appeal)).toEqual(expectedResult);
+		expect(formatQuestionnaireAppealInformationSection(appeal, LPA_USER_ROLE)).toEqual(
+			expectedResult
+		);
 	});
 });


### PR DESCRIPTION
## Ticket Number

<!-- Add the number from the Jira board -->

https://pins-ds.atlassian.net/browse/A2-1477

## Description of change

Update headline info for LPA dashboard pages to show Appellant or Agent name and contact details (previously just Applicant and appellant name). Do not apply this change to other pages using headline component.

Removed formatApplicantDetails function as not used anywhere.

<!-- Please describe the change -->

## Checklist

<!-- Put an `x` in all the boxes that apply: -->

- [ ] Requires infrastructure changes
- [ ] I have updated the documentation accordingly
- [x] My commit history in this PR is linear
- [x] New features have tests
- [ ] Breaking change (team conversation required)

## Important

Please do not merge from `main` (please only [rebase](https://github.com/Planning-Inspectorate/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
