### PR TITLE
Fix/a2 1791 increase character count for appellant final comments

### DIFF
--- a/packages/database/src/migrations/20241217101207_increase_appellant_final_comment_to_max/migration.sql
+++ b/packages/database/src/migrations/20241217101207_increase_appellant_final_comment_to_max/migration.sql
@@ -1,0 +1,19 @@
+BEGIN TRY
+
+BEGIN TRAN;
+
+-- AlterTable
+ALTER TABLE [dbo].[AppellantFinalCommentSubmission] ALTER COLUMN [appellantFinalCommentDetails] NVARCHAR(max) NULL;
+
+COMMIT TRAN;
+
+END TRY
+BEGIN CATCH
+
+IF @@TRANCOUNT > 0
+BEGIN
+    ROLLBACK TRAN;
+END;
+THROW
+
+END CATCH

--- a/packages/database/src/schema.prisma
+++ b/packages/database/src/schema.prisma
@@ -1072,7 +1072,7 @@ model AppellantFinalCommentSubmission {
   submitted Boolean @default(false) /// whether the final comment has been submitted to BO
 
   appellantFinalComment                Boolean?
-  appellantFinalCommentDetails         String?
+  appellantFinalCommentDetails         String?  @db.NVarChar(MAX)
   appellantFinalCommentDocuments       Boolean?
   uploadAppellantFinalCommentDocuments Boolean?
 

--- a/packages/forms-web-app/src/dynamic-forms/questions.js
+++ b/packages/forms-web-app/src/dynamic-forms/questions.js
@@ -2231,8 +2231,8 @@ exports.questionProps = {
 			new RequiredValidator('Enter your final comments'),
 			new StringValidator({
 				maxLength: {
-					maxLength: appealFormV2.textInputMaxLength,
-					maxLengthMessage: `Your final comments must be ${appealFormV2.textInputMaxLength} characters or less`
+					maxLength: appealFormV2.textAreaMaxLength,
+					maxLengthMessage: `Your final comments must be ${appealFormV2.textAreaMaxLength} characters or less`
 				}
 			}),
 			new ConfirmationCheckboxValidator({


### PR DESCRIPTION
## Ticket Number

<!-- Add the number from the Jira board -->

https://pins-ds.atlassian.net/browse/A2-1791

## Description of change
Increase character count for appellant final comments

Forms:
  - Updated appellant final comments validator to allow up to 32500 characters
  - Amended the error message to change the limit from 1000 to 32500

API:
  - Updated the prisma schema for appellant final comment details in the AppellantFinalCommentSubmission model
  - Generated a migration for the update above
  
Test:
  - Tested manually in browser

## Checklist

<!-- Put an `x` in all the boxes that apply: -->

- [ ] Requires infrastructure changes
- [ ] I have updated the documentation accordingly
- [x] My commit history in this PR is linear
- [ ] New features have tests
- [ ] Breaking change (team conversation required)

## Important

Please do not merge from `main` (please only [rebase](https://github.com/Planning-Inspectorate/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
