### PR TITLE
Fix/a2 2156 decided appeals page no results

### DIFF
--- a/packages/forms-web-app/src/routes/file-based-router/comment-planning-appeal/appeals/controller.js
+++ b/packages/forms-web-app/src/routes/file-based-router/comment-planning-appeal/appeals/controller.js
@@ -10,6 +10,13 @@ const { SERVICE_USER_TYPE } = require('pins-data-model');
 /** @type {import('express').RequestHandler} */
 const appeals = async (req, res) => {
 	const postcode = req.query.search || req.session.interestedParty?.searchPostcode;
+
+	// remove navigation reference and redirect to first page if no postcode
+	if (!postcode) {
+		req.session.navigationHistory.shift();
+		return res.redirect('enter-appeal-reference');
+	}
+
 	/** @type {import('#utils/appeals-view').AppealViewModel[]} */
 	const postcodeSearchResults = await req.appealsApiClient.getPostcodeSearchResults({
 		postcode,

--- a/packages/forms-web-app/src/routes/file-based-router/comment-planning-appeal/appeals/controller.test.js
+++ b/packages/forms-web-app/src/routes/file-based-router/comment-planning-appeal/appeals/controller.test.js
@@ -31,6 +31,19 @@ describe('appeals Controller Tests', () => {
 		};
 	});
 
+	it('should handle navigation history and redirect if session + query params do not contain postcode', async () => {
+		req.query.search = undefined;
+		req.session = {
+			interestedParty: {},
+			navigationHistory: ['test1', 'test2']
+		};
+
+		await appeals(req, res);
+
+		expect(res.redirect).toHaveBeenCalledWith('enter-appeal-reference');
+		expect(req.session.navigationHistory).toEqual(['test2']);
+	});
+
 	it('should redirect to no-results page with correct navigation history if no search results are found', async () => {
 		req.query.search = 'AB12 3CD';
 		req.appealsApiClient.getPostcodeSearchResults.mockResolvedValue([]);

--- a/packages/forms-web-app/src/routes/file-based-router/comment-planning-appeal/decided-appeals/controller.js
+++ b/packages/forms-web-app/src/routes/file-based-router/comment-planning-appeal/decided-appeals/controller.js
@@ -14,22 +14,19 @@ const decidedAppeals = async (req, res) => {
 		'decided-only': true
 	});
 
-	if (!decidedAppeals.length) {
-		return res.redirect(`appeal-search-no-results?search=${postcode}`);
+	if (decidedAppeals) {
+		decidedAppeals.forEach((appeal) => {
+			appeal.formattedAddress = formatAddress(appeal);
+			appeal.formattedCaseDecisionDate = formatDateForDisplay(appeal.caseDecisionOutcomeDate);
+			appeal.formattedDecisionColour = mapDecisionColour(appeal.caseDecisionOutcome);
+			appeal.appealTypeName = caseTypeNameWithDefault(appeal.appealTypeCode);
+			appeal.caseDecisionOutcome =
+				appeal.caseDecisionOutcome in APPEAL_CASE_DECISION_OUTCOME
+					? APPEAL_CASE_DECISION_OUTCOME[appeal.caseDecisionOutcome].name
+					: appeal.caseDecisionOutcome;
+		});
+		decidedAppeals.sort(sortByCaseDecisionDate);
 	}
-
-	decidedAppeals.forEach((appeal) => {
-		appeal.formattedAddress = formatAddress(appeal);
-		appeal.formattedCaseDecisionDate = formatDateForDisplay(appeal.caseDecisionOutcomeDate);
-		appeal.formattedDecisionColour = mapDecisionColour(appeal.caseDecisionOutcome);
-		appeal.appealTypeName = caseTypeNameWithDefault(appeal.appealTypeCode);
-		appeal.caseDecisionOutcome =
-			appeal.caseDecisionOutcome in APPEAL_CASE_DECISION_OUTCOME
-				? APPEAL_CASE_DECISION_OUTCOME[appeal.caseDecisionOutcome].name
-				: appeal.caseDecisionOutcome;
-	});
-
-	decidedAppeals.sort(sortByCaseDecisionDate);
 
 	let renderLocals = { postcode, decidedAppeals };
 

--- a/packages/forms-web-app/src/routes/file-based-router/comment-planning-appeal/decided-appeals/controller.js
+++ b/packages/forms-web-app/src/routes/file-based-router/comment-planning-appeal/decided-appeals/controller.js
@@ -8,6 +8,13 @@ const { formatDateForDisplay } = require('@pins/common/src/lib/format-date');
 /** @type {import('express').RequestHandler} */
 const decidedAppeals = async (req, res) => {
 	const postcode = req.query.search || req.session.interestedParty?.searchPostcode;
+
+	// remove navigation reference and redirect to first page if no postcode
+	if (!postcode) {
+		req.session.navigationHistory.shift();
+		return res.redirect('enter-appeal-reference');
+	}
+
 	/** @type {import('#utils/appeals-view').AppealViewModel[]} */
 	const decidedAppeals = await req.appealsApiClient.getPostcodeSearchResults({
 		postcode,

--- a/packages/forms-web-app/src/routes/file-based-router/comment-planning-appeal/decided-appeals/controller.test.js
+++ b/packages/forms-web-app/src/routes/file-based-router/comment-planning-appeal/decided-appeals/controller.test.js
@@ -53,6 +53,31 @@ describe('decidedAppeals', () => {
 		});
 	});
 
+	it('should render correctly if no results returned from appeals API', async () => {
+		req.session = { interestedParty: { searchPostcode: 'AB12 3CD' } };
+		req.appealsApiClient.getPostcodeSearchResults.mockResolvedValue([]);
+
+		await decidedAppeals(req, res);
+
+		expect(res.render).toHaveBeenCalledWith('comment-planning-appeal/decided-appeals/index', {
+			postcode: 'AB12 3CD',
+			decidedAppeals: []
+		});
+	});
+
+	it('should handle no postcode existing in the session + in the url query params', async () => {
+		req.session = {
+			interestedParty: {},
+			navigationHistory: ['page1', 'page2']
+		};
+		req.query.search = undefined;
+
+		await decidedAppeals(req, res);
+
+		expect(res.redirect).toHaveBeenCalledWith('enter-appeal-reference');
+		expect(req.session.navigationHistory).toEqual(['page2']);
+	});
+
 	it('should override default backlink if no postcode in session', async () => {
 		req.session = { navigationHistory: ['thispage', 'lastpage'] };
 		req.appealsApiClient.getPostcodeSearchResults.mockResolvedValue([appeal]);

--- a/packages/forms-web-app/src/routes/file-based-router/comment-planning-appeal/decided-appeals/controller.test.js
+++ b/packages/forms-web-app/src/routes/file-based-router/comment-planning-appeal/decided-appeals/controller.test.js
@@ -32,12 +32,6 @@ describe('decidedAppeals', () => {
 		};
 	});
 
-	it('should redirect to no results page if no appeals are found', async () => {
-		req.appealsApiClient.getPostcodeSearchResults.mockResolvedValue([]);
-		await decidedAppeals(req, res);
-		expect(res.redirect).toHaveBeenCalledWith('appeal-search-no-results?search=AB12 3CD');
-	});
-
 	it('should format and sort appeals correctly and render the results', async () => {
 		req.session = { interestedParty: { searchPostcode: 'AB12 3CD' } };
 		req.appealsApiClient.getPostcodeSearchResults.mockResolvedValue([appeal]);

--- a/packages/forms-web-app/src/routes/file-based-router/comment-planning-appeal/decided-appeals/index.njk
+++ b/packages/forms-web-app/src/routes/file-based-router/comment-planning-appeal/decided-appeals/index.njk
@@ -5,6 +5,7 @@
  {%- from "govuk/components/tag/macro.njk" import govukTag -%}
 
 {% block content %}
+  {% if decidedAppeals.length %}
   <div class="govuk-form-group">
     <h1 class="govuk-label govuk-label--l">{{ decidedAppeals.length }} decided Appeals found {{ postcode }}</h1>
     <table class="govuk-table govuk-!-margin-top-3">
@@ -39,4 +40,14 @@
       </tbody>
     </table>
   </div>
+  {% else %}
+    <h1 class="govuk-heading-l">Decided appeals at {{ postcode }}</h1>
+    <h2 class="govuk-heading-m">0 results</h2>
+    <p class="govuk-body">There are no decided appeals at {{ postcode }}.</p>
+    <p class="govuk-body">You can:</p>
+    <ul class="govuk-list govuk-list--bullet">
+        <li><a href="enter-postcode" class="govuk-link">enter a different postcode</a></li>
+        <li>try searching for this case on the <a href="https://acp.planninginspectorate.gov.uk/" class="govuk-link"> Appeals Casework Portal</a></li>
+    </ul>
+  {% endif %}
 {% endblock content %}

--- a/packages/forms-web-app/src/views/layouts/comment-planning-appeal/main.njk
+++ b/packages/forms-web-app/src/views/layouts/comment-planning-appeal/main.njk
@@ -4,7 +4,7 @@
 {% from "govuk/components/back-link/macro.njk" import govukBackLink %}
 {% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
 {% block pageTitle %}
-  {{ "Error: " + title if errors else title }}  - Comment on a planning appeal - GOV.UK
+  {{ "Error: " + title if errors or error else title }}  - Comment on a planning appeal - GOV.UK
 {% endblock pageTitle %}
 {% block head %}
   {% include "includes/head.njk" %}


### PR DESCRIPTION
## Ticket Number

<!-- Add the number from the Jira board -->

https://pins-ds.atlassian.net/browse/A2-2156

## Description of change

<!-- Please describe the change -->

* display appropriate text on decided appeals page if no results
* handle navigation given issues with not preserving postcode information
* add 'Error' to page title text if postcode validation fails  

## Checklist

<!-- Put an `x` in all the boxes that apply: -->

- [ ] Requires infrastructure changes
- [ ] I have updated the documentation accordingly
- [ ] My commit history in this PR is linear
- [ ] New features have tests
- [ ] Breaking change (team conversation required)

## Important

Please do not merge from `main` (please only [rebase](https://github.com/Planning-Inspectorate/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
