### PR TITLE
Task/replace appeal type const

### DIFF
--- a/packages/common/src/constants.js
+++ b/packages/common/src/constants.js
@@ -11,15 +11,6 @@ module.exports = {
 		CONFIRMED: 'confirmed',
 		REMOVED: 'removed'
 	},
-	APPEALS_CASE_DATA: {
-		APPEAL_TYPE: {
-			HAS: 'Householder (HAS) Appeal',
-			S78: 'Full Planning (S78) Appeal',
-			S20: 'Listed Building (S20) Appeal'
-		},
-		APPEAL_TYPE_CODE: { HAS: 'HAS', S78: 'S78', S20: 'S20' },
-		VALIDITY: { IS_VALID: 'Valid' }
-	},
 	/**
 	 * @type {Record<string, AppealToUserRoles>}
 	 */

--- a/packages/common/src/database/data-static.js
+++ b/packages/common/src/database/data-static.js
@@ -46,7 +46,13 @@ const APPEAL_TO_USER_ROLES = {
  */
 const CASE_TYPES = {
 	HAS: { id: 1001, key: APPEAL_CASE_TYPE.D, type: 'Householder', processCode: 'HAS' },
-	S78: { id: 1005, key: APPEAL_CASE_TYPE.W, type: 'Full Planning', processCode: 'S78' }
+	S78: { id: 1005, key: APPEAL_CASE_TYPE.W, type: 'Full Planning', processCode: 'S78' },
+	S20: {
+		id: 1006,
+		key: APPEAL_CASE_TYPE.Y,
+		type: 'Planned listed building and conservation area appeal',
+		processCode: 'S20'
+	}
 	// { id: 1000, key: 'C', type: 'Enforcement notice appeal' },
 	// { id: 1002, key: 'F', type: 'Enforcement listed building and conservation area appeal' },
 	// { key: 'G', type: 'Discontinuance notice appeal' },
@@ -56,7 +62,6 @@ const CASE_TYPES = {
 	// { key: 'S', type: 'Affordable housing obligation appeal' },
 	// { key: 'V', type: 'Call-in application' },
 	// { key: 'X', type: 'Lawful development certificate appeal' },
-	// { id: 1006, key: 'Y', type: 'Planned listed building and conservation area appeal' },
 	// { id: 1007, key: 'Z', type: 'Commercial (CAS) appeal' }
 };
 

--- a/packages/forms-web-app/__tests__/unit/controllers/full-appeal/submit-appeal/list-of-documents.test.js
+++ b/packages/forms-web-app/__tests__/unit/controllers/full-appeal/submit-appeal/list-of-documents.test.js
@@ -16,7 +16,7 @@ const {
 	baseS78SubmissionUrl,
 	taskListUrl
 } = require('../../../../../src/dynamic-forms/s78-appeal-form/journey');
-const { APPEALS_CASE_DATA } = require('@pins/common/src/constants');
+const { CASE_TYPES } = require('@pins/common/src/database/data-static');
 
 const apiClient = {
 	createAppellantSubmission: jest.fn()
@@ -87,7 +87,7 @@ describe('controllers/full-appeal/submit-appeal/list-of-documents', () => {
 			expect(apiClient.createAppellantSubmission).toHaveBeenCalledWith({
 				appealId: mockAppealSqlId,
 				LPACode: 'testLPACode',
-				appealTypeCode: APPEALS_CASE_DATA.APPEAL_TYPE_CODE.S78,
+				appealTypeCode: CASE_TYPES.S78.processCode,
 				applicationDecisionDate: mockDecisionDate,
 				applicationReference: mockPlanningApplicationNumber,
 				applicationDecision: mockEligibility.applicationDecision

--- a/packages/forms-web-app/src/controllers/appeal-householder-decision/list-of-documents.js
+++ b/packages/forms-web-app/src/controllers/appeal-householder-decision/list-of-documents.js
@@ -3,7 +3,8 @@ const { getDepartmentFromId } = require('../../services/department.service');
 const { getLPAById, deleteAppeal } = require('../../lib/appeals-api-wrapper');
 const { postSaveAndReturn } = require('../appeal-householder-decision/save');
 const { FLAG } = require('@pins/common/src/feature-flags');
-const { APPEALS_CASE_DATA } = require('@pins/common/src/constants');
+const { CASE_TYPES } = require('@pins/common/src/database/data-static');
+
 const { isFeatureActive } = require('../../featureFlag');
 const {
 	baseHASSubmissionUrl,
@@ -42,7 +43,7 @@ const postListOfDocuments = async (req, res) => {
 			const appealSubmission = await req.appealsApiClient.createAppellantSubmission({
 				appealId: appeal.appealSqlId,
 				LPACode: lpaCode,
-				appealTypeCode: APPEALS_CASE_DATA.APPEAL_TYPE_CODE.HAS, // we should define this in a table + align with data model
+				appealTypeCode: CASE_TYPES.HAS.processCode,
 				applicationDecisionDate: appeal.decisionDate,
 				applicationReference: appeal.planningApplicationNumber,
 				applicationDecision: appeal.eligibility.applicationDecision

--- a/packages/forms-web-app/src/controllers/appeals/continue.js
+++ b/packages/forms-web-app/src/controllers/appeals/continue.js
@@ -1,5 +1,6 @@
 const { APPEAL_ID } = require('@pins/business-rules/src/constants');
-const { APPEALS_CASE_DATA } = require('@pins/common/src/constants');
+const { CASE_TYPES } = require('@pins/common/src/database/data-static');
+
 const { APPEAL_USER_ROLES } = require('@pins/common/src/constants');
 const { isAppealSubmission, isV2Submission } = require('@pins/common/src/lib/format-address');
 
@@ -9,8 +10,8 @@ const appealSubmissionContinueUrls = {
 };
 
 const typeCodeToAppealUrlStub = {
-	[APPEALS_CASE_DATA.APPEAL_TYPE_CODE.HAS]: 'householder',
-	[APPEALS_CASE_DATA.APPEAL_TYPE_CODE.S78]: 'full-planning'
+	[CASE_TYPES.HAS.processCode]: 'householder',
+	[CASE_TYPES.S78.processCode]: 'full-planning'
 };
 
 /**

--- a/packages/forms-web-app/src/controllers/full-appeal/submit-appeal/list-of-documents.js
+++ b/packages/forms-web-app/src/controllers/full-appeal/submit-appeal/list-of-documents.js
@@ -8,7 +8,8 @@ const {
 } = require('../../../lib/full-appeal/views');
 const { postSaveAndReturn } = require('../../save');
 const { FLAG } = require('@pins/common/src/feature-flags');
-const { APPEALS_CASE_DATA } = require('@pins/common/src/constants');
+const { CASE_TYPES } = require('@pins/common/src/database/data-static');
+
 const { isFeatureActive } = require('../../../featureFlag');
 const {
 	baseS78SubmissionUrl,
@@ -48,7 +49,7 @@ const postListOfDocuments = async (req, res) => {
 			const appealSubmission = await req.appealsApiClient.createAppellantSubmission({
 				appealId: appeal.appealSqlId,
 				LPACode: lpaCode,
-				appealTypeCode: APPEALS_CASE_DATA.APPEAL_TYPE_CODE.S78, // we should define this in a table + align with data model
+				appealTypeCode: CASE_TYPES.S78.processCode,
 				applicationDecisionDate: appeal.decisionDate,
 				applicationReference: appeal.planningApplicationNumber,
 				applicationDecision: appeal.eligibility.applicationDecision

--- a/packages/forms-web-app/src/controllers/selected-appeal/appeal-details/appeal-documents-rows.js
+++ b/packages/forms-web-app/src/controllers/selected-appeal/appeal-details/appeal-documents-rows.js
@@ -1,5 +1,6 @@
 const { formatDocumentDetails, formatNewDescription } = require('@pins/common');
-const { APPEALS_CASE_DATA } = require('@pins/common/src/constants');
+const { CASE_TYPES } = require('@pins/common/src/database/data-static');
+
 const { APPEAL_DOCUMENT_TYPE } = require('pins-data-model');
 
 /**
@@ -29,7 +30,7 @@ exports.documentsRows = (caseData) => {
 		{
 			keyText: 'Plans, drawings and supporting documents',
 			valueText: formatDocumentDetails(documents, APPEAL_DOCUMENT_TYPE.PLANS_DRAWINGS),
-			condition: () => caseData.appealTypeCode === APPEALS_CASE_DATA.APPEAL_TYPE_CODE.S78,
+			condition: () => caseData.appealTypeCode === CASE_TYPES.S78.processCode,
 			isEscaped: true
 		},
 		{

--- a/packages/forms-web-app/src/controllers/selected-appeal/appeal-details/appeal-documents-rows.test.js
+++ b/packages/forms-web-app/src/controllers/selected-appeal/appeal-details/appeal-documents-rows.test.js
@@ -1,5 +1,6 @@
 const { documentsRows } = require('./appeal-documents-rows');
-const { APPEALS_CASE_DATA } = require('@pins/common/src/constants');
+const { CASE_TYPES } = require('@pins/common/src/database/data-static');
+
 const { APPEAL_DOCUMENT_TYPE } = require('pins-data-model');
 
 describe('appeal-documents-rows', () => {
@@ -30,14 +31,14 @@ describe('appeal-documents-rows', () => {
 
 	describe('Plans, drawings and supporting documents', () => {
 		it('should display field if S78', () => {
-			const rows = documentsRows({ appealTypeCode: APPEALS_CASE_DATA.APPEAL_TYPE_CODE.S78 });
+			const rows = documentsRows({ appealTypeCode: CASE_TYPES.S78.processCode });
 			expect(rows[2].keyText).toEqual('Plans, drawings and supporting documents');
 			expect(rows[2].valueText).toEqual('No');
 			expect(rows[2].condition()).toEqual(true);
 			expect(rows[2].isEscaped).toEqual(true);
 		});
 		it('should not display field if not S78', () => {
-			const rows = documentsRows({ appealTypeCode: APPEALS_CASE_DATA.APPEAL_TYPE_CODE.HAS });
+			const rows = documentsRows({ appealTypeCode: CASE_TYPES.HAS.processCode });
 			expect(rows[2].keyText).toEqual('Plans, drawings and supporting documents');
 			expect(rows[2].valueText).toEqual('No');
 			expect(rows[2].condition()).toEqual(false);

--- a/packages/forms-web-app/src/controllers/selected-appeal/questionnaire-details/constraints-details-rows.js
+++ b/packages/forms-web-app/src/controllers/selected-appeal/questionnaire-details/constraints-details-rows.js
@@ -5,7 +5,8 @@ const {
 	documentExists,
 	boolToYesNo
 } = require('@pins/common');
-const { APPEALS_CASE_DATA } = require('@pins/common/src/constants');
+const { CASE_TYPES } = require('@pins/common/src/database/data-static');
+
 const { LISTED_RELATION_TYPES } = require('@pins/common/src/database/data-static');
 const { APPEAL_DOCUMENT_TYPE } = require('pins-data-model');
 const { isNotUndefinedOrNull } = require('#lib/is-not-undefined-or-null');
@@ -18,7 +19,7 @@ const { isNotUndefinedOrNull } = require('#lib/is-not-undefined-or-null');
 exports.constraintsRows = (caseData) => {
 	const documents = caseData.Documents || [];
 
-	const isHASAppeal = caseData.appealTypeCode === APPEALS_CASE_DATA.APPEAL_TYPE_CODE.HAS;
+	const isHASAppeal = caseData.appealTypeCode === CASE_TYPES.HAS.processCode;
 
 	const affectedListedBuildings = caseData.ListedBuildings?.filter(
 		(x) => x.type === LISTED_RELATION_TYPES.affected

--- a/packages/forms-web-app/src/controllers/selected-appeal/questionnaire-details/constraints-details-rows.test.js
+++ b/packages/forms-web-app/src/controllers/selected-appeal/questionnaire-details/constraints-details-rows.test.js
@@ -1,4 +1,5 @@
-const { APPEALS_CASE_DATA } = require('@pins/common/src/constants');
+const { CASE_TYPES } = require('@pins/common/src/database/data-static');
+
 const { LISTED_RELATION_TYPES } = require('@pins/common/src/database/data-static');
 const { constraintsRows } = require('./constraints-details-rows');
 const { APPEAL_DOCUMENT_TYPE } = require('pins-data-model');
@@ -238,7 +239,7 @@ describe('constraintsRows', () => {
 
 	it('should create rows with correct data for HAS appeal', () => {
 		const caseData = {
-			appealTypeCode: APPEALS_CASE_DATA.APPEAL_TYPE_CODE.HAS,
+			appealTypeCode: CASE_TYPES.HAS.processCode,
 			isCorrectAppealType: true,
 			ListedBuildings: [
 				{

--- a/packages/forms-web-app/src/controllers/selected-appeal/questionnaire-details/planning-officer-details-rows.js
+++ b/packages/forms-web-app/src/controllers/selected-appeal/questionnaire-details/planning-officer-details-rows.js
@@ -5,7 +5,8 @@ const {
 	boolToYesNo
 } = require('@pins/common');
 const { APPEAL_DOCUMENT_TYPE } = require('pins-data-model');
-const { APPEALS_CASE_DATA } = require('@pins/common/src/constants');
+const { CASE_TYPES } = require('@pins/common/src/database/data-static');
+
 const { formatDateForDisplay } = require('@pins/common/src/lib/format-date');
 
 const { isNotUndefinedOrNull } = require('#lib/is-not-undefined-or-null');
@@ -36,7 +37,7 @@ exports.planningOfficerReportRows = (caseData) => {
 			keyText: 'Plans, drawings and list of plans',
 			valueText: formatDocumentDetails(documents, APPEAL_DOCUMENT_TYPE.PLANS_DRAWINGS),
 			condition: () =>
-				caseData.appealTypeCode === APPEALS_CASE_DATA.APPEAL_TYPE_CODE.HAS &&
+				caseData.appealTypeCode === CASE_TYPES.HAS.processCode &&
 				documentExists(documents, APPEAL_DOCUMENT_TYPE.PLANS_DRAWINGS),
 			isEscaped: true
 		},

--- a/packages/forms-web-app/src/controllers/selected-appeal/questionnaire-details/planning-officer-details-rows.test.js
+++ b/packages/forms-web-app/src/controllers/selected-appeal/questionnaire-details/planning-officer-details-rows.test.js
@@ -1,6 +1,6 @@
 const { planningOfficerReportRows } = require('./planning-officer-details-rows');
 const { APPEAL_DOCUMENT_TYPE } = require('pins-data-model');
-const { APPEALS_CASE_DATA } = require('@pins/common/src/constants');
+const { CASE_TYPES } = require('@pins/common/src/database/data-static');
 
 const date = new Date('2020-12-17T03:24:00');
 const formattedDate = '17 Dec 2020';
@@ -8,7 +8,7 @@ const formattedDate = '17 Dec 2020';
 describe('planningOfficerReportRows', () => {
 	it('should create row with correct data if relevant case fields exist and files uploaded/field values otherwise populated', () => {
 		const caseData = {
-			appealTypeCode: APPEALS_CASE_DATA.APPEAL_TYPE_CODE.HAS,
+			appealTypeCode: CASE_TYPES.HAS.processCode,
 			infrastructureLevy: true,
 			infrastructureLevyAdopted: true,
 			infrastructureLevyAdoptedDate: date,
@@ -137,7 +137,7 @@ describe('planningOfficerReportRows', () => {
 	});
 	it('should handle false values correctly', () => {
 		const caseData = {
-			appealTypeCode: APPEALS_CASE_DATA.APPEAL_TYPE_CODE.HAS,
+			appealTypeCode: CASE_TYPES.HAS.processCode,
 			infrastructureLevy: false,
 			infrastructureLevyAdopted: false,
 			Documents: []
@@ -183,7 +183,7 @@ describe('planningOfficerReportRows', () => {
 
 	it('should set plans, drawings and list of plans condition as false if not HAS appeal type', () => {
 		const caseData = {
-			appealTypeCode: APPEALS_CASE_DATA.APPEAL_TYPE_CODE.S78,
+			appealTypeCode: CASE_TYPES.S78.processCode,
 			infrastructureLevy: true,
 			infrastructureLevyAdopted: true,
 			infrastructureLevyAdoptedDate: date,

--- a/packages/forms-web-app/src/dynamic-forms/controller.js
+++ b/packages/forms-web-app/src/dynamic-forms/controller.js
@@ -10,7 +10,9 @@ const {
 	formatQuestionnaireAppealInformationSection
 } = require('./dynamic-components/utils/submission-information-utils');
 const { APPEAL_ID } = require('@pins/business-rules/src/constants');
-const { APPEALS_CASE_DATA, LPA_USER_ROLE } = require('@pins/common/src/constants');
+const { LPA_USER_ROLE } = require('@pins/common/src/constants');
+const { CASE_TYPES } = require('@pins/common/src/database/data-static');
+
 const { getDepartmentFromId } = require('../services/department.service');
 const { getLPAById, deleteAppeal } = require('../lib/appeals-api-wrapper');
 const { formatDateForDisplay } = require('@pins/common/src/lib/format-date');
@@ -22,16 +24,16 @@ const { CONSTS } = require('../consts');
 const { storePdfQuestionnaireSubmission } = require('../services/pdf.service');
 
 const appealTypeToDetails = {
-	[APPEAL_ID.HOUSEHOLDER]: {
-		appealTypeCode: APPEALS_CASE_DATA.APPEAL_TYPE_CODE.HAS,
+	[CASE_TYPES.HAS.id]: {
+		appealTypeCode: CASE_TYPES.HAS.processCode,
 		taskListUrlStub: 'householder'
 	},
-	[APPEAL_ID.PLANNING_SECTION_78]: {
-		appealTypeCode: APPEALS_CASE_DATA.APPEAL_TYPE_CODE.S78,
+	[CASE_TYPES.S78.id]: {
+		appealTypeCode: CASE_TYPES.S78.processCode,
 		taskListUrlStub: 'full-planning'
 	},
-	[APPEAL_ID.PLANNING_LISTED_BUILDING]: {
-		appealTypeCode: APPEALS_CASE_DATA.APPEAL_TYPE_CODE.S20,
+	[CASE_TYPES.S20.id]: {
+		appealTypeCode: CASE_TYPES.S20.processCode,
 		taskListUrlStub: 'listed-building'
 	}
 };

--- a/packages/forms-web-app/src/dynamic-forms/dynamic-components/utils/submission-information-utils.js
+++ b/packages/forms-web-app/src/dynamic-forms/dynamic-components/utils/submission-information-utils.js
@@ -1,10 +1,11 @@
 const { getLPA, getLPAById } = require('../../../lib/appeals-api-wrapper');
-const { APPEALS_CASE_DATA } = require('@pins/common/src/constants');
+const { CASE_TYPES } = require('@pins/common/src/database/data-static');
+
 const { formatAddress } = require('@pins/common/src/lib/format-address');
 const { formatApplicant } = require('@pins/common/src/lib/format-applicant');
 const typeCodeToSubmissionInformationString = {
-	[APPEALS_CASE_DATA.APPEAL_TYPE_CODE.HAS]: 'Householder',
-	[APPEALS_CASE_DATA.APPEAL_TYPE_CODE.S78]: 'Full planning'
+	[CASE_TYPES.HAS.processCode]: 'Householder',
+	[CASE_TYPES.S78.processCode]: 'Full planning'
 };
 const { formatDateForDisplay } = require('@pins/common/src/lib/format-date');
 

--- a/packages/forms-web-app/src/dynamic-forms/dynamic-components/utils/submission-information-utils.test.js
+++ b/packages/forms-web-app/src/dynamic-forms/dynamic-components/utils/submission-information-utils.test.js
@@ -3,18 +3,15 @@ const {
 	formatQuestionnaireAppealInformationSection
 } = require('./submission-information-utils');
 const { getLPA, getLPAById } = require('../../../lib/appeals-api-wrapper');
-const {
-	APPEALS_CASE_DATA,
-	APPEAL_USER_ROLES,
-	LPA_USER_ROLE
-} = require('@pins/common/src/constants');
+const { APPEAL_USER_ROLES, LPA_USER_ROLE } = require('@pins/common/src/constants');
+const { CASE_TYPES } = require('@pins/common/src/database/data-static');
 
 jest.mock('../../../lib/appeals-api-wrapper');
 
 describe('formatBeforeYouStartSection', () => {
 	const mockAppellantSubmission = {
 		LPACode: '123',
-		appealTypeCode: APPEALS_CASE_DATA.APPEAL_TYPE_CODE.HAS,
+		appealTypeCode: CASE_TYPES.HAS.processCode,
 		applicationDecisionDate: '2023-01-01'
 	};
 

--- a/packages/forms-web-app/src/lib/dashboard-functions.js
+++ b/packages/forms-web-app/src/lib/dashboard-functions.js
@@ -47,9 +47,9 @@ const { calculateDueInDays } = require('./calculate-due-in-days');
 
 const {
 	getAppealTypeName,
-	getAppealTypeNameByTypeCode,
-	mapTypeCodeToAppealId
+	getAppealTypeNameByTypeCode
 } = require('./full-appeal/map-planning-application');
+const { mapTypeCodeToAppealId } = require('@pins/common');
 const { businessRulesDeadline } = require('./calculate-deadline');
 const { APPEAL_CASE_STATUS } = require('pins-data-model');
 const { calculateDaysSinceInvalidated } = require('./calculate-days-since-invalidated');

--- a/packages/forms-web-app/src/lib/full-appeal/map-planning-application.js
+++ b/packages/forms-web-app/src/lib/full-appeal/map-planning-application.js
@@ -1,5 +1,5 @@
 const { APPEAL_ID } = require('@pins/business-rules/src/constants');
-const { APPEALS_CASE_DATA } = require('@pins/common/src/constants');
+const { CASE_TYPES } = require('@pins/common/src/database/data-static');
 
 const mapPlanningApplication = (application) => {
 	switch (application) {
@@ -31,26 +31,17 @@ const getAppealTypeName = (appealId) => {
 
 const getAppealTypeNameByTypeCode = (typeCode) => {
 	switch (typeCode) {
-		case APPEALS_CASE_DATA.APPEAL_TYPE_CODE.S78:
+		case CASE_TYPES.S78.processCode:
 			return 'Full appeal';
-		case APPEALS_CASE_DATA.APPEAL_TYPE_CODE.HAS:
+		case CASE_TYPES.HAS.processCode:
 			return 'Householder appeal';
 		default:
 			return '';
 	}
 };
 
-const mapTypeCodeToAppealId = (typeCode) => {
-	const typeCodeToAppealId = {
-		[APPEALS_CASE_DATA.APPEAL_TYPE_CODE.HAS]: APPEAL_ID.HOUSEHOLDER,
-		[APPEALS_CASE_DATA.APPEAL_TYPE_CODE.S78]: APPEAL_ID.PLANNING_SECTION_78
-	};
-	return typeCodeToAppealId[typeCode];
-};
-
 module.exports = {
 	getAppealTypeName,
 	getAppealTypeNameByTypeCode,
-	mapPlanningApplication,
-	mapTypeCodeToAppealId
+	mapPlanningApplication
 };

--- a/packages/forms-web-app/src/routes/appellant-submission/submission-form.js
+++ b/packages/forms-web-app/src/routes/appellant-submission/submission-form.js
@@ -19,9 +19,10 @@ const dynamicReqFilesToReqBodyFiles = require('../../dynamic-forms/middleware/dy
 const getJourneyResponse = require('../../dynamic-forms/middleware/get-journey-response-for-appellant');
 const checkNotSubmitted = require('../../dynamic-forms/middleware/check-not-submitted');
 const { businessRulesDeadline } = require('../../lib/calculate-deadline');
-const { mapTypeCodeToAppealId } = require('../../lib/full-appeal/map-planning-application');
+const { mapTypeCodeToAppealId } = require('@pins/common');
 const { format } = require('date-fns');
-const { APPEALS_CASE_DATA } = require('@pins/common/src/constants');
+const { CASE_TYPES } = require('@pins/common/src/database/data-static');
+
 const { getJourney } = require('../../dynamic-forms/middleware/get-journey');
 const { journeys } = require('../../journeys');
 const checkDecisionDateDeadline = require('../../middleware/check-decision-date-deadline');
@@ -35,11 +36,11 @@ const {
 const dashboardUrl = `/${YOUR_APPEALS}`;
 
 const typeCodeToTaskListDetails = {
-	[APPEALS_CASE_DATA.APPEAL_TYPE_CODE.HAS]: {
+	[CASE_TYPES.HAS.processCode]: {
 		stub: 'householder',
 		pageCaption: 'Householder Appeal'
 	},
-	[APPEALS_CASE_DATA.APPEAL_TYPE_CODE.S78]: {
+	[CASE_TYPES.S78.processCode]: {
 		stub: 'full-planning',
 		pageCaption: 'Full Planning Appeal'
 	}

--- a/packages/forms-web-app/src/services/pdf.service.js
+++ b/packages/forms-web-app/src/services/pdf.service.js
@@ -13,7 +13,8 @@ const {
 } = require('../lib/full-appeal/views');
 const logger = require('../lib/logger');
 const { CONSTS } = require('../consts');
-const { APPEALS_CASE_DATA } = require('@pins/common/src/constants');
+const { CASE_TYPES } = require('@pins/common/src/database/data-static');
+
 const { addCSStoHtml } = require('#lib/add-css-to-html');
 
 const defaultFileName = 'appeal-form';
@@ -124,8 +125,8 @@ const storePdfAppeal = async ({ appeal, fileName, sid }) => {
 // Functions relating to V2 appeal forms
 
 const typeCodeToAppealUrlStub = {
-	[APPEALS_CASE_DATA.APPEAL_TYPE_CODE.HAS]: 'householder',
-	[APPEALS_CASE_DATA.APPEAL_TYPE_CODE.S78]: 'full-planning'
+	[CASE_TYPES.HAS.processCode]: 'householder',
+	[CASE_TYPES.S78.processCode]: 'full-planning'
 };
 
 /**


### PR DESCRIPTION
## Ticket Number

<!-- Add the number from the Jira board -->

## Description of change

Replace all instances all case_type const with data static so we have a single place to reference appeal types
Still some duplication left with constants in business rules

## Checklist

<!-- Put an `x` in all the boxes that apply: -->

- [ ] Requires infrastructure changes
- [ ] I have updated the documentation accordingly
- [x] My commit history in this PR is linear
- [ ] New features have tests
- [ ] Breaking change (team conversation required)

## Important

Please do not merge from `main` (please only [rebase](https://github.com/Planning-Inspectorate/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
