### PR TITLE
fix(a2-1973): fix backlink if no postcode search results

### DIFF
--- a/packages/forms-web-app/src/routes/file-based-router/comment-planning-appeal/appeals/controller.js
+++ b/packages/forms-web-app/src/routes/file-based-router/comment-planning-appeal/appeals/controller.js
@@ -17,6 +17,8 @@ const appeals = async (req, res) => {
 	});
 
 	if (!postcodeSearchResults.length) {
+		// remove this page from navigation history to ensure back button functions correctly on redirect
+		req.session.navigationHistory.shift();
 		return res.redirect(`appeal-search-no-results?search=${postcode}&type=postcode`);
 	}
 

--- a/packages/forms-web-app/src/routes/file-based-router/comment-planning-appeal/appeals/controller.test.js
+++ b/packages/forms-web-app/src/routes/file-based-router/comment-planning-appeal/appeals/controller.test.js
@@ -31,9 +31,13 @@ describe('appeals Controller Tests', () => {
 		};
 	});
 
-	it('should redirect to no-results page if no search results are found', async () => {
+	it('should redirect to no-results page with correct navigation history if no search results are found', async () => {
 		req.query.search = 'AB12 3CD';
 		req.appealsApiClient.getPostcodeSearchResults.mockResolvedValue([]);
+		req.session.navigationHistory = [
+			'/comment-planning-appeal/appeals',
+			'/comment-planning-appeal/enter-postcode'
+		];
 
 		await appeals(req, res);
 
@@ -44,6 +48,7 @@ describe('appeals Controller Tests', () => {
 		expect(res.redirect).toHaveBeenCalledWith(
 			'appeal-search-no-results?search=AB12 3CD&type=postcode'
 		);
+		expect(req.session.navigationHistory).toEqual(['/comment-planning-appeal/enter-postcode']);
 	});
 
 	it('should render the appeals page with formatted data', async () => {
@@ -57,6 +62,10 @@ describe('appeals Controller Tests', () => {
 			}
 		];
 		req.appealsApiClient.getPostcodeSearchResults.mockResolvedValue(postcodeSearchResults);
+		req.session.navigationHistory = [
+			'/comment-planning-appeal/appeals',
+			'/comment-planning-appeal/enter-postcode'
+		];
 		formatAddress.mockReturnValue('Formatted Address');
 		getOpenAppeals.mockReturnValue(postcodeSearchResults);
 		getClosedAppeals.mockReturnValue([]);
@@ -77,5 +86,9 @@ describe('appeals Controller Tests', () => {
 			openAppeals: postcodeSearchResults,
 			closedAppeals: []
 		});
+		expect(req.session.navigationHistory).toEqual([
+			'/comment-planning-appeal/appeals',
+			'/comment-planning-appeal/enter-postcode'
+		]);
 	});
 });


### PR DESCRIPTION
## Ticket Number

<!-- Add the number from the Jira board -->

https://pins-ds.atlassian.net/browse/A2-1973

## Description of change

Removes invalid path from navigation history to ensure back button works if no postcodes returned by search.

<!-- Please describe the change -->

## Checklist

<!-- Put an `x` in all the boxes that apply: -->

- [ ] Requires infrastructure changes
- [ ] I have updated the documentation accordingly
- [ ] My commit history in this PR is linear
- [ ] New features have tests
- [ ] Breaking change (team conversation required)

## Important

Please do not merge from `main` (please only [rebase](https://github.com/Planning-Inspectorate/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
