### PR TITLE
Fix/a2 1805 update no search result content

### DIFF
--- a/packages/database/src/seed/data-dev.js
+++ b/packages/database/src/seed/data-dev.js
@@ -135,7 +135,8 @@ const appealIds = {
 	appealEight: '756d6bfb-dde8-4532-a041-86c226a23a08',
 	appealNine: 'd8290e68-bfbb-3bc8-b621-5a9590aa29fd',
 	appealTen: 'f933b0e0-1694-11ef-ab42-cbf3edc5e3fd',
-	appeal11: 'ee283ae8-7a92-4afe-a93f-405689b1f35b'
+	appeal11: 'ee283ae8-7a92-4afe-a93f-405689b1f35b',
+	appeal12: '7573b265-f529-4b0b-adf1-659cc70c180f'
 };
 
 const caseReferences = {
@@ -147,7 +148,8 @@ const caseReferences = {
 	caseReferenceSix: '1010106',
 	caseReferenceSeven: '1010107',
 	caseReferenceEight: '1010108',
-	caseReferenceNine: '1010109'
+	caseReferenceNine: '1010109',
+	caseReferenceTen: '1010110'
 };
 
 const appellantSubmissionIds = {
@@ -284,6 +286,7 @@ const appeals = [
 	{ id: appealIds.appealNine },
 	{ id: appealIds.appealTen },
 	{ id: appealIds.appeal11 },
+	{ id: appealIds.appeal12 },
 	{
 		id: appealSubmissionDraft.id,
 		legacyAppealSubmissionId: appealSubmissionDraft.id,
@@ -597,6 +600,36 @@ const appealCases = [
 		caseDecisionOutcomeDate: pickRandom(datesNMonthsAgo(4)),
 		CaseDecisionOutcome: {
 			connect: { key: APPEAL_CASE_DECISION_OUTCOME.DISMISSED }
+		}
+	},
+	{
+		Appeal: {
+			connect: { id: appealIds.appeal12 }
+		},
+		LPACode: 'Q9999',
+		siteAddressLine1: '123 Fake Street',
+		siteAddressTown: 'Birmingham',
+		siteAddressCounty: 'West Midlands',
+		siteAddressPostcode: 'B44 0QS',
+		appellantCostsAppliedFor: false,
+		casePublishedDate: pickRandom(datesNMonthsAgo(2)),
+		caseCreatedDate: pickRandom(datesNMonthsAgo(2)),
+		caseSubmittedDate: pickRandom(datesNMonthsAgo(2)),
+		CaseType: {
+			connect: { processCode: 'S78' }
+		},
+		CaseStatus: {
+			connect: { key: APPEAL_CASE_STATUS.COMPLETE }
+		},
+		caseReference: caseReferences.caseReferenceTen,
+		applicationDecision: '',
+		applicationDecisionDate: pickRandom(datesNMonthsAgo(1)),
+		applicationReference: '12/2323238/PLA',
+		lpaQuestionnaireDueDate: pickRandom(datesNMonthsAgo(2)),
+		interestedPartyRepsDueDate: pickRandom(datesNMonthsAgo(2)),
+		caseDecisionOutcomeDate: pickRandom(datesNMonthsAgo(4)),
+		CaseDecisionOutcome: {
+			connect: { key: APPEAL_CASE_DECISION_OUTCOME.ALLOWED }
 		}
 	},
 	...lpaAppealCaseData

--- a/packages/forms-web-app/src/routes/file-based-router/comment-planning-appeal/appeal-search-no-results/controller.js
+++ b/packages/forms-web-app/src/routes/file-based-router/comment-planning-appeal/appeal-search-no-results/controller.js
@@ -21,12 +21,23 @@ const appealSearchNoResults = async (req, res) => {
 	const paragraph = formatParagraphWording(typeOfSearch);
 	const linkToRelatedSearchPage = formatLink(typeOfSearch);
 
+	const decidedAppeals =
+		typeOfSearch === 'postcode'
+			? await req.appealsApiClient.getPostcodeSearchResults({
+					postcode: searchQuery,
+					'decided-only': true
+			  })
+			: [];
+
+	const viewDecidedAppeals = decidedAppeals.length > 0 ? true : false;
+
 	res.render(`comment-planning-appeal/appeal-search-no-results/index`, {
 		pageTitle,
 		pageHeading,
 		paragraph,
 		linkToRelatedSearchPage,
-		searchQuery
+		searchQuery,
+		viewDecidedAppeals
 	});
 };
 

--- a/packages/forms-web-app/src/routes/file-based-router/comment-planning-appeal/appeal-search-no-results/controller.js
+++ b/packages/forms-web-app/src/routes/file-based-router/comment-planning-appeal/appeal-search-no-results/controller.js
@@ -37,7 +37,8 @@ const appealSearchNoResults = async (req, res) => {
 		paragraph,
 		linkToRelatedSearchPage,
 		searchQuery,
-		viewDecidedAppeals
+		viewDecidedAppeals,
+		typeOfSearch
 	});
 };
 

--- a/packages/forms-web-app/src/routes/file-based-router/comment-planning-appeal/appeal-search-no-results/controller.test.js
+++ b/packages/forms-web-app/src/routes/file-based-router/comment-planning-appeal/appeal-search-no-results/controller.test.js
@@ -12,7 +12,10 @@ describe('appealSearchNoResults Controller Tests', () => {
 
 	beforeEach(() => {
 		req = {
-			query: {}
+			query: {},
+			appealsApiClient: {
+				getPostcodeSearchResults: jest.fn()
+			}
 		};
 		res = {
 			render: jest.fn(),
@@ -34,6 +37,12 @@ describe('appealSearchNoResults Controller Tests', () => {
 			type: 'postcode'
 		};
 
+		const mockDecidedAppeals = [
+			{ id: '1', caseReference: '1234' },
+			{ id: '2', caseReference: '5678' }
+		];
+
+		req.appealsApiClient.getPostcodeSearchResults.mockResolvedValue(mockDecidedAppeals);
 		formatTitlePrefix.mockReturnValue('Title Prefix');
 		formatParagraphWording.mockReturnValue('Paragraph Wording');
 		formatLink.mockReturnValue('Link');
@@ -43,6 +52,10 @@ describe('appealSearchNoResults Controller Tests', () => {
 		expect(formatTitlePrefix).toHaveBeenCalledWith('postcode');
 		expect(formatParagraphWording).toHaveBeenCalledWith('postcode');
 		expect(formatLink).toHaveBeenCalledWith('postcode');
+		expect(req.appealsApiClient.getPostcodeSearchResults).toHaveBeenCalledWith({
+			postcode: 'test search',
+			'decided-only': true
+		});
 		expect(res.render).toHaveBeenCalledWith(
 			'comment-planning-appeal/appeal-search-no-results/index',
 			{
@@ -50,7 +63,9 @@ describe('appealSearchNoResults Controller Tests', () => {
 				pageHeading: 'Title Prefix',
 				paragraph: 'Paragraph Wording',
 				linkToRelatedSearchPage: 'Link',
-				searchQuery: 'test search'
+				searchQuery: 'test search',
+				viewDecidedAppeals: true,
+				typeOfSearch: 'postcode'
 			}
 		);
 	});
@@ -61,6 +76,9 @@ describe('appealSearchNoResults Controller Tests', () => {
 			type: ['not a string']
 		};
 
+		const mockDecidedAppeals = [];
+
+		req.appealsApiClient.getPostcodeSearchResults.mockResolvedValue(mockDecidedAppeals);
 		formatTitlePrefix.mockReturnValue('Title Prefix');
 		formatParagraphWording.mockReturnValue('Paragraph Wording');
 		formatLink.mockReturnValue('Link');
@@ -77,7 +95,9 @@ describe('appealSearchNoResults Controller Tests', () => {
 				pageHeading: 'Title Prefix',
 				paragraph: 'Paragraph Wording',
 				linkToRelatedSearchPage: 'Link',
-				searchQuery: 'test search'
+				searchQuery: 'test search',
+				viewDecidedAppeals: false,
+				typeOfSearch: 'postcode'
 			}
 		);
 	});

--- a/packages/forms-web-app/src/routes/file-based-router/comment-planning-appeal/appeal-search-no-results/index.njk
+++ b/packages/forms-web-app/src/routes/file-based-router/comment-planning-appeal/appeal-search-no-results/index.njk
@@ -9,9 +9,27 @@
             <label class="govuk-label govuk-label--l" for="appeal-reference">{{pageHeading}} {{ searchQuery }}</label>
             <p class="govuk-body govuk-label--m"><strong>0 results</strong></p>
             <p class="govuk-body">{{paragraph}} {{searchQuery}}.</p>
-            <p class="govuk-body">
-                <a href="{{linkToRelatedSearchPage}}" class="govuk-link">Find a planning appeal</a>
-            </p>
+            <p class="govuk-body">You can:</p>
+            <ul class="govuk-list govuk-list--bullet">
+                {% if typeOfSearch === 'postcode' %}
+                    <li>
+                        <a href="{{linkToRelatedSearchPage}}" class="govuk-link">enter a different postcode</a>
+                    </li>
+                    {% if viewDecidedAppeals %}
+                        <li>
+                            <a href="decided-appeals?search={{ searchQuery | replace(' ', '+') }}">view decided appeals at {{ searchQuery }}</a>
+                        </li>
+                    {% endif %}
+                {% else %}
+                    <li>
+                        <a href="{{linkToRelatedSearchPage}}" class="govuk-link">find a different appeal</a>
+                    </li>
+                {% endif %}
+                    <li>
+                        try searching for this case on the <a href="https://acp.planninginspectorate.gov.uk/" class="govuk-link">Appeals Casework Portal</a> 
+                    </li>
+                </ul> 
+            
         </div>
     </form>
 {% endblock content %}


### PR DESCRIPTION
## Ticket Number

<!-- Add the number from the Jira board -->

https://pins-ds.atlassian.net/browse/A2-1805

## Description of change

<!-- Please describe the change -->
updates the content shown on the comment planning appeal service.
if a user searches by postcode but there are no active appeal cases it gives an option to view decided appeals for that postcode if there are any

## Checklist

<!-- Put an `x` in all the boxes that apply: -->

- [ ] Requires infrastructure changes
- [ ] I have updated the documentation accordingly
- [x] My commit history in this PR is linear
- [x] New features have tests
- [ ] Breaking change (team conversation required)

## Important

Please do not merge from `main` (please only [rebase](https://github.com/Planning-Inspectorate/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
