### PR TITLE
fix(data model 1.9.16): bump data model to 1.9.16

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -62,7 +62,7 @@
 				"openid-client": "^5.6.4",
 				"pino": "^9.2.0",
 				"pino-http": "^10.1.0",
-				"pins-data-model": "github:Planning-Inspectorate/data-model#1.9.15",
+				"pins-data-model": "github:Planning-Inspectorate/data-model#1.9.16",
 				"puppeteer-core": "^23.11.1",
 				"stream-json": "^1.8.0",
 				"swagger-jsdoc": "^6.2.8",
@@ -15145,8 +15145,8 @@
 			"license": "MIT"
 		},
 		"node_modules/pins-data-model": {
-			"version": "1.9.15",
-			"resolved": "git+ssh://git@github.com/Planning-Inspectorate/data-model.git#6fa24df52de7626fd09936dec24c58532c9e1add",
+			"version": "1.9.16",
+			"resolved": "git+ssh://git@github.com/Planning-Inspectorate/data-model.git#74f30d23ccd43fe1d72ed903dc21360b7e812d88",
 			"license": "MIT",
 			"dependencies": {
 				"jsonc-parser": "^3.3.1"

--- a/package.json
+++ b/package.json
@@ -136,7 +136,7 @@
 		"openid-client": "^5.6.4",
 		"pino": "^9.2.0",
 		"pino-http": "^10.1.0",
-		"pins-data-model": "github:Planning-Inspectorate/data-model#1.9.15",
+		"pins-data-model": "github:Planning-Inspectorate/data-model#1.9.16",
 		"puppeteer-core": "^23.11.1",
 		"stream-json": "^1.8.0",
 		"swagger-jsdoc": "^6.2.8",


### PR DESCRIPTION

## Description of change

Bump data model to 1.9.16

## Checklist

<!-- Put an `x` in all the boxes that apply: -->

- [ ] Requires infrastructure changes
- [ ] I have updated the documentation accordingly
- [ ] My commit history in this PR is linear
- [ ] New features have tests
- [ ] Breaking change (team conversation required)

## Important

Please do not merge from `main` (please only [rebase](https://github.com/Planning-Inspectorate/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
