### PR TITLE
Fix/a2 189 poe seed data

### DIFF
--- a/packages/database/src/seed/lpa-appeal-case-data-dev.js
+++ b/packages/database/src/seed/lpa-appeal-case-data-dev.js
@@ -1244,6 +1244,9 @@ const lpaAppealCaseData = [
 		proofsOfEvidenceDueDate: pickRandom(datesNMonthsAgo(1)),
 		LPAProofsSubmitted: pickRandom(datesNMonthsAgo(1)),
 		appellantsProofsSubmitted: pickRandom(datesNMonthsAgo(1)),
+		lpaProofEvidencePublished: true,
+		appellantProofEvidencePublished: true,
+		rule6ProofsEvidencePublished: true,
 		CaseDecisionOutcome: {
 			connect: { key: APPEAL_CASE_DECISION_OUTCOME.SPLIT_DECISION }
 		},

--- a/packages/forms-web-app/src/controllers/selected-appeal/representations/index.js
+++ b/packages/forms-web-app/src/controllers/selected-appeal/representations/index.js
@@ -58,7 +58,9 @@ exports.get = (representationParams, layoutTemplate = 'layouts/no-banner-link/ma
 			userType == APPEAL_USER_ROLES.RULE_6_PARTY &&
 			submittingParty == APPEAL_USER_ROLES.RULE_6_PARTY
 		) {
-			const serviceUserId = getServiceUserId(req);
+			const serviceUserId = await getServiceUserId(req);
+			console.log('oioioioio');
+			console.log(serviceUserId);
 			representationsForDisplay = filterRepresentationsForRule6ViewingRule6(
 				caseData,
 				serviceUserId,

--- a/packages/forms-web-app/src/controllers/selected-appeal/representations/index.js
+++ b/packages/forms-web-app/src/controllers/selected-appeal/representations/index.js
@@ -59,8 +59,6 @@ exports.get = (representationParams, layoutTemplate = 'layouts/no-banner-link/ma
 			submittingParty == APPEAL_USER_ROLES.RULE_6_PARTY
 		) {
 			const serviceUserId = await getServiceUserId(req);
-			console.log('oioioioio');
-			console.log(serviceUserId);
 			representationsForDisplay = filterRepresentationsForRule6ViewingRule6(
 				caseData,
 				serviceUserId,


### PR DESCRIPTION
## Ticket Number

https://pins-ds.atlassian.net/browse/A2-189

## Description of change

Updates seed data, adds an await to getServiceUserId call used when rule 6parties looking at rule6 reps

## Checklist

<!-- Put an `x` in all the boxes that apply: -->

- [ ] Requires infrastructure changes
- [ ] I have updated the documentation accordingly
- x My commit history in this PR is linear
- [ ] New features have tests
- [ ] Breaking change (team conversation required)

## Important

Please do not merge from `main` (please only [rebase](https://github.com/Planning-Inspectorate/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
