### PR TITLE
feat(a2-2363): expand action banner triggers

### DIFF
--- a/packages/forms-web-app/src/controllers/selected-appeal/action-banners.js
+++ b/packages/forms-web-app/src/controllers/selected-appeal/action-banners.js
@@ -23,6 +23,7 @@ const shouldDisplayQuestionnaireDueNotification = (caseData, userType) =>
  */
 const shouldDisplayStatementsDueBannerLPA = (caseData, userType) => {
 	return (
+		!!caseData.statementDueDate &&
 		userType === LPA_USER_ROLE &&
 		deadlineHasPassed(caseData.lpaQuestionnaireDueDate) &&
 		!caseData.LPAStatementSubmitted &&
@@ -37,6 +38,7 @@ const shouldDisplayStatementsDueBannerLPA = (caseData, userType) => {
  */
 const shouldDisplayStatementsDueBannerRule6 = (caseData, userType) => {
 	return (
+		!!caseData.rule6StatementDueDate &&
 		userType === APPEAL_USER_ROLES.RULE_6_PARTY &&
 		!!caseData.lpaQuestionnairePublishedDate &&
 		!caseData.rule6StatementSubmitted &&
@@ -51,6 +53,7 @@ const shouldDisplayStatementsDueBannerRule6 = (caseData, userType) => {
  */
 const shouldDisplayFinalCommentsDueBannerLPA = (caseData, userType) => {
 	return (
+		!!caseData.finalCommentsDueDate &&
 		userType === LPA_USER_ROLE &&
 		deadlineHasPassed(caseData.statementDueDate) &&
 		deadlineHasPassed(caseData.interestedPartyRepsDueDate) &&
@@ -66,6 +69,7 @@ const shouldDisplayFinalCommentsDueBannerLPA = (caseData, userType) => {
  */
 const shouldDisplayFinalCommentsDueBannerAppellant = (caseData, userType) => {
 	return (
+		!!caseData.finalCommentsDueDate &&
 		userType === APPEAL_USER_ROLES.APPELLANT &&
 		deadlineHasPassed(caseData.statementDueDate) &&
 		deadlineHasPassed(caseData.interestedPartyRepsDueDate) &&
@@ -81,6 +85,7 @@ const shouldDisplayFinalCommentsDueBannerAppellant = (caseData, userType) => {
  */
 const shouldDisplayProofEvidenceDueBannerAppellant = (caseData, userType) => {
 	return (
+		!!caseData.proofsOfEvidenceDueDate &&
 		userType === APPEAL_USER_ROLES.APPELLANT &&
 		deadlineHasPassed(caseData.statementDueDate) &&
 		deadlineHasPassed(caseData.interestedPartyRepsDueDate) &&
@@ -97,6 +102,7 @@ const shouldDisplayProofEvidenceDueBannerAppellant = (caseData, userType) => {
  */
 const shouldDisplayProofEvidenceDueBannerLPA = (caseData, userType) => {
 	return (
+		!!caseData.proofsOfEvidenceDueDate &&
 		userType === LPA_USER_ROLE &&
 		deadlineHasPassed(caseData.statementDueDate) &&
 		deadlineHasPassed(caseData.interestedPartyRepsDueDate) &&
@@ -113,6 +119,7 @@ const shouldDisplayProofEvidenceDueBannerLPA = (caseData, userType) => {
  */
 const shouldDisplayProofEvidenceDueBannerRule6 = (caseData, userType) => {
 	return (
+		!!caseData.rule6ProofEvidenceDueDate &&
 		userType === APPEAL_USER_ROLES.RULE_6_PARTY &&
 		deadlineHasPassed(caseData.rule6StatementDueDate) &&
 		deadlineHasPassed(caseData.interestedPartyRepsDueDate) &&

--- a/packages/forms-web-app/src/controllers/selected-appeal/action-banners.test.js
+++ b/packages/forms-web-app/src/controllers/selected-appeal/action-banners.test.js
@@ -49,6 +49,15 @@ describe('Action Banner Tests', () => {
 			caseData.lpaQuestionnaireDueDate = subDays(currentDate, 1);
 			expect(shouldDisplayStatementsDueBannerLPA(caseData, LPA_USER_ROLE)).toBe(true);
 		});
+		it('should return false for HAS with no statementDueDate', () => {
+			const hasCaseData = {
+				lpaQuestionnaireSubmittedDate: null,
+				lpaQuestionnaireDueDate: subDays(currentDate, 1),
+				lpaQuestionnairePublishedDate: null,
+				statementDueDate: null
+			};
+			expect(shouldDisplayStatementsDueBannerLPA(hasCaseData, LPA_USER_ROLE)).toBe(false);
+		});
 		it('should return false when LPAStatementSubmitted is true', () => {
 			caseData.LPAStatementSubmitted = true;
 			expect(shouldDisplayStatementsDueBannerLPA(caseData, LPA_USER_ROLE)).toBe(false);


### PR DESCRIPTION
## Ticket Number

https://pins-ds.atlassian.net/browse/A2-2363

## Description of change

Expands trigger logic for action banners to include check for existence of relevant date

## Checklist

- [ ] Requires infrastructure changes
- [ ] I have updated the documentation accordingly
- X My commit history in this PR is linear
-  X New features have tests
- [ ] Breaking change (team conversation required)

## Important

Please do not merge from `main` (please only [rebase](https://github.com/Planning-Inspectorate/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
