### PR TITLE
fix(a2-183): make upload booleans nullable

### DIFF
--- a/packages/appeals-service-api/src/spec/api-types.d.ts
+++ b/packages/appeals-service-api/src/spec/api-types.d.ts
@@ -635,7 +635,7 @@ export interface AppellantFinalCommentSubmission {
 	appellantFinalComment?: boolean;
 	appellantFinalCommentDetails?: string;
 	appellantFinalCommentDocuments?: boolean;
-	uploadAppellantFinalCommentDocuments?: boolean;
+	uploadAppellantFinalCommentDocuments?: boolean | null;
 	SubmissionDocumentUpload?: SubmissionDocumentUpload[];
 }
 
@@ -662,9 +662,9 @@ export interface AppellantProofOfEvidenceSubmission {
 	updatedAt?: string;
 	/** whether the proof of evidence has been submitted to BO */
 	submitted?: boolean;
-	uploadAppellantProofOfEvidenceDocuments?: boolean;
+	uploadAppellantProofOfEvidenceDocuments?: boolean | null;
 	appellantWitnesses?: boolean;
-	uploadAppellantWitnessesEvidence?: boolean;
+	uploadAppellantWitnessesEvidence?: boolean | null;
 	SubmissionDocumentUpload?: SubmissionDocumentUpload[];
 }
 
@@ -731,18 +731,18 @@ export interface AppellantSubmission {
 	appellantLinkedCaseAdd?: boolean;
 	appellantLinkedCase?: boolean;
 	SubmissionLinkedCase?: object[];
-	uploadOriginalApplicationForm?: boolean;
-	uploadApplicationDecisionLetter?: boolean;
-	uploadAppellantStatement?: boolean;
-	uploadCostApplication?: boolean;
-	uploadChangeOfDescriptionEvidence?: boolean;
-	uploadOwnershipCertificate?: boolean;
-	uploadStatementCommonGround?: boolean;
-	uploadDesignAccessStatement?: boolean;
-	uploadPlansDrawings?: boolean;
-	uploadNewPlansDrawings?: boolean;
-	uploadOtherNewDocuments?: boolean;
-	uploadPlanningObligation?: boolean;
+	uploadOriginalApplicationForm?: boolean | null;
+	uploadApplicationDecisionLetter?: boolean | null;
+	uploadAppellantStatement?: boolean | null;
+	uploadCostApplication?: boolean | null;
+	uploadChangeOfDescriptionEvidence?: boolean | null;
+	uploadOwnershipCertificate?: boolean | null;
+	uploadStatementCommonGround?: boolean | null;
+	uploadDesignAccessStatement?: boolean | null;
+	uploadPlansDrawings?: boolean | null;
+	uploadNewPlansDrawings?: boolean | null;
+	uploadOtherNewDocuments?: boolean | null;
+	uploadPlanningObligation?: boolean | null;
 	SubmissionDocumentUpload?: object[];
 	siteAddress?: boolean;
 	SubmissionAddress?: SubmissionAddress[];
@@ -1067,7 +1067,7 @@ export interface LPAFinalCommentSubmission {
 	lpaFinalComment?: boolean;
 	lpaFinalCommentDetails?: string;
 	lpaFinalCommentDocuments?: boolean;
-	uploadLPAFinalCommentDocuments?: boolean;
+	uploadLPAFinalCommentDocuments?: boolean | null;
 	SubmissionDocumentUpload?: SubmissionDocumentUpload[];
 }
 
@@ -1094,9 +1094,9 @@ export interface LPAProofOfEvidenceSubmission {
 	updatedAt?: string;
 	/** whether the proof of evidence has been submitted to BO */
 	submitted?: boolean;
-	uploadLpaProofOfEvidenceDocuments?: boolean;
+	uploadLpaProofOfEvidenceDocuments?: boolean | null;
 	lpaWitnesses?: boolean;
-	uploadLpaWitnessesEvidence?: boolean;
+	uploadLpaWitnessesEvidence?: boolean | null;
 	SubmissionDocumentUpload?: SubmissionDocumentUpload[];
 }
 
@@ -1120,19 +1120,19 @@ export interface LPAQuestionnaireSubmission {
 	changedListedBuildingNumber?: string;
 	addChangedListedBuilding?: boolean;
 	conservationArea?: boolean;
-	uploadConservation?: boolean;
+	uploadConservation?: boolean | null;
 	greenBelt?: boolean;
-	uploadWhoNotified?: boolean;
-	uploadLettersEmails?: boolean;
-	uploadPressAdvert?: boolean;
+	uploadWhoNotified?: boolean | null;
+	uploadLettersEmails?: boolean | null;
+	uploadPressAdvert?: boolean | null;
 	consultationResponses?: boolean;
-	uploadConsultationResponses?: boolean;
+	uploadConsultationResponses?: boolean | null;
 	notificationMethod?: string;
-	uploadSiteNotice?: boolean;
+	uploadSiteNotice?: boolean | null;
 	otherPartyRepresentations?: boolean;
-	uploadRepresentations?: boolean;
-	uploadPlanningOfficerReport?: boolean;
-	uploadPlansDrawings?: boolean;
+	uploadRepresentations?: boolean | null;
+	uploadPlanningOfficerReport?: boolean | null;
+	uploadPlansDrawings?: boolean | null;
 	lpaSiteAccess?: boolean;
 	lpaSiteAccessDetails?: string;
 	neighbourSiteAccess?: boolean;
@@ -1151,22 +1151,22 @@ export interface LPAQuestionnaireSubmission {
 	newConditions?: boolean;
 	newConditionDetails?: string;
 	emergingPlan?: boolean;
-	uploadEmergingPlan?: boolean;
-	uploadDevelopmentPlanPolicies?: boolean;
-	uploadOtherPolicies?: boolean;
+	uploadEmergingPlan?: boolean | null;
+	uploadDevelopmentPlanPolicies?: boolean | null;
+	uploadOtherPolicies?: boolean | null;
 	infrastructureLevy?: boolean;
-	uploadInfrastructureLevy?: boolean;
+	uploadInfrastructureLevy?: boolean | null;
 	infrastructureLevyAdopted?: boolean;
 	/** @format date-time */
 	infrastructureLevyAdoptedDate?: string;
 	/** @format date-time */
 	infrastructureLevyExpectedDate?: string;
-	uploadLettersInterestedParties?: boolean;
+	uploadLettersInterestedParties?: boolean | null;
 	treePreservationOrder?: boolean;
-	uploadTreePreservationOrder?: boolean;
-	uploadDefinitiveMapStatement?: boolean;
+	uploadTreePreservationOrder?: boolean | null;
+	uploadDefinitiveMapStatement?: boolean | null;
 	supplementaryPlanningDocs?: boolean;
-	uploadSupplementaryPlanningDocs?: boolean;
+	uploadSupplementaryPlanningDocs?: boolean | null;
 	affectsScheduledMonument?: boolean;
 	gypsyTraveller?: boolean;
 	statutoryConsultees?: boolean;
@@ -1179,12 +1179,12 @@ export interface LPAQuestionnaireSubmission {
 	screeningOpinion?: boolean;
 	environmentalStatement?: boolean;
 	environmentalImpactSchedule?: string;
-	uploadEnvironmentalStatement?: boolean;
+	uploadEnvironmentalStatement?: boolean | null;
 	columnTwoThreshold?: boolean;
 	sensitiveArea?: boolean;
 	sensitiveAreaDetails?: string;
-	uploadScreeningOpinion?: boolean;
-	uploadScreeningDirection?: boolean;
+	uploadScreeningOpinion?: boolean | null;
+	uploadScreeningDirection?: boolean | null;
 	developmentDescription?: string;
 	requiresEnvironmentalStatement?: boolean;
 	SubmissionAddress?: object[];
@@ -1213,7 +1213,7 @@ export interface LPAStatementSubmission {
 	submitted?: boolean;
 	lpaStatement?: string;
 	addtionalDocuments?: boolean;
-	uploadLpaStatementDocuments?: boolean;
+	uploadLpaStatementDocuments?: boolean | null;
 }
 
 /** The neighbouring address related to an appeal */
@@ -1406,9 +1406,9 @@ export interface Rule6ProofOfEvidenceSubmission {
 	updatedAt?: string;
 	/** whether the proof of evidence has been submitted to BO */
 	submitted?: boolean;
-	uploadRule6ProofOfEvidenceDocuments?: boolean;
+	uploadRule6ProofOfEvidenceDocuments?: boolean | null;
 	rule6Witnesses?: boolean;
-	uploadRule6WitnessesEvidence?: boolean;
+	uploadRule6WitnessesEvidence?: boolean | null;
 	SubmissionDocumentUpload?: SubmissionDocumentUpload[];
 }
 
@@ -1437,7 +1437,7 @@ export interface Rule6StatementSubmission {
 	submitted?: boolean;
 	rule6Statement?: string;
 	rule6AdditionalDocuments?: boolean;
-	uploadRule6StatementDocuments?: boolean;
+	uploadRule6StatementDocuments?: boolean | null;
 	SubmissionDocumentUpload?: SubmissionDocumentUpload[];
 }
 

--- a/packages/appeals-service-api/src/spec/appellant-final-comment-submission.yaml
+++ b/packages/appeals-service-api/src/spec/appellant-final-comment-submission.yaml
@@ -52,6 +52,7 @@ components:
           type: boolean
         uploadAppellantFinalCommentDocuments:
           type: boolean
+          nullable: true
         SubmissionDocumentUpload:
           type: array
           items:

--- a/packages/appeals-service-api/src/spec/appellant-proof-of-evidence-submission.yaml
+++ b/packages/appeals-service-api/src/spec/appellant-proof-of-evidence-submission.yaml
@@ -48,10 +48,12 @@ components:
           description: whether the proof of evidence has been submitted to BO
         uploadAppellantProofOfEvidenceDocuments:
           type: boolean
+          nullable: true
         appellantWitnesses:
           type: boolean
         uploadAppellantWitnessesEvidence:
           type: boolean
+          nullable: true
         SubmissionDocumentUpload:
           type: array
           items:

--- a/packages/appeals-service-api/src/spec/appellant-submission.yaml
+++ b/packages/appeals-service-api/src/spec/appellant-submission.yaml
@@ -141,28 +141,40 @@ components:
 
         uploadOriginalApplicationForm:
           type: boolean
+          nullable: true
         uploadApplicationDecisionLetter:
           type: boolean
+          nullable: true
         uploadAppellantStatement:
           type: boolean
+          nullable: true
         uploadCostApplication:
           type: boolean
+          nullable: true
         uploadChangeOfDescriptionEvidence:
           type: boolean
+          nullable: true
         uploadOwnershipCertificate:
           type: boolean
+          nullable: true
         uploadStatementCommonGround:
           type: boolean
+          nullable: true
         uploadDesignAccessStatement:
           type: boolean
+          nullable: true
         uploadPlansDrawings:
           type: boolean
+          nullable: true
         uploadNewPlansDrawings:
           type: boolean
+          nullable: true
         uploadOtherNewDocuments:
           type: boolean
+          nullable: true
         uploadPlanningObligation:
           type: boolean
+          nullable: true
         SubmissionDocumentUpload:
           type: array
           items:

--- a/packages/appeals-service-api/src/spec/lpa-final-comment-submission.yaml
+++ b/packages/appeals-service-api/src/spec/lpa-final-comment-submission.yaml
@@ -52,6 +52,7 @@ components:
           type: boolean
         uploadLPAFinalCommentDocuments:
           type: boolean
+          nullable: true
         SubmissionDocumentUpload:
           type: array
           items:

--- a/packages/appeals-service-api/src/spec/lpa-proof-of-evidence-submission.yaml
+++ b/packages/appeals-service-api/src/spec/lpa-proof-of-evidence-submission.yaml
@@ -48,10 +48,12 @@ components:
           description: whether the proof of evidence has been submitted to BO
         uploadLpaProofOfEvidenceDocuments:
           type: boolean
+          nullable: true
         lpaWitnesses:
           type: boolean
         uploadLpaWitnessesEvidence:
           type: boolean
+          nullable: true
         SubmissionDocumentUpload:
           type: array
           items:

--- a/packages/appeals-service-api/src/spec/lpa-questionnaire-submission.yaml
+++ b/packages/appeals-service-api/src/spec/lpa-questionnaire-submission.yaml
@@ -44,30 +44,39 @@ components:
           type: boolean
         uploadConservation:
           type: boolean
+          nullable: true
         greenBelt:
           type: boolean
         uploadWhoNotified:
           type: boolean
+          nullable: true
         uploadLettersEmails:
           type: boolean
+          nullable: true
         uploadPressAdvert:
           type: boolean
+          nullable: true
         consultationResponses:
           type: boolean
         uploadConsultationResponses:
           type: boolean
+          nullable: true
         notificationMethod:
           type: string
         uploadSiteNotice:
           type: boolean
+          nullable: true
         otherPartyRepresentations:
           type: boolean
         uploadRepresentations:
           type: boolean
+          nullable: true
         uploadPlanningOfficerReport:
           type: boolean
+          nullable: true
         uploadPlansDrawings:
           type: boolean
+          nullable: true
         lpaSiteAccess:
           type: boolean
         lpaSiteAccessDetails:
@@ -106,14 +115,18 @@ components:
           type: boolean
         uploadEmergingPlan:
           type: boolean
+          nullable: true
         uploadDevelopmentPlanPolicies:
           type: boolean
+          nullable: true
         uploadOtherPolicies:
           type: boolean
+          nullable: true
         infrastructureLevy:
           type: boolean
         uploadInfrastructureLevy:
           type: boolean
+          nullable: true
         infrastructureLevyAdopted:
           type: boolean
         infrastructureLevyAdoptedDate:
@@ -124,16 +137,20 @@ components:
           format: date-time
         uploadLettersInterestedParties:
           type: boolean
+          nullable: true
         treePreservationOrder:
           type: boolean
         uploadTreePreservationOrder:
           type: boolean
+          nullable: true
         uploadDefinitiveMapStatement:
           type: boolean
+          nullable: true
         supplementaryPlanningDocs:
           type: boolean
         uploadSupplementaryPlanningDocs:
           type: boolean
+          nullable: true
         affectsScheduledMonument:
           type: boolean
         gypsyTraveller:
@@ -160,6 +177,7 @@ components:
           type: string
         uploadEnvironmentalStatement:
           type: boolean
+          nullable: true
         columnTwoThreshold:
           type: boolean
         sensitiveArea:
@@ -168,8 +186,10 @@ components:
           type: string
         uploadScreeningOpinion:
           type: boolean
+          nullable: true
         uploadScreeningDirection:
           type: boolean
+          nullable: true
         developmentDescription:
           type: string
         requiresEnvironmentalStatement:

--- a/packages/appeals-service-api/src/spec/lpa-statement-submission.yaml
+++ b/packages/appeals-service-api/src/spec/lpa-statement-submission.yaml
@@ -44,3 +44,4 @@ components:
           type: boolean
         uploadLpaStatementDocuments:
           type: boolean
+          nullable: true

--- a/packages/appeals-service-api/src/spec/rule-6-proof-of-evidence-submission.yaml
+++ b/packages/appeals-service-api/src/spec/rule-6-proof-of-evidence-submission.yaml
@@ -53,10 +53,12 @@ components:
           description: whether the proof of evidence has been submitted to BO
         uploadRule6ProofOfEvidenceDocuments:
           type: boolean
+          nullable: true
         rule6Witnesses:
           type: boolean
         uploadRule6WitnessesEvidence:
           type: boolean
+          nullable: true
         SubmissionDocumentUpload:
           type: array
           items:

--- a/packages/appeals-service-api/src/spec/rule-6-statement-submission.yaml
+++ b/packages/appeals-service-api/src/spec/rule-6-statement-submission.yaml
@@ -53,6 +53,7 @@ components:
           type: boolean
         uploadRule6StatementDocuments:
           type: boolean
+          nullable: true
         SubmissionDocumentUpload:
           type: array
           items:

--- a/packages/forms-web-app/src/dynamic-forms/controller.js
+++ b/packages/forms-web-app/src/dynamic-forms/controller.js
@@ -253,6 +253,11 @@ exports.save = async (req, res) => {
 	const { section, question } = req.params;
 	const { journey, journeyResponse } = res.locals;
 
+	console.log('journeyOIOIOI');
+	console.log(journey);
+	console.log('wakwakwak');
+	console.log(journeyResponse);
+
 	const sectionObj = journey.getSection(section);
 	const questionObj = journey.getQuestionBySectionAndName(section, question);
 

--- a/packages/forms-web-app/src/dynamic-forms/controller.js
+++ b/packages/forms-web-app/src/dynamic-forms/controller.js
@@ -253,11 +253,6 @@ exports.save = async (req, res) => {
 	const { section, question } = req.params;
 	const { journey, journeyResponse } = res.locals;
 
-	console.log('journeyOIOIOI');
-	console.log(journey);
-	console.log('wakwakwak');
-	console.log(journeyResponse);
-
 	const sectionObj = journey.getSection(section);
 	const questionObj = journey.getQuestionBySectionAndName(section, question);
 

--- a/packages/forms-web-app/src/journeys/question-overrides/multi-file-upload.js
+++ b/packages/forms-web-app/src/journeys/question-overrides/multi-file-upload.js
@@ -241,12 +241,6 @@ function removeDocuments(apiClient, journeyId) {
  * @returns {Promise<void>}
  */
 async function saveAction(req, res, journey, section, journeyResponse) {
-	// check for saving validation errors
-	const saveViewModel = this.checkForSavingErrors(req, section, journey);
-	if (saveViewModel) {
-		return this.renderAction(res, saveViewModel);
-	}
-
 	const previouslyUploadedFiles = this.getRelevantUploadedFiles(journeyResponse);
 
 	const { uploadedFiles } = await getDataToSave.call(this, req, journeyResponse);
@@ -270,6 +264,7 @@ async function saveAction(req, res, journey, section, journeyResponse) {
 	);
 	const allUploadedFiles = [...previouslyUploadedFiles, ...uploadedFiles].filter(Boolean);
 	const isQuestionAnswered = allUploadedFiles.length > 0;
+
 	const removedAllPreviousFiles = req.body.removedFiles?.length === previouslyUploadedFiles.length;
 
 	let responseToSave;
@@ -288,6 +283,12 @@ async function saveAction(req, res, journey, section, journeyResponse) {
 	}
 
 	await this.saveResponseToDB(req.appealsApiClient, journey.response, responseToSave);
+
+	// check for saving validation errors
+	const saveViewModel = this.checkForSavingErrors(req, section, journey);
+	if (saveViewModel) {
+		return this.renderAction(res, saveViewModel);
+	}
 
 	// move to the next question
 	return this.handleNextQuestion(res, journey, section.segment, this.fieldName);


### PR DESCRIPTION
## Ticket Number

https://pins-ds.atlassian.net/browse/A2-183

## Description of change
Make upload[documents] fields nullable in spec files in order to prevent api errors if deleted uploaded files.

Following the call to remove files (in the getDataToSave function) the array of SubmissionDocumentUploads on the journeyResponse is now updated - this fixes and issue where the removed file continued to be shown on the upload page and the action on the task list remained at change rather than upload, even if the doc was removed.  This was caused by the fact that the journeyResponse was not updated until the next page was called and the previouslyUploadedDocuments array did not take account of the removed files.

## Checklist

<!-- Put an `x` in all the boxes that apply: -->

- [ ] Requires infrastructure changes
- [ ] I have updated the documentation accordingly
- [ ] My commit history in this PR is linear
- [ ] New features have tests
- [ ] Breaking change (team conversation required)

## Important

Please do not merge from `main` (please only [rebase](https://github.com/Planning-Inspectorate/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
