### PR TITLE
Fix/a2 1789 increase character count for lpa final comments

### DIFF
--- a/packages/database/src/migrations/20241217124139_increase_lpa_final_comment_to_max/migration.sql
+++ b/packages/database/src/migrations/20241217124139_increase_lpa_final_comment_to_max/migration.sql
@@ -1,0 +1,19 @@
+BEGIN TRY
+
+BEGIN TRAN;
+
+-- AlterTable
+ALTER TABLE [dbo].[LPAFinalCommentSubmission] ALTER COLUMN [lpaFinalCommentDetails] NVARCHAR(max) NULL;
+
+COMMIT TRAN;
+
+END TRY
+BEGIN CATCH
+
+IF @@TRANCOUNT > 0
+BEGIN
+    ROLLBACK TRAN;
+END;
+THROW
+
+END CATCH

--- a/packages/database/src/schema.prisma
+++ b/packages/database/src/schema.prisma
@@ -1049,7 +1049,7 @@ model LPAFinalCommentSubmission {
   submitted Boolean @default(false) /// whether the final comment has been submitted to BO
 
   lpaFinalComment                Boolean?
-  lpaFinalCommentDetails         String?
+  lpaFinalCommentDetails         String?  @db.NVarChar(MAX)
   lpaFinalCommentDocuments       Boolean?
   uploadLPAFinalCommentDocuments Boolean?
 

--- a/packages/forms-web-app/src/config.js
+++ b/packages/forms-web-app/src/config.js
@@ -142,6 +142,7 @@ module.exports = {
 			},
 			appealFormV2: {
 				textInputMaxLength: 1000,
+				textAreaMediumLength: 8000,
 				textAreaMaxLength: 32500
 			}
 		},

--- a/packages/forms-web-app/src/dynamic-forms/questions.js
+++ b/packages/forms-web-app/src/dynamic-forms/questions.js
@@ -2291,8 +2291,8 @@ exports.questionProps = {
 			new RequiredValidator('Enter your final comments'),
 			new StringValidator({
 				maxLength: {
-					maxLength: appealFormV2.textInputMaxLength,
-					maxLengthMessage: `Your final comments must be ${appealFormV2.textInputMaxLength} characters or less`
+					maxLength: appealFormV2.textAreaMediumLength,
+					maxLengthMessage: `Your final comments must be ${appealFormV2.textAreaMediumLength} characters or less`
 				}
 			}),
 			new ConfirmationCheckboxValidator({


### PR DESCRIPTION
## Ticket Number

<!-- Add the number from the Jira board -->

https://pins-ds.atlassian.net/browse/A2-1789

## Description of change
Increase character count for lpa final comments

Forms:
  - Updated lpa final comments validator to allow up to 8000 characters
  - Amended the error message to change the limit from 1000 to 8000

API:
  - Updated the prisma schema for appellant final comment details in the LPAFinalCommentSubmission model
  - Generated a migration for the update above
  
Test:
  - Tested manually in browser

## Checklist

<!-- Put an `x` in all the boxes that apply: -->

- [ ] Requires infrastructure changes
- [ ] I have updated the documentation accordingly
- [x] My commit history in this PR is linear
- [ ] New features have tests
- [ ] Breaking change (team conversation required)

## Important

Please do not merge from `main` (please only [rebase](https://github.com/Planning-Inspectorate/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
