### PR TITLE
fix(a2-1793): increase character count for interested party comments

### DIFF
--- a/packages/database/src/migrations/20241216112517_allow_max_comments_in_interested_party_submissions/migration.sql
+++ b/packages/database/src/migrations/20241216112517_allow_max_comments_in_interested_party_submissions/migration.sql
@@ -1,0 +1,19 @@
+BEGIN TRY
+
+BEGIN TRAN;
+
+-- AlterTable
+ALTER TABLE [dbo].[InterestedPartySubmission] ALTER COLUMN [comments] NVARCHAR(max) NOT NULL;
+
+COMMIT TRAN;
+
+END TRY
+BEGIN CATCH
+
+IF @@TRANCOUNT > 0
+BEGIN
+    ROLLBACK TRAN;
+END;
+THROW
+
+END CATCH

--- a/packages/database/src/schema.prisma
+++ b/packages/database/src/schema.prisma
@@ -671,7 +671,7 @@ model InterestedPartySubmission {
   county        String?
   postcode      String?
   emailAddress  String?
-  comments      String
+  comments      String     @db.NVarChar(Max)
   createdAt     DateTime   @default(now())
   AppealCase    AppealCase @relation(fields: [caseReference], references: [caseReference])
 }

--- a/packages/forms-web-app/src/validators/interested-parties/add-comments.js
+++ b/packages/forms-web-app/src/validators/interested-parties/add-comments.js
@@ -5,8 +5,8 @@ const ruleComments = () =>
 		.notEmpty()
 		.withMessage('Enter your comments')
 		.bail()
-		.isLength({ min: 1, max: 1000 })
-		.withMessage('Comments must be 1000 characters or less');
+		.isLength({ min: 1, max: 8000 })
+		.withMessage('Comments must be 8000 characters or less');
 
 const ruleCommentsConfirmation = () =>
 	body('comments-confirmation')


### PR DESCRIPTION
## Ticket Number

<!-- Add the number from the Jira board -->

https://pins-ds.atlassian.net/browse/A2-1793

## Description of change
Increase character count for interested party comments

Forms:
  - Updated add-comment validator to allow up to 8000 characters
  - Amended the error message to change the limit from 1000 to 8000

API:
  - Updated the prisma schema for comments in the InterestedPartySubmission model
  - Generated a migration for the update above
  
Note, I was unable to test as I was unable to reach the specified page with my test data locally but I'm confident this will work.

## Checklist

<!-- Put an `x` in all the boxes that apply: -->

- [ ] Requires infrastructure changes
- [ ] I have updated the documentation accordingly
- [x] My commit history in this PR is linear
- [ ] New features have tests
- [ ] Breaking change (team conversation required)

## Important

Please do not merge from `main` (please only [rebase](https://github.com/Planning-Inspectorate/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
