### PR TITLE
Fix/appeal user details

### DIFF
--- a/packages/appeals-service-api/src/routes/v2/appeal-cases/_caseReference/representations/controller.js
+++ b/packages/appeals-service-api/src/routes/v2/appeal-cases/_caseReference/representations/controller.js
@@ -7,8 +7,10 @@ const {
 const logger = require('#lib/logger');
 const ApiError = require('#errors/apiError');
 
-const { LPAQuestionnaireSubmissionRepository } = require('../lpa-questionnaire-submission/repo');
+const { AppealCaseRepository } = require('../../repo');
+const caseRepo = new AppealCaseRepository();
 
+const { LPAQuestionnaireSubmissionRepository } = require('../lpa-questionnaire-submission/repo');
 const submissionRepo = new LPAQuestionnaireSubmissionRepository();
 
 /**
@@ -33,6 +35,16 @@ async function getAppealCaseWithRepresentations(req, res) {
 			await submissionRepo.lpaCanModifyCase({
 				caseReference: caseReference,
 				userLpa: lpaCode
+			});
+		} catch (error) {
+			logger.error({ error }, 'get representations: invalid user access');
+			throw ApiError.forbidden();
+		}
+	} else {
+		try {
+			await caseRepo.userCanModifyCase({
+				caseReference: caseReference,
+				userId: req.auth?.payload.sub
 			});
 		} catch (error) {
 			logger.error({ error }, 'get representations: invalid user access');

--- a/packages/appeals-service-api/src/routes/v2/appeal-cases/repo.js
+++ b/packages/appeals-service-api/src/routes/v2/appeal-cases/repo.js
@@ -482,6 +482,7 @@ class AppealCaseRepository {
 
 	/**
 	 * @param {{ caseReference: string, userId: string }} params
+	 * @returns {Promise<boolean>}
 	 */
 	async appellantCanModifyCase({ caseReference, userId }) {
 		try {
@@ -513,6 +514,7 @@ class AppealCaseRepository {
 
 	/**
 	 * @param {{ caseReference: string, userId: string }} params
+	 * @returns {Promise<boolean>}
 	 */
 	async rule6PartyCanModifyCase({ caseReference, userId }) {
 		try {
@@ -528,6 +530,45 @@ class AppealCaseRepository {
 								where: {
 									userId,
 									role: APPEAL_USER_ROLES.RULE_6_PARTY
+								}
+							}
+						}
+					}
+				}
+			});
+
+			return true;
+		} catch (err) {
+			logger.error({ err }, 'invalid user access');
+			throw ApiError.forbidden();
+		}
+	}
+
+	/**
+	 * checks user can modify case, does not work for LPA users
+	 * @param {{ caseReference: string, userId: string }} params
+	 * @returns {Promise<boolean>}
+	 */
+	async userCanModifyCase({ caseReference, userId }) {
+		try {
+			await this.dbClient.appealCase.findUniqueOrThrow({
+				where: {
+					caseReference
+				},
+				select: {
+					Appeal: {
+						select: {
+							id: true,
+							Users: {
+								where: {
+									userId,
+									role: {
+										in: [
+											APPEAL_USER_ROLES.RULE_6_PARTY,
+											APPEAL_USER_ROLES.APPELLANT,
+											APPEAL_USER_ROLES.AGENT
+										]
+									}
 								}
 							}
 						}

--- a/packages/appeals-service-api/src/routes/v2/appellant-submissions/_id/submit/index.spec.js
+++ b/packages/appeals-service-api/src/routes/v2/appellant-submissions/_id/submit/index.spec.js
@@ -3,6 +3,7 @@ const http = require('http');
 const app = require('../../../../../app');
 const { sendEvents } = require('../../../../../../src/infrastructure/event-client');
 const { createPrismaClient } = require('#db-client');
+const { seedStaticData } = require('@pins/database/src/seed/data-static');
 const crypto = require('crypto');
 
 const server = http.createServer(app);
@@ -14,254 +15,14 @@ const sqlClient = createPrismaClient();
  * @typedef {import('../appellant-submission').AppellantSubmission} AppellantSubmission
  */
 
-jest.mock('../service', () => ({
-	/**
-	 * @param {{appellantSubmissionId: string}} args
-	 * @returns {Partial<AppellantSubmission> | null}
-	 */
-	getForBOSubmission: ({ appellantSubmissionId }) => {
-		switch (appellantSubmissionId) {
-			case '001':
-				return {
-					appealId: 'f70dd26f-3776-4685-a79c-a81dbe8790b6',
-					LPACode: 'LPA_001',
-					appealTypeCode: 'HAS',
-					applicationDecisionDate: new Date('2024-01-01'),
-					applicationDecision: 'refused',
-					onApplicationDate: new Date('2024-01-01'),
-					isAppellant: true,
-					contactFirstName: 'Testy',
-					contactLastName: 'McTest',
-					contactCompanyName: 'Test',
-					ownsAllLand: true,
-					appellantGreenBelt: false,
-					updateDevelopmentDescription: false,
-					knowsOtherOwners: 'yes',
-					costApplication: false,
-					appellantSiteSafety: 'yes',
-					appellantSiteSafety_appellantSiteSafetyDetails: "It's dangerous",
-					appellantSiteAccess: 'yes',
-					appellantSiteAccess_appellantSiteAccessDetails: 'Come and see',
-					applicationReference: '123',
-					developmentDescriptionOriginal: 'A test description',
-					appellantLinkedCaseReference: 'no',
-					contactPhoneNumber: '12345657',
-					// @ts-ignore
-					siteAreaSquareMetres: 22,
-					appellantLinkedCaseAdd: false,
-					appellantLinkedCase: false,
-					SubmissionLinkedCase: [],
-					uploadOriginalApplicationForm: true,
-					uploadApplicationDecisionLetter: false,
-					uploadAppellantStatement: false,
-					uploadCostApplication: false,
-					uploadChangeOfDescriptionEvidence: false,
-					SubmissionDocumentUpload: [
-						{
-							id: 'img_001',
-							fileName: 'img.jpg',
-							originalFileName: 'oimg.jpg',
-							appellantSubmissionId: '001',
-							name: 'img.jpg',
-							location: '/img.jpg',
-							type: 'jpg',
-							storageId: '001',
-							questionnaireId: '001'
-						}
-					],
-					siteAddress: true,
-					SubmissionAddress: [
-						{
-							id: 'add_001',
-							appellantSubmissionId: '001',
-							addressLine1: 'Somewhere',
-							addressLine2: 'Somewhere St',
-							townCity: 'Somewhereville',
-							postcode: 'SOM3 W3R',
-							fieldName: 'siteAddress',
-							questionnaireId: '001',
-							county: 'Somewhere'
-						}
-					],
-					SubmissionListedBuilding: [],
-					Appeal: {
-						Users: [
-							{
-								AppealUser: {
-									email: 'test@test.com'
-								}
-							}
-						]
-					}
-				};
-			case '002':
-				return {
-					appealId: '29eee0be-d395-4039-a277-7435e7ab0b66',
-					LPACode: 'LPA_002',
-					appealTypeCode: 'HAS',
-					applicationDecisionDate: new Date('2024-01-01'),
-					applicationDecision: 'refused',
-					onApplicationDate: new Date('2024-01-01'),
-					isAppellant: false,
-					appellantFirstName: 'Test App',
-					appellantLastName: 'Testington',
-					contactFirstName: 'Testy',
-					contactLastName: 'McTest',
-					contactCompanyName: 'Test Agents',
-					ownsAllLand: true,
-					appellantGreenBelt: false,
-					updateDevelopmentDescription: false,
-					costApplication: false,
-					appellantSiteSafety: 'yes',
-					appellantSiteSafety_appellantSiteSafetyDetails: "It's dangerous",
-					appellantSiteAccess: 'yes',
-					appellantSiteAccess_appellantSiteAccessDetails: 'Come and see',
-					applicationReference: '234',
-					developmentDescriptionOriginal: 'A test description',
-					appellantLinkedCaseReference: 'no',
-					contactPhoneNumber: '12345657',
-					// @ts-ignore
-					siteAreaSquareMetres: 25,
-					appellantLinkedCaseAdd: false,
-					appellantLinkedCase: false,
-					SubmissionLinkedCase: [],
-					uploadOriginalApplicationForm: true,
-					uploadApplicationDecisionLetter: false,
-					uploadAppellantStatement: false,
-					uploadCostApplication: false,
-					uploadChangeOfDescriptionEvidence: false,
-					SubmissionDocumentUpload: [
-						{
-							id: 'img_002',
-							fileName: 'img.jpg',
-							originalFileName: 'oimg.jpg',
-							appellantSubmissionId: '002',
-							name: 'img.jpg',
-							location: '/img.jpg',
-							type: 'jpg',
-							storageId: '001',
-							questionnaireId: '002'
-						}
-					],
-					siteAddress: true,
-					SubmissionAddress: [
-						{
-							id: 'add_002',
-							appellantSubmissionId: '002',
-							addressLine1: 'Somewhere',
-							addressLine2: 'Somewhere St',
-							townCity: 'Somewhereville',
-							postcode: 'SOM3 W3R',
-							fieldName: 'siteAddress',
-							questionnaireId: '002',
-							county: 'Somewhere'
-						}
-					],
-					SubmissionListedBuilding: [],
-					Appeal: {
-						Users: [
-							{
-								AppealUser: {
-									email: 'test@test.com'
-								}
-							}
-						]
-					}
-				};
-			case '003':
-				return {
-					appealId: '7e791a1c-e0ca-4089-9fce-bdef405b9ce1',
-					LPACode: '123',
-					appealTypeCode: 'S78',
-					applicationReference: '567',
-					onApplicationDate: new Date(),
-					applicationDecision: 'granted',
-					applicationDecisionDate: new Date(),
-					appellantSiteAccess_appellantSiteAccessDetails: 'Access details',
-					appellantSiteSafety_appellantSiteSafetyDetails: 'Safety details',
-					appellantGreenBelt: true,
-					siteAreaSquareMetres: 100,
-					ownsAllLand: true,
-					ownsSomeLand: false,
-					knowsOtherOwners: 'yes',
-					knowsAllOwners: 'no',
-					advertisedAppeal: true,
-					informedOwners: true,
-					developmentDescriptionOriginal: 'Original description',
-					updateDevelopmentDescription: true,
-					appellantFirstName: 'Test App',
-					appellantLastName: 'Testington',
-					contactFirstName: 'Testy',
-					contactLastName: 'McTest',
-					contactPhoneNumber: '12345657',
-					costApplication: true,
-					isAppellant: false,
-
-					Appeal: {
-						Users: [
-							{
-								AppealUser: { email: 'email' }
-							}
-						]
-					},
-					SubmissionLinkedCase: [{ caseReference: 'case123' }],
-					SubmissionDocumentUpload: [
-						{
-							id: 'img_003',
-							fileName: 'img.jpg',
-							originalFileName: 'oimg.jpg',
-							appellantSubmissionId: '003',
-							name: 'img.jpg',
-							location: '/img.jpg',
-							type: 'jpg',
-							storageId: '001',
-							questionnaireId: '003'
-						}
-					],
-					SubmissionAddress: [
-						{
-							id: 'add_002',
-							appellantSubmissionId: '002',
-							addressLine1: 'Somewhere',
-							addressLine2: 'Somewhere St',
-							townCity: 'Somewhereville',
-							postcode: 'SOM3 W3R',
-							fieldName: 'siteAddress',
-							questionnaireId: '002',
-							county: 'Somewhere'
-						}
-					],
-
-					agriculturalHolding: true,
-					tenantAgriculturalHolding: true,
-					otherTenantsAgriculturalHolding: true,
-					informedTenantsAgriculturalHolding: true,
-
-					planningObligation: true,
-					statusPlanningObligation: 'test',
-
-					appellantProcedurePreference: 'inquiry',
-					appellantPreferInquiryDetails: 'details',
-					appellantPreferInquiryDuration: 13,
-					appellantPreferInquiryWitnesses: 3
-				};
-			default:
-				return null;
-		}
-	},
-	markAppealAsSubmitted: jest.fn()
-}));
-
 jest.mock('../../../../../../src/configuration/featureFlag', () => ({
 	isFeatureActive() {
 		return true;
 	}
 }));
-
 jest.mock('../../../../../../src/infrastructure/event-client', () => ({
 	sendEvents: jest.fn()
 }));
-
 jest.mock('../../../../../../src/services/object-store');
 jest.mock('../../../../../../src/services/lpa.service', () => {
 	class LpaService {
@@ -273,9 +34,7 @@ jest.mock('../../../../../../src/services/lpa.service', () => {
 	}
 	return LpaService;
 });
-
 jest.mock('#lib/notify');
-
 jest.mock('express-oauth2-jwt-bearer', () => {
 	let currentSub = '';
 
@@ -295,13 +54,12 @@ jest.mock('express-oauth2-jwt-bearer', () => {
 		}
 	};
 });
-
 jest.mock('express-oauth2-jwt-bearer');
 
 /** @type {import('pins-data-model/src/schemas').AppellantSubmissionCommand} */
 const formattedHAS1 = {
 	casedata: {
-		submissionId: 'f70dd26f-3776-4685-a79c-a81dbe8790b6',
+		submissionId: expect.any(String),
 		advertisedAppeal: null,
 		appellantCostsAppliedFor: false,
 		applicationDate: '2024-01-01T00:00:00.000Z',
@@ -348,7 +106,7 @@ const formattedHAS1 = {
 	],
 	users: [
 		{
-			emailAddress: 'test@test.com',
+			emailAddress: expect.any(String),
 			firstName: 'Testy',
 			lastName: 'McTest',
 			salutation: null,
@@ -362,7 +120,7 @@ const formattedHAS1 = {
 /** @type {import('pins-data-model/src/schemas').AppellantSubmissionCommand} */
 const formattedHAS2 = {
 	casedata: {
-		submissionId: '29eee0be-d395-4039-a277-7435e7ab0b66',
+		submissionId: expect.any(String),
 		advertisedAppeal: null,
 		appellantCostsAppliedFor: false,
 		applicationDate: '2024-01-01T00:00:00.000Z',
@@ -409,7 +167,7 @@ const formattedHAS2 = {
 	],
 	users: [
 		{
-			emailAddress: 'test@test.com',
+			emailAddress: expect.any(String),
 			firstName: 'Testy',
 			lastName: 'McTest',
 			salutation: null,
@@ -432,7 +190,7 @@ const formattedHAS2 = {
 /** @type {import('pins-data-model/src/schemas').AppellantSubmissionCommand} */
 const formattedS78 = {
 	casedata: {
-		submissionId: '7e791a1c-e0ca-4089-9fce-bdef405b9ce1',
+		submissionId: expect.any(String),
 		advertisedAppeal: true,
 		appellantCostsAppliedFor: true,
 		applicationDate: expect.any(String),
@@ -493,7 +251,7 @@ const formattedS78 = {
 	],
 	users: [
 		{
-			emailAddress: 'email',
+			emailAddress: expect.any(String),
 			firstName: 'Testy',
 			lastName: 'McTest',
 			salutation: null,
@@ -513,11 +271,244 @@ const formattedS78 = {
 	]
 };
 
+let appeal1;
+let appeal2;
+let appeal3;
+
 beforeAll(async () => {
+	await seedStaticData(sqlClient);
+
 	const user = await sqlClient.appealUser.create({
 		data: { email: crypto.randomUUID() + '@example.com' }
 	});
 	validUser = user.id;
+
+	const appeals = [
+		{ id: 'f70dd26f-3776-4685-a79c-a81dbe8790b6' },
+		{ id: '29eee0be-d395-4039-a277-7435e7ab0b66' },
+		{ id: '7e791a1c-e0ca-4089-9fce-bdef405b9ce1' }
+	];
+	await sqlClient.appeal.createMany({ data: appeals });
+
+	await sqlClient.appealToUser.createMany({
+		data: [
+			{
+				appealId: appeals[0].id,
+				userId: user.id,
+				role: 'Appellant'
+			},
+			{
+				appealId: appeals[1].id,
+				userId: user.id,
+				role: 'Appellant'
+			},
+			{
+				appealId: appeals[2].id,
+				userId: user.id,
+				role: 'Appellant'
+			}
+		]
+	});
+
+	await sqlClient.appellantSubmission.createMany({
+		data: [
+			{
+				appealId: appeals[0].id,
+				LPACode: 'LPA_001',
+				appealTypeCode: 'HAS',
+				applicationDecisionDate: new Date('2024-01-01'),
+				applicationDecision: 'refused',
+				onApplicationDate: new Date('2024-01-01'),
+				isAppellant: true,
+				contactFirstName: 'Testy',
+				contactLastName: 'McTest',
+				contactCompanyName: 'Test',
+				ownsAllLand: true,
+				appellantGreenBelt: false,
+				updateDevelopmentDescription: false,
+				knowsOtherOwners: 'yes',
+				costApplication: false,
+				appellantSiteSafety: 'yes',
+				appellantSiteSafety_appellantSiteSafetyDetails: "It's dangerous",
+				appellantSiteAccess: 'yes',
+				appellantSiteAccess_appellantSiteAccessDetails: 'Come and see',
+				applicationReference: '123',
+				developmentDescriptionOriginal: 'A test description',
+				appellantLinkedCaseReference: 'no',
+				contactPhoneNumber: '12345657',
+				siteAreaSquareMetres: 22,
+				appellantLinkedCaseAdd: false,
+				appellantLinkedCase: false,
+				uploadOriginalApplicationForm: true,
+				uploadApplicationDecisionLetter: false,
+				uploadAppellantStatement: false,
+				uploadCostApplication: false,
+				uploadChangeOfDescriptionEvidence: false
+			},
+			{
+				appealId: appeals[1].id,
+				LPACode: 'LPA_002',
+				appealTypeCode: 'HAS',
+				applicationDecisionDate: new Date('2024-01-01'),
+				applicationDecision: 'refused',
+				onApplicationDate: new Date('2024-01-01'),
+				isAppellant: false,
+				appellantFirstName: 'Test App',
+				appellantLastName: 'Testington',
+				contactFirstName: 'Testy',
+				contactLastName: 'McTest',
+				contactCompanyName: 'Test Agents',
+				ownsAllLand: true,
+				appellantGreenBelt: false,
+				updateDevelopmentDescription: false,
+				costApplication: false,
+				appellantSiteSafety: 'yes',
+				appellantSiteSafety_appellantSiteSafetyDetails: "It's dangerous",
+				appellantSiteAccess: 'yes',
+				appellantSiteAccess_appellantSiteAccessDetails: 'Come and see',
+				applicationReference: '234',
+				developmentDescriptionOriginal: 'A test description',
+				appellantLinkedCaseReference: 'no',
+				contactPhoneNumber: '12345657',
+				siteAreaSquareMetres: 25,
+				appellantLinkedCaseAdd: false,
+				appellantLinkedCase: false,
+				uploadOriginalApplicationForm: true,
+				uploadApplicationDecisionLetter: false,
+				uploadAppellantStatement: false,
+				uploadCostApplication: false,
+				uploadChangeOfDescriptionEvidence: false
+			},
+			{
+				appealId: appeals[2].id,
+				LPACode: '123',
+				appealTypeCode: 'S78',
+				applicationReference: '567',
+				onApplicationDate: new Date(),
+				applicationDecision: 'granted',
+				applicationDecisionDate: new Date(),
+				appellantSiteAccess_appellantSiteAccessDetails: 'Access details',
+				appellantSiteSafety_appellantSiteSafetyDetails: 'Safety details',
+				appellantGreenBelt: true,
+				siteAreaSquareMetres: 100,
+				ownsAllLand: true,
+				ownsSomeLand: false,
+				knowsOtherOwners: 'yes',
+				knowsAllOwners: 'no',
+				advertisedAppeal: true,
+				informedOwners: true,
+				developmentDescriptionOriginal: 'Original description',
+				updateDevelopmentDescription: true,
+				appellantFirstName: 'Test App',
+				appellantLastName: 'Testington',
+				contactFirstName: 'Testy',
+				contactLastName: 'McTest',
+				contactPhoneNumber: '12345657',
+				costApplication: true,
+				isAppellant: false,
+				agriculturalHolding: true,
+				tenantAgriculturalHolding: true,
+				otherTenantsAgriculturalHolding: true,
+				informedTenantsAgriculturalHolding: true,
+				planningObligation: true,
+				statusPlanningObligation: 'test',
+				appellantProcedurePreference: 'inquiry',
+				appellantPreferInquiryDetails: 'details',
+				appellantPreferInquiryDuration: 13,
+				appellantPreferInquiryWitnesses: 3
+			}
+		]
+	});
+
+	const submissions = await sqlClient.appellantSubmission.findMany({
+		where: {
+			appealId: {
+				in: appeals.map((a) => a.id)
+			}
+		},
+		select: {
+			id: true,
+			appealId: true
+		}
+	});
+
+	appeal1 = submissions.filter((x) => x.appealId === appeals[0].id)[0];
+	appeal2 = submissions.filter((x) => x.appealId === appeals[1].id)[0];
+	appeal3 = submissions.filter((x) => x.appealId === appeals[2].id)[0];
+
+	await sqlClient.submissionDocumentUpload.createMany({
+		data: [
+			{
+				fileName: 'img.jpg',
+				originalFileName: 'oimg.jpg',
+				appellantSubmissionId: appeal1.id,
+				name: 'img.jpg',
+				location: '/img.jpg',
+				type: 'jpg',
+				storageId: '001'
+			},
+			{
+				fileName: 'img.jpg',
+				originalFileName: 'oimg.jpg',
+				appellantSubmissionId: appeal2.id,
+				name: 'img.jpg',
+				location: '/img.jpg',
+				type: 'jpg',
+				storageId: '001'
+			},
+			{
+				fileName: 'img.jpg',
+				originalFileName: 'oimg.jpg',
+				appellantSubmissionId: appeal3.id,
+				name: 'img.jpg',
+				location: '/img.jpg',
+				type: 'jpg',
+				storageId: '001'
+			}
+		]
+	});
+
+	await sqlClient.submissionAddress.createMany({
+		data: [
+			{
+				appellantSubmissionId: appeal1.id,
+				addressLine1: 'Somewhere',
+				addressLine2: 'Somewhere St',
+				townCity: 'Somewhereville',
+				postcode: 'SOM3 W3R',
+				fieldName: 'siteAddress',
+				county: 'Somewhere'
+			},
+			{
+				appellantSubmissionId: appeal2.id,
+				addressLine1: 'Somewhere',
+				addressLine2: 'Somewhere St',
+				townCity: 'Somewhereville',
+				postcode: 'SOM3 W3R',
+				fieldName: 'siteAddress',
+				county: 'Somewhere'
+			},
+			{
+				appellantSubmissionId: appeal3.id,
+				addressLine1: 'Somewhere',
+				addressLine2: 'Somewhere St',
+				townCity: 'Somewhereville',
+				postcode: 'SOM3 W3R',
+				fieldName: 'siteAddress',
+				county: 'Somewhere'
+			}
+		]
+	});
+
+	await sqlClient.submissionLinkedCase.createMany({
+		data: [
+			{
+				caseReference: 'case123',
+				fieldName: 'linked',
+				appellantSubmissionId: appeal3.id
+			}
+		]
+	});
 });
 
 afterAll(async () => {
@@ -525,19 +516,31 @@ afterAll(async () => {
 });
 
 describe('/api/v2/appeal-cases/:caseReference/submit', () => {
-	it.each([
-		['HAS', '001', formattedHAS1],
-		['HAS', '002', formattedHAS2],
-		['S78', '003', formattedS78]
-	])('Formats %s appeal submission then sends it to back office', async (_, id, expectation) => {
+	it('should format appeals and send to service bus', async () => {
 		const { setCurrentSub } = require('express-oauth2-jwt-bearer');
 		setCurrentSub(validUser);
 
-		await appealsApi.post(`/api/v2/appellant-submissions/${id}/submit`).expect(200);
+		await appealsApi.post(`/api/v2/appellant-submissions/${appeal1.id}/submit`).expect(200);
 
 		expect(sendEvents).toHaveBeenCalledWith(
 			'appeal-fo-appellant-submission',
-			[expectation],
+			[formattedHAS1],
+			'Create'
+		);
+
+		await appealsApi.post(`/api/v2/appellant-submissions/${appeal2.id}/submit`).expect(200);
+
+		expect(sendEvents).toHaveBeenCalledWith(
+			'appeal-fo-appellant-submission',
+			[formattedHAS2],
+			'Create'
+		);
+
+		await appealsApi.post(`/api/v2/appellant-submissions/${appeal3.id}/submit`).expect(200);
+
+		expect(sendEvents).toHaveBeenCalledWith(
+			'appeal-fo-appellant-submission',
+			[formattedS78],
 			'Create'
 		);
 	});

--- a/packages/appeals-service-api/src/routes/v2/appellant-submissions/repo.js
+++ b/packages/appeals-service-api/src/routes/v2/appellant-submissions/repo.js
@@ -324,6 +324,9 @@ module.exports = class Repo {
 								where: {
 									userId,
 									role: { in: [APPEAL_USER_ROLES.APPELLANT, APPEAL_USER_ROLES.AGENT] }
+								},
+								include: {
+									AppealUser: true
 								}
 							}
 						}

--- a/packages/business-rules/src/rules/appeal-case/case-due-dates.js
+++ b/packages/business-rules/src/rules/appeal-case/case-due-dates.js
@@ -8,6 +8,13 @@ const { representationExists } = require('@pins/common/src/lib/representations')
  */
 
 /**
+ * appeal is visible for LPA but not open for LPAQ yet
+ * @param {AppealCaseDetailed} appealCaseData
+ * @returns {boolean}
+ */
+exports.isNewAppealForLPA = (appealCaseData) => !appealCaseData.lpaQuestionnaireDueDate;
+
+/**
  * questionnaire is open for LPA
  * @param {AppealCaseDetailed} appealCaseData
  * @returns {boolean}

--- a/packages/business-rules/src/rules/appeal-case/case-due-dates.test.js
+++ b/packages/business-rules/src/rules/appeal-case/case-due-dates.test.js
@@ -1,4 +1,5 @@
 const {
+	isNewAppealForLPA,
 	isLPAQuestionnaireOpen,
 	isLPAQuestionnaireDue,
 	isLPAStatementOpen,
@@ -38,6 +39,17 @@ describe('case-due-dates', () => {
 	});
 
 	describe('LPAQ', () => {
+		describe('isNewAppealForLPA', () => {
+			it('should return true if lpaQuestionnaireDueDate not set', () => {
+				expect(isNewAppealForLPA(appealCaseData)).toBe(true);
+			});
+
+			it('should return false if lpaQuestionnaireDueDate is set', () => {
+				appealCaseData.lpaQuestionnaireDueDate = '2025-03-01';
+				expect(isNewAppealForLPA(appealCaseData)).toBe(false);
+			});
+		});
+
 		describe('isLPAQuestionnaireOpen', () => {
 			it('should return true if lpaQuestionnaireDueDate is set and lpaq has not been submitted', () => {
 				appealCaseData.lpaQuestionnaireDueDate = '2025-03-01';

--- a/packages/forms-web-app/src/dynamic-forms/middleware/get-journey-response-for-appellant-proof-evidence.js
+++ b/packages/forms-web-app/src/dynamic-forms/middleware/get-journey-response-for-appellant-proof-evidence.js
@@ -12,46 +12,52 @@ const {
 	}
 } = require('../../lib/views');
 
-module.exports = () => async (req, res, next) => {
-	const referenceId = req.params.referenceId;
-	const appealOverviewUrl = `${APPEAL_OVERVIEW}/${referenceId}`;
-	let result;
+/**
+ * @param {boolean} checkSubmitted
+ * @returns {import('express').Handler}
+ */
+module.exports =
+	(checkSubmitted = true) =>
+	async (req, res, next) => {
+		const referenceId = req.params.referenceId;
+		const appealOverviewUrl = `${APPEAL_OVERVIEW}/${referenceId}`;
+		let result;
 
-	const appeal = await req.appealsApiClient.getAppealCaseByCaseRef(referenceId);
+		const appeal = await req.appealsApiClient.getAppealCaseByCaseRef(referenceId);
 
-	if (!isAppellantProofsOfEvidenceOpen(appeal)) {
-		req.session.navigationHistory.shift();
-		return res.redirect(appealOverviewUrl);
-	}
-
-	const journeyType = APPELLANT_JOURNEY_TYPES_FORMATTED.PROOF_EVIDENCE;
-
-	try {
-		const dbResponse = await req.appealsApiClient.getAppellantProofOfEvidenceSubmission(
-			referenceId
-		);
-		const convertedResponse = mapDBResponseToJourneyResponseFormat(dbResponse);
-		result = new JourneyResponse(
-			journeyType,
-			referenceId,
-			convertedResponse,
-			dbResponse.AppealCase?.LPACode
-		);
-	} catch (err) {
-		if (err instanceof ApiClientError && err.code === 404) {
-			logger.debug('proof of evidence not found, creating and returning default response');
-			await req.appealsApiClient.postAppellantProofOfEvidenceSubmission(referenceId);
-		} else {
-			logger.error(err);
+		if (checkSubmitted && !isAppellantProofsOfEvidenceOpen(appeal)) {
+			req.session.navigationHistory.shift();
+			return res.redirect(appealOverviewUrl);
 		}
-		// return default response
-		result = getDefaultResponse(journeyType, referenceId, appeal.LPACode);
-	}
 
-	res.locals.journeyResponse = result;
+		const journeyType = APPELLANT_JOURNEY_TYPES_FORMATTED.PROOF_EVIDENCE;
 
-	return next();
-};
+		try {
+			const dbResponse = await req.appealsApiClient.getAppellantProofOfEvidenceSubmission(
+				referenceId
+			);
+			const convertedResponse = mapDBResponseToJourneyResponseFormat(dbResponse);
+			result = new JourneyResponse(
+				journeyType,
+				referenceId,
+				convertedResponse,
+				dbResponse.AppealCase?.LPACode
+			);
+		} catch (err) {
+			if (err instanceof ApiClientError && err.code === 404) {
+				logger.debug('proof of evidence not found, creating and returning default response');
+				await req.appealsApiClient.postAppellantProofOfEvidenceSubmission(referenceId);
+			} else {
+				logger.error(err);
+			}
+			// return default response
+			result = getDefaultResponse(journeyType, referenceId, appeal.LPACode);
+		}
+
+		res.locals.journeyResponse = result;
+
+		return next();
+	};
 
 /**
  * returns a default response for a journey

--- a/packages/forms-web-app/src/dynamic-forms/middleware/get-journey-response-for-lpa-final-comments.js
+++ b/packages/forms-web-app/src/dynamic-forms/middleware/get-journey-response-for-lpa-final-comments.js
@@ -14,54 +14,60 @@ const {
 	}
 } = require('../../lib/views');
 
-module.exports = () => async (req, res, next) => {
-	const referenceId = req.params.referenceId;
-	const appealOverviewUrl = `${APPEAL_OVERVIEW}/${referenceId}`;
-	let result;
+/**
+ * @param {boolean} checkSubmitted
+ * @returns {import('express').Handler}
+ */
+module.exports =
+	(checkSubmitted = true) =>
+	async (req, res, next) => {
+		const referenceId = req.params.referenceId;
+		const appealOverviewUrl = `${APPEAL_OVERVIEW}/${referenceId}`;
+		let result;
 
-	const user = getUserFromSession(req);
+		const user = getUserFromSession(req);
 
-	const appeal = await req.appealsApiClient.getUsersAppealCase({
-		caseReference: referenceId,
-		userId: user.id,
-		role: LPA_USER_ROLE
-	});
+		const appeal = await req.appealsApiClient.getUsersAppealCase({
+			caseReference: referenceId,
+			userId: user.id,
+			role: LPA_USER_ROLE
+		});
 
-	if (!isLPAFinalCommentOpen(appeal)) {
-		req.session.navigationHistory.shift();
-		return res.redirect(appealOverviewUrl);
-	}
-
-	const journeyType = LPA_JOURNEY_TYPES_FORMATTED.FINAL_COMMENTS;
-
-	try {
-		const dbResponse = await req.appealsApiClient.getLPAFinalCommentSubmission(referenceId);
-		const convertedResponse = mapDBResponseToJourneyResponseFormat(dbResponse);
-		result = new JourneyResponse(
-			journeyType,
-			referenceId,
-			convertedResponse,
-			dbResponse.AppealCase?.LPACode
-		);
-	} catch (err) {
-		if (err instanceof ApiClientError && err.code === 404) {
-			logger.debug('lpa final comment not found, creating and returning default response');
-			await req.appealsApiClient.postLPAFinalCommentSubmission(referenceId);
-		} else {
-			logger.error(err);
+		if (checkSubmitted && !isLPAFinalCommentOpen(appeal)) {
+			req.session.navigationHistory.shift();
+			return res.redirect(appealOverviewUrl);
 		}
-		// return default response
-		result = getDefaultResponse(journeyType, referenceId, user.lpaCode);
-	}
 
-	if (result.LPACode !== user.lpaCode) {
-		return res.status(404).render('error/not-found');
-	}
+		const journeyType = LPA_JOURNEY_TYPES_FORMATTED.FINAL_COMMENTS;
 
-	res.locals.journeyResponse = result;
+		try {
+			const dbResponse = await req.appealsApiClient.getLPAFinalCommentSubmission(referenceId);
+			const convertedResponse = mapDBResponseToJourneyResponseFormat(dbResponse);
+			result = new JourneyResponse(
+				journeyType,
+				referenceId,
+				convertedResponse,
+				dbResponse.AppealCase?.LPACode
+			);
+		} catch (err) {
+			if (err instanceof ApiClientError && err.code === 404) {
+				logger.debug('lpa final comment not found, creating and returning default response');
+				await req.appealsApiClient.postLPAFinalCommentSubmission(referenceId);
+			} else {
+				logger.error(err);
+			}
+			// return default response
+			result = getDefaultResponse(journeyType, referenceId, user.lpaCode);
+		}
 
-	return next();
-};
+		if (result.LPACode !== user.lpaCode) {
+			return res.status(404).render('error/not-found');
+		}
+
+		res.locals.journeyResponse = result;
+
+		return next();
+	};
 
 /**
  * returns a default response for a journey

--- a/packages/forms-web-app/src/dynamic-forms/middleware/get-journey-response-for-lpa-proof-evidence.js
+++ b/packages/forms-web-app/src/dynamic-forms/middleware/get-journey-response-for-lpa-proof-evidence.js
@@ -14,55 +14,61 @@ const {
 	}
 } = require('../../lib/views');
 
-module.exports = () => async (req, res, next) => {
-	const referenceId = req.params.referenceId;
-	const encodedReferenceId = encodeURIComponent(referenceId);
-	const appealOverviewUrl = `${APPEAL_OVERVIEW}/${referenceId}`;
-	let result;
+/**
+ * @param {boolean} checkSubmitted
+ * @returns {import('express').Handler}
+ */
+module.exports =
+	(checkSubmitted = true) =>
+	async (req, res, next) => {
+		const referenceId = req.params.referenceId;
+		const encodedReferenceId = encodeURIComponent(referenceId);
+		const appealOverviewUrl = `${APPEAL_OVERVIEW}/${referenceId}`;
+		let result;
 
-	const user = getUserFromSession(req);
+		const user = getUserFromSession(req);
 
-	const appeal = await req.appealsApiClient.getUsersAppealCase({
-		caseReference: encodedReferenceId,
-		userId: user.id,
-		role: LPA_USER_ROLE
-	});
+		const appeal = await req.appealsApiClient.getUsersAppealCase({
+			caseReference: encodedReferenceId,
+			userId: user.id,
+			role: LPA_USER_ROLE
+		});
 
-	if (!isLPAProofsOfEvidenceOpen(appeal)) {
-		req.session.navigationHistory.shift();
-		return res.redirect(appealOverviewUrl);
-	}
-
-	const journeyType = LPA_JOURNEY_TYPES_FORMATTED.PROOF_EVIDENCE;
-
-	try {
-		const dbResponse = await req.appealsApiClient.getLpaProofOfEvidenceSubmission(referenceId);
-		const convertedResponse = mapDBResponseToJourneyResponseFormat(dbResponse);
-		result = new JourneyResponse(
-			journeyType,
-			referenceId,
-			convertedResponse,
-			dbResponse.AppealCase?.LPACode
-		);
-	} catch (err) {
-		if (err instanceof ApiClientError && err.code === 404) {
-			logger.debug('statement not found, creating and returning default response');
-			await req.appealsApiClient.postLpaProofOfEvidenceSubmission(referenceId);
-		} else {
-			logger.error(err);
+		if (checkSubmitted && !isLPAProofsOfEvidenceOpen(appeal)) {
+			req.session.navigationHistory.shift();
+			return res.redirect(appealOverviewUrl);
 		}
-		// return default response
-		result = getDefaultResponse(journeyType, referenceId, user.lpaCode);
-	}
 
-	if (result.LPACode !== user.lpaCode) {
-		return res.status(404).render('error/not-found');
-	}
+		const journeyType = LPA_JOURNEY_TYPES_FORMATTED.PROOF_EVIDENCE;
 
-	res.locals.journeyResponse = result;
+		try {
+			const dbResponse = await req.appealsApiClient.getLpaProofOfEvidenceSubmission(referenceId);
+			const convertedResponse = mapDBResponseToJourneyResponseFormat(dbResponse);
+			result = new JourneyResponse(
+				journeyType,
+				referenceId,
+				convertedResponse,
+				dbResponse.AppealCase?.LPACode
+			);
+		} catch (err) {
+			if (err instanceof ApiClientError && err.code === 404) {
+				logger.debug('statement not found, creating and returning default response');
+				await req.appealsApiClient.postLpaProofOfEvidenceSubmission(referenceId);
+			} else {
+				logger.error(err);
+			}
+			// return default response
+			result = getDefaultResponse(journeyType, referenceId, user.lpaCode);
+		}
 
-	return next();
-};
+		if (result.LPACode !== user.lpaCode) {
+			return res.status(404).render('error/not-found');
+		}
+
+		res.locals.journeyResponse = result;
+
+		return next();
+	};
 
 /**
  * returns a default response for a journey

--- a/packages/forms-web-app/src/dynamic-forms/middleware/get-journey-response-for-lpa.js
+++ b/packages/forms-web-app/src/dynamic-forms/middleware/get-journey-response-for-lpa.js
@@ -14,58 +14,64 @@ const {
 	}
 } = require('../../lib/views');
 
-module.exports = () => async (req, res, next) => {
-	const referenceId = req.params.referenceId;
-	const encodedReferenceId = encodeURIComponent(referenceId);
-	let result;
+/**
+ * @param {boolean} checkSubmitted
+ * @returns {import('express').Handler}
+ */
+module.exports =
+	(checkSubmitted = true) =>
+	async (req, res, next) => {
+		const referenceId = req.params.referenceId;
+		const encodedReferenceId = encodeURIComponent(referenceId);
+		let result;
 
-	const user = getUserFromSession(req);
+		const user = getUserFromSession(req);
 
-	const appeal = await req.appealsApiClient.getUsersAppealCase({
-		caseReference: encodedReferenceId,
-		userId: user.id,
-		role: LPA_USER_ROLE
-	});
+		const appeal = await req.appealsApiClient.getUsersAppealCase({
+			caseReference: encodedReferenceId,
+			userId: user.id,
+			role: LPA_USER_ROLE
+		});
 
-	if (!isLPAQuestionnaireOpen(appeal)) {
-		req.session.navigationHistory.shift();
-		return res.redirect('/' + DASHBOARD);
-	}
-
-	const appealType = LPA_JOURNEY_TYPES_FORMATTED[appeal.appealTypeCode];
-
-	if (typeof appealType === 'undefined') {
-		throw new Error('appealType is undefined');
-	}
-
-	try {
-		const dbResponse = await req.appealsApiClient.getLPAQuestionnaire(referenceId);
-		const convertedResponse = mapDBResponseToJourneyResponseFormat(dbResponse);
-		result = new JourneyResponse(
-			appealType,
-			referenceId,
-			convertedResponse,
-			dbResponse.AppealCase?.LPACode
-		);
-	} catch (err) {
-		if (err instanceof ApiClientError && err.code === 404) {
-			logger.debug('questionnaire not found, creating and returning default response');
-			await req.appealsApiClient.postLPAQuestionnaire(referenceId);
-		} else {
-			logger.error(err);
+		if (checkSubmitted && !isLPAQuestionnaireOpen(appeal)) {
+			req.session.navigationHistory.shift();
+			return res.redirect('/' + DASHBOARD);
 		}
-		// return default response
-		result = getDefaultResponse(appealType, referenceId, user.lpaCode);
-	}
 
-	if (result.LPACode !== user.lpaCode) {
-		return res.status(404).render('error/not-found');
-	}
+		const appealType = LPA_JOURNEY_TYPES_FORMATTED[appeal.appealTypeCode];
 
-	res.locals.journeyResponse = result;
+		if (typeof appealType === 'undefined') {
+			throw new Error('appealType is undefined');
+		}
 
-	return next();
-};
+		try {
+			const dbResponse = await req.appealsApiClient.getLPAQuestionnaire(referenceId);
+			const convertedResponse = mapDBResponseToJourneyResponseFormat(dbResponse);
+			result = new JourneyResponse(
+				appealType,
+				referenceId,
+				convertedResponse,
+				dbResponse.AppealCase?.LPACode
+			);
+		} catch (err) {
+			if (err instanceof ApiClientError && err.code === 404) {
+				logger.debug('questionnaire not found, creating and returning default response');
+				await req.appealsApiClient.postLPAQuestionnaire(referenceId);
+			} else {
+				logger.error(err);
+			}
+			// return default response
+			result = getDefaultResponse(appealType, referenceId, user.lpaCode);
+		}
+
+		if (result.LPACode !== user.lpaCode) {
+			return res.status(404).render('error/not-found');
+		}
+
+		res.locals.journeyResponse = result;
+
+		return next();
+	};
 
 /**
  * returns a default response for a journey

--- a/packages/forms-web-app/src/dynamic-forms/middleware/get-journey-response-for-lpa.js
+++ b/packages/forms-web-app/src/dynamic-forms/middleware/get-journey-response-for-lpa.js
@@ -3,8 +3,16 @@ const { LPA_JOURNEY_TYPES_FORMATTED } = require('../journey-factory');
 const logger = require('#lib/logger');
 const { getUserFromSession } = require('../../services/user.service');
 const { mapDBResponseToJourneyResponseFormat } = require('./utils');
+const {
+	isLPAQuestionnaireOpen
+} = require('@pins/business-rules/src/rules/appeal-case/case-due-dates');
 const { ApiClientError } = require('@pins/common/src/client/api-client-error.js');
 const { LPA_USER_ROLE } = require('@pins/common/src/constants');
+const {
+	VIEW: {
+		LPA_DASHBOARD: { DASHBOARD }
+	}
+} = require('../../lib/views');
 
 module.exports = () => async (req, res, next) => {
 	const referenceId = req.params.referenceId;
@@ -18,6 +26,11 @@ module.exports = () => async (req, res, next) => {
 		userId: user.id,
 		role: LPA_USER_ROLE
 	});
+
+	if (!isLPAQuestionnaireOpen(appeal)) {
+		req.session.navigationHistory.shift();
+		return res.redirect('/' + DASHBOARD);
+	}
 
 	const appealType = LPA_JOURNEY_TYPES_FORMATTED[appeal.appealTypeCode];
 

--- a/packages/forms-web-app/src/dynamic-forms/middleware/get-journey-response-for-lpa.test.js
+++ b/packages/forms-web-app/src/dynamic-forms/middleware/get-journey-response-for-lpa.test.js
@@ -17,13 +17,16 @@ describe('getJourneyResponse', () => {
 	const mockValidTestLpaUser = { id: '123', lpaCode: testLPACode };
 	const mockValidNotTestLpaUser = { lpaCode: noneTestLPACode };
 	const invalidLpaUser = {};
-	const mockAppeal = { appealTypeCode: 'HAS' };
+	const mockAppeal = { appealTypeCode: 'HAS', lpaQuestionnaireDueDate: new Date() };
 	const testDBResponse = { answer1: '1', AppealCase: { LPACode: testLPACode } };
 
 	beforeEach(() => {
 		req = {
 			params: {
 				referenceId: refId
+			},
+			session: {
+				navigationHistory: ['']
 			}
 		};
 
@@ -41,6 +44,7 @@ describe('getJourneyResponse', () => {
 			res.locals = jest.fn().mockReturnValue(res);
 			res.sendStatus = jest.fn().mockReturnValue(res);
 			res.status = jest.fn().mockReturnValue(res);
+			res.redirect = jest.fn().mockReturnValue(res);
 			return res;
 		};
 		res = mockResponse();
@@ -104,6 +108,17 @@ describe('getJourneyResponse', () => {
 		expect(next).toHaveBeenCalled();
 	});
 
+	it('should redirect user to dashboard if lpaq not open', async () => {
+		getUserFromSession.mockReturnValue(mockValidNotTestLpaUser);
+		req.appealsApiClient.getUsersAppealCase.mockImplementation(() =>
+			Promise.resolve({ ...mockAppeal, lpaQuestionnaireSubmittedDate: new Date() })
+		);
+
+		await getJourneyResponse()(req, res, next);
+
+		expect(res.redirect).toHaveBeenCalled();
+	});
+
 	it('should return a 404 not found response if user lpa does not match', async () => {
 		getUserFromSession.mockReturnValue(mockValidNotTestLpaUser);
 		req.appealsApiClient.getUsersAppealCase.mockImplementation(() => Promise.resolve(mockAppeal));
@@ -133,7 +148,7 @@ describe('getJourneyResponse', () => {
 	it('should throw error if unknown appealType', async () => {
 		getUserFromSession.mockReturnValue(mockValidTestLpaUser);
 		req.appealsApiClient.getUsersAppealCase.mockImplementation(() =>
-			Promise.resolve({ appealTypeCode: 'nope' })
+			Promise.resolve({ appealTypeCode: 'nope', lpaQuestionnaireDueDate: new Date() })
 		);
 
 		await expect(getJourneyResponse()(req, res, next)).rejects.toThrowError('');

--- a/packages/forms-web-app/src/dynamic-forms/middleware/get-journey-response-for-lpa.test.js
+++ b/packages/forms-web-app/src/dynamic-forms/middleware/get-journey-response-for-lpa.test.js
@@ -119,6 +119,17 @@ describe('getJourneyResponse', () => {
 		expect(res.redirect).toHaveBeenCalled();
 	});
 
+	it('should not redirect user if lpaq not open but checkSubmitted is false', async () => {
+		getUserFromSession.mockReturnValue(mockValidNotTestLpaUser);
+		req.appealsApiClient.getUsersAppealCase.mockImplementation(() =>
+			Promise.resolve({ ...mockAppeal, lpaQuestionnaireSubmittedDate: new Date() })
+		);
+
+		await getJourneyResponse(false)(req, res, next);
+
+		expect(res.redirect).not.toHaveBeenCalled();
+	});
+
 	it('should return a 404 not found response if user lpa does not match', async () => {
 		getUserFromSession.mockReturnValue(mockValidNotTestLpaUser);
 		req.appealsApiClient.getUsersAppealCase.mockImplementation(() => Promise.resolve(mockAppeal));

--- a/packages/forms-web-app/src/dynamic-forms/middleware/get-journey-response-for-rule-6-statement.js
+++ b/packages/forms-web-app/src/dynamic-forms/middleware/get-journey-response-for-rule-6-statement.js
@@ -12,44 +12,50 @@ const {
 	}
 } = require('../../lib/views');
 
-module.exports = () => async (req, res, next) => {
-	const referenceId = req.params.referenceId;
-	const appealOverviewUrl = `${APPEAL_OVERVIEW}/${referenceId}`;
-	let result;
+/**
+ * @param {boolean} checkSubmitted
+ * @returns {import('express').Handler}
+ */
+module.exports =
+	(checkSubmitted = true) =>
+	async (req, res, next) => {
+		const referenceId = req.params.referenceId;
+		const appealOverviewUrl = `${APPEAL_OVERVIEW}/${referenceId}`;
+		let result;
 
-	const appeal = await req.appealsApiClient.getAppealCaseByCaseRef(referenceId);
+		const appeal = await req.appealsApiClient.getAppealCaseByCaseRef(referenceId);
 
-	if (!isRule6StatementOpen(appeal)) {
-		req.session.navigationHistory.shift();
-		return res.redirect(appealOverviewUrl);
-	}
-
-	const journeyType = RULE_6_JOURNEY_TYPES_FORMATTED.STATEMENT;
-
-	try {
-		const dbResponse = await req.appealsApiClient.getRule6StatementSubmission(referenceId);
-		const convertedResponse = mapDBResponseToJourneyResponseFormat(dbResponse);
-		result = new JourneyResponse(
-			journeyType,
-			referenceId,
-			convertedResponse,
-			dbResponse.AppealCase?.LPACode
-		);
-	} catch (err) {
-		if (err instanceof ApiClientError && err.code === 404) {
-			logger.debug('rule 6 statement not found, creating and returning default response');
-			await req.appealsApiClient.postRule6StatementSubmission(referenceId);
-		} else {
-			logger.error(err);
+		if (checkSubmitted && !isRule6StatementOpen(appeal)) {
+			req.session.navigationHistory.shift();
+			return res.redirect(appealOverviewUrl);
 		}
-		// return default response
-		result = getDefaultResponse(journeyType, referenceId, appeal.LPACode);
-	}
 
-	res.locals.journeyResponse = result;
+		const journeyType = RULE_6_JOURNEY_TYPES_FORMATTED.STATEMENT;
 
-	return next();
-};
+		try {
+			const dbResponse = await req.appealsApiClient.getRule6StatementSubmission(referenceId);
+			const convertedResponse = mapDBResponseToJourneyResponseFormat(dbResponse);
+			result = new JourneyResponse(
+				journeyType,
+				referenceId,
+				convertedResponse,
+				dbResponse.AppealCase?.LPACode
+			);
+		} catch (err) {
+			if (err instanceof ApiClientError && err.code === 404) {
+				logger.debug('rule 6 statement not found, creating and returning default response');
+				await req.appealsApiClient.postRule6StatementSubmission(referenceId);
+			} else {
+				logger.error(err);
+			}
+			// return default response
+			result = getDefaultResponse(journeyType, referenceId, appeal.LPACode);
+		}
+
+		res.locals.journeyResponse = result;
+
+		return next();
+	};
 
 /**
  * returns a default response for a journey

--- a/packages/forms-web-app/src/lib/dashboard-functions.js
+++ b/packages/forms-web-app/src/lib/dashboard-functions.js
@@ -3,7 +3,7 @@ const {
 	mapDecisionLabel
 } = require('@pins/business-rules/src/utils/decision-outcome');
 const {
-	isLPAQuestionnaireOpen,
+	isNewAppealForLPA,
 	isLPAQuestionnaireDue,
 	isLPAStatementOpen,
 	isRule6StatementOpen,
@@ -91,7 +91,7 @@ const mapToLPADashboardDisplayData = (appealCaseData) => ({
 	address: formatAddress(appealCaseData),
 	appealType: appealCaseData.appealTypeCode,
 	nextJourneyDue: determineJourneyToDisplayLPADashboard(appealCaseData),
-	isNewAppeal: isLPAQuestionnaireOpen(appealCaseData),
+	isNewAppeal: isNewAppealForLPA(appealCaseData),
 	displayInvalid: displayInvalidAppeal(appealCaseData),
 	appealDecision: mapDecisionLabel(appealCaseData.caseDecisionOutcome),
 	appealDecisionColor: mapDecisionColour(appealCaseData.caseDecisionOutcome),

--- a/packages/forms-web-app/src/routes/appeals/final-comments/index.js
+++ b/packages/forms-web-app/src/routes/appeals/final-comments/index.js
@@ -76,7 +76,7 @@ router.post(
 router.get(
 	'/:referenceId/submitted',
 	setDefaultSection(),
-	getJourneyResponse(),
+	getJourneyResponse(false),
 	getJourney(journeys),
 	appellantFinalCommentSubmitted
 );

--- a/packages/forms-web-app/src/routes/appeals/proof-evidence/index.js
+++ b/packages/forms-web-app/src/routes/appeals/proof-evidence/index.js
@@ -76,7 +76,7 @@ router.post(
 router.get(
 	'/:referenceId/submitted-proof-evidence',
 	setDefaultSection(),
-	getJourneyResponse(),
+	getJourneyResponse(false),
 	getJourney(journeys),
 	appellantProofEvidenceSubmitted
 );

--- a/packages/forms-web-app/src/routes/lpa-dashboard/final-comments.js
+++ b/packages/forms-web-app/src/routes/lpa-dashboard/final-comments.js
@@ -85,7 +85,7 @@ router.post(
 
 router.get(
 	'/final-comments/:referenceId/submitted',
-	getJourneyResponse(),
+	getJourneyResponse(false),
 	getJourney(journeys),
 	validationErrorHandler,
 	lpaFinalCommentSubmitted

--- a/packages/forms-web-app/src/routes/lpa-dashboard/proof-evidence.js
+++ b/packages/forms-web-app/src/routes/lpa-dashboard/proof-evidence.js
@@ -76,7 +76,7 @@ router.post(
 router.get(
 	'/proof-evidence/:referenceId/submitted-proof-evidence',
 	setDefaultSection(),
-	getJourneyResponse(),
+	getJourneyResponse(false),
 	getJourney(journeys),
 	lpaProofEvidenceSubmitted
 );

--- a/packages/forms-web-app/src/routes/lpa-dashboard/questionnaire.js
+++ b/packages/forms-web-app/src/routes/lpa-dashboard/questionnaire.js
@@ -105,7 +105,7 @@ router.post(
 
 router.get(
 	'/full-planning/:referenceId/questionnaire-submitted',
-	getJourneyResponse(),
+	getJourneyResponse(false),
 	getJourney(journeys),
 	validationErrorHandler,
 	lpaSubmitted

--- a/packages/forms-web-app/src/routes/lpa-dashboard/statement.js
+++ b/packages/forms-web-app/src/routes/lpa-dashboard/statement.js
@@ -74,7 +74,7 @@ router.get(
 
 router.get(
 	'/appeal-statement/:referenceId/submitted-appeal-statement',
-	getJourneyResponse(),
+	getJourneyResponse(false),
 	getJourney(journeys),
 	validationErrorHandler,
 	appealStatementSubmitted

--- a/packages/forms-web-app/src/routes/rule-6/appeal-statement.js
+++ b/packages/forms-web-app/src/routes/rule-6/appeal-statement.js
@@ -69,7 +69,7 @@ router.post(
 router.get(
 	'/appeal-statement/:referenceId/submitted-appeal-statement',
 	setDefaultSection(),
-	getJourneyResponse(),
+	getJourneyResponse(false),
 	getJourney(journeys),
 	rule6StatementSubmitted
 );

--- a/packages/forms-web-app/src/routes/rule-6/proof-evidence.js
+++ b/packages/forms-web-app/src/routes/rule-6/proof-evidence.js
@@ -71,7 +71,7 @@ router.post(
 router.get(
 	'/proof-evidence/:referenceId/submitted-proof-evidence',
 	setDefaultSection(),
-	getJourneyResponse(),
+	getJourneyResponse(false),
 	getJourney(journeys),
 	rule6ProofEvidenceSubmitted
 );


### PR DESCRIPTION
## Description of change

https://pins-ds.atlassian.net/browse/A2-1107
- include appeal user for BO submission - causes failure on submission
- add appeal ownership checks to appeal representation lookup - users can see each other's appeals without this check

https://pins-ds.atlassian.net/browse/A2-2475
- show new appeal on correct dashboard for LPA - mistake made in simplifying led to this appearing in awaiting review
- add lpaq open check in middleware - matches the logic for other journeys for consistency 
- fix redirect from submitted pages - was redirecting on submit confirmation pages

## Checklist

<!-- Put an `x` in all the boxes that apply: -->

- [ ] Requires infrastructure changes
- [ ] I have updated the documentation accordingly
- [x] My commit history in this PR is linear
- [x] New features have tests
- [ ] Breaking change (team conversation required)

## Important

Please do not merge from `main` (please only [rebase](https://github.com/Planning-Inspectorate/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
