### PR TITLE
Feat/a2 1786 stop lpa rule6 entering inactive journey

### DIFF
--- a/packages/database/src/seed/data-dev.js
+++ b/packages/database/src/seed/data-dev.js
@@ -141,7 +141,8 @@ const appealIds = {
 	appeal12: '7573b265-f529-4b0b-adf1-659cc70c180f',
 	appeal13: '1f72d00c-03fa-48be-8ded-a9580e65f7a5',
 	appeal14: '437c4af5-7440-486d-98e9-b37a748be96c',
-	appeal15: '5b769d3f-466c-427a-9d58-d9823239ee9b'
+	appeal15: '5b769d3f-466c-427a-9d58-d9823239ee9b',
+	appeal16: 'e2e772d4-e688-465f-802c-59a69e43a9ea'
 };
 
 const caseReferences = {
@@ -157,7 +158,8 @@ const caseReferences = {
 	caseReferenceTen: '1010110',
 	caseReference13: '2201010',
 	caseReference14: '2211010',
-	caseReference15: '2221010'
+	caseReference15: '2221010',
+	caseReference16: '2231010'
 };
 
 const appellantSubmissionIds = {
@@ -298,6 +300,7 @@ const appeals = [
 	{ id: appealIds.appeal13 },
 	{ id: appealIds.appeal14 },
 	{ id: appealIds.appeal15 },
+	{ id: appealIds.appeal16 },
 	{
 		id: appealSubmissionDraft.id,
 		legacyAppealSubmissionId: appealSubmissionDraft.id,
@@ -691,6 +694,8 @@ const appealCases = [
 		CaseStatus: {
 			connect: { key: APPEAL_CASE_STATUS.FINAL_COMMENTS }
 		},
+		lpaQuestionnaireSubmittedDate: pickRandom(datesNMonthsAgo(1)),
+		LPAStatementSubmitted: pickRandom(datesNMonthsAgo(1)),
 		appellantCommentsSubmitted: new Date(),
 		appellantFinalCommentsSubmitted: true,
 		ProcedureType: {
@@ -725,11 +730,53 @@ const appealCases = [
 		appellantCommentsSubmitted: pickRandom(datesNMonthsAgo(1)),
 		appellantFinalCommentsSubmitted: true,
 		finalCommentsDueDate: pickRandom(datesNMonthsAgo(1)),
+		lpaQuestionnaireSubmittedDate: pickRandom(datesNMonthsAgo(1)),
+		LPAStatementSubmitted: pickRandom(datesNMonthsAgo(1)),
+		LPACommentsSubmitted: pickRandom(datesNMonthsAgo(1)),
 		appellantsProofsSubmitted: new Date(),
+		lpaProofEvidenceSubmitted: true,
+		LPAProofsSubmitted: new Date(),
+		rule6ProofEvidenceSubmitted: true,
+		rule6ProofEvidenceSubmittedDate: pickRandom(datesNMonthsAgo(1)),
 		ProcedureType: {
 			connect: { key: APPEAL_CASE_PROCEDURE.INQUIRY }
 		},
 		caseReference: caseReferences.caseReference15,
+		applicationDecision: '',
+		applicationDecisionDate: pickRandom(datesNMonthsAgo(1)),
+		applicationReference: '12/2323238/PLA',
+		lpaQuestionnaireDueDate: pickRandom(datesNMonthsAgo(2)),
+		interestedPartyRepsDueDate: pickRandom(datesNMonthsAgo(2))
+	},
+	{
+		Appeal: {
+			connect: { id: appealIds.appeal16 }
+		},
+		LPACode: 'Q9999',
+		siteAddressLine1: '124 Fake Street',
+		siteAddressTown: 'Bristol',
+		siteAddressCounty: 'Bristolshire',
+		siteAddressPostcode: 'BS1 6PN',
+		appellantCostsAppliedFor: false,
+		casePublishedDate: pickRandom(datesNMonthsAgo(1)),
+		caseCreatedDate: pickRandom(datesNMonthsAgo(1)),
+		caseSubmittedDate: pickRandom(datesNMonthsAgo(1)),
+		CaseType: {
+			connect: { processCode: 'S78' }
+		},
+		CaseStatus: {
+			connect: { key: APPEAL_CASE_STATUS.STATEMENTS }
+		},
+		lpaQuestionnaireSubmittedDate: pickRandom(datesNMonthsAgo(1)),
+		LPAStatementSubmitted: pickRandom(datesNMonthsAgo(1)),
+		rule6StatementSubmitted: true,
+		rule6StatementSubmittedDate: pickRandom(datesNMonthsAgo(1)),
+		appellantCommentsSubmitted: new Date(),
+		appellantFinalCommentsSubmitted: true,
+		ProcedureType: {
+			connect: { key: APPEAL_CASE_PROCEDURE.INQUIRY }
+		},
+		caseReference: caseReferences.caseReference16,
 		applicationDecision: '',
 		applicationDecisionDate: pickRandom(datesNMonthsAgo(1)),
 		applicationReference: '12/2323238/PLA',
@@ -882,6 +929,16 @@ const appealToUsers = [
 	{
 		appealId: appealIds.appealEight,
 		userId: rule6Parties.r6Eight.id,
+		role: APPEAL_USER_ROLES.RULE_6_PARTY
+	},
+	{
+		appealId: appealIds.appeal15,
+		userId: rule6Parties.r6One.id,
+		role: APPEAL_USER_ROLES.RULE_6_PARTY
+	},
+	{
+		appealId: appealIds.appeal16,
+		userId: rule6Parties.r6One.id,
 		role: APPEAL_USER_ROLES.RULE_6_PARTY
 	},
 	...linkedLpaR6Appeals

--- a/packages/forms-web-app/src/dynamic-forms/middleware/check-not-submitted.js
+++ b/packages/forms-web-app/src/dynamic-forms/middleware/check-not-submitted.js
@@ -1,7 +1,5 @@
 const {
-	VIEW: {
-		SELECTED_APPEAL: { APPEAL_OVERVIEW }
-	}
+	VIEW: { SELECTED_APPEAL, LPA_DASHBOARD, RULE_6 }
 } = require('../../lib/views');
 /**
  * @param {string} alreadySubmittedUrl
@@ -10,9 +8,18 @@ const {
 module.exports = (alreadySubmittedUrl) => (req, res, next) => {
 	const journeyResponse = res?.locals?.journeyResponse;
 
+	let userAppealOverview;
+	if (req.session?.user?.isLpaUser) {
+		userAppealOverview = LPA_DASHBOARD.APPEAL_OVERVIEW;
+	} else if (req.session?.user?.isRule6User) {
+		userAppealOverview = RULE_6.APPEAL_OVERVIEW;
+	} else {
+		userAppealOverview = SELECTED_APPEAL.APPEAL_OVERVIEW;
+	}
+
 	const redirectPageUrl =
-		alreadySubmittedUrl === APPEAL_OVERVIEW
-			? `${alreadySubmittedUrl}/${journeyResponse.referenceId}`
+		alreadySubmittedUrl === userAppealOverview
+			? `${userAppealOverview}/${journeyResponse.referenceId}`
 			: alreadySubmittedUrl;
 
 	if (

--- a/packages/forms-web-app/src/dynamic-forms/middleware/check-not-submitted.test.js
+++ b/packages/forms-web-app/src/dynamic-forms/middleware/check-not-submitted.test.js
@@ -1,15 +1,20 @@
 const checkNotSubmitted = require('./check-not-submitted');
-
+const {
+	VIEW: { SELECTED_APPEAL, LPA_DASHBOARD, RULE_6 }
+} = require('../../lib/views');
 const testUrl = '/test';
 
 describe('dynamic-forms/middleware/check-not-submitted', () => {
 	let mockReq;
 
 	beforeEach(() => {
-		mockReq = () => ({
+		mockReq = (userType = null) => ({
 			cookies: {},
 			log: {},
-			params: {}
+			params: {},
+			session: {
+				user: userType
+			}
 		});
 	});
 
@@ -116,5 +121,62 @@ describe('dynamic-forms/middleware/check-not-submitted', () => {
 
 			expected(req, res, next);
 		});
+	});
+	it('should redirect to LPA dashboard if submitted is yes and user is LPA', () => {
+		const next = jest.fn();
+		const req = mockReq({ isLpaUser: true });
+		const res = {
+			locals: {
+				journeyResponse: {
+					answers: {
+						submitted: 'yes'
+					},
+					referenceId: '123'
+				}
+			},
+			redirect: jest.fn()
+		};
+
+		checkNotSubmitted(LPA_DASHBOARD.APPEAL_OVERVIEW)(req, res, next);
+
+		expect(res.redirect).toHaveBeenCalledWith(`${LPA_DASHBOARD.APPEAL_OVERVIEW}/123`);
+	});
+	it('should redirect to Rule 6 dashboard if submitted is yes and user is Rule 6', () => {
+		const next = jest.fn();
+		const req = mockReq({ isRule6User: true });
+		const res = {
+			locals: {
+				journeyResponse: {
+					answers: {
+						submitted: 'yes'
+					},
+					referenceId: '456'
+				}
+			},
+			redirect: jest.fn()
+		};
+
+		checkNotSubmitted(RULE_6.APPEAL_OVERVIEW)(req, res, next);
+
+		expect(res.redirect).toHaveBeenCalledWith(`${RULE_6.APPEAL_OVERVIEW}/456`);
+	});
+	it('should redirect to appellant dashboard if submitted is yes and user is appellant', () => {
+		const next = jest.fn();
+		const req = mockReq();
+		const res = {
+			locals: {
+				journeyResponse: {
+					answers: {
+						submitted: 'yes'
+					},
+					referenceId: '789'
+				}
+			},
+			redirect: jest.fn()
+		};
+
+		checkNotSubmitted(SELECTED_APPEAL.APPEAL_OVERVIEW)(req, res, next);
+
+		expect(res.redirect).toHaveBeenCalledWith(`${SELECTED_APPEAL.APPEAL_OVERVIEW}/789`);
 	});
 });

--- a/packages/forms-web-app/src/dynamic-forms/middleware/get-journey-response-for-lpa-final-comments.js
+++ b/packages/forms-web-app/src/dynamic-forms/middleware/get-journey-response-for-lpa-final-comments.js
@@ -1,13 +1,20 @@
 const { JourneyResponse } = require('../journey-response');
 const { LPA_JOURNEY_TYPES_FORMATTED } = require('../journey-factory');
+const { APPEAL_CASE_STATUS } = require('pins-data-model');
 const logger = require('#lib/logger');
 const { getUserFromSession } = require('../../services/user.service');
 const { mapDBResponseToJourneyResponseFormat } = require('./utils');
 const { ApiClientError } = require('@pins/common/src/client/api-client-error.js');
 const { LPA_USER_ROLE } = require('@pins/common/src/constants');
+const {
+	VIEW: {
+		LPA_DASHBOARD: { APPEAL_OVERVIEW }
+	}
+} = require('../../lib/views');
 
 module.exports = () => async (req, res, next) => {
 	const referenceId = req.params.referenceId;
+	const appealOverviewUrl = `${APPEAL_OVERVIEW}/${referenceId}`;
 	let result;
 
 	const user = getUserFromSession(req);
@@ -17,6 +24,10 @@ module.exports = () => async (req, res, next) => {
 		userId: user.id,
 		role: LPA_USER_ROLE
 	});
+
+	if (appeal.caseStatus !== APPEAL_CASE_STATUS.FINAL_COMMENTS) {
+		return res.redirect(appealOverviewUrl);
+	}
 
 	let journeyType;
 

--- a/packages/forms-web-app/src/dynamic-forms/middleware/get-journey-response-for-lpa-proof-evidence.js
+++ b/packages/forms-web-app/src/dynamic-forms/middleware/get-journey-response-for-lpa-proof-evidence.js
@@ -1,14 +1,21 @@
 const { JourneyResponse } = require('../journey-response');
 const { LPA_JOURNEY_TYPES_FORMATTED } = require('../journey-factory');
+const { APPEAL_CASE_STATUS } = require('pins-data-model');
 const logger = require('#lib/logger');
 const { getUserFromSession } = require('../../services/user.service');
 const { mapDBResponseToJourneyResponseFormat } = require('./utils');
 const { ApiClientError } = require('@pins/common/src/client/api-client-error.js');
 const { LPA_USER_ROLE } = require('@pins/common/src/constants');
+const {
+	VIEW: {
+		LPA_DASHBOARD: { APPEAL_OVERVIEW }
+	}
+} = require('../../lib/views');
 
 module.exports = () => async (req, res, next) => {
 	const referenceId = req.params.referenceId;
 	const encodedReferenceId = encodeURIComponent(referenceId);
+	const appealOverviewUrl = `${APPEAL_OVERVIEW}/${referenceId}`;
 	let result;
 
 	const user = getUserFromSession(req);
@@ -18,6 +25,10 @@ module.exports = () => async (req, res, next) => {
 		userId: user.id,
 		role: LPA_USER_ROLE
 	});
+
+	if (appeal.caseStatus !== APPEAL_CASE_STATUS.EVIDENCE) {
+		return res.redirect(appealOverviewUrl);
+	}
 
 	let journeyType;
 

--- a/packages/forms-web-app/src/dynamic-forms/middleware/get-journey-response-for-lpa-statement.js
+++ b/packages/forms-web-app/src/dynamic-forms/middleware/get-journey-response-for-lpa-statement.js
@@ -1,15 +1,22 @@
 const { JourneyResponse } = require('../journey-response');
 const { LPA_JOURNEY_TYPES_FORMATTED } = require('../journey-factory');
+const { APPEAL_CASE_STATUS } = require('pins-data-model');
 const logger = require('#lib/logger');
 const { getUserFromSession } = require('../../services/user.service');
 const { mapDBResponseToJourneyResponseFormat } = require('./utils');
 const { deadlineHasPassed } = require('../../lib/deadline-has-passed');
 const { ApiClientError } = require('@pins/common/src/client/api-client-error.js');
 const { LPA_USER_ROLE } = require('@pins/common/src/constants');
+const {
+	VIEW: {
+		LPA_DASHBOARD: { APPEAL_OVERVIEW }
+	}
+} = require('../../lib/views');
 
 module.exports = () => async (req, res, next) => {
 	const referenceId = req.params.referenceId;
 	const encodedReferenceId = encodeURIComponent(referenceId);
+	const appealOverviewUrl = `${APPEAL_OVERVIEW}/${referenceId}`;
 	let result;
 
 	const user = getUserFromSession(req);
@@ -19,6 +26,10 @@ module.exports = () => async (req, res, next) => {
 		userId: user.id,
 		role: LPA_USER_ROLE
 	});
+
+	if (appeal.caseStatus !== APPEAL_CASE_STATUS.STATEMENTS) {
+		return res.redirect(appealOverviewUrl);
+	}
 
 	let journeyType;
 

--- a/packages/forms-web-app/src/dynamic-forms/middleware/get-journey-response-for-rule-6-proof-evidence.js
+++ b/packages/forms-web-app/src/dynamic-forms/middleware/get-journey-response-for-rule-6-proof-evidence.js
@@ -1,14 +1,25 @@
 const { JourneyResponse } = require('../journey-response');
 const { RULE_6_JOURNEY_TYPES_FORMATTED } = require('../journey-factory');
+const { APPEAL_CASE_STATUS } = require('pins-data-model');
 const logger = require('#lib/logger');
 const { mapDBResponseToJourneyResponseFormat } = require('./utils');
 const { ApiClientError } = require('@pins/common/src/client/api-client-error.js');
+const {
+	VIEW: {
+		RULE_6: { APPEAL_OVERVIEW }
+	}
+} = require('../../lib/views');
 
 module.exports = () => async (req, res, next) => {
 	const referenceId = req.params.referenceId;
+	const appealOverviewUrl = `${APPEAL_OVERVIEW}/${referenceId}`;
 	let result;
 
 	const appeal = await req.appealsApiClient.getAppealCaseByCaseRef(referenceId);
+
+	if (appeal.caseStatus !== APPEAL_CASE_STATUS.EVIDENCE) {
+		return res.redirect(appealOverviewUrl);
+	}
 
 	const journeyType = RULE_6_JOURNEY_TYPES_FORMATTED.PROOF_EVIDENCE;
 

--- a/packages/forms-web-app/src/dynamic-forms/middleware/get-journey-response-for-rule-6-statement.js
+++ b/packages/forms-web-app/src/dynamic-forms/middleware/get-journey-response-for-rule-6-statement.js
@@ -1,14 +1,25 @@
 const { JourneyResponse } = require('../journey-response');
 const { RULE_6_JOURNEY_TYPES_FORMATTED } = require('../journey-factory');
+const { APPEAL_CASE_STATUS } = require('pins-data-model');
 const logger = require('#lib/logger');
 const { mapDBResponseToJourneyResponseFormat } = require('./utils');
 const { ApiClientError } = require('@pins/common/src/client/api-client-error.js');
+const {
+	VIEW: {
+		RULE_6: { APPEAL_OVERVIEW }
+	}
+} = require('../../lib/views');
 
 module.exports = () => async (req, res, next) => {
 	const referenceId = req.params.referenceId;
+	const appealOverviewUrl = `${APPEAL_OVERVIEW}/${referenceId}`;
 	let result;
 
 	const appeal = await req.appealsApiClient.getAppealCaseByCaseRef(referenceId);
+
+	if (appeal.caseStatus !== APPEAL_CASE_STATUS.STATEMENTS) {
+		return res.redirect(appealOverviewUrl);
+	}
 
 	const journeyType = RULE_6_JOURNEY_TYPES_FORMATTED.STATEMENT;
 

--- a/packages/forms-web-app/src/lib/views.js
+++ b/packages/forms-web-app/src/lib/views.js
@@ -196,7 +196,8 @@ const VIEW = {
 		CONFIRM_ADD_USER: 'manage-appeals/confirm-add-user',
 		CONFIRM_REMOVE_USER: 'manage-appeals/confirm-remove-user',
 		YOUR_EMAIL_ADDRESS: 'manage-appeals/your-email-address',
-		DECIDED_APPEALS: 'manage-appeals/decided-appeals'
+		DECIDED_APPEALS: 'manage-appeals/decided-appeals',
+		APPEAL_OVERVIEW: '/manage-appeals'
 	},
 
 	INTERESTED_PARTY_COMMENTS: {
@@ -210,7 +211,8 @@ const VIEW = {
 		NEED_NEW_CODE: 'rule-6/need-new-code',
 		REQUEST_NEW_CODE: 'rule-6/request-new-code',
 		DASHBOARD: 'rule-6/your-appeals',
-		DECIDED_APPEALS: 'rule-6/decided-appeals'
+		DECIDED_APPEALS: 'rule-6/decided-appeals',
+		APPEAL_OVERVIEW: '/rule-6'
 	},
 
 	MESSAGES: {

--- a/packages/forms-web-app/src/routes/lpa-dashboard/final-comments.js
+++ b/packages/forms-web-app/src/routes/lpa-dashboard/final-comments.js
@@ -29,11 +29,11 @@ const { SERVICE_USER_TYPE } = require('pins-data-model');
 
 const {
 	VIEW: {
-		LPA_DASHBOARD: { DASHBOARD }
+		LPA_DASHBOARD: { APPEAL_OVERVIEW }
 	}
 } = require('#lib/views');
 
-const dashboardUrl = `/${DASHBOARD}`;
+const appealOverviewUrl = APPEAL_OVERVIEW;
 
 const router = express.Router();
 
@@ -68,7 +68,7 @@ router.get(
 	getJourneyResponse(),
 	getJourney(journeys),
 	redirectToUnansweredQuestion([lpaFinalCommentSkipConditions]),
-	checkNotSubmitted(dashboardUrl),
+	checkNotSubmitted(appealOverviewUrl),
 	lpaFinalCommentTaskList
 );
 
@@ -78,7 +78,7 @@ router.post(
 	setDefaultSection(),
 	getJourneyResponse(),
 	getJourney(journeys),
-	checkNotSubmitted(dashboardUrl),
+	checkNotSubmitted(appealOverviewUrl),
 	validationErrorHandler,
 	submitLpaFinalComment
 );
@@ -97,7 +97,7 @@ router.get(
 	setDefaultSection(),
 	getJourneyResponse(),
 	getJourney(journeys),
-	checkNotSubmitted(dashboardUrl),
+	checkNotSubmitted(appealOverviewUrl),
 	question
 );
 
@@ -107,7 +107,7 @@ router.post(
 	setDefaultSection(),
 	getJourneyResponse(),
 	getJourney(journeys),
-	checkNotSubmitted(dashboardUrl),
+	checkNotSubmitted(appealOverviewUrl),
 	dynamicReqFilesToReqBodyFiles(),
 	validate(),
 	validationErrorHandler,

--- a/packages/forms-web-app/src/routes/lpa-dashboard/proof-evidence.js
+++ b/packages/forms-web-app/src/routes/lpa-dashboard/proof-evidence.js
@@ -27,10 +27,10 @@ const { SERVICE_USER_TYPE } = require('pins-data-model');
 
 const {
 	VIEW: {
-		APPEALS: { YOUR_APPEALS }
+		LPA_DASHBOARD: { APPEAL_OVERVIEW }
 	}
 } = require('../../lib/views');
-const dashboardUrl = `/${YOUR_APPEALS}`;
+const appealOverviewUrl = APPEAL_OVERVIEW;
 
 const router = express.Router();
 
@@ -59,7 +59,7 @@ router.get(
 	getJourneyResponse(),
 	getJourney(journeys),
 	redirectToUnansweredQuestion([lpaProofEvidenceSkipConditions]),
-	checkNotSubmitted(dashboardUrl),
+	checkNotSubmitted(appealOverviewUrl),
 	proofOfEvidenceTaskList
 );
 
@@ -68,7 +68,7 @@ router.post(
 	'/proof-evidence/:referenceId',
 	getJourneyResponse(),
 	getJourney(journeys),
-	checkNotSubmitted(dashboardUrl),
+	checkNotSubmitted(appealOverviewUrl),
 	validationErrorHandler,
 	submitLpaProofEvidence
 );
@@ -87,7 +87,7 @@ router.get(
 	setDefaultSection(),
 	getJourneyResponse(),
 	getJourney(journeys),
-	checkNotSubmitted(dashboardUrl),
+	checkNotSubmitted(appealOverviewUrl),
 	question
 );
 
@@ -97,7 +97,7 @@ router.post(
 	setDefaultSection(),
 	getJourneyResponse(),
 	getJourney(journeys),
-	checkNotSubmitted(dashboardUrl),
+	checkNotSubmitted(appealOverviewUrl),
 	dynamicReqFilesToReqBodyFiles(),
 	validate(),
 	validationErrorHandler,

--- a/packages/forms-web-app/src/routes/lpa-dashboard/statement.js
+++ b/packages/forms-web-app/src/routes/lpa-dashboard/statement.js
@@ -29,11 +29,11 @@ const { SERVICE_USER_TYPE } = require('pins-data-model');
 
 const {
 	VIEW: {
-		LPA_DASHBOARD: { DASHBOARD }
+		LPA_DASHBOARD: { APPEAL_OVERVIEW }
 	}
 } = require('#lib/views');
 
-const dashboardUrl = `/${DASHBOARD}`;
+const appealOverviewUrl = APPEAL_OVERVIEW;
 
 const router = express.Router();
 
@@ -68,7 +68,7 @@ router.get(
 	getJourneyResponse(),
 	getJourney(journeys),
 	redirectToUnansweredQuestion([skipIfNoAdditionalDocuments]),
-	checkNotSubmitted(dashboardUrl),
+	checkNotSubmitted(appealOverviewUrl),
 	statementTaskList
 );
 
@@ -86,7 +86,7 @@ router.get(
 	setDefaultSection(),
 	getJourneyResponse(),
 	getJourney(journeys),
-	checkNotSubmitted(dashboardUrl),
+	checkNotSubmitted(appealOverviewUrl),
 	question
 );
 
@@ -96,7 +96,7 @@ router.post(
 	setDefaultSection(),
 	getJourneyResponse(),
 	getJourney(journeys),
-	checkNotSubmitted(dashboardUrl),
+	checkNotSubmitted(appealOverviewUrl),
 	dynamicReqFilesToReqBodyFiles(),
 	validate(),
 	validationErrorHandler,
@@ -109,7 +109,7 @@ router.post(
 	setDefaultSection(),
 	getJourneyResponse(),
 	getJourney(journeys),
-	checkNotSubmitted(dashboardUrl),
+	checkNotSubmitted(appealOverviewUrl),
 	validationErrorHandler,
 	submitLpaStatement
 );
@@ -120,7 +120,7 @@ router.get(
 	setDefaultSection(),
 	getJourneyResponse(),
 	getJourney(journeys),
-	checkNotSubmitted(dashboardUrl),
+	checkNotSubmitted(appealOverviewUrl),
 	remove
 );
 

--- a/packages/forms-web-app/src/routes/rule-6/appeal-statement.js
+++ b/packages/forms-web-app/src/routes/rule-6/appeal-statement.js
@@ -25,10 +25,10 @@ const { caseTypeNameWithDefault } = require('@pins/common/src/lib/format-case-ty
 
 const {
 	VIEW: {
-		RULE_6: { DASHBOARD }
+		RULE_6: { APPEAL_OVERVIEW }
 	}
 } = require('../../lib/views');
-const dashboardUrl = `/${DASHBOARD}`;
+const appealOverviewUrl = APPEAL_OVERVIEW;
 
 const router = express.Router();
 
@@ -52,7 +52,7 @@ router.get(
 	getJourneyResponse(),
 	getJourney(journeys),
 	redirectToUnansweredQuestion([rule6StatementSkipConditions]),
-	checkNotSubmitted(dashboardUrl),
+	checkNotSubmitted(appealOverviewUrl),
 	statementTaskList
 );
 
@@ -61,7 +61,7 @@ router.post(
 	'/appeal-statement/:referenceId',
 	getJourneyResponse(),
 	getJourney(journeys),
-	checkNotSubmitted(dashboardUrl),
+	checkNotSubmitted(appealOverviewUrl),
 	validationErrorHandler,
 	submitRule6Statement
 );
@@ -80,7 +80,7 @@ router.get(
 	setDefaultSection(),
 	getJourneyResponse(),
 	getJourney(journeys),
-	checkNotSubmitted(dashboardUrl),
+	checkNotSubmitted(appealOverviewUrl),
 	question
 );
 
@@ -90,7 +90,7 @@ router.post(
 	setDefaultSection(),
 	getJourneyResponse(),
 	getJourney(journeys),
-	checkNotSubmitted(dashboardUrl),
+	checkNotSubmitted(appealOverviewUrl),
 	dynamicReqFilesToReqBodyFiles(),
 	validate(),
 	validationErrorHandler,

--- a/packages/forms-web-app/src/routes/rule-6/proof-evidence.js
+++ b/packages/forms-web-app/src/routes/rule-6/proof-evidence.js
@@ -27,10 +27,10 @@ const { caseTypeNameWithDefault } = require('@pins/common/src/lib/format-case-ty
 
 const {
 	VIEW: {
-		RULE_6: { DASHBOARD }
+		RULE_6: { APPEAL_OVERVIEW }
 	}
 } = require('../../lib/views');
-const dashboardUrl = `/${DASHBOARD}`;
+const appealOverviewUrl = APPEAL_OVERVIEW;
 
 const router = express.Router();
 
@@ -54,7 +54,7 @@ router.get(
 	getJourneyResponse(),
 	getJourney(journeys),
 	redirectToUnansweredQuestion([rule6ProofEvidenceSkipConditions]),
-	checkNotSubmitted(dashboardUrl),
+	checkNotSubmitted(appealOverviewUrl),
 	proofOfEvidenceTaskList
 );
 
@@ -63,7 +63,7 @@ router.post(
 	'/proof-evidence/:referenceId',
 	getJourneyResponse(),
 	getJourney(journeys),
-	checkNotSubmitted(dashboardUrl),
+	checkNotSubmitted(appealOverviewUrl),
 	validationErrorHandler,
 	submitRule6ProofEvidence
 );
@@ -82,7 +82,7 @@ router.get(
 	setDefaultSection(),
 	getJourneyResponse(),
 	getJourney(journeys),
-	checkNotSubmitted(dashboardUrl),
+	checkNotSubmitted(appealOverviewUrl),
 	question
 );
 
@@ -92,7 +92,7 @@ router.post(
 	setDefaultSection(),
 	getJourneyResponse(),
 	getJourney(journeys),
-	checkNotSubmitted(dashboardUrl),
+	checkNotSubmitted(appealOverviewUrl),
 	dynamicReqFilesToReqBodyFiles(),
 	validate(),
 	validationErrorHandler,


### PR DESCRIPTION
## Ticket Number

<!-- Add the number from the Jira board -->

https://pins-ds.atlassian.net/browse/A2-1786
https://pins-ds.atlassian.net/browse/A2-1405

## Description of change

<!-- Please describe the change -->
Stops LPA and rule 6 parties entering journeys that are not active
Also stops them entering journeys that are active but already submitted

## Checklist

<!-- Put an `x` in all the boxes that apply: -->

- [ ] Requires infrastructure changes
- [ ] I have updated the documentation accordingly
- [x] My commit history in this PR is linear
- [x] New features have tests
- [ ] Breaking change (team conversation required)

## Important

Please do not merge from `main` (please only [rebase](https://github.com/Planning-Inspectorate/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
