### PR TITLE
fix(a2-1770): fix backlink for subquestions

### DIFF
--- a/packages/forms-web-app/src/dynamic-forms/journey.js
+++ b/packages/forms-web-app/src/dynamic-forms/journey.js
@@ -229,7 +229,10 @@ class Journey {
 						);
 					}
 
-					if (question.fieldName === questionSegment) {
+					if (
+						question.fieldName === questionSegment ||
+						(reverse && question.subQuestion?.fieldName === questionSegment)
+					) {
 						takeNextQuestion = true;
 					}
 				}

--- a/packages/forms-web-app/src/dynamic-forms/journey.test.js
+++ b/packages/forms-web-app/src/dynamic-forms/journey.test.js
@@ -11,7 +11,12 @@ const mockSections = [
 				prepQuestionForRendering: jest.fn(),
 				shouldDisplay: () => true
 			},
-			{ fieldName: 'question3', text: 'Question 3', shouldDisplay: () => true },
+			{
+				fieldName: 'question3',
+				text: 'Question 3',
+				shouldDisplay: () => true,
+				subQuestion: { fieldName: 'question3subquestion' }
+			},
 			{ fieldName: 'question4', text: 'Question 4', shouldDisplay: () => true }
 		]
 	},
@@ -445,6 +450,21 @@ describe('Journey class', () => {
 			const nextQuestionUrl = journey.getNextQuestionUrl(section.segment, name, false);
 
 			expect(nextQuestionUrl).toBe(`base/${section.segment}/${nextQuestionName}?id=1`);
+		});
+
+		it('should return previous question url if passed subquestion fieldname', () => {
+			const section = mockSections[0];
+			const name = section.questions[2].subQuestion.fieldName;
+			const prevQuestionName = section.questions[1].fieldName;
+
+			const journey = new Journey(constructorArgs);
+			journey.sections = mockSections;
+
+			const nextQuestionUrl = journey.getNextQuestionUrl(section.segment, name, true);
+
+			expect(nextQuestionUrl).toBe(
+				`${constructorArgs.makeBaseUrl()}/${section.segment}/${prevQuestionName}`
+			);
 		});
 	});
 


### PR DESCRIPTION
## Ticket Number

<!-- Add the number from the Jira board -->

https://pins-ds.atlassian.net/browse/A2-1770

## Description of change

<!-- Please describe the change -->

Adds check for subquestion fieldname when getting previous question url.

## Checklist

<!-- Put an `x` in all the boxes that apply: -->

- [ ] Requires infrastructure changes
- [ ] I have updated the documentation accordingly
- [ ] My commit history in this PR is linear
- [ ] New features have tests
- [ ] Breaking change (team conversation required)

## Important

Please do not merge from `main` (please only [rebase](https://github.com/Planning-Inspectorate/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
