### PR TITLE
feat(a2-2074): handle multiple listed building relationship types

### DIFF
--- a/packages/appeals-service-api/src/routes/v2/appeal-cases/appeal-cases.spec.js
+++ b/packages/appeals-service-api/src/routes/v2/appeal-cases/appeal-cases.spec.js
@@ -4,6 +4,7 @@ const { buildQueryString } = require('@pins/common/src/client/utils');
 const app = require('../../../app');
 const { createPrismaClient } = require('../../../db/db-client');
 const { seedStaticData } = require('@pins/database/src/seed/data-static');
+const { LISTED_RELATION_TYPES } = require('@pins/common/src/database/data-static');
 
 const { isFeatureActive } = require('../../../configuration/featureFlag');
 const { blobMetaGetter } = require('../../../../src/services/object-store');
@@ -372,7 +373,7 @@ describe('appeal-cases', () => {
 			const appealCase = await sqlClient.appealCase.findFirst({
 				where: { caseReference: testCases[0].caseReference },
 				include: {
-					AffectedListedBuildings: true,
+					ListedBuildings: true,
 					AppealCaseLpaNotificationMethod: true,
 					NeighbouringAddresses: true,
 					CaseType: true,
@@ -380,7 +381,9 @@ describe('appeal-cases', () => {
 				}
 			});
 
-			expect(appealCase?.AffectedListedBuildings.length).toBe(3); // the number of listed buildings in example json
+			expect(
+				appealCase?.ListedBuildings.filter((x) => x.type === LISTED_RELATION_TYPES.affected).length
+			).toBe(3); // the number of listed buildings in example json
 			expect(appealCase?.AppealCaseLpaNotificationMethod.length).toBe(2); // the number of notification methods in example json
 			expect(appealCase?.NeighbouringAddresses.length).toBe(4); // the number of neighbouring addresses in example json
 			expect(appealCase?.CaseType?.processCode).toBe('HAS');

--- a/packages/appeals-service-api/src/routes/v2/users/_id/appeal-cases/_caseReference/repo.js
+++ b/packages/appeals-service-api/src/routes/v2/users/_id/appeal-cases/_caseReference/repo.js
@@ -48,7 +48,7 @@ module.exports = class Repo {
 				},
 				include: {
 					Documents: DocumentsArgsPublishedOnly,
-					AffectedListedBuildings: true,
+					ListedBuildings: true,
 					AppealCaseLpaNotificationMethod: true,
 					NeighbouringAddresses: true,
 					ProcedureType: true,
@@ -86,7 +86,7 @@ module.exports = class Repo {
 					},
 					include: {
 						Documents: DocumentsArgsPublishedOnly,
-						AffectedListedBuildings: true,
+						ListedBuildings: true,
 						AppealCaseLpaNotificationMethod: true,
 						NeighbouringAddresses: true,
 						ProcedureType: true,

--- a/packages/appeals-service-api/src/spec/api-types.d.ts
+++ b/packages/appeals-service-api/src/spec/api-types.d.ts
@@ -468,7 +468,7 @@ export interface AppealCase {
 	rule6ProofEvidenceSubmittedDate?: string;
 	interestedPartyCommentsPublished?: boolean;
 	Rule6Parties?: object[];
-	AffectedListedBuildings?: object[];
+	ListedBuildings?: object[];
 	Documents?: object[];
 	NeighbouringAddresses?: object[];
 	Events?: Event[];

--- a/packages/appeals-service-api/src/spec/appeal-case.yaml
+++ b/packages/appeals-service-api/src/spec/appeal-case.yaml
@@ -571,7 +571,7 @@ components:
           items:
             type: object
 
-        AffectedListedBuildings:
+        ListedBuildings:
           type: array
           items:
             type: object

--- a/packages/common/src/database/data-static.js
+++ b/packages/common/src/database/data-static.js
@@ -134,6 +134,14 @@ const CASE_RELATION_TYPES = {
 	nearby: 'nearby'
 };
 
+/**
+ * @type {Object<string, 'affected'|'changed'>}
+ */
+const LISTED_RELATION_TYPES = {
+	affected: 'affected',
+	changed: 'changed'
+};
+
 module.exports = {
 	APPEAL_TO_USER_ROLES,
 	CASE_TYPES,
@@ -143,5 +151,6 @@ module.exports = {
 	CASE_OUTCOMES,
 	CASE_VALIDATION_OUTCOMES,
 	LPAQ_VALIDATION_OUTCOMES,
-	CASE_RELATION_TYPES
+	CASE_RELATION_TYPES,
+	LISTED_RELATION_TYPES
 };

--- a/packages/database/src/migrations/20250115131138_/migration.sql
+++ b/packages/database/src/migrations/20250115131138_/migration.sql
@@ -1,0 +1,19 @@
+BEGIN TRY
+
+BEGIN TRAN;
+
+-- AlterTable
+ALTER TABLE [dbo].[AppealCaseListedBuilding] ADD [type] NVARCHAR(1000) NOT NULL CONSTRAINT [AppealCaseListedBuilding_type_df] DEFAULT 'affected';
+
+COMMIT TRAN;
+
+END TRY
+BEGIN CATCH
+
+IF @@TRANCOUNT > 0
+BEGIN
+    ROLLBACK TRAN;
+END;
+THROW
+
+END CATCH

--- a/packages/database/src/schema.prisma
+++ b/packages/database/src/schema.prisma
@@ -402,7 +402,7 @@ model AppealCase {
   AppellantProofOfEvidenceSubmission AppellantProofOfEvidenceSubmission?
 
   Rule6Parties                    Rule6Party[]
-  AffectedListedBuildings         AppealCaseListedBuilding[]
+  ListedBuildings                 AppealCaseListedBuilding[]
   Documents                       Document[]
   NeighbouringAddresses           NeighbouringAddress[]
   Events                          Event[]
@@ -498,6 +498,8 @@ model AppealCaseListedBuilding {
 
   listedBuildingReference String
   ListedBuilding          ListedBuilding @relation(fields: [listedBuildingReference], references: [reference])
+
+  type String @default("affected")
 }
 
 /// possible notification methods.

--- a/packages/document-service-api/test/developer/developer.test.js
+++ b/packages/document-service-api/test/developer/developer.test.js
@@ -15,7 +15,7 @@ const { appealDocuments } = require('@pins/database/src/seed/appeal-documents-de
 const blobClient = require('#lib/back-office-storage-client');
 const fs = require('fs');
 
-jest.setTimeout(20000);
+jest.setTimeout(100000);
 
 jest.mock('../../src/configuration/featureFlag', () => ({
 	isFeatureActive: () => true

--- a/packages/forms-web-app/src/controllers/selected-appeal/questionnaire-details/constraints-details-rows.test.js
+++ b/packages/forms-web-app/src/controllers/selected-appeal/questionnaire-details/constraints-details-rows.test.js
@@ -1,16 +1,27 @@
 const { APPEALS_CASE_DATA } = require('@pins/common/src/constants');
+const { LISTED_RELATION_TYPES } = require('@pins/common/src/database/data-static');
 const { constraintsRows } = require('./constraints-details-rows');
 const { APPEAL_DOCUMENT_TYPE } = require('pins-data-model');
 
 describe('constraintsRows', () => {
 	it('should create rows with correct data if relevant case data fields exist and field values true/files uploaded/otherwise populated', () => {
 		const caseData = {
-			AffectedListedBuildings: [
+			ListedBuildings: [
 				{
-					listedBuildingReference: 'Building 1'
+					listedBuildingReference: 'Building 1',
+					type: LISTED_RELATION_TYPES.affected
 				},
 				{
-					listedBuildingReference: 'Building 2'
+					listedBuildingReference: 'Building 2',
+					type: LISTED_RELATION_TYPES.affected
+				},
+				{
+					listedBuildingReference: 'Building 3',
+					type: LISTED_RELATION_TYPES.changed
+				},
+				{
+					listedBuildingReference: 'Building 4',
+					type: LISTED_RELATION_TYPES.changed
 				}
 			],
 			scheduledMonument: true,
@@ -38,78 +49,86 @@ describe('constraintsRows', () => {
 			]
 		};
 		const rows = constraintsRows(caseData);
-		expect(rows.length).toEqual(15);
+		expect(rows.length).toEqual(17);
 		expect(rows[0].condition()).toEqual(true);
 		expect(rows[0].keyText).toEqual('Is this the correct type of appeal');
 		expect(rows[0].valueText).toEqual('Yes');
 
 		expect(rows[1].condition()).toEqual(true);
-		expect(rows[1].keyText).toEqual('Affects a listed building');
+		expect(rows[1].keyText).toEqual('Changes a listed building');
 		expect(rows[1].valueText).toEqual('Yes');
 
 		expect(rows[2].condition()).toEqual(true);
 		expect(rows[2].keyText).toEqual('Listed building details');
-		expect(rows[2].valueText).toEqual('Building 1\nBuilding 2');
+		expect(rows[2].valueText).toEqual('Building 3\nBuilding 4');
 
 		expect(rows[3].condition()).toEqual(true);
-		expect(rows[3].keyText).toEqual('Affects a scheduled monument');
+		expect(rows[3].keyText).toEqual('Affects a listed building');
 		expect(rows[3].valueText).toEqual('Yes');
 
 		expect(rows[4].condition()).toEqual(true);
-		expect(rows[4].keyText).toEqual('Conservation area');
-		expect(rows[4].valueText).toEqual('No');
+		expect(rows[4].keyText).toEqual('Listed building details');
+		expect(rows[4].valueText).toEqual('Building 1\nBuilding 2');
 
-		expect(rows[5].condition()).toEqual(false);
-		expect(rows[5].keyText).toEqual('Uploaded conservation area map and guidance');
-		expect(rows[5].valueText).toEqual('No');
-		expect(rows[5].isEscaped).toEqual(true);
+		expect(rows[5].condition()).toEqual(true);
+		expect(rows[5].keyText).toEqual('Affects a scheduled monument');
+		expect(rows[5].valueText).toEqual('Yes');
 
 		expect(rows[6].condition()).toEqual(true);
-		expect(rows[6].keyText).toEqual('Protected species');
-		expect(rows[6].valueText).toEqual('Yes');
+		expect(rows[6].keyText).toEqual('Conservation area');
+		expect(rows[6].valueText).toEqual('No');
 
-		expect(rows[7].condition()).toEqual(true);
-		expect(rows[7].keyText).toEqual('Green belt');
-		expect(rows[7].valueText).toEqual('Yes');
+		expect(rows[7].condition()).toEqual(false);
+		expect(rows[7].keyText).toEqual('Uploaded conservation area map and guidance');
+		expect(rows[7].valueText).toEqual('No');
+		expect(rows[7].isEscaped).toEqual(true);
 
 		expect(rows[8].condition()).toEqual(true);
-		expect(rows[8].keyText).toEqual('Area of outstanding natural beauty');
+		expect(rows[8].keyText).toEqual('Protected species');
 		expect(rows[8].valueText).toEqual('Yes');
 
 		expect(rows[9].condition()).toEqual(true);
-		expect(rows[9].keyText).toEqual('Designated sites');
+		expect(rows[9].keyText).toEqual('Green belt');
 		expect(rows[9].valueText).toEqual('Yes');
 
 		expect(rows[10].condition()).toEqual(true);
-		expect(rows[10].keyText).toEqual('Tree Preservation Order');
+		expect(rows[10].keyText).toEqual('Area of outstanding natural beauty');
 		expect(rows[10].valueText).toEqual('Yes');
 
 		expect(rows[11].condition()).toEqual(true);
-		expect(rows[11].keyText).toEqual('Uploaded Tree Preservation Order extent');
-		expect(rows[11].valueText).toEqual(
-			'<a href="/published-document/12347" class="govuk-link">tree.pdf</a>'
-		);
-		expect(rows[11].isEscaped).toEqual(true);
+		expect(rows[11].keyText).toEqual('Designated sites');
+		expect(rows[11].valueText).toEqual('Yes');
 
 		expect(rows[12].condition()).toEqual(true);
-		expect(rows[12].keyText).toEqual('Gypsy or Traveller');
+		expect(rows[12].keyText).toEqual('Tree Preservation Order');
 		expect(rows[12].valueText).toEqual('Yes');
 
 		expect(rows[13].condition()).toEqual(true);
-		expect(rows[13].keyText).toEqual('Public right of way');
-		expect(rows[13].valueText).toEqual('Yes');
+		expect(rows[13].keyText).toEqual('Uploaded Tree Preservation Order extent');
+		expect(rows[13].valueText).toEqual(
+			'<a href="/published-document/12347" class="govuk-link">tree.pdf</a>'
+		);
+		expect(rows[13].isEscaped).toEqual(true);
 
 		expect(rows[14].condition()).toEqual(true);
-		expect(rows[14].keyText).toEqual('Uploaded definitive map and statement extract');
-		expect(rows[14].valueText).toEqual(
+		expect(rows[14].keyText).toEqual('Gypsy or Traveller');
+		expect(rows[14].valueText).toEqual('Yes');
+
+		expect(rows[15].condition()).toEqual(true);
+		expect(rows[15].keyText).toEqual('Public right of way');
+		expect(rows[15].valueText).toEqual('Yes');
+
+		expect(rows[16].condition()).toEqual(true);
+		expect(rows[16].keyText).toEqual('Uploaded definitive map and statement extract');
+		expect(rows[16].valueText).toEqual(
 			'<a href="/published-document/12348" class="govuk-link">definitive-statement.pdf</a>'
 		);
-		expect(rows[14].isEscaped).toEqual(true);
+		expect(rows[16].isEscaped).toEqual(true);
 	});
 
 	it('should create rows with correct data if relevant case data fields and field values false/no files uploaded/otherwise not populated', () => {
 		const caseData = {
-			AffectedListedBuildings: [],
+			ListedBuildings: [],
 			scheduledMonument: false,
 			isCorrectAppealType: false,
 			protectedSpecies: false,
@@ -122,81 +141,89 @@ describe('constraintsRows', () => {
 			Documents: []
 		};
 		const rows = constraintsRows(caseData);
-		expect(rows.length).toEqual(15);
+		expect(rows.length).toEqual(17);
 		expect(rows[0].condition()).toEqual(true);
 		expect(rows[0].keyText).toEqual('Is this the correct type of appeal');
 		expect(rows[0].valueText).toEqual('No');
 
-		expect(rows[1].condition()).toEqual(true);
-		expect(rows[1].keyText).toEqual('Affects a listed building');
+		expect(rows[1].condition()).toEqual(false);
+		expect(rows[1].keyText).toEqual('Changes a listed building');
 		expect(rows[1].valueText).toEqual('No');
 
 		expect(rows[2].condition()).toEqual(false);
 		expect(rows[2].keyText).toEqual('Listed building details');
 		expect(rows[2].valueText).toEqual('');
 
-		expect(rows[3].condition()).toEqual(true);
-		expect(rows[3].keyText).toEqual('Affects a scheduled monument');
+		expect(rows[3].condition()).toEqual(false);
+		expect(rows[3].keyText).toEqual('Affects a listed building');
 		expect(rows[3].valueText).toEqual('No');
 
-		expect(rows[4].condition()).toEqual(true);
-		expect(rows[4].keyText).toEqual('Conservation area');
-		expect(rows[4].valueText).toEqual('No');
+		expect(rows[4].condition()).toEqual(false);
+		expect(rows[4].keyText).toEqual('Listed building details');
+		expect(rows[4].valueText).toEqual('');
 
-		expect(rows[5].condition()).toEqual(false);
-		expect(rows[5].keyText).toEqual('Uploaded conservation area map and guidance');
+		expect(rows[5].condition()).toEqual(true);
+		expect(rows[5].keyText).toEqual('Affects a scheduled monument');
 		expect(rows[5].valueText).toEqual('No');
-		expect(rows[5].isEscaped).toEqual(true);
 
 		expect(rows[6].condition()).toEqual(true);
-		expect(rows[6].keyText).toEqual('Protected species');
+		expect(rows[6].keyText).toEqual('Conservation area');
 		expect(rows[6].valueText).toEqual('No');
 
-		expect(rows[7].condition()).toEqual(true);
-		expect(rows[7].keyText).toEqual('Green belt');
+		expect(rows[7].condition()).toEqual(false);
+		expect(rows[7].keyText).toEqual('Uploaded conservation area map and guidance');
 		expect(rows[7].valueText).toEqual('No');
+		expect(rows[7].isEscaped).toEqual(true);
 
 		expect(rows[8].condition()).toEqual(true);
-		expect(rows[8].keyText).toEqual('Area of outstanding natural beauty');
+		expect(rows[8].keyText).toEqual('Protected species');
 		expect(rows[8].valueText).toEqual('No');
 
 		expect(rows[9].condition()).toEqual(true);
-		expect(rows[9].keyText).toEqual('Designated sites');
+		expect(rows[9].keyText).toEqual('Green belt');
 		expect(rows[9].valueText).toEqual('No');
 
 		expect(rows[10].condition()).toEqual(true);
-		expect(rows[10].keyText).toEqual('Tree Preservation Order');
+		expect(rows[10].keyText).toEqual('Area of outstanding natural beauty');
 		expect(rows[10].valueText).toEqual('No');
 
-		expect(rows[11].condition()).toEqual(false);
-		expect(rows[11].keyText).toEqual('Uploaded Tree Preservation Order extent');
+		expect(rows[11].condition()).toEqual(true);
+		expect(rows[11].keyText).toEqual('Designated sites');
 		expect(rows[11].valueText).toEqual('No');
-		expect(rows[11].isEscaped).toEqual(true);
 
 		expect(rows[12].condition()).toEqual(true);
-		expect(rows[12].keyText).toEqual('Gypsy or Traveller');
+		expect(rows[12].keyText).toEqual('Tree Preservation Order');
 		expect(rows[12].valueText).toEqual('No');
 
-		expect(rows[13].condition()).toEqual(true);
-		expect(rows[13].keyText).toEqual('Public right of way');
+		expect(rows[13].condition()).toEqual(false);
+		expect(rows[13].keyText).toEqual('Uploaded Tree Preservation Order extent');
 		expect(rows[13].valueText).toEqual('No');
+		expect(rows[13].isEscaped).toEqual(true);
 
-		expect(rows[14].condition()).toEqual(false);
-		expect(rows[14].keyText).toEqual('Uploaded definitive map and statement extract');
+		expect(rows[14].condition()).toEqual(true);
+		expect(rows[14].keyText).toEqual('Gypsy or Traveller');
 		expect(rows[14].valueText).toEqual('No');
-		expect(rows[14].isEscaped).toEqual(true);
+
+		expect(rows[15].condition()).toEqual(true);
+		expect(rows[15].keyText).toEqual('Public right of way');
+		expect(rows[15].valueText).toEqual('No');
+
+		expect(rows[16].condition()).toEqual(false);
+		expect(rows[16].keyText).toEqual('Uploaded definitive map and statement extract');
+		expect(rows[16].valueText).toEqual('No');
+		expect(rows[16].isEscaped).toEqual(true);
 	});
 
 	it('should create rows with correct conditions if fields do not exist', () => {
 		const rows = constraintsRows({ Documents: [] });
-		expect(rows.length).toEqual(15);
+		expect(rows.length).toEqual(17);
 		expect(rows[0].condition()).toEqual(false);
 		expect(rows[1].condition()).toEqual(false);
 		expect(rows[2].condition()).toEqual(false);
 		expect(rows[3].condition()).toEqual(false);
-		expect(rows[4].condition()).toEqual(true);
+		expect(rows[4].condition()).toEqual(false);
 		expect(rows[5].condition()).toEqual(false);
-		expect(rows[6].condition()).toEqual(false);
+		expect(rows[6].condition()).toEqual(true);
 		expect(rows[7].condition()).toEqual(false);
 		expect(rows[8].condition()).toEqual(false);
 		expect(rows[9].condition()).toEqual(false);
@@ -205,18 +232,30 @@ describe('constraintsRows', () => {
 		expect(rows[12].condition()).toEqual(false);
 		expect(rows[13].condition()).toEqual(false);
 		expect(rows[14].condition()).toEqual(false);
+		expect(rows[15].condition()).toEqual(false);
+		expect(rows[16].condition()).toEqual(false);
 	});
 
 	it('should create rows with correct data for HAS appeal', () => {
 		const caseData = {
 			appealTypeCode: APPEALS_CASE_DATA.APPEAL_TYPE_CODE.HAS,
 			isCorrectAppealType: true,
-			AffectedListedBuildings: [
+			ListedBuildings: [
 				{
-					listedBuildingReference: 'Building 1'
+					listedBuildingReference: 'Building 1',
+					type: LISTED_RELATION_TYPES.affected
 				},
 				{
-					listedBuildingReference: 'Building 2'
+					listedBuildingReference: 'Building 2',
+					type: LISTED_RELATION_TYPES.affected
+				},
+				{
+					listedBuildingReference: 'Building 3',
+					type: LISTED_RELATION_TYPES.changed
+				},
+				{
+					listedBuildingReference: 'Building 4',
+					type: LISTED_RELATION_TYPES.changed
 				}
 			],
 			scheduledMonument: false,
@@ -238,44 +277,52 @@ describe('constraintsRows', () => {
 		};
 		const rows = constraintsRows(caseData);
 
-		expect(rows.length).toEqual(15);
+		expect(rows.length).toEqual(17);
 		expect(rows[0].condition()).toEqual(true);
 		expect(rows[0].keyText).toEqual('Is this the correct type of appeal');
 		expect(rows[0].valueText).toEqual('Yes');
 
 		expect(rows[1].condition()).toEqual(true);
-		expect(rows[1].keyText).toEqual('Affects a listed building');
+		expect(rows[1].keyText).toEqual('Changes a listed building');
 		expect(rows[1].valueText).toEqual('Yes');
 
 		expect(rows[2].condition()).toEqual(true);
 		expect(rows[2].keyText).toEqual('Listed building details');
-		expect(rows[2].valueText).toEqual('Building 1\nBuilding 2');
+		expect(rows[2].valueText).toEqual('Building 3\nBuilding 4');
 
-		expect(rows[3].condition()).toEqual(false);
+		expect(rows[3].condition()).toEqual(true);
+		expect(rows[3].keyText).toEqual('Affects a listed building');
+		expect(rows[3].valueText).toEqual('Yes');
 
 		expect(rows[4].condition()).toEqual(true);
-		expect(rows[4].keyText).toEqual('Conservation area');
-		expect(rows[4].valueText).toEqual('Yes');
+		expect(rows[4].keyText).toEqual('Listed building details');
+		expect(rows[4].valueText).toEqual('Building 1\nBuilding 2');
 
-		expect(rows[5].condition()).toEqual(true);
-		expect(rows[5].keyText).toEqual('Uploaded conservation area map and guidance');
-		expect(rows[5].valueText).toEqual(
-			'<a href="/published-document/12345" class="govuk-link">conservationmap1.pdf</a>\n<a href="/published-document/12346" class="govuk-link">conservationmap2.pdf</a>'
-		);
-		expect(rows[5].isEscaped).toEqual(true);
+		expect(rows[5].condition()).toEqual(false);
 
-		expect(rows[6].condition()).toEqual(false);
+		expect(rows[6].condition()).toEqual(true);
+		expect(rows[6].keyText).toEqual('Conservation area');
+		expect(rows[6].valueText).toEqual('Yes');
 
 		expect(rows[7].condition()).toEqual(true);
-		expect(rows[7].keyText).toEqual('Green belt');
-		expect(rows[7].valueText).toEqual('Yes');
+		expect(rows[7].keyText).toEqual('Uploaded conservation area map and guidance');
+		expect(rows[7].valueText).toEqual(
+			'<a href="/published-document/12345" class="govuk-link">conservationmap1.pdf</a>\n<a href="/published-document/12346" class="govuk-link">conservationmap2.pdf</a>'
+		);
+		expect(rows[7].isEscaped).toEqual(true);
 
 		expect(rows[8].condition()).toEqual(false);
-		expect(rows[9].condition()).toEqual(false);
+
+		expect(rows[9].condition()).toEqual(true);
+		expect(rows[9].keyText).toEqual('Green belt');
+		expect(rows[9].valueText).toEqual('Yes');
+
 		expect(rows[10].condition()).toEqual(false);
 		expect(rows[11].condition()).toEqual(false);
 		expect(rows[12].condition()).toEqual(false);
 		expect(rows[13].condition()).toEqual(false);
 		expect(rows[14].condition()).toEqual(false);
+		expect(rows[15].condition()).toEqual(false);
+		expect(rows[16].condition()).toEqual(false);
 	});
 });


### PR DESCRIPTION
## Ticket Number

<!-- Add the number from the Jira board -->

https://pins-ds.atlassian.net/browse/A2-2074

## Description of change

Handling s78 cases from back office - we need to handle a different listed building array
Adds a type field to the database relation and propagates that throughout the codebase
Handles adding relations on put, currently this will be unused until we receive s78 cases

## Checklist

<!-- Put an `x` in all the boxes that apply: -->

- [ ] Requires infrastructure changes
- [ ] I have updated the documentation accordingly
- [x] My commit history in this PR is linear
- [x] New features have tests
- [ ] Breaking change (team conversation required)

## Important

Please do not merge from `main` (please only [rebase](https://github.com/Planning-Inspectorate/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
