### PR TITLE
fix(a2-1792): increase max character count for rule6 statements

### DIFF
--- a/packages/database/src/migrations/20241216162049_increase_rule6_statement_to_max/migration.sql
+++ b/packages/database/src/migrations/20241216162049_increase_rule6_statement_to_max/migration.sql
@@ -1,0 +1,19 @@
+BEGIN TRY
+
+BEGIN TRAN;
+
+-- AlterTable
+ALTER TABLE [dbo].[Rule6StatementSubmission] ALTER COLUMN [rule6Statement] NVARCHAR(max) NULL;
+
+COMMIT TRAN;
+
+END TRY
+BEGIN CATCH
+
+IF @@TRANCOUNT > 0
+BEGIN
+    ROLLBACK TRAN;
+END;
+THROW
+
+END CATCH

--- a/packages/database/src/schema.prisma
+++ b/packages/database/src/schema.prisma
@@ -956,7 +956,7 @@ model Rule6StatementSubmission {
   // state
   submitted Boolean @default(false) /// whether the lpa statement has been submitted to BO
 
-  rule6Statement                String?
+  rule6Statement                String?  @db.NVarChar(Max)
   rule6AdditionalDocuments      Boolean?
   uploadRule6StatementDocuments Boolean?
 

--- a/packages/forms-web-app/src/config.js
+++ b/packages/forms-web-app/src/config.js
@@ -141,7 +141,8 @@ module.exports = {
 				postcodeMinLength: process.env.POSTCODE_MIN_LENGTH || 0
 			},
 			appealFormV2: {
-				textInputMaxLength: 1000
+				textInputMaxLength: 1000,
+				textAreaMaxLength: 32500
 			}
 		},
 		stringValidation: {

--- a/packages/forms-web-app/src/dynamic-forms/questions.js
+++ b/packages/forms-web-app/src/dynamic-forms/questions.js
@@ -2177,8 +2177,8 @@ exports.questionProps = {
 			new RequiredValidator('Enter your statement'),
 			new StringValidator({
 				maxLength: {
-					maxLength: appealFormV2.textInputMaxLength,
-					maxLengthMessage: `Your statement must be ${appealFormV2.textInputMaxLength} characters or less`
+					maxLength: appealFormV2.textAreaMaxLength,
+					maxLengthMessage: `Your statement must be ${appealFormV2.textAreaMaxLength} characters or less`
 				}
 			})
 		]


### PR DESCRIPTION
## Ticket Number

<!-- Add the number from the Jira board -->

https://pins-ds.atlassian.net/browse/A2-1792

## Description of change
Increase character count for rule6 statements

Forms:
  - Updated rule6 statement validator to allow up to 32500 characters
  - Amended the error message to change the limit from 1000 to 32500

API:
  - Updated the prisma schema for statements in the Rule6StatementSubmission model
  - Generated a migration for the update above
  
Test:
  - Tested manually in browser

## Checklist

<!-- Put an `x` in all the boxes that apply: -->

- [ ] Requires infrastructure changes
- [ ] I have updated the documentation accordingly
- [x] My commit history in this PR is linear
- [ ] New features have tests
- [ ] Breaking change (team conversation required)

## Important

Please do not merge from `main` (please only [rebase](https://github.com/Planning-Inspectorate/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
