### PR TITLE
fix(a2-1791): fix max character count for lpa statements

### DIFF
--- a/packages/forms-web-app/src/dynamic-forms/dynamic-components/utils/format-number.js
+++ b/packages/forms-web-app/src/dynamic-forms/dynamic-components/utils/format-number.js
@@ -1,0 +1,6 @@
+function formatNumber(number) {
+	const numberFormatter = new Intl.NumberFormat('en-GB');
+	return numberFormatter.format(number);
+}
+
+module.exports = formatNumber;

--- a/packages/forms-web-app/src/dynamic-forms/dynamic-components/utils/format-number.test.js
+++ b/packages/forms-web-app/src/dynamic-forms/dynamic-components/utils/format-number.test.js
@@ -1,0 +1,19 @@
+const formatNumber = require('./format-number');
+
+describe('format-number', () => {
+	it('should format 100 as 100', () => {
+		expect(formatNumber('100')).toBe('100');
+	});
+
+	it('should format 1000 as 1,000', () => {
+		expect(formatNumber('1000')).toBe('1,000');
+	});
+
+	it('should format 32500 as 32,500', () => {
+		expect(formatNumber('32500')).toBe('32,500');
+	});
+
+	it('should format 32500000 as 32,500,000', () => {
+		expect(formatNumber('32500000')).toBe('32,500,000');
+	});
+});

--- a/packages/forms-web-app/src/dynamic-forms/questions.js
+++ b/packages/forms-web-app/src/dynamic-forms/questions.js
@@ -54,6 +54,7 @@ const { createQuestions } = require('./create-questions');
 // method overrides
 const multiFileUploadOverrides = require('../journeys/question-overrides/multi-file-upload');
 const siteAddressOverrides = require('../journeys/question-overrides/site-address');
+const formatNumber = require('./dynamic-components/utils/format-number');
 
 /** @typedef {import('./question-props').QuestionProps} QuestionProps */
 /** @typedef {import('./question')} Question */
@@ -2137,7 +2138,9 @@ exports.questionProps = {
 			new StringValidator({
 				maxLength: {
 					maxLength: appealFormV2.textAreaMaxLength,
-					maxLengthMessage: `Your statement must be ${appealFormV2.textAreaMaxLength} characters or less`
+					maxLengthMessage: `Your statement must be ${formatNumber(
+						appealFormV2.textAreaMaxLength
+					)} characters or less`
 				}
 			})
 		]
@@ -2178,7 +2181,9 @@ exports.questionProps = {
 			new StringValidator({
 				maxLength: {
 					maxLength: appealFormV2.textAreaMaxLength,
-					maxLengthMessage: `Your statement must be ${appealFormV2.textAreaMaxLength} characters or less`
+					maxLengthMessage: `Your statement must be ${formatNumber(
+						appealFormV2.textAreaMaxLength
+					)} characters or less`
 				}
 			})
 		]
@@ -2231,8 +2236,10 @@ exports.questionProps = {
 			new RequiredValidator('Enter your final comments'),
 			new StringValidator({
 				maxLength: {
-					maxLength: appealFormV2.textAreaMaxLength,
-					maxLengthMessage: `Your final comments must be ${appealFormV2.textAreaMaxLength} characters or less`
+					maxLength: appealFormV2.textAreaMediumLength,
+					maxLengthMessage: `Your final comments must be ${formatNumber(
+						appealFormV2.textAreaMediumLength
+					)} characters or less`
 				}
 			}),
 			new ConfirmationCheckboxValidator({
@@ -2292,7 +2299,9 @@ exports.questionProps = {
 			new StringValidator({
 				maxLength: {
 					maxLength: appealFormV2.textAreaMediumLength,
-					maxLengthMessage: `Your final comments must be ${appealFormV2.textAreaMediumLength} characters or less`
+					maxLengthMessage: `Your final comments must be ${formatNumber(
+						appealFormV2.textAreaMediumLength
+					)} characters or less`
 				}
 			}),
 			new ConfirmationCheckboxValidator({

--- a/packages/forms-web-app/src/validators/interested-parties/add-comments.js
+++ b/packages/forms-web-app/src/validators/interested-parties/add-comments.js
@@ -6,7 +6,7 @@ const ruleComments = () =>
 		.withMessage('Enter your comments')
 		.bail()
 		.isLength({ min: 1, max: 8000 })
-		.withMessage('Comments must be 8000 characters or less');
+		.withMessage(`Comments must be 8,000 characters or less`);
 
 const ruleCommentsConfirmation = () =>
 	body('comments-confirmation')


### PR DESCRIPTION
## Ticket Number

<!-- Add the number from the Jira board -->

https://pins-ds.atlassian.net/browse/A2-1776
https://pins-ds.atlassian.net/browse/A2-1789
https://pins-ds.atlassian.net/browse/A2-1791
https://pins-ds.atlassian.net/browse/A2-1792
https://pins-ds.atlassian.net/browse/A2-1793

## Description of change
Fix character count for appellant final comments and add commas to the error message for all the above character counts.

Forms:
  - Updated appellant final comments validator to only allow up to 8000 characters
  - Amended the error message to change the limit to 8,000
  - Added a formatNumber function to insert commas where required
  - Updated the above character count error messages so the limit contains commas
  
Test:
  - Created unit tests for formatNumber
  - Tested manually in browser

## Checklist

<!-- Put an `x` in all the boxes that apply: -->

- [ ] Requires infrastructure changes
- [ ] I have updated the documentation accordingly
- [x] My commit history in this PR is linear
- [ ] New features have tests
- [ ] Breaking change (team conversation required)

## Important

Please do not merge from `main` (please only [rebase](https://github.com/Planning-Inspectorate/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
