### PR TITLE
fix(A2-1905): stop zip download link being added to nav history

### DIFF
--- a/packages/forms-web-app/src/middleware/navigation-history.js
+++ b/packages/forms-web-app/src/middleware/navigation-history.js
@@ -33,7 +33,7 @@ module.exports =
 		const currentPage = req.baseUrl + req.path;
 
 		// prevent document links being added to nav history
-		if (currentPage.includes('published-document')) {
+		if (currentPage.includes('published-document') || currentPage.includes('/download/')) {
 			next();
 			return;
 		}


### PR DESCRIPTION
## Ticket Number

<!-- Add the number from the Jira board -->

https://pins-ds.atlassian.net/browse/A2-1905

## Description of change

<!-- Please describe the change -->
when lpa user is on the questionnaire details page and clicks the download documents zip, stops the link being added to nav history:
/manage-appeals/1000014/download/back-office/documents/lpa-questionnaire

should stop other future links being added if they use a similar format

## Checklist

<!-- Put an `x` in all the boxes that apply: -->

- [ ] Requires infrastructure changes
- [ ] I have updated the documentation accordingly
- [x] My commit history in this PR is linear
- [ ] New features have tests
- [ ] Breaking change (team conversation required)

## Important

Please do not merge from `main` (please only [rebase](https://github.com/Planning-Inspectorate/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
