### PR TITLE
fix: implement errors correctly in api

### DIFF
--- a/packages/appeals-service-api/__tests__/unit/controllers/local-planning-authorities.test.js
+++ b/packages/appeals-service-api/__tests__/unit/controllers/local-planning-authorities.test.js
@@ -46,7 +46,8 @@ describe('LPAs controller test', () => {
 		};
 		res = {
 			status: jest.fn(),
-			send: jest.fn()
+			send: jest.fn(),
+			json: jest.fn()
 		};
 
 		res.status.mockReturnValue(res);
@@ -57,7 +58,7 @@ describe('LPAs controller test', () => {
 			const data = ['some array'];
 			await list(req, res);
 
-			expect(res.send).toBeCalledWith({
+			expect(res.json).toHaveBeenCalledWith({
 				data,
 				page: 1,
 				limit: data.length,
@@ -76,7 +77,7 @@ describe('LPAs controller test', () => {
 
 			await list(req, res);
 
-			expect(res.send).toBeCalledWith({
+			expect(res.json).toHaveBeenCalledWith({
 				data,
 				page: 1,
 				limit: data.length,

--- a/packages/appeals-service-api/__tests__/unit/controllers/save-and-return.test.js
+++ b/packages/appeals-service-api/__tests__/unit/controllers/save-and-return.test.js
@@ -43,9 +43,10 @@ describe('Save And Return API', () => {
 		it('should respond with - ERROR 400 when appealId is null', async () => {
 			req.body = { appealId: null };
 
-			await expect(async () => saveAndReturnCreate(req, res)).rejects.toThrowError('');
+			await saveAndReturnCreate(req, res);
 			expect(res.status).toHaveBeenCalledWith(400);
-			expect(createSavedAppealDocument).toBeCalledTimes(0);
+			expect(res.send).toHaveBeenCalledWith('Invalid Id');
+			expect(createSavedAppealDocument).toHaveBeenCalledTimes(0);
 		});
 	});
 
@@ -56,7 +57,7 @@ describe('Save And Return API', () => {
 			await saveAndReturnGet(req, res);
 			expect(getSavedAppealDocument).toHaveBeenCalledWith('12345');
 			expect(res.status).toHaveBeenCalledWith(200);
-			expect(res.send).toHaveBeenCalledWith({ appealId: '12345' });
+			expect(res.json).toHaveBeenCalledWith({ appealId: '12345' });
 		});
 	});
 });

--- a/packages/appeals-service-api/__tests__/unit/errors/apiError.test.js
+++ b/packages/appeals-service-api/__tests__/unit/errors/apiError.test.js
@@ -1,0 +1,20 @@
+const ApiError = require('../../../src/errors/apiError');
+
+describe('ApiError', () => {
+	const nonErrorFunctions = ['buildErrorFormat'];
+	describe('static API errors work', () => {
+		const errors = Object.getOwnPropertyNames(ApiError).filter(
+			(prop) => !nonErrorFunctions.includes(prop) && typeof ApiError[prop] === 'function'
+		);
+
+		test.each(errors)('%s', (errorType) => {
+			const result = ApiError[errorType]();
+			expect(result).toBeInstanceOf(ApiError);
+			expect(result).toBeInstanceOf(Error);
+			expect(typeof result.code).toBe('number');
+			expect(result.code.toString().length).toBe(3);
+			expect(typeof result.message).toBe('string');
+			expect(Array.isArray(result.errors)).toBe(true);
+		});
+	});
+});

--- a/packages/appeals-service-api/__tests__/unit/mocks.js
+++ b/packages/appeals-service-api/__tests__/unit/mocks.js
@@ -11,6 +11,7 @@ const mockRes = () => {
 	const res = {};
 	res.status = jest.fn();
 	res.send = jest.fn();
+	res.json = jest.fn();
 	res.status.mockReturnValue(res);
 	res.send.mockReturnValue(res);
 

--- a/packages/appeals-service-api/src/app.js
+++ b/packages/appeals-service-api/src/app.js
@@ -46,7 +46,6 @@ app
 			}
 		})
 	)
-	.use(bodyParser.json())
 	.use(compression()) /* gzip compression */
 	.use('/', routes)
 	.use(openApiValidationErrorHandler)

--- a/packages/appeals-service-api/src/controllers/local-planning-authorities.js
+++ b/packages/appeals-service-api/src/controllers/local-planning-authorities.js
@@ -54,12 +54,12 @@ const list = async (req, res) => {
 		totalResult: data.length
 	};
 
-	res.send(output);
+	res.json(output);
 };
 
 const create = async (req, res) => {
 	const lpaList = await lpaService.createLpaList(req.body);
-	res.status(200).send(lpaList);
+	res.status(200).json(lpaList);
 };
 
 module.exports = {

--- a/packages/appeals-service-api/src/controllers/save.js
+++ b/packages/appeals-service-api/src/controllers/save.js
@@ -7,8 +7,7 @@ const {
 async function saveAndReturnCreate(req, res) {
 	const appeal = req.body;
 	if (!appeal || !appeal.id) {
-		res.status(400).send('Invalid Id');
-		throw new Error('');
+		return res.status(400).send('Invalid Id');
 	}
 
 	const sendEmail = appeal.skipReturnEmail !== true;
@@ -19,13 +18,13 @@ async function saveAndReturnCreate(req, res) {
 		await sendContinueWithAppealEmail(appeal);
 	}
 
-	res.status(201).send(appeal);
+	res.status(201).json(appeal);
 }
 
 async function saveAndReturnGet(req, res) {
 	const { id } = req.params;
 	const appeal = await getSavedAppealDocument(id);
-	res.status(200).send(appeal);
+	res.status(200).json(appeal);
 }
 
 module.exports = {

--- a/packages/appeals-service-api/src/errors/apiError.js
+++ b/packages/appeals-service-api/src/errors/apiError.js
@@ -3,14 +3,21 @@
  * @property {Array.<string>} errors
  */
 
-class ApiError {
+class ApiError extends Error {
 	/**
 	 * @param {number} code
-	 * @param {ErrorMessages} messages
+	 * @param {ErrorMessages|string} messages
 	 */
 	constructor(code, messages) {
-		this.code = code;
-		this.message = messages;
+		if (typeof messages === 'string') {
+			super(messages);
+			this.errors = [messages];
+		} else {
+			super('ApiError');
+			this.errors = messages.errors;
+		}
+
+		this.code = code || 500;
 	}
 
 	/**

--- a/packages/appeals-service-api/src/errors/apiErrorHandler.js
+++ b/packages/appeals-service-api/src/errors/apiErrorHandler.js
@@ -11,7 +11,7 @@ function apiErrorHandler(err, req, res, next) {
 	if (err instanceof ApiError) {
 		const errorMessage = {
 			code: err.code,
-			errors: err.message.errors
+			errors: err.errors
 		};
 		res.status(err.code).json(errorMessage);
 		return;

--- a/packages/appeals-service-api/src/routes/appeals.js
+++ b/packages/appeals-service-api/src/routes/appeals.js
@@ -1,5 +1,5 @@
 const express = require('express');
-
+const ApiError = require('#errors/apiError');
 const {
 	updateAppeal,
 	getAppeal,
@@ -14,56 +14,52 @@ const {
 const router = express.Router();
 
 router.get('/:id', async (req, res) => {
-	let statusCode = 200;
-	let body = '';
 	try {
-		body = await getAppeal(req.params.id);
+		const body = await getAppeal(req.params.id);
+		res.status(200).send(body);
 	} catch (error) {
-		statusCode = error.code;
-		body = error.message.errors;
-	} finally {
-		res.status(statusCode).send(body);
+		if (!(error instanceof ApiError)) {
+			throw error;
+		}
+		return res.status(error.code).send(error.errors);
 	}
 });
 
 router.post('/', createAppeal);
 
 router.put('/:id', appealInsertValidationRules, async (req, res) => {
-	let statusCode = 200;
-	let body = '';
 	try {
-		body = await updateAppeal(req.params.id, req.body);
+		const body = await updateAppeal(req.params.id, req.body);
+		res.status(200).send(body);
 	} catch (error) {
-		statusCode = error.code;
-		body = error.message.errors;
-	} finally {
-		res.status(statusCode).send(body);
+		if (!(error instanceof ApiError)) {
+			throw error;
+		}
+		return res.status(error.code).send(error.errors);
 	}
 });
 
 router.patch('/:id', appealUpdateValidationRules, async (req, res) => {
-	let statusCode = 200;
-	let body = '';
 	try {
-		body = await updateAppeal(req.params.id, req.body);
+		const body = await updateAppeal(req.params.id, req.body);
+		res.status(200).send(body);
 	} catch (error) {
-		statusCode = error.code;
-		body = error.message.errors;
-	} finally {
-		res.status(statusCode).send(body);
+		if (!(error instanceof ApiError)) {
+			throw error;
+		}
+		return res.status(error.code).send(error.errors);
 	}
 });
 
 router.delete('/:id', async (req, res) => {
-	let statusCode = 200;
-	let body = {};
 	try {
 		await deleteAppeal(req.params.id);
+		res.status(200).send({});
 	} catch (error) {
-		statusCode = error.code;
-		body = error.message.errors;
-	} finally {
-		res.status(statusCode).send(body);
+		if (!(error instanceof ApiError)) {
+			throw error;
+		}
+		return res.status(error.code).send(error.errors);
 	}
 });
 

--- a/packages/appeals-service-api/src/routes/appeals.js
+++ b/packages/appeals-service-api/src/routes/appeals.js
@@ -16,12 +16,12 @@ const router = express.Router();
 router.get('/:id', async (req, res) => {
 	try {
 		const body = await getAppeal(req.params.id);
-		res.status(200).send(body);
+		res.status(200).json(body);
 	} catch (error) {
 		if (!(error instanceof ApiError)) {
 			throw error;
 		}
-		return res.status(error.code).send(error.errors);
+		return res.status(error.code).json(error.errors);
 	}
 });
 
@@ -30,36 +30,36 @@ router.post('/', createAppeal);
 router.put('/:id', appealInsertValidationRules, async (req, res) => {
 	try {
 		const body = await updateAppeal(req.params.id, req.body);
-		res.status(200).send(body);
+		res.status(200).json(body);
 	} catch (error) {
 		if (!(error instanceof ApiError)) {
 			throw error;
 		}
-		return res.status(error.code).send(error.errors);
+		return res.status(error.code).json(error.errors);
 	}
 });
 
 router.patch('/:id', appealUpdateValidationRules, async (req, res) => {
 	try {
 		const body = await updateAppeal(req.params.id, req.body);
-		res.status(200).send(body);
+		res.status(200).json(body);
 	} catch (error) {
 		if (!(error instanceof ApiError)) {
 			throw error;
 		}
-		return res.status(error.code).send(error.errors);
+		return res.status(error.code).json(error.errors);
 	}
 });
 
 router.delete('/:id', async (req, res) => {
 	try {
 		await deleteAppeal(req.params.id);
-		res.status(200).send({});
+		res.status(200).json({});
 	} catch (error) {
 		if (!(error instanceof ApiError)) {
 			throw error;
 		}
-		return res.status(error.code).send(error.errors);
+		return res.status(error.code).json(error.errors);
 	}
 });
 

--- a/packages/appeals-service-api/src/routes/back-office.js
+++ b/packages/appeals-service-api/src/routes/back-office.js
@@ -19,7 +19,7 @@ router.post('/appeals/:id', async (req, res) => {
 		if (!(error instanceof ApiError)) {
 			throw error;
 		}
-		return res.status(error.code).send(error.message.errors);
+		return res.status(error.code).send(error.errors);
 	}
 });
 
@@ -37,7 +37,7 @@ router.get('/appeals/:id', async (req, res) => {
 		if (!(error instanceof ApiError)) {
 			throw error;
 		}
-		return res.status(error.code).send(error.message.errors);
+		return res.status(error.code).send(error.errors);
 	}
 });
 module.exports = router;

--- a/packages/appeals-service-api/src/routes/back-office.js
+++ b/packages/appeals-service-api/src/routes/back-office.js
@@ -14,12 +14,12 @@ router.post('/appeals/:id', async (req, res) => {
 		// leaving commented out for now, not expecting to need to submit v1 appeals to new back office: AAPD-582 + AAPD-1535
 		// await backOfficeV2Service.submitAppeal(req.params.id);
 		await backOfficeService.saveAppealForSubmission(req.params.id);
-		return res.status(202).send({});
+		return res.status(202).json({});
 	} catch (error) {
 		if (!(error instanceof ApiError)) {
 			throw error;
 		}
-		return res.status(error.code).send(error.errors);
+		return res.status(error.code).json(error.errors);
 	}
 });
 
@@ -32,12 +32,12 @@ router.get('/appeals/:id', async (req, res) => {
 	try {
 		let body = await backOfficeService.getAppealForSubmission(req.params.id);
 		logger.info({ body }, '/appeals/:id, backOfficeService.getAppealForSubmission');
-		return res.status(202).send(body);
+		return res.status(202).json(body);
 	} catch (error) {
 		if (!(error instanceof ApiError)) {
 			throw error;
 		}
-		return res.status(error.code).send(error.errors);
+		return res.status(error.code).json(error.errors);
 	}
 });
 module.exports = router;

--- a/packages/appeals-service-api/src/routes/for-manual-intervention.js
+++ b/packages/appeals-service-api/src/routes/for-manual-intervention.js
@@ -9,24 +9,24 @@ const forManualInterventionService = new ForManualInterventionService();
 router.get('/appeals/:id', async (req, res) => {
 	try {
 		const body = await forManualInterventionService.getAppealForManualIntervention(req.params.id);
-		res.status(202).send(body);
+		res.status(202).json(body);
 	} catch (error) {
 		if (!(error instanceof ApiError)) {
 			throw error;
 		}
-		return res.status(error.code).send(error.errors);
+		return res.status(error.code).json(error.errors);
 	}
 });
 
 router.get('/appeals', async (req, res) => {
 	try {
 		const body = await forManualInterventionService.getAllAppealsForManualIntervention();
-		res.status(202).send(body);
+		res.status(202).json(body);
 	} catch (error) {
 		if (!(error instanceof ApiError)) {
 			throw error;
 		}
-		return res.status(error.code).send(error.errors);
+		return res.status(error.code).json(error.errors);
 	}
 });
 

--- a/packages/appeals-service-api/src/routes/for-manual-intervention.js
+++ b/packages/appeals-service-api/src/routes/for-manual-intervention.js
@@ -1,33 +1,32 @@
 const express = require('express');
 const router = express.Router();
+const ApiError = require('#errors/apiError');
 
 const ForManualInterventionService = require('../services/for-manual-intervention.service');
 
 const forManualInterventionService = new ForManualInterventionService();
 
 router.get('/appeals/:id', async (req, res) => {
-	let statusCode = 202;
-	let body = {};
 	try {
-		body = await forManualInterventionService.getAppealForManualIntervention(req.params.id);
+		const body = await forManualInterventionService.getAppealForManualIntervention(req.params.id);
+		res.status(202).send(body);
 	} catch (error) {
-		statusCode = error.code;
-		body = error.message.errors;
-	} finally {
-		res.status(statusCode).send(body);
+		if (!(error instanceof ApiError)) {
+			throw error;
+		}
+		return res.status(error.code).send(error.errors);
 	}
 });
 
 router.get('/appeals', async (req, res) => {
-	let statusCode = 202;
-	let body = {};
 	try {
-		body = await forManualInterventionService.getAllAppealsForManualIntervention();
+		const body = await forManualInterventionService.getAllAppealsForManualIntervention();
+		res.status(202).send(body);
 	} catch (error) {
-		statusCode = error.code;
-		body = error.message.errors;
-	} finally {
-		res.status(statusCode).send(body);
+		if (!(error instanceof ApiError)) {
+			throw error;
+		}
+		return res.status(error.code).send(error.errors);
 	}
 });
 

--- a/packages/appeals-service-api/src/routes/index.js
+++ b/packages/appeals-service-api/src/routes/index.js
@@ -23,7 +23,7 @@ router.get('/', (req, res) => {
 });
 
 router.get('/health', (req, res) => {
-	res.status(200).send({
+	res.status(200).json({
 		status: 'OK',
 		uptime: process.uptime(),
 		commit: config.gitSha

--- a/packages/appeals-service-api/src/routes/v2/appeal-cases/_caseReference/appeal-final-comments/controller.js
+++ b/packages/appeals-service-api/src/routes/v2/appeal-cases/_caseReference/appeal-final-comments/controller.js
@@ -18,7 +18,7 @@ async function getAppealFinalCommentsForCase(req, res) {
 		if (!comments || comments.length === 0) {
 			throw ApiError.withMessage(404, `No ${type} final comments found for this case reference`);
 		}
-		res.status(200).send(comments);
+		res.status(200).json(comments);
 	} catch (error) {
 		logger.error(`Failed to get appeal final comments: ${error}`);
 		throw error;

--- a/packages/appeals-service-api/src/routes/v2/appeal-cases/_caseReference/appeal-statements/controller.js
+++ b/packages/appeals-service-api/src/routes/v2/appeal-cases/_caseReference/appeal-statements/controller.js
@@ -34,7 +34,7 @@ async function getAppealStatementsForCase(req, res) {
 			throw ApiError.withMessage(400, 'invalid statement type');
 		}
 
-		res.status(200).send(statements);
+		res.status(200).json(statements);
 	} catch (error) {
 		logger.error(`Failed to get appeal statements: ${error}`);
 		throw error;

--- a/packages/appeals-service-api/src/routes/v2/appeal-cases/_caseReference/appellant-can-modify-case.js
+++ b/packages/appeals-service-api/src/routes/v2/appeal-cases/_caseReference/appellant-can-modify-case.js
@@ -17,7 +17,7 @@ module.exports = async (req, res, next) => {
 		next();
 	} catch (error) {
 		if (error instanceof ApiError) {
-			res.status(error.code || 500).send(error.message.errors);
+			res.status(error.code || 500).send(error.errors);
 		} else {
 			res.status(500).send('An unexpected error occurred');
 		}

--- a/packages/appeals-service-api/src/routes/v2/appeal-cases/_caseReference/appellant-can-modify-case.js
+++ b/packages/appeals-service-api/src/routes/v2/appeal-cases/_caseReference/appellant-can-modify-case.js
@@ -17,7 +17,7 @@ module.exports = async (req, res, next) => {
 		next();
 	} catch (error) {
 		if (error instanceof ApiError) {
-			res.status(error.code || 500).send(error.errors);
+			res.status(error.code).json(error.errors);
 		} else {
 			res.status(500).send('An unexpected error occurred');
 		}

--- a/packages/appeals-service-api/src/routes/v2/appeal-cases/_caseReference/appellant-final-comment-submission/controller.js
+++ b/packages/appeals-service-api/src/routes/v2/appeal-cases/_caseReference/appellant-final-comment-submission/controller.js
@@ -16,11 +16,11 @@ async function getAppellantFinalCommentSubmission(req, res) {
 		if (!content) {
 			throw ApiError.withMessage(404, 'Comment not found');
 		}
-		res.status(200).send(content);
+		res.status(200).json(content);
 	} catch (error) {
 		if (error instanceof ApiError) {
 			logger.error(`Failed to get comment: ${error.code} // ${error.errors}`);
-			res.status(error.code || 500).send(error.errors);
+			res.status(error.code).json(error.errors);
 		} else {
 			logger.error(error);
 			res.status(500).send('An unexpected error occurred');
@@ -37,11 +37,11 @@ async function createAppellantFinalCommentSubmission(req, res) {
 		if (!content) {
 			throw ApiError.withMessage(400, 'Unable to create comment');
 		}
-		res.status(200).send(content);
+		res.status(200).json(content);
 	} catch (error) {
 		if (error instanceof ApiError) {
 			logger.error(`Failed to create comment: ${error.code} // ${error.errors}`);
-			res.status(error.code || 500).send(error.errors);
+			res.status(error.code).json(error.errors);
 		} else {
 			logger.error(error);
 			res.status(500).send('An unexpected error occurred');
@@ -58,14 +58,14 @@ async function patchAppellantFinalCommentSubmission(req, res) {
 		if (!content) {
 			throw ApiError.withMessage(404, 'Comment not found');
 		}
-		res.status(200).send(content);
+		res.status(200).json(content);
 	} catch (error) {
 		if (error instanceof ApiError) {
 			logger.error(`Failed to update comment: ${error.code} // ${error.errors}`);
-			res.status(error.code || 500).send(error.errors);
+			res.status(error.code).json(error.errors);
 		} else if (error instanceof PrismaClientValidationError) {
 			logger.error(`invalid request: ${error.message}`);
-			res.status(400).send({ errors: ['Bad request'] });
+			res.status(400).json({ errors: ['Bad request'] });
 		} else {
 			logger.error(error);
 			res.status(500).send('An unexpected error occurred');

--- a/packages/appeals-service-api/src/routes/v2/appeal-cases/_caseReference/appellant-final-comment-submission/controller.js
+++ b/packages/appeals-service-api/src/routes/v2/appeal-cases/_caseReference/appellant-final-comment-submission/controller.js
@@ -19,8 +19,8 @@ async function getAppellantFinalCommentSubmission(req, res) {
 		res.status(200).send(content);
 	} catch (error) {
 		if (error instanceof ApiError) {
-			logger.error(`Failed to get comment: ${error.code} // ${error.message.errors}`);
-			res.status(error.code || 500).send(error.message.errors);
+			logger.error(`Failed to get comment: ${error.code} // ${error.errors}`);
+			res.status(error.code || 500).send(error.errors);
 		} else {
 			logger.error(error);
 			res.status(500).send('An unexpected error occurred');
@@ -40,8 +40,8 @@ async function createAppellantFinalCommentSubmission(req, res) {
 		res.status(200).send(content);
 	} catch (error) {
 		if (error instanceof ApiError) {
-			logger.error(`Failed to create comment: ${error.code} // ${error.message.errors}`);
-			res.status(error.code || 500).send(error.message.errors);
+			logger.error(`Failed to create comment: ${error.code} // ${error.errors}`);
+			res.status(error.code || 500).send(error.errors);
 		} else {
 			logger.error(error);
 			res.status(500).send('An unexpected error occurred');
@@ -61,8 +61,8 @@ async function patchAppellantFinalCommentSubmission(req, res) {
 		res.status(200).send(content);
 	} catch (error) {
 		if (error instanceof ApiError) {
-			logger.error(`Failed to update comment: ${error.code} // ${error.message.errors}`);
-			res.status(error.code || 500).send(error.message.errors);
+			logger.error(`Failed to update comment: ${error.code} // ${error.errors}`);
+			res.status(error.code || 500).send(error.errors);
 		} else if (error instanceof PrismaClientValidationError) {
 			logger.error(`invalid request: ${error.message}`);
 			res.status(400).send({ errors: ['Bad request'] });

--- a/packages/appeals-service-api/src/routes/v2/appeal-cases/_caseReference/appellant-final-comment-submission/document-upload/controller.js
+++ b/packages/appeals-service-api/src/routes/v2/appeal-cases/_caseReference/appellant-final-comment-submission/document-upload/controller.js
@@ -15,8 +15,8 @@ async function createSubmissionDocumentUpload(req, res) {
 		res.status(200).send(content);
 	} catch (error) {
 		if (error instanceof ApiError) {
-			logger.error(`Failed to create document upload: ${error.code} // ${error.message.errors}`);
-			res.status(error.code || 500).send(error.message.errors);
+			logger.error(`Failed to create document upload: ${error.code} // ${error.errors}`);
+			res.status(error.code || 500).send(error.errors);
 		} else {
 			logger.error(error);
 			res.status(500).send('An unexpected error occurred');
@@ -37,8 +37,8 @@ async function deleteSubmissionDocumentUpload(req, res) {
 		res.status(200).send(content);
 	} catch (error) {
 		if (error instanceof ApiError) {
-			logger.error(`Failed to delete document upload: ${error.code} // ${error.message.errors}`);
-			res.status(error.code || 500).send(error.message.errors);
+			logger.error(`Failed to delete document upload: ${error.code} // ${error.errors}`);
+			res.status(error.code || 500).send(error.errors);
 		} else {
 			logger.error(error);
 			res.status(500).send('An unexpected error occurred');

--- a/packages/appeals-service-api/src/routes/v2/appeal-cases/_caseReference/appellant-final-comment-submission/document-upload/controller.js
+++ b/packages/appeals-service-api/src/routes/v2/appeal-cases/_caseReference/appellant-final-comment-submission/document-upload/controller.js
@@ -12,11 +12,11 @@ async function createSubmissionDocumentUpload(req, res) {
 		if (!content) {
 			throw ApiError.unableToCreateDocumentUpload();
 		}
-		res.status(200).send(content);
+		res.status(200).json(content);
 	} catch (error) {
 		if (error instanceof ApiError) {
 			logger.error(`Failed to create document upload: ${error.code} // ${error.errors}`);
-			res.status(error.code || 500).send(error.errors);
+			res.status(error.code).json(error.errors);
 		} else {
 			logger.error(error);
 			res.status(500).send('An unexpected error occurred');
@@ -34,11 +34,11 @@ async function deleteSubmissionDocumentUpload(req, res) {
 		if (!content) {
 			throw ApiError.unableToDeleteDocumentUpload();
 		}
-		res.status(200).send(content);
+		res.status(200).json(content);
 	} catch (error) {
 		if (error instanceof ApiError) {
 			logger.error(`Failed to delete document upload: ${error.code} // ${error.errors}`);
-			res.status(error.code || 500).send(error.errors);
+			res.status(error.code).json(error.errors);
 		} else {
 			logger.error(error);
 			res.status(500).send('An unexpected error occurred');

--- a/packages/appeals-service-api/src/routes/v2/appeal-cases/_caseReference/appellant-proof-evidence-submission/controller.js
+++ b/packages/appeals-service-api/src/routes/v2/appeal-cases/_caseReference/appellant-proof-evidence-submission/controller.js
@@ -19,8 +19,8 @@ async function getAppellantProofOfEvidenceSubmission(req, res) {
 		res.status(200).send(content);
 	} catch (error) {
 		if (error instanceof ApiError) {
-			logger.error(`Failed to get proof of evidence: ${error.code} // ${error.message.errors}`);
-			res.status(error.code || 500).send(error.message.errors);
+			logger.error(`Failed to get proof of evidence: ${error.code} // ${error.errors}`);
+			res.status(error.code || 500).send(error.errors);
 		} else {
 			logger.error(error);
 			res.status(500).send('An unexpected error occurred');
@@ -40,8 +40,8 @@ async function createAppellantProofOfEvidenceSubmission(req, res) {
 		res.status(200).send(content);
 	} catch (error) {
 		if (error instanceof ApiError) {
-			logger.error(`Failed to create proof of evidence: ${error.code} // ${error.message.errors}`);
-			res.status(error.code || 500).send(error.message.errors);
+			logger.error(`Failed to create proof of evidence: ${error.code} // ${error.errors}`);
+			res.status(error.code || 500).send(error.errors);
 		} else {
 			logger.error(error);
 			res.status(500).send('An unexpected error occurred');
@@ -64,8 +64,8 @@ async function patchAppellantProofOfEvidenceSubmission(req, res) {
 		res.status(200).send(content);
 	} catch (error) {
 		if (error instanceof ApiError) {
-			logger.error(`Failed to update proof of evidence: ${error.code} // ${error.message.errors}`);
-			res.status(error.code || 500).send(error.message.errors);
+			logger.error(`Failed to update proof of evidence: ${error.code} // ${error.errors}`);
+			res.status(error.code || 500).send(error.errors);
 		} else if (error instanceof PrismaClientValidationError) {
 			logger.error(`invalid request: ${error.message}`);
 			res.status(400).send({ errors: ['Bad request'] });

--- a/packages/appeals-service-api/src/routes/v2/appeal-cases/_caseReference/appellant-proof-evidence-submission/controller.js
+++ b/packages/appeals-service-api/src/routes/v2/appeal-cases/_caseReference/appellant-proof-evidence-submission/controller.js
@@ -16,11 +16,11 @@ async function getAppellantProofOfEvidenceSubmission(req, res) {
 		if (!content) {
 			throw ApiError.withMessage(404, 'Proof of evidence not found');
 		}
-		res.status(200).send(content);
+		res.status(200).json(content);
 	} catch (error) {
 		if (error instanceof ApiError) {
 			logger.error(`Failed to get proof of evidence: ${error.code} // ${error.errors}`);
-			res.status(error.code || 500).send(error.errors);
+			res.status(error.code).json(error.errors);
 		} else {
 			logger.error(error);
 			res.status(500).send('An unexpected error occurred');
@@ -37,11 +37,11 @@ async function createAppellantProofOfEvidenceSubmission(req, res) {
 		if (!content) {
 			throw ApiError.withMessage(400, 'Unable to create proof of evidence');
 		}
-		res.status(200).send(content);
+		res.status(200).json(content);
 	} catch (error) {
 		if (error instanceof ApiError) {
 			logger.error(`Failed to create proof of evidence: ${error.code} // ${error.errors}`);
-			res.status(error.code || 500).send(error.errors);
+			res.status(error.code).json(error.errors);
 		} else {
 			logger.error(error);
 			res.status(500).send('An unexpected error occurred');
@@ -61,14 +61,14 @@ async function patchAppellantProofOfEvidenceSubmission(req, res) {
 		if (!content) {
 			throw ApiError.withMessage(404, 'Proof of evidence not found');
 		}
-		res.status(200).send(content);
+		res.status(200).json(content);
 	} catch (error) {
 		if (error instanceof ApiError) {
 			logger.error(`Failed to update proof of evidence: ${error.code} // ${error.errors}`);
-			res.status(error.code || 500).send(error.errors);
+			res.status(error.code).json(error.errors);
 		} else if (error instanceof PrismaClientValidationError) {
 			logger.error(`invalid request: ${error.message}`);
-			res.status(400).send({ errors: ['Bad request'] });
+			res.status(400).json({ errors: ['Bad request'] });
 		} else {
 			logger.error(error);
 			res.status(500).send('An unexpected error occurred');

--- a/packages/appeals-service-api/src/routes/v2/appeal-cases/_caseReference/appellant-proof-evidence-submission/document-upload/controller.js
+++ b/packages/appeals-service-api/src/routes/v2/appeal-cases/_caseReference/appellant-proof-evidence-submission/document-upload/controller.js
@@ -15,8 +15,8 @@ async function createSubmissionDocumentUpload(req, res) {
 		res.status(200).send(content);
 	} catch (error) {
 		if (error instanceof ApiError) {
-			logger.error(`Failed to create document upload: ${error.code} // ${error.message.errors}`);
-			res.status(error.code || 500).send(error.message.errors);
+			logger.error(`Failed to create document upload: ${error.code} // ${error.errors}`);
+			res.status(error.code || 500).send(error.errors);
 		} else {
 			logger.error(error);
 			res.status(500).send('An unexpected error occurred');
@@ -37,8 +37,8 @@ async function deleteSubmissionDocumentUpload(req, res) {
 		res.status(200).send(content);
 	} catch (error) {
 		if (error instanceof ApiError) {
-			logger.error(`Failed to delete document upload: ${error.code} // ${error.message.errors}`);
-			res.status(error.code || 500).send(error.message.errors);
+			logger.error(`Failed to delete document upload: ${error.code} // ${error.errors}`);
+			res.status(error.code || 500).send(error.errors);
 		} else {
 			logger.error(error);
 			res.status(500).send('An unexpected error occurred');

--- a/packages/appeals-service-api/src/routes/v2/appeal-cases/_caseReference/appellant-proof-evidence-submission/document-upload/controller.js
+++ b/packages/appeals-service-api/src/routes/v2/appeal-cases/_caseReference/appellant-proof-evidence-submission/document-upload/controller.js
@@ -12,11 +12,11 @@ async function createSubmissionDocumentUpload(req, res) {
 		if (!content) {
 			throw ApiError.unableToCreateDocumentUpload();
 		}
-		res.status(200).send(content);
+		res.status(200).json(content);
 	} catch (error) {
 		if (error instanceof ApiError) {
 			logger.error(`Failed to create document upload: ${error.code} // ${error.errors}`);
-			res.status(error.code || 500).send(error.errors);
+			res.status(error.code).json(error.errors);
 		} else {
 			logger.error(error);
 			res.status(500).send('An unexpected error occurred');
@@ -34,11 +34,11 @@ async function deleteSubmissionDocumentUpload(req, res) {
 		if (!content) {
 			throw ApiError.unableToDeleteDocumentUpload();
 		}
-		res.status(200).send(content);
+		res.status(200).json(content);
 	} catch (error) {
 		if (error instanceof ApiError) {
 			logger.error(`Failed to delete document upload: ${error.code} // ${error.errors}`);
-			res.status(error.code || 500).send(error.errors);
+			res.status(error.code).json(error.errors);
 		} else {
 			logger.error(error);
 			res.status(500).send('An unexpected error occurred');

--- a/packages/appeals-service-api/src/routes/v2/appeal-cases/_caseReference/events/controller.js
+++ b/packages/appeals-service-api/src/routes/v2/appeal-cases/_caseReference/events/controller.js
@@ -10,7 +10,7 @@ async function getAppealEvents(req, res) {
 		type,
 		includePast: includePast === 'true'
 	});
-	res.status(200).send(content);
+	res.status(200).json(content);
 }
 
 module.exports = {

--- a/packages/appeals-service-api/src/routes/v2/appeal-cases/_caseReference/interested-party-comments/controller.js
+++ b/packages/appeals-service-api/src/routes/v2/appeal-cases/_caseReference/interested-party-comments/controller.js
@@ -18,7 +18,7 @@ async function getCommentsForCase(req, res) {
 		throw ApiError.withMessage(404, 'No comments found for this case reference');
 	}
 
-	res.status(200).send(comments);
+	res.status(200).json(comments);
 }
 
 /**
@@ -36,7 +36,7 @@ async function createComment(req, res) {
 
 		const createdComment = await createInterestedPartyComment({ ...commentData, caseReference });
 
-		res.status(200).send(createdComment);
+		res.status(200).json(createdComment);
 	} catch (err) {
 		logger.error('Error creating comment', { err });
 		throw err;

--- a/packages/appeals-service-api/src/routes/v2/appeal-cases/_caseReference/lpa-final-comment-submission/controller.js
+++ b/packages/appeals-service-api/src/routes/v2/appeal-cases/_caseReference/lpa-final-comment-submission/controller.js
@@ -16,11 +16,11 @@ async function getLPAFinalCommentSubmission(req, res) {
 		if (!content) {
 			throw ApiError.withMessage(404, 'LPA Final Comment not found');
 		}
-		res.status(200).send(content);
+		res.status(200).json(content);
 	} catch (error) {
 		if (error instanceof ApiError) {
 			logger.error(`Failed to get LPA Final Comment: ${error.code} // ${error.errors}`);
-			res.status(error.code || 500).send(error.errors);
+			res.status(error.code).json(error.errors);
 		} else {
 			logger.error(error);
 			res.status(500).send('An unexpected error occurred');
@@ -37,11 +37,11 @@ async function createLPAFinalCommentSubmission(req, res) {
 		if (!content) {
 			throw ApiError.withMessage(400, 'Unable to create LPA Final Comment');
 		}
-		res.status(200).send(content);
+		res.status(200).json(content);
 	} catch (error) {
 		if (error instanceof ApiError) {
 			logger.error(`Failed to create LPA Final Comment: ${error.code} // ${error.errors}`);
-			res.status(error.code || 500).send(error.errors);
+			res.status(error.code).json(error.errors);
 		} else {
 			logger.error(error);
 			res.status(500).send('An unexpected error occurred');
@@ -58,14 +58,14 @@ async function patchLPAFinalCommentSubmission(req, res) {
 		if (!content) {
 			throw ApiError.withMessage(404, 'LPA Final Comment not found');
 		}
-		res.status(200).send(content);
+		res.status(200).json(content);
 	} catch (error) {
 		if (error instanceof ApiError) {
 			logger.error(`Failed to update LPA Final Comment: ${error.code} // ${error.errors}`);
-			res.status(error.code || 500).send(error.errors);
+			res.status(error.code).json(error.errors);
 		} else if (error instanceof PrismaClientValidationError) {
 			logger.error(`invalid request: ${error.message}`);
-			res.status(400).send({ errors: ['Bad request'] });
+			res.status(400).json({ errors: ['Bad request'] });
 		} else {
 			logger.error(error);
 			res.status(500).send('An unexpected error occurred');

--- a/packages/appeals-service-api/src/routes/v2/appeal-cases/_caseReference/lpa-final-comment-submission/controller.js
+++ b/packages/appeals-service-api/src/routes/v2/appeal-cases/_caseReference/lpa-final-comment-submission/controller.js
@@ -19,8 +19,8 @@ async function getLPAFinalCommentSubmission(req, res) {
 		res.status(200).send(content);
 	} catch (error) {
 		if (error instanceof ApiError) {
-			logger.error(`Failed to get LPA Final Comment: ${error.code} // ${error.message.errors}`);
-			res.status(error.code || 500).send(error.message.errors);
+			logger.error(`Failed to get LPA Final Comment: ${error.code} // ${error.errors}`);
+			res.status(error.code || 500).send(error.errors);
 		} else {
 			logger.error(error);
 			res.status(500).send('An unexpected error occurred');
@@ -40,8 +40,8 @@ async function createLPAFinalCommentSubmission(req, res) {
 		res.status(200).send(content);
 	} catch (error) {
 		if (error instanceof ApiError) {
-			logger.error(`Failed to create LPA Final Comment: ${error.code} // ${error.message.errors}`);
-			res.status(error.code || 500).send(error.message.errors);
+			logger.error(`Failed to create LPA Final Comment: ${error.code} // ${error.errors}`);
+			res.status(error.code || 500).send(error.errors);
 		} else {
 			logger.error(error);
 			res.status(500).send('An unexpected error occurred');
@@ -61,8 +61,8 @@ async function patchLPAFinalCommentSubmission(req, res) {
 		res.status(200).send(content);
 	} catch (error) {
 		if (error instanceof ApiError) {
-			logger.error(`Failed to update LPA Final Comment: ${error.code} // ${error.message.errors}`);
-			res.status(error.code || 500).send(error.message.errors);
+			logger.error(`Failed to update LPA Final Comment: ${error.code} // ${error.errors}`);
+			res.status(error.code || 500).send(error.errors);
 		} else if (error instanceof PrismaClientValidationError) {
 			logger.error(`invalid request: ${error.message}`);
 			res.status(400).send({ errors: ['Bad request'] });

--- a/packages/appeals-service-api/src/routes/v2/appeal-cases/_caseReference/lpa-final-comment-submission/document-upload/controller.js
+++ b/packages/appeals-service-api/src/routes/v2/appeal-cases/_caseReference/lpa-final-comment-submission/document-upload/controller.js
@@ -15,8 +15,8 @@ async function createSubmissionDocumentUpload(req, res) {
 		res.status(200).send(content);
 	} catch (error) {
 		if (error instanceof ApiError) {
-			logger.error(`Failed to create document upload: ${error.code} // ${error.message.errors}`);
-			res.status(error.code || 500).send(error.message.errors);
+			logger.error(`Failed to create document upload: ${error.code} // ${error.errors}`);
+			res.status(error.code || 500).send(error.errors);
 		} else {
 			logger.error(error);
 			res.status(500).send('An unexpected error occurred');
@@ -37,8 +37,8 @@ async function deleteSubmissionDocumentUpload(req, res) {
 		res.status(200).send(content);
 	} catch (error) {
 		if (error instanceof ApiError) {
-			logger.error(`Failed to delete document upload: ${error.code} // ${error.message.errors}`);
-			res.status(error.code || 500).send(error.message.errors);
+			logger.error(`Failed to delete document upload: ${error.code} // ${error.errors}`);
+			res.status(error.code || 500).send(error.errors);
 		} else {
 			logger.error(error);
 			res.status(500).send('An unexpected error occurred');

--- a/packages/appeals-service-api/src/routes/v2/appeal-cases/_caseReference/lpa-final-comment-submission/document-upload/controller.js
+++ b/packages/appeals-service-api/src/routes/v2/appeal-cases/_caseReference/lpa-final-comment-submission/document-upload/controller.js
@@ -12,11 +12,11 @@ async function createSubmissionDocumentUpload(req, res) {
 		if (!content) {
 			throw ApiError.unableToCreateDocumentUpload();
 		}
-		res.status(200).send(content);
+		res.status(200).json(content);
 	} catch (error) {
 		if (error instanceof ApiError) {
 			logger.error(`Failed to create document upload: ${error.code} // ${error.errors}`);
-			res.status(error.code || 500).send(error.errors);
+			res.status(error.code).json(error.errors);
 		} else {
 			logger.error(error);
 			res.status(500).send('An unexpected error occurred');
@@ -34,11 +34,11 @@ async function deleteSubmissionDocumentUpload(req, res) {
 		if (!content) {
 			throw ApiError.unableToDeleteDocumentUpload();
 		}
-		res.status(200).send(content);
+		res.status(200).json(content);
 	} catch (error) {
 		if (error instanceof ApiError) {
 			logger.error(`Failed to delete document upload: ${error.code} // ${error.errors}`);
-			res.status(error.code || 500).send(error.errors);
+			res.status(error.code).json(error.errors);
 		} else {
 			logger.error(error);
 			res.status(500).send('An unexpected error occurred');

--- a/packages/appeals-service-api/src/routes/v2/appeal-cases/_caseReference/lpa-proof-evidence-submission/controller.js
+++ b/packages/appeals-service-api/src/routes/v2/appeal-cases/_caseReference/lpa-proof-evidence-submission/controller.js
@@ -19,8 +19,8 @@ async function getLpaProofOfEvidenceSubmission(req, res) {
 		res.status(200).send(content);
 	} catch (error) {
 		if (error instanceof ApiError) {
-			logger.error(`Failed to get proof of evidence: ${error.code} // ${error.message.errors}`);
-			res.status(error.code || 500).send(error.message.errors);
+			logger.error(`Failed to get proof of evidence: ${error.code} // ${error.errors}`);
+			res.status(error.code || 500).send(error.errors);
 		} else {
 			logger.error(error);
 			res.status(500).send('An unexpected error occurred');
@@ -40,8 +40,8 @@ async function createLpaProofOfEvidenceSubmission(req, res) {
 		res.status(200).send(content);
 	} catch (error) {
 		if (error instanceof ApiError) {
-			logger.error(`Failed to create proof of evidence: ${error.code} // ${error.message.errors}`);
-			res.status(error.code || 500).send(error.message.errors);
+			logger.error(`Failed to create proof of evidence: ${error.code} // ${error.errors}`);
+			res.status(error.code || 500).send(error.errors);
 		} else {
 			logger.error(error);
 			res.status(500).send('An unexpected error occurred');
@@ -61,8 +61,8 @@ async function patchLpaProofOfEvidenceSubmission(req, res) {
 		res.status(200).send(content);
 	} catch (error) {
 		if (error instanceof ApiError) {
-			logger.error(`Failed to update proof of evidence: ${error.code} // ${error.message.errors}`);
-			res.status(error.code || 500).send(error.message.errors);
+			logger.error(`Failed to update proof of evidence: ${error.code} // ${error.errors}`);
+			res.status(error.code || 500).send(error.errors);
 		} else if (error instanceof PrismaClientValidationError) {
 			logger.error(`invalid request: ${error.message}`);
 			res.status(400).send({ errors: ['Bad request'] });

--- a/packages/appeals-service-api/src/routes/v2/appeal-cases/_caseReference/lpa-proof-evidence-submission/controller.js
+++ b/packages/appeals-service-api/src/routes/v2/appeal-cases/_caseReference/lpa-proof-evidence-submission/controller.js
@@ -16,11 +16,11 @@ async function getLpaProofOfEvidenceSubmission(req, res) {
 		if (!content) {
 			throw ApiError.withMessage(404, 'Proof of evidence not found');
 		}
-		res.status(200).send(content);
+		res.status(200).json(content);
 	} catch (error) {
 		if (error instanceof ApiError) {
 			logger.error(`Failed to get proof of evidence: ${error.code} // ${error.errors}`);
-			res.status(error.code || 500).send(error.errors);
+			res.status(error.code).json(error.errors);
 		} else {
 			logger.error(error);
 			res.status(500).send('An unexpected error occurred');
@@ -37,11 +37,11 @@ async function createLpaProofOfEvidenceSubmission(req, res) {
 		if (!content) {
 			throw ApiError.withMessage(400, 'Unable to create proof of evidence');
 		}
-		res.status(200).send(content);
+		res.status(200).json(content);
 	} catch (error) {
 		if (error instanceof ApiError) {
 			logger.error(`Failed to create proof of evidence: ${error.code} // ${error.errors}`);
-			res.status(error.code || 500).send(error.errors);
+			res.status(error.code).json(error.errors);
 		} else {
 			logger.error(error);
 			res.status(500).send('An unexpected error occurred');
@@ -58,14 +58,14 @@ async function patchLpaProofOfEvidenceSubmission(req, res) {
 		if (!content) {
 			throw ApiError.withMessage(404, 'Proof of evidence not found');
 		}
-		res.status(200).send(content);
+		res.status(200).json(content);
 	} catch (error) {
 		if (error instanceof ApiError) {
 			logger.error(`Failed to update proof of evidence: ${error.code} // ${error.errors}`);
-			res.status(error.code || 500).send(error.errors);
+			res.status(error.code).json(error.errors);
 		} else if (error instanceof PrismaClientValidationError) {
 			logger.error(`invalid request: ${error.message}`);
-			res.status(400).send({ errors: ['Bad request'] });
+			res.status(400).json({ errors: ['Bad request'] });
 		} else {
 			logger.error(error);
 			res.status(500).send('An unexpected error occurred');

--- a/packages/appeals-service-api/src/routes/v2/appeal-cases/_caseReference/lpa-proof-evidence-submission/document-upload/controller.js
+++ b/packages/appeals-service-api/src/routes/v2/appeal-cases/_caseReference/lpa-proof-evidence-submission/document-upload/controller.js
@@ -15,8 +15,8 @@ async function createSubmissionDocumentUpload(req, res) {
 		res.status(200).send(content);
 	} catch (error) {
 		if (error instanceof ApiError) {
-			logger.error(`Failed to create document upload: ${error.code} // ${error.message.errors}`);
-			res.status(error.code || 500).send(error.message.errors);
+			logger.error(`Failed to create document upload: ${error.code} // ${error.errors}`);
+			res.status(error.code || 500).send(error.errors);
 		} else {
 			logger.error(error);
 			res.status(500).send('An unexpected error occurred');
@@ -37,8 +37,8 @@ async function deleteSubmissionDocumentUpload(req, res) {
 		res.status(200).send(content);
 	} catch (error) {
 		if (error instanceof ApiError) {
-			logger.error(`Failed to delete document upload: ${error.code} // ${error.message.errors}`);
-			res.status(error.code || 500).send(error.message.errors);
+			logger.error(`Failed to delete document upload: ${error.code} // ${error.errors}`);
+			res.status(error.code || 500).send(error.errors);
 		} else {
 			logger.error(error);
 			res.status(500).send('An unexpected error occurred');

--- a/packages/appeals-service-api/src/routes/v2/appeal-cases/_caseReference/lpa-proof-evidence-submission/document-upload/controller.js
+++ b/packages/appeals-service-api/src/routes/v2/appeal-cases/_caseReference/lpa-proof-evidence-submission/document-upload/controller.js
@@ -12,11 +12,11 @@ async function createSubmissionDocumentUpload(req, res) {
 		if (!content) {
 			throw ApiError.unableToCreateDocumentUpload();
 		}
-		res.status(200).send(content);
+		res.status(200).json(content);
 	} catch (error) {
 		if (error instanceof ApiError) {
 			logger.error(`Failed to create document upload: ${error.code} // ${error.errors}`);
-			res.status(error.code || 500).send(error.errors);
+			res.status(error.code).json(error.errors);
 		} else {
 			logger.error(error);
 			res.status(500).send('An unexpected error occurred');
@@ -34,11 +34,11 @@ async function deleteSubmissionDocumentUpload(req, res) {
 		if (!content) {
 			throw ApiError.unableToDeleteDocumentUpload();
 		}
-		res.status(200).send(content);
+		res.status(200).json(content);
 	} catch (error) {
 		if (error instanceof ApiError) {
 			logger.error(`Failed to delete document upload: ${error.code} // ${error.errors}`);
-			res.status(error.code || 500).send(error.errors);
+			res.status(error.code).json(error.errors);
 		} else {
 			logger.error(error);
 			res.status(500).send('An unexpected error occurred');

--- a/packages/appeals-service-api/src/routes/v2/appeal-cases/_caseReference/lpa-questionnaire-submission/address/controller.js
+++ b/packages/appeals-service-api/src/routes/v2/appeal-cases/_caseReference/lpa-questionnaire-submission/address/controller.js
@@ -10,7 +10,7 @@ async function createSubmissionAddress(req, res) {
 	if (!content) {
 		throw ApiError.unableToCreateAddress();
 	}
-	res.status(200).send(content);
+	res.status(200).json(content);
 }
 
 /**
@@ -22,7 +22,7 @@ async function deleteSubmissionAddress(req, res) {
 	if (!content) {
 		throw ApiError.unableToDeleteAddress();
 	}
-	res.status(200).send(content);
+	res.status(200).json(content);
 }
 
 module.exports = {

--- a/packages/appeals-service-api/src/routes/v2/appeal-cases/_caseReference/lpa-questionnaire-submission/controller.js
+++ b/packages/appeals-service-api/src/routes/v2/appeal-cases/_caseReference/lpa-questionnaire-submission/controller.js
@@ -17,11 +17,11 @@ async function getLPAQuestionnaireSubmission(req, res) {
 		if (!content) {
 			throw ApiError.questionnaireNotFound();
 		}
-		res.status(200).send(content);
+		res.status(200).json(content);
 	} catch (error) {
 		if (error instanceof ApiError) {
 			logger.error(`Failed to get questionnaire: ${error.code} // ${error.errors}`);
-			res.status(error.code || 500).send(error.errors);
+			res.status(error.code).json(error.errors);
 		} else {
 			logger.error(error);
 			res.status(500).send('An unexpected error occurred');
@@ -38,11 +38,11 @@ async function createLPAQuestionnaireSubmission(req, res) {
 		if (!content) {
 			throw ApiError.unableToCreateQuestionnaire();
 		}
-		res.status(200).send(content);
+		res.status(200).json(content);
 	} catch (error) {
 		if (error instanceof ApiError) {
 			logger.error(`Failed to create questionnaire: ${error.code} // ${error.errors}`);
-			res.status(error.code || 500).send(error.errors);
+			res.status(error.code).json(error.errors);
 		} else {
 			logger.error(error);
 			res.status(500).send('An unexpected error occurred');
@@ -59,14 +59,14 @@ async function patchLPAQuestionnaireSubmission(req, res) {
 		if (!content) {
 			throw ApiError.questionnaireNotFound();
 		}
-		res.status(200).send(content);
+		res.status(200).json(content);
 	} catch (error) {
 		if (error instanceof ApiError) {
 			logger.error(`Failed to update questionnaire: ${error.code} // ${error.errors}`);
-			res.status(error.code || 500).send(error.errors);
+			res.status(error.code).json(error.errors);
 		} else if (error instanceof PrismaClientValidationError) {
 			logger.error(`invalid request: ${error.message}`);
-			res.status(400).send({ errors: ['Bad request'] });
+			res.status(400).json({ errors: ['Bad request'] });
 		} else {
 			logger.error(error);
 			res.status(500).send('An unexpected error occurred');
@@ -93,7 +93,7 @@ async function getLPAQuestionnaireDownloadDetailsByCaseReference(req, res) {
 
 	const result = await getLPAQuestionnaireDownloadDetails(caseReference);
 
-	res.send(result);
+	res.json(result);
 }
 
 module.exports = {

--- a/packages/appeals-service-api/src/routes/v2/appeal-cases/_caseReference/lpa-questionnaire-submission/controller.js
+++ b/packages/appeals-service-api/src/routes/v2/appeal-cases/_caseReference/lpa-questionnaire-submission/controller.js
@@ -20,8 +20,8 @@ async function getLPAQuestionnaireSubmission(req, res) {
 		res.status(200).send(content);
 	} catch (error) {
 		if (error instanceof ApiError) {
-			logger.error(`Failed to get questionnaire: ${error.code} // ${error.message.errors}`);
-			res.status(error.code || 500).send(error.message.errors);
+			logger.error(`Failed to get questionnaire: ${error.code} // ${error.errors}`);
+			res.status(error.code || 500).send(error.errors);
 		} else {
 			logger.error(error);
 			res.status(500).send('An unexpected error occurred');
@@ -41,8 +41,8 @@ async function createLPAQuestionnaireSubmission(req, res) {
 		res.status(200).send(content);
 	} catch (error) {
 		if (error instanceof ApiError) {
-			logger.error(`Failed to create questionnaire: ${error.code} // ${error.message.errors}`);
-			res.status(error.code || 500).send(error.message.errors);
+			logger.error(`Failed to create questionnaire: ${error.code} // ${error.errors}`);
+			res.status(error.code || 500).send(error.errors);
 		} else {
 			logger.error(error);
 			res.status(500).send('An unexpected error occurred');
@@ -62,8 +62,8 @@ async function patchLPAQuestionnaireSubmission(req, res) {
 		res.status(200).send(content);
 	} catch (error) {
 		if (error instanceof ApiError) {
-			logger.error(`Failed to update questionnaire: ${error.code} // ${error.message.errors}`);
-			res.status(error.code || 500).send(error.message.errors);
+			logger.error(`Failed to update questionnaire: ${error.code} // ${error.errors}`);
+			res.status(error.code || 500).send(error.errors);
 		} else if (error instanceof PrismaClientValidationError) {
 			logger.error(`invalid request: ${error.message}`);
 			res.status(400).send({ errors: ['Bad request'] });

--- a/packages/appeals-service-api/src/routes/v2/appeal-cases/_caseReference/lpa-questionnaire-submission/document-upload/controller.js
+++ b/packages/appeals-service-api/src/routes/v2/appeal-cases/_caseReference/lpa-questionnaire-submission/document-upload/controller.js
@@ -15,8 +15,8 @@ async function createSubmissionDocumentUpload(req, res) {
 		res.status(200).send(content);
 	} catch (error) {
 		if (error instanceof ApiError) {
-			logger.error(`Failed to create document upload: ${error.code} // ${error.message.errors}`);
-			res.status(error.code || 500).send(error.message.errors);
+			logger.error(`Failed to create document upload: ${error.code} // ${error.errors}`);
+			res.status(error.code || 500).send(error.errors);
 		} else {
 			logger.error(error);
 			res.status(500).send('An unexpected error occurred');
@@ -37,8 +37,8 @@ async function deleteSubmissionDocumentUpload(req, res) {
 		res.status(200).send(content);
 	} catch (error) {
 		if (error instanceof ApiError) {
-			logger.error(`Failed to delete document upload: ${error.code} // ${error.message.errors}`);
-			res.status(error.code || 500).send(error.message.errors);
+			logger.error(`Failed to delete document upload: ${error.code} // ${error.errors}`);
+			res.status(error.code || 500).send(error.errors);
 		} else {
 			logger.error(error);
 			res.status(500).send('An unexpected error occurred');

--- a/packages/appeals-service-api/src/routes/v2/appeal-cases/_caseReference/lpa-questionnaire-submission/document-upload/controller.js
+++ b/packages/appeals-service-api/src/routes/v2/appeal-cases/_caseReference/lpa-questionnaire-submission/document-upload/controller.js
@@ -12,11 +12,11 @@ async function createSubmissionDocumentUpload(req, res) {
 		if (!content) {
 			throw ApiError.unableToCreateDocumentUpload();
 		}
-		res.status(200).send(content);
+		res.status(200).json(content);
 	} catch (error) {
 		if (error instanceof ApiError) {
 			logger.error(`Failed to create document upload: ${error.code} // ${error.errors}`);
-			res.status(error.code || 500).send(error.errors);
+			res.status(error.code).json(error.errors);
 		} else {
 			logger.error(error);
 			res.status(500).send('An unexpected error occurred');
@@ -34,11 +34,11 @@ async function deleteSubmissionDocumentUpload(req, res) {
 		if (!content) {
 			throw ApiError.unableToDeleteDocumentUpload();
 		}
-		res.status(200).send(content);
+		res.status(200).json(content);
 	} catch (error) {
 		if (error instanceof ApiError) {
 			logger.error(`Failed to delete document upload: ${error.code} // ${error.errors}`);
-			res.status(error.code || 500).send(error.errors);
+			res.status(error.code).json(error.errors);
 		} else {
 			logger.error(error);
 			res.status(500).send('An unexpected error occurred');

--- a/packages/appeals-service-api/src/routes/v2/appeal-cases/_caseReference/lpa-questionnaire-submission/linked-case/controller.js
+++ b/packages/appeals-service-api/src/routes/v2/appeal-cases/_caseReference/lpa-questionnaire-submission/linked-case/controller.js
@@ -10,7 +10,7 @@ async function createSubmissionLinkedCase(req, res) {
 	if (!content) {
 		throw ApiError.unableToCreateLinkedCase();
 	}
-	res.status(200).send(content);
+	res.status(200).json(content);
 }
 
 /**
@@ -22,7 +22,7 @@ async function deleteSubmissionLinkedCase(req, res) {
 	if (!content) {
 		throw ApiError.unableToDeleteLinkedCase();
 	}
-	res.status(200).send(content);
+	res.status(200).json(content);
 }
 
 module.exports = {

--- a/packages/appeals-service-api/src/routes/v2/appeal-cases/_caseReference/lpa-questionnaire-submission/listed-building/controller.js
+++ b/packages/appeals-service-api/src/routes/v2/appeal-cases/_caseReference/lpa-questionnaire-submission/listed-building/controller.js
@@ -10,7 +10,7 @@ async function createQuestionnaireListedBuilding(req, res) {
 	if (!content) {
 		throw ApiError.unableToCreateListedBuilding();
 	}
-	res.status(200).send(content);
+	res.status(200).json(content);
 }
 
 /**
@@ -22,7 +22,7 @@ async function deleteQuestionnaireListedBuilding(req, res) {
 	if (!content) {
 		throw ApiError.unableToDeleteListedBuilding();
 	}
-	res.status(200).send(content);
+	res.status(200).json(content);
 }
 
 module.exports = {

--- a/packages/appeals-service-api/src/routes/v2/appeal-cases/_caseReference/lpa-questionnaire-submission/lpa-can-modify-case.js
+++ b/packages/appeals-service-api/src/routes/v2/appeal-cases/_caseReference/lpa-questionnaire-submission/lpa-can-modify-case.js
@@ -17,7 +17,7 @@ module.exports = async (req, res, next) => {
 		next();
 	} catch (error) {
 		if (error instanceof ApiError) {
-			res.status(error.code || 500).send(error.message.errors);
+			res.status(error.code || 500).send(error.errors);
 		} else {
 			res.status(500).send('An unexpected error occurred');
 		}

--- a/packages/appeals-service-api/src/routes/v2/appeal-cases/_caseReference/lpa-questionnaire-submission/lpa-can-modify-case.js
+++ b/packages/appeals-service-api/src/routes/v2/appeal-cases/_caseReference/lpa-questionnaire-submission/lpa-can-modify-case.js
@@ -17,7 +17,7 @@ module.exports = async (req, res, next) => {
 		next();
 	} catch (error) {
 		if (error instanceof ApiError) {
-			res.status(error.code || 500).send(error.errors);
+			res.status(error.code).json(error.errors);
 		} else {
 			res.status(500).send('An unexpected error occurred');
 		}

--- a/packages/appeals-service-api/src/routes/v2/appeal-cases/_caseReference/lpa-statement-submission/controller.js
+++ b/packages/appeals-service-api/src/routes/v2/appeal-cases/_caseReference/lpa-statement-submission/controller.js
@@ -19,8 +19,8 @@ async function getLPAStatementSubmission(req, res) {
 		res.status(200).send(content);
 	} catch (error) {
 		if (error instanceof ApiError) {
-			logger.error(`Failed to get statement: ${error.code} // ${error.message.errors}`);
-			res.status(error.code || 500).send(error.message.errors);
+			logger.error(`Failed to get statement: ${error.code} // ${error.errors}`);
+			res.status(error.code || 500).send(error.errors);
 		} else {
 			logger.error(error);
 			res.status(500).send('An unexpected error occurred');
@@ -40,8 +40,8 @@ async function createLPAStatementSubmission(req, res) {
 		res.status(200).send(content);
 	} catch (error) {
 		if (error instanceof ApiError) {
-			logger.error(`Failed to create statement: ${error.code} // ${error.message.errors}`);
-			res.status(error.code || 500).send(error.message.errors);
+			logger.error(`Failed to create statement: ${error.code} // ${error.errors}`);
+			res.status(error.code || 500).send(error.errors);
 		} else {
 			logger.error(error);
 			res.status(500).send('An unexpected error occurred');
@@ -61,8 +61,8 @@ async function patchLPAStatementSubmission(req, res) {
 		res.status(200).send(content);
 	} catch (error) {
 		if (error instanceof ApiError) {
-			logger.error(`Failed to update statement: ${error.code} // ${error.message.errors}`);
-			res.status(error.code || 500).send(error.message.errors);
+			logger.error(`Failed to update statement: ${error.code} // ${error.errors}`);
+			res.status(error.code || 500).send(error.errors);
 		} else if (error instanceof PrismaClientValidationError) {
 			logger.error(`invalid request: ${error.message}`);
 			res.status(400).send({ errors: ['Bad request'] });

--- a/packages/appeals-service-api/src/routes/v2/appeal-cases/_caseReference/lpa-statement-submission/controller.js
+++ b/packages/appeals-service-api/src/routes/v2/appeal-cases/_caseReference/lpa-statement-submission/controller.js
@@ -16,11 +16,11 @@ async function getLPAStatementSubmission(req, res) {
 		if (!content) {
 			throw ApiError.withMessage(404, 'Statement not found');
 		}
-		res.status(200).send(content);
+		res.status(200).json(content);
 	} catch (error) {
 		if (error instanceof ApiError) {
 			logger.error(`Failed to get statement: ${error.code} // ${error.errors}`);
-			res.status(error.code || 500).send(error.errors);
+			res.status(error.code).json(error.errors);
 		} else {
 			logger.error(error);
 			res.status(500).send('An unexpected error occurred');
@@ -37,11 +37,11 @@ async function createLPAStatementSubmission(req, res) {
 		if (!content) {
 			throw ApiError.withMessage(400, 'Unable to create statement');
 		}
-		res.status(200).send(content);
+		res.status(200).json(content);
 	} catch (error) {
 		if (error instanceof ApiError) {
 			logger.error(`Failed to create statement: ${error.code} // ${error.errors}`);
-			res.status(error.code || 500).send(error.errors);
+			res.status(error.code).json(error.errors);
 		} else {
 			logger.error(error);
 			res.status(500).send('An unexpected error occurred');
@@ -58,14 +58,14 @@ async function patchLPAStatementSubmission(req, res) {
 		if (!content) {
 			throw ApiError.withMessage(404, 'Statement not found');
 		}
-		res.status(200).send(content);
+		res.status(200).json(content);
 	} catch (error) {
 		if (error instanceof ApiError) {
 			logger.error(`Failed to update statement: ${error.code} // ${error.errors}`);
-			res.status(error.code || 500).send(error.errors);
+			res.status(error.code).json(error.errors);
 		} else if (error instanceof PrismaClientValidationError) {
 			logger.error(`invalid request: ${error.message}`);
-			res.status(400).send({ errors: ['Bad request'] });
+			res.status(400).json({ errors: ['Bad request'] });
 		} else {
 			logger.error(error);
 			res.status(500).send('An unexpected error occurred');

--- a/packages/appeals-service-api/src/routes/v2/appeal-cases/_caseReference/lpa-statement-submission/document-upload/controller.js
+++ b/packages/appeals-service-api/src/routes/v2/appeal-cases/_caseReference/lpa-statement-submission/document-upload/controller.js
@@ -15,8 +15,8 @@ async function createSubmissionDocumentUpload(req, res) {
 		res.status(200).send(content);
 	} catch (error) {
 		if (error instanceof ApiError) {
-			logger.error(`Failed to create document upload: ${error.code} // ${error.message.errors}`);
-			res.status(error.code || 500).send(error.message.errors);
+			logger.error(`Failed to create document upload: ${error.code} // ${error.errors}`);
+			res.status(error.code || 500).send(error.errors);
 		} else {
 			logger.error(error);
 			res.status(500).send('An unexpected error occurred');
@@ -37,8 +37,8 @@ async function deleteSubmissionDocumentUpload(req, res) {
 		res.status(200).send(content);
 	} catch (error) {
 		if (error instanceof ApiError) {
-			logger.error(`Failed to delete document upload: ${error.code} // ${error.message.errors}`);
-			res.status(error.code || 500).send(error.message.errors);
+			logger.error(`Failed to delete document upload: ${error.code} // ${error.errors}`);
+			res.status(error.code || 500).send(error.errors);
 		} else {
 			logger.error(error);
 			res.status(500).send('An unexpected error occurred');

--- a/packages/appeals-service-api/src/routes/v2/appeal-cases/_caseReference/lpa-statement-submission/document-upload/controller.js
+++ b/packages/appeals-service-api/src/routes/v2/appeal-cases/_caseReference/lpa-statement-submission/document-upload/controller.js
@@ -12,11 +12,11 @@ async function createSubmissionDocumentUpload(req, res) {
 		if (!content) {
 			throw ApiError.unableToCreateDocumentUpload();
 		}
-		res.status(200).send(content);
+		res.status(200).json(content);
 	} catch (error) {
 		if (error instanceof ApiError) {
 			logger.error(`Failed to create document upload: ${error.code} // ${error.errors}`);
-			res.status(error.code || 500).send(error.errors);
+			res.status(error.code).json(error.errors);
 		} else {
 			logger.error(error);
 			res.status(500).send('An unexpected error occurred');
@@ -34,11 +34,11 @@ async function deleteSubmissionDocumentUpload(req, res) {
 		if (!content) {
 			throw ApiError.unableToDeleteDocumentUpload();
 		}
-		res.status(200).send(content);
+		res.status(200).json(content);
 	} catch (error) {
 		if (error instanceof ApiError) {
 			logger.error(`Failed to delete document upload: ${error.code} // ${error.errors}`);
-			res.status(error.code || 500).send(error.errors);
+			res.status(error.code).json(error.errors);
 		} else {
 			logger.error(error);
 			res.status(500).send('An unexpected error occurred');

--- a/packages/appeals-service-api/src/routes/v2/appeal-cases/_caseReference/representations/controller.js
+++ b/packages/appeals-service-api/src/routes/v2/appeal-cases/_caseReference/representations/controller.js
@@ -56,7 +56,7 @@ async function getAppealCaseWithRepresentations(req, res) {
 				email,
 				isLpa
 			);
-		res.status(200).send(caseWithRepresentations);
+		res.status(200).json(caseWithRepresentations);
 	} catch (error) {
 		logger.error(`Failed to get case with representations for ${caseReference}: ${error}`);
 		throw error;

--- a/packages/appeals-service-api/src/routes/v2/appeal-cases/_caseReference/rule-6-party-can-modify-case.js
+++ b/packages/appeals-service-api/src/routes/v2/appeal-cases/_caseReference/rule-6-party-can-modify-case.js
@@ -17,7 +17,7 @@ module.exports = async (req, res, next) => {
 		next();
 	} catch (error) {
 		if (error instanceof ApiError) {
-			res.status(error.code || 500).send(error.message.errors);
+			res.status(error.code || 500).send(error.errors);
 		} else {
 			res.status(500).send('An unexpected error occurred');
 		}

--- a/packages/appeals-service-api/src/routes/v2/appeal-cases/_caseReference/rule-6-party-can-modify-case.js
+++ b/packages/appeals-service-api/src/routes/v2/appeal-cases/_caseReference/rule-6-party-can-modify-case.js
@@ -17,7 +17,7 @@ module.exports = async (req, res, next) => {
 		next();
 	} catch (error) {
 		if (error instanceof ApiError) {
-			res.status(error.code || 500).send(error.errors);
+			res.status(error.code).json(error.errors);
 		} else {
 			res.status(500).send('An unexpected error occurred');
 		}

--- a/packages/appeals-service-api/src/routes/v2/appeal-cases/_caseReference/rule-6-proof-evidence-submission/controller.js
+++ b/packages/appeals-service-api/src/routes/v2/appeal-cases/_caseReference/rule-6-proof-evidence-submission/controller.js
@@ -18,11 +18,11 @@ async function getRule6ProofOfEvidenceSubmission(req, res) {
 		if (!content) {
 			throw ApiError.withMessage(404, 'Proof of evidence not found');
 		}
-		res.status(200).send(content);
+		res.status(200).json(content);
 	} catch (error) {
 		if (error instanceof ApiError) {
 			logger.error(`Failed to get proof of evidence: ${error.code} // ${error.errors}`);
-			res.status(error.code || 500).send(error.errors);
+			res.status(error.code).json(error.errors);
 		} else {
 			logger.error(error);
 			res.status(500).send('An unexpected error occurred');
@@ -41,11 +41,11 @@ async function createRule6ProofOfEvidenceSubmission(req, res) {
 		if (!content) {
 			throw ApiError.withMessage(400, 'Unable to create proof of evidence');
 		}
-		res.status(200).send(content);
+		res.status(200).json(content);
 	} catch (error) {
 		if (error instanceof ApiError) {
 			logger.error(`Failed to create proof of evidence: ${error.code} // ${error.errors}`);
-			res.status(error.code || 500).send(error.errors);
+			res.status(error.code).json(error.errors);
 		} else {
 			logger.error(error);
 			res.status(500).send('An unexpected error occurred');
@@ -68,14 +68,14 @@ async function patchRule6ProofOfEvidenceSubmission(req, res) {
 		if (!content) {
 			throw ApiError.withMessage(404, 'Proof of evidence not found');
 		}
-		res.status(200).send(content);
+		res.status(200).json(content);
 	} catch (error) {
 		if (error instanceof ApiError) {
 			logger.error(`Failed to update proof of evidence: ${error.code} // ${error.errors}`);
-			res.status(error.code || 500).send(error.errors);
+			res.status(error.code).json(error.errors);
 		} else if (error instanceof PrismaClientValidationError) {
 			logger.error(`invalid request: ${error.message}`);
-			res.status(400).send({ errors: ['Bad request'] });
+			res.status(400).json({ errors: ['Bad request'] });
 		} else {
 			logger.error(error);
 			res.status(500).send('An unexpected error occurred');

--- a/packages/appeals-service-api/src/routes/v2/appeal-cases/_caseReference/rule-6-proof-evidence-submission/controller.js
+++ b/packages/appeals-service-api/src/routes/v2/appeal-cases/_caseReference/rule-6-proof-evidence-submission/controller.js
@@ -21,8 +21,8 @@ async function getRule6ProofOfEvidenceSubmission(req, res) {
 		res.status(200).send(content);
 	} catch (error) {
 		if (error instanceof ApiError) {
-			logger.error(`Failed to get proof of evidence: ${error.code} // ${error.message.errors}`);
-			res.status(error.code || 500).send(error.message.errors);
+			logger.error(`Failed to get proof of evidence: ${error.code} // ${error.errors}`);
+			res.status(error.code || 500).send(error.errors);
 		} else {
 			logger.error(error);
 			res.status(500).send('An unexpected error occurred');
@@ -44,8 +44,8 @@ async function createRule6ProofOfEvidenceSubmission(req, res) {
 		res.status(200).send(content);
 	} catch (error) {
 		if (error instanceof ApiError) {
-			logger.error(`Failed to create proof of evidence: ${error.code} // ${error.message.errors}`);
-			res.status(error.code || 500).send(error.message.errors);
+			logger.error(`Failed to create proof of evidence: ${error.code} // ${error.errors}`);
+			res.status(error.code || 500).send(error.errors);
 		} else {
 			logger.error(error);
 			res.status(500).send('An unexpected error occurred');
@@ -71,8 +71,8 @@ async function patchRule6ProofOfEvidenceSubmission(req, res) {
 		res.status(200).send(content);
 	} catch (error) {
 		if (error instanceof ApiError) {
-			logger.error(`Failed to update proof of evidence: ${error.code} // ${error.message.errors}`);
-			res.status(error.code || 500).send(error.message.errors);
+			logger.error(`Failed to update proof of evidence: ${error.code} // ${error.errors}`);
+			res.status(error.code || 500).send(error.errors);
 		} else if (error instanceof PrismaClientValidationError) {
 			logger.error(`invalid request: ${error.message}`);
 			res.status(400).send({ errors: ['Bad request'] });

--- a/packages/appeals-service-api/src/routes/v2/appeal-cases/_caseReference/rule-6-proof-evidence-submission/document-upload/controller.js
+++ b/packages/appeals-service-api/src/routes/v2/appeal-cases/_caseReference/rule-6-proof-evidence-submission/document-upload/controller.js
@@ -16,8 +16,8 @@ async function createSubmissionDocumentUpload(req, res) {
 		res.status(200).send(content);
 	} catch (error) {
 		if (error instanceof ApiError) {
-			logger.error(`Failed to create document upload: ${error.code} // ${error.message.errors}`);
-			res.status(error.code || 500).send(error.message.errors);
+			logger.error(`Failed to create document upload: ${error.code} // ${error.errors}`);
+			res.status(error.code || 500).send(error.errors);
 		} else {
 			logger.error(error);
 			res.status(500).send('An unexpected error occurred');
@@ -39,8 +39,8 @@ async function deleteSubmissionDocumentUpload(req, res) {
 		res.status(200).send(content);
 	} catch (error) {
 		if (error instanceof ApiError) {
-			logger.error(`Failed to delete document upload: ${error.code} // ${error.message.errors}`);
-			res.status(error.code || 500).send(error.message.errors);
+			logger.error(`Failed to delete document upload: ${error.code} // ${error.errors}`);
+			res.status(error.code || 500).send(error.errors);
 		} else {
 			logger.error(error);
 			res.status(500).send('An unexpected error occurred');

--- a/packages/appeals-service-api/src/routes/v2/appeal-cases/_caseReference/rule-6-proof-evidence-submission/document-upload/controller.js
+++ b/packages/appeals-service-api/src/routes/v2/appeal-cases/_caseReference/rule-6-proof-evidence-submission/document-upload/controller.js
@@ -13,11 +13,11 @@ async function createSubmissionDocumentUpload(req, res) {
 		if (!content) {
 			throw ApiError.unableToCreateDocumentUpload();
 		}
-		res.status(200).send(content);
+		res.status(200).json(content);
 	} catch (error) {
 		if (error instanceof ApiError) {
 			logger.error(`Failed to create document upload: ${error.code} // ${error.errors}`);
-			res.status(error.code || 500).send(error.errors);
+			res.status(error.code).json(error.errors);
 		} else {
 			logger.error(error);
 			res.status(500).send('An unexpected error occurred');
@@ -36,11 +36,11 @@ async function deleteSubmissionDocumentUpload(req, res) {
 		if (!content) {
 			throw ApiError.unableToDeleteDocumentUpload();
 		}
-		res.status(200).send(content);
+		res.status(200).json(content);
 	} catch (error) {
 		if (error instanceof ApiError) {
 			logger.error(`Failed to delete document upload: ${error.code} // ${error.errors}`);
-			res.status(error.code || 500).send(error.errors);
+			res.status(error.code).json(error.errors);
 		} else {
 			logger.error(error);
 			res.status(500).send('An unexpected error occurred');

--- a/packages/appeals-service-api/src/routes/v2/appeal-cases/_caseReference/rule-6-statement-submission/controller.js
+++ b/packages/appeals-service-api/src/routes/v2/appeal-cases/_caseReference/rule-6-statement-submission/controller.js
@@ -18,11 +18,11 @@ async function getRule6StatementSubmission(req, res) {
 		if (!content) {
 			throw ApiError.withMessage(404, 'Rule 6 Statement not found');
 		}
-		res.status(200).send(content);
+		res.status(200).json(content);
 	} catch (error) {
 		if (error instanceof ApiError) {
 			logger.error(`Failed to get rule 6 statement: ${error.code} // ${error.errors}`);
-			res.status(error.code || 500).send(error.errors);
+			res.status(error.code).json(error.errors);
 		} else {
 			logger.error(error);
 			res.status(500).send('An unexpected error occurred');
@@ -41,11 +41,11 @@ async function createRule6StatementSubmission(req, res) {
 		if (!content) {
 			throw ApiError.withMessage(400, 'Unable to create rule 6 statement');
 		}
-		res.status(200).send(content);
+		res.status(200).json(content);
 	} catch (error) {
 		if (error instanceof ApiError) {
 			logger.error(`Failed to create rule 6 statement: ${error.code} // ${error.errors}`);
-			res.status(error.code || 500).send(error.errors);
+			res.status(error.code).json(error.errors);
 		} else {
 			logger.error(error);
 			res.status(500).send('An unexpected error occurred');
@@ -64,14 +64,14 @@ async function patchRule6StatementSubmission(req, res) {
 		if (!content) {
 			throw ApiError.withMessage(404, 'Rule 6 Statement not found');
 		}
-		res.status(200).send(content);
+		res.status(200).json(content);
 	} catch (error) {
 		if (error instanceof ApiError) {
 			logger.error(`Failed to update rule 6 statement: ${error.code} // ${error.errors}`);
-			res.status(error.code || 500).send(error.errors);
+			res.status(error.code).json(error.errors);
 		} else if (error instanceof PrismaClientValidationError) {
 			logger.error(`invalid request: ${error.message}`);
-			res.status(400).send({ errors: ['Bad request'] });
+			res.status(400).json({ errors: ['Bad request'] });
 		} else {
 			logger.error(error);
 			res.status(500).send('An unexpected error occurred');

--- a/packages/appeals-service-api/src/routes/v2/appeal-cases/_caseReference/rule-6-statement-submission/controller.js
+++ b/packages/appeals-service-api/src/routes/v2/appeal-cases/_caseReference/rule-6-statement-submission/controller.js
@@ -21,8 +21,8 @@ async function getRule6StatementSubmission(req, res) {
 		res.status(200).send(content);
 	} catch (error) {
 		if (error instanceof ApiError) {
-			logger.error(`Failed to get rule 6 statement: ${error.code} // ${error.message.errors}`);
-			res.status(error.code || 500).send(error.message.errors);
+			logger.error(`Failed to get rule 6 statement: ${error.code} // ${error.errors}`);
+			res.status(error.code || 500).send(error.errors);
 		} else {
 			logger.error(error);
 			res.status(500).send('An unexpected error occurred');
@@ -44,8 +44,8 @@ async function createRule6StatementSubmission(req, res) {
 		res.status(200).send(content);
 	} catch (error) {
 		if (error instanceof ApiError) {
-			logger.error(`Failed to create rule 6 statement: ${error.code} // ${error.message.errors}`);
-			res.status(error.code || 500).send(error.message.errors);
+			logger.error(`Failed to create rule 6 statement: ${error.code} // ${error.errors}`);
+			res.status(error.code || 500).send(error.errors);
 		} else {
 			logger.error(error);
 			res.status(500).send('An unexpected error occurred');
@@ -67,8 +67,8 @@ async function patchRule6StatementSubmission(req, res) {
 		res.status(200).send(content);
 	} catch (error) {
 		if (error instanceof ApiError) {
-			logger.error(`Failed to update rule 6 statement: ${error.code} // ${error.message.errors}`);
-			res.status(error.code || 500).send(error.message.errors);
+			logger.error(`Failed to update rule 6 statement: ${error.code} // ${error.errors}`);
+			res.status(error.code || 500).send(error.errors);
 		} else if (error instanceof PrismaClientValidationError) {
 			logger.error(`invalid request: ${error.message}`);
 			res.status(400).send({ errors: ['Bad request'] });

--- a/packages/appeals-service-api/src/routes/v2/appeal-cases/_caseReference/rule-6-statement-submission/document-upload/controller.js
+++ b/packages/appeals-service-api/src/routes/v2/appeal-cases/_caseReference/rule-6-statement-submission/document-upload/controller.js
@@ -16,8 +16,8 @@ async function createSubmissionDocumentUpload(req, res) {
 		res.status(200).send(content);
 	} catch (error) {
 		if (error instanceof ApiError) {
-			logger.error(`Failed to create document upload: ${error.code} // ${error.message.errors}`);
-			res.status(error.code || 500).send(error.message.errors);
+			logger.error(`Failed to create document upload: ${error.code} // ${error.errors}`);
+			res.status(error.code || 500).send(error.errors);
 		} else {
 			logger.error(error);
 			res.status(500).send('An unexpected error occurred');
@@ -39,8 +39,8 @@ async function deleteSubmissionDocumentUpload(req, res) {
 		res.status(200).send(content);
 	} catch (error) {
 		if (error instanceof ApiError) {
-			logger.error(`Failed to delete document upload: ${error.code} // ${error.message.errors}`);
-			res.status(error.code || 500).send(error.message.errors);
+			logger.error(`Failed to delete document upload: ${error.code} // ${error.errors}`);
+			res.status(error.code || 500).send(error.errors);
 		} else {
 			logger.error(error);
 			res.status(500).send('An unexpected error occurred');

--- a/packages/appeals-service-api/src/routes/v2/appeal-cases/_caseReference/rule-6-statement-submission/document-upload/controller.js
+++ b/packages/appeals-service-api/src/routes/v2/appeal-cases/_caseReference/rule-6-statement-submission/document-upload/controller.js
@@ -13,11 +13,11 @@ async function createSubmissionDocumentUpload(req, res) {
 		if (!content) {
 			throw ApiError.unableToCreateDocumentUpload();
 		}
-		res.status(200).send(content);
+		res.status(200).json(content);
 	} catch (error) {
 		if (error instanceof ApiError) {
 			logger.error(`Failed to create document upload: ${error.code} // ${error.errors}`);
-			res.status(error.code || 500).send(error.errors);
+			res.status(error.code).json(error.errors);
 		} else {
 			logger.error(error);
 			res.status(500).send('An unexpected error occurred');
@@ -36,11 +36,11 @@ async function deleteSubmissionDocumentUpload(req, res) {
 		if (!content) {
 			throw ApiError.unableToDeleteDocumentUpload();
 		}
-		res.status(200).send(content);
+		res.status(200).json(content);
 	} catch (error) {
 		if (error instanceof ApiError) {
 			logger.error(`Failed to delete document upload: ${error.code} // ${error.errors}`);
-			res.status(error.code || 500).send(error.errors);
+			res.status(error.code).json(error.errors);
 		} else {
 			logger.error(error);
 			res.status(500).send('An unexpected error occurred');

--- a/packages/appeals-service-api/src/routes/v2/appeal-cases/controller.js
+++ b/packages/appeals-service-api/src/routes/v2/appeal-cases/controller.js
@@ -26,7 +26,7 @@ async function getByCaseReference(req, res) {
 		if (!appealCase) {
 			throw ApiError.withMessage(404, 'not found');
 		}
-		res.status(200).send(appealCase);
+		res.status(200).json(appealCase);
 	} catch (err) {
 		if (err instanceof ApiError) {
 			throw err; // re-throw 404
@@ -47,7 +47,7 @@ async function putByCaseReference(req, res) {
 	}
 	try {
 		const appealCase = await putCase(caseReference, req.body);
-		res.status(200).send(appealCase);
+		res.status(200).json(appealCase);
 	} catch (err) {
 		if (err instanceof ApiError) {
 			throw err; // re-throw service errors
@@ -102,7 +102,7 @@ async function listByLpaCode(req, res) {
 			withAppellant: isWithAppellant,
 			caseStatus
 		});
-		res.status(200).send(appealCases);
+		res.status(200).json(appealCases);
 	} catch (err) {
 		logger.error({ error: err, lpaCode, decidedOnly }, 'error fetching cases by lpa code');
 		throw ApiError.withMessage(500, 'unexpected error');
@@ -136,7 +136,7 @@ async function listByPostcode(req, res) {
 			decidedOnly: isDecidedOnly,
 			withAppellant: isWithAppellant
 		});
-		res.status(200).send(appealCases);
+		res.status(200).json(appealCases);
 	} catch (err) {
 		logger.error({ error: err, postcode, decidedOnly }, 'error fetching cases by postcode');
 		throw ApiError.withMessage(500, 'unexpected error');
@@ -169,7 +169,7 @@ async function countByLpaCode(req, res) {
 	const isDecidedOnly = decidedOnly === 'true';
 	try {
 		const count = await repo.countByLpaCode({ lpaCode, decidedOnly: isDecidedOnly });
-		res.status(200).send({ count });
+		res.status(200).json({ count });
 	} catch (err) {
 		logger.error({ error: err, lpaCode, decidedOnly }, 'error counting cases by lpa code');
 		throw ApiError.withMessage(500, 'unexpected error');

--- a/packages/appeals-service-api/src/routes/v2/appeals/_id/controller.js
+++ b/packages/appeals-service-api/src/routes/v2/appeals/_id/controller.js
@@ -15,12 +15,12 @@ exports.patch = async (req, res) => {
 		const appeal = await patch({ appealId, data });
 
 		if (!appeal) {
-			res.status(404).send({ error: 'Appeal not found' });
+			res.status(404).json({ error: 'Appeal not found' });
 			return;
 		}
 
-		res.send(appeal);
+		res.json(appeal);
 	} catch (error) {
-		res.status(500).send({ error: 'Internal server error' });
+		res.status(500).json({ error: 'Internal server error' });
 	}
 };

--- a/packages/appeals-service-api/src/routes/v2/appeals/controller.js
+++ b/packages/appeals-service-api/src/routes/v2/appeals/controller.js
@@ -27,7 +27,7 @@ async function getUserAppeals(req, res) {
 		throw ApiError.userNotFound();
 	}
 
-	res.status(200).send(content);
+	res.status(200).json(content);
 }
 
 /**

--- a/packages/appeals-service-api/src/routes/v2/appellant-submissions/_id/address/controller.js
+++ b/packages/appeals-service-api/src/routes/v2/appellant-submissions/_id/address/controller.js
@@ -15,7 +15,7 @@ async function createSubmissionAddress(req, res) {
 	if (!content) {
 		throw ApiError.unableToCreateAddress();
 	}
-	res.status(200).send(content);
+	res.status(200).json(content);
 }
 
 /**
@@ -36,7 +36,7 @@ async function deleteSubmissionAddress(req, res) {
 	if (!content) {
 		throw ApiError.unableToDeleteAddress();
 	}
-	res.status(200).send(content);
+	res.status(200).json(content);
 }
 
 module.exports = {

--- a/packages/appeals-service-api/src/routes/v2/appellant-submissions/_id/controller.js
+++ b/packages/appeals-service-api/src/routes/v2/appellant-submissions/_id/controller.js
@@ -19,7 +19,7 @@ exports.get = async (req, res) => {
 
 	const submission = await get({ appellantSubmissionId, userId });
 
-	res.send(submission);
+	res.json(submission);
 };
 
 /**
@@ -42,7 +42,7 @@ exports.patch = async (req, res) => {
 
 	const submission = await patch({ appellantSubmissionId, userId, data });
 
-	res.send(submission);
+	res.json(submission);
 };
 
 // Endpoint which checks whether a user is linked with an appellant submission
@@ -64,7 +64,7 @@ exports.confirm = async (req, res) => {
 
 	const result = await confirmOwnership({ appellantSubmissionId, userId });
 
-	res.status(200).send(result);
+	res.status(200).json(result);
 };
 
 // Endpoint for retrieving details required for appellant submission pdf generation
@@ -86,7 +86,7 @@ exports.getDownloadDetails = async (req, res) => {
 
 	const result = await getDownloadDetails({ appellantSubmissionId, userId });
 
-	res.send(result);
+	res.json(result);
 };
 
 // Endpoint for retrieving details required for appellant submission pdf generation
@@ -108,5 +108,5 @@ exports.getCaseReference = async (req, res) => {
 
 	const result = await getCaseReference({ appellantSubmissionId, userId });
 
-	res.send(result);
+	res.json(result);
 };

--- a/packages/appeals-service-api/src/routes/v2/appellant-submissions/_id/document-upload/controller.js
+++ b/packages/appeals-service-api/src/routes/v2/appellant-submissions/_id/document-upload/controller.js
@@ -15,8 +15,8 @@ async function createSubmissionDocumentUpload(req, res) {
 		res.status(200).send(content);
 	} catch (error) {
 		if (error instanceof ApiError) {
-			logger.error(`Failed to create document upload: ${error.code} // ${error.message.errors}`);
-			res.status(error.code || 500).send(error.message.errors);
+			logger.error(`Failed to create document upload: ${error.code} // ${error.errors}`);
+			res.status(error.code || 500).send(error.errors);
 		} else {
 			logger.error(error);
 			res.status(500).send('An unexpected error occurred');
@@ -37,8 +37,8 @@ async function deleteSubmissionDocumentUpload(req, res) {
 		res.status(200).send(content);
 	} catch (error) {
 		if (error instanceof ApiError) {
-			logger.error(`Failed to delete document upload: ${error.code} // ${error.message.errors}`);
-			res.status(error.code || 500).send(error.message.errors);
+			logger.error(`Failed to delete document upload: ${error.code} // ${error.errors}`);
+			res.status(error.code || 500).send(error.errors);
 		} else {
 			logger.error(error);
 			res.status(500).send('An unexpected error occurred');

--- a/packages/appeals-service-api/src/routes/v2/appellant-submissions/_id/document-upload/controller.js
+++ b/packages/appeals-service-api/src/routes/v2/appellant-submissions/_id/document-upload/controller.js
@@ -12,11 +12,11 @@ async function createSubmissionDocumentUpload(req, res) {
 		if (!content) {
 			throw ApiError.unableToCreateDocumentUpload();
 		}
-		res.status(200).send(content);
+		res.status(200).json(content);
 	} catch (error) {
 		if (error instanceof ApiError) {
 			logger.error(`Failed to create document upload: ${error.code} // ${error.errors}`);
-			res.status(error.code || 500).send(error.errors);
+			res.status(error.code).json(error.errors);
 		} else {
 			logger.error(error);
 			res.status(500).send('An unexpected error occurred');
@@ -34,11 +34,11 @@ async function deleteSubmissionDocumentUpload(req, res) {
 		if (!content) {
 			throw ApiError.unableToDeleteDocumentUpload();
 		}
-		res.status(200).send(content);
+		res.status(200).json(content);
 	} catch (error) {
 		if (error instanceof ApiError) {
 			logger.error(`Failed to delete document upload: ${error.code} // ${error.errors}`);
-			res.status(error.code || 500).send(error.errors);
+			res.status(error.code).json(error.errors);
 		} else {
 			logger.error(error);
 			res.status(500).send('An unexpected error occurred');

--- a/packages/appeals-service-api/src/routes/v2/appellant-submissions/_id/linked-case/controller.js
+++ b/packages/appeals-service-api/src/routes/v2/appellant-submissions/_id/linked-case/controller.js
@@ -11,7 +11,7 @@ async function createSubmissionLinkedCase(req, res) {
 	if (!content) {
 		throw ApiError.unableToCreateLinkedCase();
 	}
-	res.status(200).send(content);
+	res.status(200).json(content);
 }
 
 /**
@@ -23,7 +23,7 @@ async function deleteSubmissionLinkedCase(req, res) {
 	if (!content) {
 		throw ApiError.unableToDeleteLinkedCase();
 	}
-	res.status(200).send(content);
+	res.status(200).json(content);
 }
 
 module.exports = {

--- a/packages/appeals-service-api/src/routes/v2/appellant-submissions/_id/user-owns-submission.js
+++ b/packages/appeals-service-api/src/routes/v2/appellant-submissions/_id/user-owns-submission.js
@@ -17,7 +17,7 @@ module.exports = async (req, res, next) => {
 		next();
 	} catch (error) {
 		if (error instanceof ApiError) {
-			res.status(error.code || 500).send(error.message.errors);
+			res.status(error.code || 500).send(error.errors);
 		} else {
 			res.status(500).send('An unexpected error occurred');
 		}

--- a/packages/appeals-service-api/src/routes/v2/appellant-submissions/_id/user-owns-submission.js
+++ b/packages/appeals-service-api/src/routes/v2/appellant-submissions/_id/user-owns-submission.js
@@ -17,7 +17,7 @@ module.exports = async (req, res, next) => {
 		next();
 	} catch (error) {
 		if (error instanceof ApiError) {
-			res.status(error.code || 500).send(error.errors);
+			res.status(error.code).json(error.errors);
 		} else {
 			res.status(500).send('An unexpected error occurred');
 		}

--- a/packages/appeals-service-api/src/routes/v2/appellant-submissions/controller.js
+++ b/packages/appeals-service-api/src/routes/v2/appellant-submissions/controller.js
@@ -15,7 +15,7 @@ exports.put = async (req, res) => {
 
 	const submission = await put({ userId, data });
 
-	res.send(submission);
+	res.json(submission);
 };
 
 /**
@@ -32,7 +32,7 @@ exports.post = async (req, res) => {
 
 	const submission = await post({ userId, data });
 
-	res.send(submission);
+	res.json(submission);
 };
 
 /**

--- a/packages/appeals-service-api/src/routes/v2/documents/controller.js
+++ b/packages/appeals-service-api/src/routes/v2/documents/controller.js
@@ -6,7 +6,7 @@ const service = require('./service');
  */
 exports.put = async (req, res) => {
 	const doc = await service.put(req.body);
-	res.send(doc);
+	res.json(doc);
 };
 
 /**

--- a/packages/appeals-service-api/src/routes/v2/events/controller.js
+++ b/packages/appeals-service-api/src/routes/v2/events/controller.js
@@ -5,5 +5,5 @@ const { put } = require('./service');
  */
 exports.put = async (req, res) => {
 	const data = await put(req.body);
-	res.send(data);
+	res.json(data);
 };

--- a/packages/appeals-service-api/src/routes/v2/interested-party-submissions/controller.js
+++ b/packages/appeals-service-api/src/routes/v2/interested-party-submissions/controller.js
@@ -14,7 +14,7 @@ exports.post = async (req, res) => {
 
 		await backOfficeV2Service.submitInterestedPartySubmission(submission);
 
-		res.status(200).send(submission);
+		res.status(200).json(submission);
 	} catch (err) {
 		logger.error(err);
 		throw ApiError.unableToSubmitIpComment();

--- a/packages/appeals-service-api/src/routes/v2/listed-buildings/controller.js
+++ b/packages/appeals-service-api/src/routes/v2/listed-buildings/controller.js
@@ -13,7 +13,7 @@ exports.put = async (req, res) => {
 		result = await put([listedBuildings]);
 	}
 
-	res.status(200).send(result);
+	res.status(200).json(result);
 };
 
 /**
@@ -22,5 +22,5 @@ exports.put = async (req, res) => {
 exports.get = async (req, res) => {
 	const listedBuildingRef = req.params.reference;
 	const lb = await get(listedBuildingRef);
-	res.status(200).send(lb);
+	res.status(200).json(lb);
 };

--- a/packages/appeals-service-api/src/routes/v2/migrate/controller.js
+++ b/packages/appeals-service-api/src/routes/v2/migrate/controller.js
@@ -53,7 +53,7 @@ async function migrateAppeals(req, res) {
 		await cursor.close();
 	}
 
-	res.status(200).send(result);
+	res.status(200).json(result);
 
 	/**
 	 * @returns {Promise<[string]>}

--- a/packages/appeals-service-api/src/routes/v2/service-users/controller.js
+++ b/packages/appeals-service-api/src/routes/v2/service-users/controller.js
@@ -5,5 +5,5 @@ const { put } = require('./service');
  */
 exports.put = async (req, res) => {
 	const serviceUser = await put(req.body);
-	res.send(serviceUser);
+	res.json(serviceUser);
 };

--- a/packages/appeals-service-api/src/routes/v2/users/_id/appeal-cases/_caseReference/controller.js
+++ b/packages/appeals-service-api/src/routes/v2/users/_id/appeal-cases/_caseReference/controller.js
@@ -24,9 +24,9 @@ exports.get = async (req, res) => {
 		});
 	} catch (error) {
 		if (error instanceof ApiError) {
-			logger.error(`Failed to get users: ${error.code} // ${error.message.errors}`);
+			logger.error(`Failed to get users: ${error.code} // ${error.errors}`);
 			statusCode = error.code;
-			body = error.message.errors;
+			body = error.errors;
 		} else {
 			logger.error('Error:', error);
 			statusCode = 500;

--- a/packages/appeals-service-api/src/routes/v2/users/_id/appeal-cases/_caseReference/controller.js
+++ b/packages/appeals-service-api/src/routes/v2/users/_id/appeal-cases/_caseReference/controller.js
@@ -33,6 +33,6 @@ exports.get = async (req, res) => {
 			body = 'An unexpected error occurred';
 		}
 	} finally {
-		res.status(statusCode).send(body);
+		res.status(statusCode).json(body);
 	}
 };

--- a/packages/appeals-service-api/src/routes/v2/users/controller.js
+++ b/packages/appeals-service-api/src/routes/v2/users/controller.js
@@ -18,7 +18,7 @@ async function userPost(req, res) {
 		throw ApiError.badRequest({ errors: ['id is not allowed'] });
 	}
 	const body = await createUser(req.body);
-	res.status(200).send(body);
+	res.status(200).json(body);
 }
 
 /**
@@ -35,7 +35,7 @@ async function userSearch(req, res) {
 		lpaCode: lpaCode?.trim()
 	});
 
-	res.status(200).send(body);
+	res.status(200).json(body);
 }
 
 /**
@@ -44,7 +44,7 @@ async function userSearch(req, res) {
 async function userGet(req, res) {
 	const body = await resolveUser(req.params.userLookup);
 
-	res.status(200).send(body);
+	res.status(200).json(body);
 }
 
 /**
@@ -63,7 +63,7 @@ async function userUpdate(req, res) {
 
 	const body = await updateUser(updateData);
 
-	res.status(200).send(body);
+	res.status(200).json(body);
 }
 
 /**
@@ -85,7 +85,7 @@ async function userLink(req, res) {
 	const user = await resolveUser(userLookup);
 	const result = await linkUserToAppeal(user.id, appealId, role);
 
-	res.status(200).send({
+	res.status(200).json({
 		userLookup,
 		appealId: result.appealId,
 		role: result.role
@@ -100,7 +100,7 @@ async function userIsRule6User(req, res) {
 
 	const result = await isRule6User(userLookup);
 
-	res.status(200).send(result);
+	res.status(200).json(result);
 }
 
 /**

--- a/packages/appeals-service-api/src/services/appeal.service.js
+++ b/packages/appeals-service-api/src/services/appeal.service.js
@@ -51,12 +51,12 @@ async function createAppeal(req, res) {
 	if (document.result && document.result.ok) {
 		logger.debug(`Appeal ${appeal.id} created`);
 		appeal.appealSqlId = sqlAppeal.id;
-		res.status(201).send(appeal);
+		res.status(201).json(appeal);
 		return;
 	}
 
 	logger.error(`Problem while ${appeal.id} created`);
-	res.status(500).send(appeal);
+	res.status(500).json(appeal);
 }
 
 /**


### PR DESCRIPTION
## Ticket Number

<!-- Add the number from the Jira board -->

## Description of change

- ApiError didn't extend js error correctly, now handles string and array passed into constructor
- Provide default code in ApiError to avoid need to handle it in routes
- Explicitly send json from api endpoints
- Removed duplicate bodyParser.json call

## Checklist

<!-- Put an `x` in all the boxes that apply: -->

- [ ] Requires infrastructure changes
- [ ] I have updated the documentation accordingly
- [x] My commit history in this PR is linear
- [ ] New features have tests
- [ ] Breaking change (team conversation required)

## Important

Please do not merge from `main` (please only [rebase](https://github.com/Planning-Inspectorate/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
