### PR TITLE
Feat/a2 1784 stop appellant entering inactive journey

### DIFF
--- a/packages/database/src/seed/data-dev.js
+++ b/packages/database/src/seed/data-dev.js
@@ -140,7 +140,8 @@ const appealIds = {
 	appeal11: 'ee283ae8-7a92-4afe-a93f-405689b1f35b',
 	appeal12: '7573b265-f529-4b0b-adf1-659cc70c180f',
 	appeal13: '1f72d00c-03fa-48be-8ded-a9580e65f7a5',
-	appeal14: '437c4af5-7440-486d-98e9-b37a748be96c'
+	appeal14: '437c4af5-7440-486d-98e9-b37a748be96c',
+	appeal15: '5b769d3f-466c-427a-9d58-d9823239ee9b'
 };
 
 const caseReferences = {
@@ -155,7 +156,8 @@ const caseReferences = {
 	caseReferenceNine: '1010109',
 	caseReferenceTen: '1010110',
 	caseReference13: '2201010',
-	caseReference14: '2211010'
+	caseReference14: '2211010',
+	caseReference15: '2221010'
 };
 
 const appellantSubmissionIds = {
@@ -295,6 +297,7 @@ const appeals = [
 	{ id: appealIds.appeal12 },
 	{ id: appealIds.appeal13 },
 	{ id: appealIds.appeal14 },
+	{ id: appealIds.appeal15 },
 	{
 		id: appealSubmissionDraft.id,
 		legacyAppealSubmissionId: appealSubmissionDraft.id,
@@ -700,6 +703,39 @@ const appealCases = [
 		lpaQuestionnaireDueDate: pickRandom(datesNMonthsAgo(2)),
 		interestedPartyRepsDueDate: pickRandom(datesNMonthsAgo(2))
 	},
+	{
+		Appeal: {
+			connect: { id: appealIds.appeal15 }
+		},
+		LPACode: 'Q9999',
+		siteAddressLine1: '125 Fake Street',
+		siteAddressTown: 'Bristol',
+		siteAddressCounty: 'Bristolshire',
+		siteAddressPostcode: 'BS1 6PN',
+		appellantCostsAppliedFor: false,
+		casePublishedDate: pickRandom(datesNMonthsAgo(1)),
+		caseCreatedDate: pickRandom(datesNMonthsAgo(1)),
+		caseSubmittedDate: pickRandom(datesNMonthsAgo(1)),
+		CaseType: {
+			connect: { processCode: 'S78' }
+		},
+		CaseStatus: {
+			connect: { key: APPEAL_CASE_STATUS.EVIDENCE }
+		},
+		appellantCommentsSubmitted: pickRandom(datesNMonthsAgo(1)),
+		appellantFinalCommentsSubmitted: true,
+		finalCommentsDueDate: pickRandom(datesNMonthsAgo(1)),
+		appellantsProofsSubmitted: new Date(),
+		ProcedureType: {
+			connect: { key: APPEAL_CASE_PROCEDURE.INQUIRY }
+		},
+		caseReference: caseReferences.caseReference15,
+		applicationDecision: '',
+		applicationDecisionDate: pickRandom(datesNMonthsAgo(1)),
+		applicationReference: '12/2323238/PLA',
+		lpaQuestionnaireDueDate: pickRandom(datesNMonthsAgo(2)),
+		interestedPartyRepsDueDate: pickRandom(datesNMonthsAgo(2))
+	},
 	...lpaAppealCaseData
 ];
 
@@ -793,6 +829,11 @@ const appealToUsers = [
 	},
 	{
 		appealId: appealIds.appeal14,
+		userId: appellants.appellantOne.id,
+		role: APPEAL_USER_ROLES.APPELLANT
+	},
+	{
+		appealId: appealIds.appeal15,
 		userId: appellants.appellantOne.id,
 		role: APPEAL_USER_ROLES.APPELLANT
 	},
@@ -1420,6 +1461,23 @@ const appealFinalComments = [
 		AppealCase: {
 			connect: {
 				caseReference: '1000014'
+			}
+		},
+		ServiceUser: {
+			connect: {
+				internalId: '19d01551-e0cb-414f-95d9-fd71422c9a89'
+			}
+		}
+	},
+	{
+		id: appealFinalCommentIds.appealFinalCommentFour,
+		submittedDate: pickRandom(datesNMonthsAgo(0.5)),
+		comments:
+			'This is the appellant final comment. Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aenean commodo ligula eget dolor. Aenean massa. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Donec quam felis, ultricies nec, pellentesque eu, pretium quis, sem. Nulla consequat massa quis enim. Donec pede justo, fringilla vel, aliquet nec, vulputate eget, arcu. In enim justo, rhoncus ut, imperdiet a, venenatis vitae, justo. Nullam dictum felis eu pede mollis pretium. Integer tincidunt. Cras dapibus. Vivamus elementum semper nisi. Aenean vulputate eleifend tellus. Aenean leo ligula, porttitor eu, consequat vitae, eleifend ac, enim. Aliquam lorem ante, dapibus in, viverra quis, feugiat a, tellus. Phasellus viverra nulla ut metus varius laoreet. Quisque rutrum. Aenean imperdiet. Etiam ultricies nisi vel augue. ',
+		wantsFinalComment: true,
+		AppealCase: {
+			connect: {
+				caseReference: caseReferences.caseReferenceOne
 			}
 		},
 		ServiceUser: {

--- a/packages/database/src/seed/data-dev.js
+++ b/packages/database/src/seed/data-dev.js
@@ -138,7 +138,9 @@ const appealIds = {
 	appealNine: 'd8290e68-bfbb-3bc8-b621-5a9590aa29fd',
 	appealTen: 'f933b0e0-1694-11ef-ab42-cbf3edc5e3fd',
 	appeal11: 'ee283ae8-7a92-4afe-a93f-405689b1f35b',
-	appeal12: '7573b265-f529-4b0b-adf1-659cc70c180f'
+	appeal12: '7573b265-f529-4b0b-adf1-659cc70c180f',
+	appeal13: '1f72d00c-03fa-48be-8ded-a9580e65f7a5',
+	appeal14: '437c4af5-7440-486d-98e9-b37a748be96c'
 };
 
 const caseReferences = {
@@ -151,7 +153,9 @@ const caseReferences = {
 	caseReferenceSeven: '1010107',
 	caseReferenceEight: '1010108',
 	caseReferenceNine: '1010109',
-	caseReferenceTen: '1010110'
+	caseReferenceTen: '1010110',
+	caseReference13: '2201010',
+	caseReference14: '2211010'
 };
 
 const appellantSubmissionIds = {
@@ -289,6 +293,8 @@ const appeals = [
 	{ id: appealIds.appealTen },
 	{ id: appealIds.appeal11 },
 	{ id: appealIds.appeal12 },
+	{ id: appealIds.appeal13 },
+	{ id: appealIds.appeal14 },
 	{
 		id: appealSubmissionDraft.id,
 		legacyAppealSubmissionId: appealSubmissionDraft.id,
@@ -634,6 +640,66 @@ const appealCases = [
 			connect: { key: APPEAL_CASE_DECISION_OUTCOME.ALLOWED }
 		}
 	},
+	{
+		Appeal: {
+			connect: { id: appealIds.appeal13 }
+		},
+		LPACode: 'Q9999',
+		siteAddressLine1: '124 Fake Street',
+		siteAddressTown: 'Bristol',
+		siteAddressCounty: 'Bristolshire',
+		siteAddressPostcode: 'BS1 6PN',
+		appellantCostsAppliedFor: false,
+		casePublishedDate: pickRandom(datesNMonthsAgo(1)),
+		caseCreatedDate: pickRandom(datesNMonthsAgo(1)),
+		caseSubmittedDate: pickRandom(datesNMonthsAgo(1)),
+		CaseType: {
+			connect: { processCode: 'S78' }
+		},
+		CaseStatus: {
+			connect: { key: APPEAL_CASE_STATUS.LPA_QUESTIONNAIRE }
+		},
+		ProcedureType: {
+			connect: { key: APPEAL_CASE_PROCEDURE.INQUIRY }
+		},
+		caseReference: caseReferences.caseReference13,
+		applicationDecision: '',
+		applicationDecisionDate: pickRandom(datesNMonthsAgo(1)),
+		applicationReference: '12/2323238/PLA',
+		lpaQuestionnaireDueDate: pickRandom(datesNMonthsAgo(2)),
+		interestedPartyRepsDueDate: pickRandom(datesNMonthsAgo(2))
+	},
+	{
+		Appeal: {
+			connect: { id: appealIds.appeal14 }
+		},
+		LPACode: 'Q9999',
+		siteAddressLine1: '124 Fake Street',
+		siteAddressTown: 'Bristol',
+		siteAddressCounty: 'Bristolshire',
+		siteAddressPostcode: 'BS1 6PN',
+		appellantCostsAppliedFor: false,
+		casePublishedDate: pickRandom(datesNMonthsAgo(1)),
+		caseCreatedDate: pickRandom(datesNMonthsAgo(1)),
+		caseSubmittedDate: pickRandom(datesNMonthsAgo(1)),
+		CaseType: {
+			connect: { processCode: 'S78' }
+		},
+		CaseStatus: {
+			connect: { key: APPEAL_CASE_STATUS.FINAL_COMMENTS }
+		},
+		appellantCommentsSubmitted: new Date(),
+		appellantFinalCommentsSubmitted: true,
+		ProcedureType: {
+			connect: { key: APPEAL_CASE_PROCEDURE.INQUIRY }
+		},
+		caseReference: caseReferences.caseReference14,
+		applicationDecision: '',
+		applicationDecisionDate: pickRandom(datesNMonthsAgo(1)),
+		applicationReference: '12/2323238/PLA',
+		lpaQuestionnaireDueDate: pickRandom(datesNMonthsAgo(2)),
+		interestedPartyRepsDueDate: pickRandom(datesNMonthsAgo(2))
+	},
 	...lpaAppealCaseData
 ];
 
@@ -717,6 +783,16 @@ const appealToUsers = [
 	},
 	{
 		appealId: appealIds.appeal11,
+		userId: appellants.appellantOne.id,
+		role: APPEAL_USER_ROLES.APPELLANT
+	},
+	{
+		appealId: appealIds.appeal13,
+		userId: appellants.appellantOne.id,
+		role: APPEAL_USER_ROLES.APPELLANT
+	},
+	{
+		appealId: appealIds.appeal14,
 		userId: appellants.appellantOne.id,
 		role: APPEAL_USER_ROLES.APPELLANT
 	},

--- a/packages/database/src/seed/data-dev.js
+++ b/packages/database/src/seed/data-dev.js
@@ -1485,23 +1485,6 @@ const appealFinalComments = [
 				internalId: '19d01551-e0cb-414f-95d9-fd71422c9a89'
 			}
 		}
-	},
-	{
-		id: appealFinalCommentIds.appealFinalCommentFour,
-		submittedDate: pickRandom(datesNMonthsAgo(0.5)),
-		comments:
-			'This is the appellant final comment. Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aenean commodo ligula eget dolor. Aenean massa. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Donec quam felis, ultricies nec, pellentesque eu, pretium quis, sem. Nulla consequat massa quis enim. Donec pede justo, fringilla vel, aliquet nec, vulputate eget, arcu. In enim justo, rhoncus ut, imperdiet a, venenatis vitae, justo. Nullam dictum felis eu pede mollis pretium. Integer tincidunt. Cras dapibus. Vivamus elementum semper nisi. Aenean vulputate eleifend tellus. Aenean leo ligula, porttitor eu, consequat vitae, eleifend ac, enim. Aliquam lorem ante, dapibus in, viverra quis, feugiat a, tellus. Phasellus viverra nulla ut metus varius laoreet. Quisque rutrum. Aenean imperdiet. Etiam ultricies nisi vel augue. ',
-		wantsFinalComment: true,
-		AppealCase: {
-			connect: {
-				caseReference: caseReferences.caseReferenceOne
-			}
-		},
-		ServiceUser: {
-			connect: {
-				internalId: '19d01551-e0cb-414f-95d9-fd71422c9a89'
-			}
-		}
 	}
 ];
 

--- a/packages/forms-web-app/src/dynamic-forms/middleware/check-not-submitted.js
+++ b/packages/forms-web-app/src/dynamic-forms/middleware/check-not-submitted.js
@@ -10,7 +10,7 @@ const {
 module.exports = (alreadySubmittedUrl) => (req, res, next) => {
 	const journeyResponse = res?.locals?.journeyResponse;
 
-	alreadySubmittedUrl =
+	const redirectPageUrl =
 		alreadySubmittedUrl === APPEAL_OVERVIEW
 			? `${alreadySubmittedUrl}/${journeyResponse.referenceId}`
 			: alreadySubmittedUrl;
@@ -19,7 +19,7 @@ module.exports = (alreadySubmittedUrl) => (req, res, next) => {
 		journeyResponse?.answers?.submitted === 'yes' ||
 		journeyResponse?.answers?.submitted === true
 	) {
-		return res.redirect(alreadySubmittedUrl);
+		return res.redirect(redirectPageUrl);
 	}
 
 	return next();

--- a/packages/forms-web-app/src/dynamic-forms/middleware/check-not-submitted.js
+++ b/packages/forms-web-app/src/dynamic-forms/middleware/check-not-submitted.js
@@ -1,9 +1,19 @@
+const {
+	VIEW: {
+		SELECTED_APPEAL: { APPEAL_OVERVIEW }
+	}
+} = require('../../lib/views');
 /**
  * @param {string} alreadySubmittedUrl
  * @returns {import('express').Handler}
  */
 module.exports = (alreadySubmittedUrl) => (req, res, next) => {
 	const journeyResponse = res?.locals?.journeyResponse;
+
+	alreadySubmittedUrl =
+		alreadySubmittedUrl === APPEAL_OVERVIEW
+			? `${alreadySubmittedUrl}/${journeyResponse.referenceId}`
+			: alreadySubmittedUrl;
 
 	if (
 		journeyResponse?.answers?.submitted === 'yes' ||

--- a/packages/forms-web-app/src/dynamic-forms/middleware/get-journey-response-for-appellant-final-comments.js
+++ b/packages/forms-web-app/src/dynamic-forms/middleware/get-journey-response-for-appellant-final-comments.js
@@ -1,14 +1,25 @@
 const { JourneyResponse } = require('../journey-response');
 const { APPELLANT_JOURNEY_TYPES_FORMATTED } = require('../journey-factory');
+const { APPEAL_CASE_STATUS } = require('pins-data-model');
 const logger = require('#lib/logger');
 const { mapDBResponseToJourneyResponseFormat } = require('./utils');
 const { ApiClientError } = require('@pins/common/src/client/api-client-error.js');
+const {
+	VIEW: {
+		SELECTED_APPEAL: { APPEAL_OVERVIEW }
+	}
+} = require('../../lib/views');
 
 module.exports = () => async (req, res, next) => {
 	const referenceId = req.params.referenceId;
+	const appealOverviewUrl = `${APPEAL_OVERVIEW}/${referenceId}`;
 	let result;
 
 	const appeal = await req.appealsApiClient.getAppealCaseByCaseRef(referenceId);
+
+	if (appeal.caseStatus !== APPEAL_CASE_STATUS.FINAL_COMMENTS) {
+		return res.redirect(appealOverviewUrl);
+	}
 
 	const journeyType = APPELLANT_JOURNEY_TYPES_FORMATTED.FINAL_COMMENTS;
 

--- a/packages/forms-web-app/src/dynamic-forms/middleware/get-journey-response-for-appellant-proof-evidence.js
+++ b/packages/forms-web-app/src/dynamic-forms/middleware/get-journey-response-for-appellant-proof-evidence.js
@@ -1,14 +1,25 @@
 const { JourneyResponse } = require('../journey-response');
 const { APPELLANT_JOURNEY_TYPES_FORMATTED } = require('../journey-factory');
+const { APPEAL_CASE_STATUS } = require('pins-data-model');
 const logger = require('#lib/logger');
 const { mapDBResponseToJourneyResponseFormat } = require('./utils');
 const { ApiClientError } = require('@pins/common/src/client/api-client-error.js');
+const {
+	VIEW: {
+		SELECTED_APPEAL: { APPEAL_OVERVIEW }
+	}
+} = require('../../lib/views');
 
 module.exports = () => async (req, res, next) => {
 	const referenceId = req.params.referenceId;
+	const appealOverviewUrl = `${APPEAL_OVERVIEW}/${referenceId}`;
 	let result;
 
 	const appeal = await req.appealsApiClient.getAppealCaseByCaseRef(referenceId);
+
+	if (appeal.caseStatus !== APPEAL_CASE_STATUS.EVIDENCE) {
+		return res.redirect(appealOverviewUrl);
+	}
 
 	const journeyType = APPELLANT_JOURNEY_TYPES_FORMATTED.PROOF_EVIDENCE;
 

--- a/packages/forms-web-app/src/lib/views.js
+++ b/packages/forms-web-app/src/lib/views.js
@@ -169,6 +169,7 @@ const VIEW = {
 	},
 
 	SELECTED_APPEAL: {
+		APPEAL_OVERVIEW: '/appeals',
 		APPEAL: 'selected-appeal/appeal',
 		APPEAL_DETAILS: 'selected-appeal/appeal-details',
 		APPEAL_QUESTIONNAIRE: 'selected-appeal/questionnaire-details',

--- a/packages/forms-web-app/src/routes/appeals/final-comments/index.js
+++ b/packages/forms-web-app/src/routes/appeals/final-comments/index.js
@@ -30,7 +30,7 @@ const {
 		SELECTED_APPEAL: { APPEAL_OVERVIEW }
 	}
 } = require('../../../lib/views');
-const appealOverviewUrl = `${APPEAL_OVERVIEW}`;
+const appealOverviewUrl = APPEAL_OVERVIEW;
 
 const router = express.Router();
 

--- a/packages/forms-web-app/src/routes/appeals/final-comments/index.js
+++ b/packages/forms-web-app/src/routes/appeals/final-comments/index.js
@@ -27,10 +27,10 @@ const { SERVICE_USER_TYPE } = require('pins-data-model');
 
 const {
 	VIEW: {
-		APPEALS: { YOUR_APPEALS }
+		SELECTED_APPEAL: { APPEAL_OVERVIEW }
 	}
 } = require('../../../lib/views');
-const dashboardUrl = `/${YOUR_APPEALS}`;
+const appealOverviewUrl = `${APPEAL_OVERVIEW}`;
 
 const router = express.Router();
 
@@ -59,7 +59,7 @@ router.get(
 	getJourneyResponse(),
 	getJourney(journeys),
 	redirectToUnansweredQuestion([appellantFinalCommentSkipConditions]),
-	checkNotSubmitted(dashboardUrl),
+	checkNotSubmitted(appealOverviewUrl),
 	finalCommentsTaskList
 );
 
@@ -68,7 +68,7 @@ router.post(
 	'/:referenceId',
 	getJourneyResponse(),
 	getJourney(journeys),
-	checkNotSubmitted(dashboardUrl),
+	checkNotSubmitted(appealOverviewUrl),
 	validationErrorHandler,
 	submitAppellantFinalComment
 );
@@ -87,7 +87,7 @@ router.get(
 	setDefaultSection(),
 	getJourneyResponse(),
 	getJourney(journeys),
-	checkNotSubmitted(dashboardUrl),
+	checkNotSubmitted(appealOverviewUrl),
 	question
 );
 
@@ -97,7 +97,7 @@ router.post(
 	setDefaultSection(),
 	getJourneyResponse(),
 	getJourney(journeys),
-	checkNotSubmitted(dashboardUrl),
+	checkNotSubmitted(appealOverviewUrl),
 	dynamicReqFilesToReqBodyFiles(),
 	validate(),
 	validationErrorHandler,

--- a/packages/forms-web-app/src/routes/appeals/index.js
+++ b/packages/forms-web-app/src/routes/appeals/index.js
@@ -20,6 +20,12 @@ router.use('/full-planning', dynamicSubmission);
 router.use('/final-comments', finalCommentsRouter);
 router.use('/proof-evidence', proofEvidenceRouter);
 
+//redirect away from non-existent journey
+router.use('/appeal-statement/:appealNumber', (req, res) => {
+	const appealNumber = req.params.appealNumber;
+	return res.redirect(`/appeals/${appealNumber}`);
+});
+
 // todo: leave at end or fix the urls defined in these routes, currently catches anything else as :appealNumber
 router.use('/', selectedAppealRouter);
 

--- a/packages/forms-web-app/src/routes/appeals/index.js
+++ b/packages/forms-web-app/src/routes/appeals/index.js
@@ -20,12 +20,6 @@ router.use('/full-planning', dynamicSubmission);
 router.use('/final-comments', finalCommentsRouter);
 router.use('/proof-evidence', proofEvidenceRouter);
 
-//redirect away from non-existent journey
-router.use('/appeal-statement/:appealNumber', (req, res) => {
-	const appealNumber = req.params.appealNumber;
-	return res.redirect(`/appeals/${appealNumber}`);
-});
-
 // todo: leave at end or fix the urls defined in these routes, currently catches anything else as :appealNumber
 router.use('/', selectedAppealRouter);
 

--- a/packages/forms-web-app/src/routes/appeals/proof-evidence/index.js
+++ b/packages/forms-web-app/src/routes/appeals/proof-evidence/index.js
@@ -27,10 +27,10 @@ const { SERVICE_USER_TYPE } = require('pins-data-model');
 
 const {
 	VIEW: {
-		APPEALS: { YOUR_APPEALS }
+		SELECTED_APPEAL: { APPEAL_OVERVIEW }
 	}
 } = require('../../../lib/views');
-const dashboardUrl = `/${YOUR_APPEALS}`;
+const appealOverviewUrl = APPEAL_OVERVIEW;
 
 const router = express.Router();
 
@@ -59,7 +59,7 @@ router.get(
 	getJourneyResponse(),
 	getJourney(journeys),
 	redirectToUnansweredQuestion([appellantProofEvidenceSkipConditions]),
-	checkNotSubmitted(dashboardUrl),
+	checkNotSubmitted(appealOverviewUrl),
 	proofOfEvidenceTaskList
 );
 
@@ -68,7 +68,7 @@ router.post(
 	'/:referenceId',
 	getJourneyResponse(),
 	getJourney(journeys),
-	checkNotSubmitted(dashboardUrl),
+	checkNotSubmitted(appealOverviewUrl),
 	validationErrorHandler,
 	submitAppellantProofEvidence
 );
@@ -87,7 +87,7 @@ router.get(
 	setDefaultSection(),
 	getJourneyResponse(),
 	getJourney(journeys),
-	checkNotSubmitted(dashboardUrl),
+	checkNotSubmitted(appealOverviewUrl),
 	question
 );
 
@@ -97,7 +97,7 @@ router.post(
 	setDefaultSection(),
 	getJourneyResponse(),
 	getJourney(journeys),
-	checkNotSubmitted(dashboardUrl),
+	checkNotSubmitted(appealOverviewUrl),
 	dynamicReqFilesToReqBodyFiles(),
 	validate(),
 	validationErrorHandler,


### PR DESCRIPTION
## Ticket Number

<!-- Add the number from the Jira board -->

https://pins-ds.atlassian.net/browse/A2-1784

## Description of change

<!-- Please describe the change -->
redirects appellant to appeal overview page away from:
final comments
appeal statement
proof of evidence 

journeys if they are not yet open or already submitted. 
appeal statement journey is not a valid journey for appellants but they could try entering the url for a given appeal

## Checklist

<!-- Put an `x` in all the boxes that apply: -->

- [ ] Requires infrastructure changes
- [ ] I have updated the documentation accordingly
- [x] My commit history in this PR is linear
- [ ] New features have tests
- [ ] Breaking change (team conversation required)

## Important

Please do not merge from `main` (please only [rebase](https://github.com/Planning-Inspectorate/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
