### PR TITLE
fix(tooling): updating to common pipeline template 3.20.1

### DIFF
--- a/azure-pipelines-deploy.yml
+++ b/azure-pipelines-deploy.yml
@@ -49,7 +49,7 @@ resources:
       type: github
       endpoint: Planning-Inspectorate
       name: Planning-Inspectorate/common-pipeline-templates
-      ref: refs/tags/release/3.20.0
+      ref: refs/tags/release/3.20.1
   pipelines:
     - pipeline: build
       source: Appeals Service Build
@@ -151,6 +151,9 @@ extends:
                   appName: web staging slot
                   appUrl: $(deploySlotOutputs.slotUrl)/health
                   buildCommit: $(resources.pipeline.build.sourceCommit)
+                  appRegistrationClientId: $(appRegistrationClientId)
+                  auth_enabled: "true"
+                  env: $(ENVIRONMENT)
       - name: Deploy
         dependsOn:
           - Stage

--- a/azure-pipelines-variables.yml
+++ b/azure-pipelines-variables.yml
@@ -1,3 +1,4 @@
 variables:
   azurecrName: pinscrsharedtoolinguks
   resourceGroup: pins-rg-appeals-service-$(ENVIRONMENT)-$(REGION_SHORT)-001
+  appRegistrationClientId: api://31bbeefd-e00b-4ef9-b12d-145e06e4ab43


### PR DESCRIPTION
## Ticket Number

<!-- Add the number from the Jira board -->

https://pins-ds.atlassian.net/browse/A2-

## Description of change
With template 3.20.1, in git verify pipeline a condition is added to verify if Microsoft Easy authentication is enabled or not. Using which token needs to generated and used to get a successful HTTP response.
By default, all the values are set as below in https://github.com/Planning-Inspectorate/common-pipeline-templates/blob/main/steps/azure_web_app_verify_git_hash.yml 

- appRegistrationClientId: ""
- auth_enabled: "false"
- env: "dev"

 auth_enabled must be set as true only for web application and for all backend applications it is set as false

<!-- Please describe the change -->

## Checklist

<!-- Put an `x` in all the boxes that apply: -->

- [ ] Requires infrastructure changes
- [ ] I have updated the documentation accordingly
- [ ] My commit history in this PR is linear
- [ ] New features have tests
- [ ] Breaking change (team conversation required)

## Important

Please do not merge from `main` (please only [rebase](https://github.com/Planning-Inspectorate/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
