### PR TITLE
fix(a2-2070): remove searchPostcode from submitted object

### DIFF
--- a/packages/forms-web-app/src/routes/file-based-router/comment-planning-appeal/check-answers/controller.js
+++ b/packages/forms-web-app/src/routes/file-based-router/comment-planning-appeal/check-answers/controller.js
@@ -1,5 +1,6 @@
 const {
 	getInterestedPartyFromSession,
+	getInterestedPartySubmissionFromSession,
 	markInterestedPartySessionAsSubmitted
 } = require('../../../../services/interested-party.service');
 const logger = require('../../../../lib/logger');
@@ -29,10 +30,10 @@ const checkAnswersGet = (req, res) => {
 /** @type {import('express').RequestHandler} */
 const checkAnswersPost = async (req, res) => {
 	/** @type {InterestedParty} */
-	const interestedParty = getInterestedPartyFromSession(req);
+	const interestedPartySubmission = getInterestedPartySubmissionFromSession(req);
 
 	try {
-		await req.appealsApiClient.submitInterestedPartySubmission(interestedParty);
+		await req.appealsApiClient.submitInterestedPartySubmission(interestedPartySubmission);
 	} catch (error) {
 		logger.error(error);
 	}

--- a/packages/forms-web-app/src/routes/file-based-router/comment-planning-appeal/check-answers/controller.test.js
+++ b/packages/forms-web-app/src/routes/file-based-router/comment-planning-appeal/check-answers/controller.test.js
@@ -1,6 +1,7 @@
 const { checkAnswersGet, checkAnswersPost } = require('./controller');
 const {
 	getInterestedPartyFromSession,
+	getInterestedPartySubmissionFromSession,
 	markInterestedPartySessionAsSubmitted
 } = require('../../../../services/interested-party.service');
 const logger = require('../../../../lib/logger');
@@ -64,11 +65,11 @@ describe('checkAnswers Controller Tests', () => {
 	describe('checkAnswersPost', () => {
 		it('should submit interested party submission and redirect to comment-submitted', async () => {
 			const interestedParty = { firstName: 'John', lastName: 'Doe', comments: 'Test comment' };
-			getInterestedPartyFromSession.mockReturnValue(interestedParty);
+			getInterestedPartySubmissionFromSession.mockReturnValue(interestedParty);
 
 			await checkAnswersPost(req, res);
 
-			expect(getInterestedPartyFromSession).toHaveBeenCalledWith(req);
+			expect(getInterestedPartySubmissionFromSession).toHaveBeenCalledWith(req);
 			expect(req.appealsApiClient.submitInterestedPartySubmission).toHaveBeenCalledWith(
 				interestedParty
 			);
@@ -79,7 +80,7 @@ describe('checkAnswers Controller Tests', () => {
 		it('should log an error if submission fails', async () => {
 			const interestedParty = { firstName: 'John', lastName: 'Doe', comments: 'Test comment' };
 			const error = new Error('Submission failed');
-			getInterestedPartyFromSession.mockReturnValue(interestedParty);
+			getInterestedPartySubmissionFromSession.mockReturnValue(interestedParty);
 			req.appealsApiClient.submitInterestedPartySubmission.mockRejectedValue(error);
 
 			await checkAnswersPost(req, res);

--- a/packages/forms-web-app/src/services/interested-party.service.js
+++ b/packages/forms-web-app/src/services/interested-party.service.js
@@ -1,7 +1,7 @@
 /**
  * @typedef {Object} InterestedParty
  * @property {string} caseReference
- * @property {string} searchPostcode
+ * @property {string} [searchPostcode]
  * @property {string} [firstName]
  * @property {string} [lastName]
  * @property {string} [emailAddress]
@@ -54,6 +54,38 @@ const getInterestedPartyFromSession = (req) => {
 };
 
 /**
+ * retrieves the interested party from session and formats for submission
+ * @param {import('express').Request} req
+ * @returns {InterestedParty} interested party
+ */
+const getInterestedPartySubmissionFromSession = (req) => {
+	const {
+		caseReference,
+		firstName,
+		lastName,
+		emailAddress,
+		addressLine1,
+		addressLine2,
+		townCity,
+		county,
+		postcode,
+		comments
+	} = req.session.interestedParty;
+	return {
+		caseReference,
+		firstName,
+		lastName,
+		emailAddress,
+		addressLine1,
+		addressLine2,
+		townCity,
+		county,
+		postcode,
+		comments
+	};
+};
+
+/**
  * resets interested party in req.session
  * @param {import('express').Request} req
  */
@@ -90,6 +122,7 @@ const checkIfInterestedPartySessionSubmitted = (req) => {
 module.exports = {
 	createInterestedPartySession,
 	getInterestedPartyFromSession,
+	getInterestedPartySubmissionFromSession,
 	updateInterestedPartySession,
 	resetInterestedPartySession,
 	checkInterestedPartySessionCaseReferenceSet,


### PR DESCRIPTION
## Ticket Number

https://pins-ds.atlassian.net/browse/A2-2070

## Description of change

Removes searchPostcode (which is used for navigation and backlinks) from submitted IP comment)

## Checklist

<!-- Put an `x` in all the boxes that apply: -->

- [ ] Requires infrastructure changes
- [ ] I have updated the documentation accordingly
- [ ] My commit history in this PR is linear
- [ ] New features have tests
- [ ] Breaking change (team conversation required)

## Important

Please do not merge from `main` (please only [rebase](https://github.com/Planning-Inspectorate/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
