### PR TITLE
chore: switch lpa for seed data

### DIFF
--- a/packages/database/src/seed/data-dev.js
+++ b/packages/database/src/seed/data-dev.js
@@ -123,6 +123,14 @@ const lpaUsers = {
 		isLpaAdmin: true,
 		lpaCode: 'Q9999',
 		lpaStatus: 'confirmed'
+	},
+	lpaAdmin2: {
+		id: '59a82253-4309-45c4-8f6e-5412e2e9be9b',
+		email: 'admin2@planninginspectorate.gov.uk',
+		isLpaUser: true,
+		isLpaAdmin: true,
+		lpaCode: 'Q1111',
+		lpaStatus: 'confirmed'
 	}
 };
 
@@ -263,6 +271,7 @@ const users = [
 	lpaUsers.lpaUser,
 	lpaUsers.lpaUser2,
 	lpaUsers.lpaAdmin,
+	lpaUsers.lpaAdmin2,
 	appellants.appellantOne,
 	appellants.appellantTwo,
 	appellants.appellantThree,
@@ -315,7 +324,7 @@ const appeals = [
 ];
 
 const commonAppealProperties = {
-	LPACode: 'Q9999',
+	LPACode: 'Q1111',
 	siteAddressLine1: '123 Fake Street',
 	siteAddressTown: 'Testville',
 	siteAddressCounty: 'Countyshire',
@@ -343,7 +352,7 @@ const appealCases = [
 		},
 		caseReference: caseReferences.caseReferenceNine,
 		caseId: 131313,
-		LPACode: 'Q9999',
+		LPACode: 'Q1111',
 		CaseType: {
 			connect: { processCode: 'HAS' }
 		},
@@ -622,7 +631,7 @@ const appealCases = [
 		Appeal: {
 			connect: { id: appealIds.appeal12 }
 		},
-		LPACode: 'Q9999',
+		LPACode: 'Q1111',
 		siteAddressLine1: '123 Fake Street',
 		siteAddressTown: 'Birmingham',
 		siteAddressCounty: 'West Midlands',
@@ -652,7 +661,7 @@ const appealCases = [
 		Appeal: {
 			connect: { id: appealIds.appeal13 }
 		},
-		LPACode: 'Q9999',
+		LPACode: 'Q1111',
 		siteAddressLine1: '124 Fake Street',
 		siteAddressTown: 'Bristol',
 		siteAddressCounty: 'Bristolshire',
@@ -682,7 +691,7 @@ const appealCases = [
 		Appeal: {
 			connect: { id: appealIds.appeal14 }
 		},
-		LPACode: 'Q9999',
+		LPACode: 'Q1111',
 		siteAddressLine1: '124 Fake Street',
 		siteAddressTown: 'Bristol',
 		siteAddressCounty: 'Bristolshire',
@@ -716,7 +725,7 @@ const appealCases = [
 		Appeal: {
 			connect: { id: appealIds.appeal15 }
 		},
-		LPACode: 'Q9999',
+		LPACode: 'Q1111',
 		siteAddressLine1: '125 Fake Street',
 		siteAddressTown: 'Bristol',
 		siteAddressCounty: 'Bristolshire',
@@ -757,7 +766,7 @@ const appealCases = [
 		Appeal: {
 			connect: { id: appealIds.appeal16 }
 		},
-		LPACode: 'Q9999',
+		LPACode: 'Q1111',
 		siteAddressLine1: '124 Fake Street',
 		siteAddressTown: 'Bristol',
 		siteAddressCounty: 'Bristolshire',
@@ -1441,7 +1450,7 @@ const interestedPartyComments = [
 const appealStatements = [
 	{
 		id: appealStatementIds.appealStatementOne,
-		lpaCode: 'Q9999',
+		lpaCode: 'Q1111',
 		submittedDate: pickRandom(datesNMonthsAgo(0.5)),
 		statement:
 			'Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aenean commodo ligula eget dolor. Aenean massa. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Donec quam felis, ultricies nec, pellentesque eu, pretium quis, sem. Nulla consequat massa quis enim. Donec pede justo, fringilla vel, aliquet nec, vulputate eget, arcu. In enim justo, rhoncus ut, imperdiet a, venenatis vitae, justo. Nullam dictum felis eu pede mollis pretium. Integer tincidunt. Cras dapibus. Vivamus elementum semper nisi. Aenean vulputate eleifend tellus. Aenean leo ligula, porttitor eu, consequat vitae, eleifend ac, enim. Aliquam lorem ante, dapibus in, viverra quis, feugiat a, tellus. Phasellus viverra nulla ut metus varius laoreet. Quisque rutrum. Aenean imperdiet. Etiam ultricies nisi vel augue. Curabitur ullamcorper ultricies nisi. Nam eget dui. Etiam rhoncus. Maecenas tempus, tellus eget condimentum rhoncus, sem quam semper libero, sit amet adipiscing sem neque sed ipsum.',
@@ -1453,7 +1462,7 @@ const appealStatements = [
 	},
 	{
 		id: appealStatementIds.appealStatementTwo,
-		lpaCode: 'Q9999',
+		lpaCode: 'Q1111',
 		submittedDate: pickRandom(datesNMonthsAgo(0.5)),
 		statement:
 			'Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aenean commodo ligula eget dolor. Aenean massa. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Donec quam felis, ultricies nec, pellentesque eu, pretium quis, sem. Nulla consequat massa quis enim. Donec pede justo, fringilla vel, aliquet nec, vulputate eget, arcu. In enim justo, rhoncus ut, imperdiet a, venenatis vitae, justo. Nullam dictum felis eu pede mollis pretium. Integer tincidunt. Cras dapibus. Vivamus elementum semper nisi. Aenean vulputate eleifend tellus. Aenean leo ligula, porttitor eu, consequat vitae, eleifend ac, enim. Aliquam lorem ante, dapibus in, viverra quis, feugiat a, tellus. Phasellus viverra nulla ut metus varius laoreet. Quisque rutrum. Aenean imperdiet. Etiam ultricies nisi vel augue. Curabitur ullamcorper ultricies nisi. Nam eget dui. Etiam rhoncus.',
@@ -1490,7 +1499,7 @@ const statementDocuments = [
 const appealFinalComments = [
 	{
 		id: appealFinalCommentIds.appealFinalCommentOne,
-		lpaCode: 'Q9999',
+		lpaCode: 'Q1111',
 		submittedDate: pickRandom(datesNMonthsAgo(0.5)),
 		comments:
 			'This is the LPA final comment. Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aenean commodo ligula eget dolor. Aenean massa. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Donec quam felis, ultricies nec, pellentesque eu, pretium quis, sem. Nulla consequat massa quis enim. Donec pede justo, fringilla vel, aliquet nec, vulputate eget, arcu. In enim justo, rhoncus ut, imperdiet a, venenatis vitae, justo. Nullam dictum felis eu pede mollis pretium. Integer tincidunt. Cras dapibus. Vivamus elementum semper nisi. Aenean vulputate eleifend tellus. Aenean leo ligula, porttitor eu, consequat vitae, eleifend ac, enim. Aliquam lorem ante, dapibus in, viverra quis, feugiat a, tellus. Phasellus viverra nulla ut metus varius laoreet. Quisque rutrum. Aenean imperdiet. Etiam ultricies nisi vel augue. Curabitur ullamcorper ultricies nisi. Nam eget dui. Etiam rhoncus.',
@@ -1503,7 +1512,7 @@ const appealFinalComments = [
 	},
 	{
 		id: appealFinalCommentIds.appealFinalCommentTwo,
-		lpaCode: 'Q9999',
+		lpaCode: 'Q1111',
 		submittedDate: pickRandom(datesNMonthsAgo(0.5)),
 		comments:
 			'This is the LPA final comment. Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aenean commodo ligula eget dolor. Aenean massa. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Donec quam felis, ultricies nec, pellentesque eu, pretium quis, sem. Nulla consequat massa quis enim. Donec pede justo, fringilla vel, aliquet nec, vulputate eget, arcu. In enim justo, rhoncus ut, imperdiet a, venenatis vitae, justo. Nullam dictum felis eu pede mollis pretium. Integer tincidunt. Cras dapibus. Vivamus elementum semper nisi. Aenean vulputate eleifend tellus. Aenean leo ligula, porttitor eu, consequat vitae, eleifend ac, enim. Aliquam lorem ante, dapibus in, viverra quis, feugiat a, tellus. Phasellus viverra nulla ut metus varius laoreet. Quisque rutrum. Aenean imperdiet. Etiam ultricies nisi vel augue. Curabitur ullamcorper ultricies nisi. Nam eget dui. Etiam rhoncus.',
@@ -1589,7 +1598,7 @@ const appellantSubmissions = [
 	// v2 appellant submissions
 	{
 		id: appellantSubmissionIds.appellantSubmissionOne,
-		LPACode: 'Q9999',
+		LPACode: 'Q1111',
 		appealTypeCode: 'HAS',
 		Appeal: {
 			connect: { id: appealIds.appealOne }
@@ -1598,7 +1607,7 @@ const appellantSubmissions = [
 	},
 	{
 		id: appellantSubmissionIds.appellantSubmissionTwo,
-		LPACode: 'Q9999',
+		LPACode: 'Q1111',
 		appealTypeCode: 'HAS',
 		applicationDecisionDate: new Date(),
 		Appeal: {
@@ -1607,7 +1616,7 @@ const appellantSubmissions = [
 	},
 	{
 		id: appellantSubmissionIds.appellantSubmissionThree,
-		LPACode: 'Q9999',
+		LPACode: 'Q1111',
 		appealTypeCode: 'HAS',
 		applicationDecisionDate: new Date('2024-03-01'),
 		Appeal: {

--- a/packages/database/src/seed/lpa-appeal-case-data-dev.js
+++ b/packages/database/src/seed/lpa-appeal-case-data-dev.js
@@ -77,7 +77,7 @@ const lpaAppeals = [
 ];
 
 const commonAppealCaseDataProperties = {
-	LPACode: 'Q9999',
+	LPACode: 'Q1111',
 	applicationDecision: 'refused',
 	applicationDecisionDate: pickRandom(datesNMonthsAgo(1)),
 	applicationDate: pickRandom(datesNMonthsAgo(2)),
@@ -617,7 +617,7 @@ const lpaAppealCaseData = [
 		Appeal: {
 			connect: { id: lpaAppealIds.appeal17 }
 		},
-		LPACode: 'Q1111',
+		LPACode: 'Q9999',
 		applicationDecision: 'refused',
 		applicationDecisionDate: pickRandom(datesNMonthsAgo(1)),
 		applicationDate: pickRandom(datesNMonthsAgo(2)),
@@ -938,7 +938,7 @@ const lpaAppealCaseData = [
 		Appeal: {
 			connect: { id: lpaAppealIds.appeal26 }
 		},
-		LPACode: 'Q9999',
+		LPACode: 'Q1111',
 		applicationDecision: 'refused',
 		applicationDecisionDate: pickRandom(datesNMonthsAgo(1)),
 		appellantCostsAppliedFor: true,
@@ -1031,7 +1031,7 @@ const lpaAppealCaseData = [
 		Appeal: {
 			connect: { id: lpaAppealIds.appeal27 }
 		},
-		LPACode: 'Q9999',
+		LPACode: 'Q1111',
 		applicationDecision: 'refused',
 		applicationDecisionDate: pickRandom(datesNMonthsAgo(1)),
 		appellantCostsAppliedFor: true,
@@ -1124,7 +1124,7 @@ const lpaAppealCaseData = [
 		Appeal: {
 			connect: { id: lpaAppealIds.appeal28 }
 		},
-		LPACode: 'Q9999',
+		LPACode: 'Q1111',
 		applicationDecision: 'refused',
 		applicationDecisionDate: pickRandom(datesNMonthsAgo(1)),
 		appellantCostsAppliedFor: true,
@@ -1217,7 +1217,7 @@ const lpaAppealCaseData = [
 		Appeal: {
 			connect: { id: lpaAppealIds.appealFifteen }
 		},
-		LPACode: 'Q9999',
+		LPACode: 'Q1111',
 		applicationDecision: 'refused',
 		applicationDecisionDate: pickRandom(datesNMonthsAgo(1)),
 		appellantCostsAppliedFor: true,


### PR DESCRIPTION
## Ticket Number

<!-- Add the number from the Jira board -->

## Description of change

Update Q1111 to be the main LPA used for seed data for v2 appeals

## Checklist

<!-- Put an `x` in all the boxes that apply: -->

- [ ] Requires infrastructure changes
- [ ] I have updated the documentation accordingly
- [ ] My commit history in this PR is linear
- [ ] New features have tests
- [ ] Breaking change (team conversation required)

## Important

Please do not merge from `main` (please only [rebase](https://github.com/Planning-Inspectorate/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
