### PR TITLE
fix(a2-2064): display owned reps when rep exists rather than date sub…

### DIFF
--- a/packages/appeals-service-api/src/repositories/sql/service-user-repository.js
+++ b/packages/appeals-service-api/src/repositories/sql/service-user-repository.js
@@ -130,7 +130,7 @@ class ServiceUserRepository {
 			}),
 
 			this.dbClient.serviceUser.findFirst({
-				where: { id: data.id }
+				where: { id: data.id, caseReference: data.caseReference }
 			})
 		]);
 

--- a/packages/forms-web-app/src/controllers/selected-appeal/appellant-sections.js
+++ b/packages/forms-web-app/src/controllers/selected-appeal/appellant-sections.js
@@ -1,4 +1,7 @@
-const { representationPublished } = require('@pins/common/src/lib/representations');
+const {
+	representationPublished,
+	representationExists
+} = require('@pins/common/src/lib/representations');
 const {
 	LPA_USER_ROLE,
 	APPEAL_USER_ROLES,
@@ -74,7 +77,8 @@ exports.sections = [
 			{
 				url: '/final-comments',
 				text: 'View your final comments',
-				condition: (appealCase) => !!appealCase.appellantCommentsSubmittedDate
+				condition: (appealCase) =>
+					representationExists(appealCase.Representations, REPRESENTATION_TYPES.FINAL_COMMENT, true)
 			},
 			{
 				url: '/lpa-final-comments',
@@ -104,7 +108,12 @@ exports.sections = [
 			{
 				url: '/proof-evidence',
 				text: 'View your proof of evidence and witnesses',
-				condition: (appealCase) => !!appealCase.appellantProofsSubmittedDate
+				condition: (appealCase) =>
+					representationExists(
+						appealCase.Representations,
+						REPRESENTATION_TYPES.PROOFS_OF_EVIDENCE,
+						true
+					)
 			},
 			{
 				url: '/lpa-proof-evidence',

--- a/packages/forms-web-app/src/controllers/selected-appeal/lpa-user-sections.js
+++ b/packages/forms-web-app/src/controllers/selected-appeal/lpa-user-sections.js
@@ -1,4 +1,7 @@
-const { representationPublished } = require('@pins/common/src/lib/representations');
+const {
+	representationPublished,
+	representationExists
+} = require('@pins/common/src/lib/representations');
 const { APPEAL_USER_ROLES, REPRESENTATION_TYPES } = require('@pins/common/src/constants');
 
 /**
@@ -32,7 +35,8 @@ exports.sections = [
 			{
 				url: '/statement',
 				text: 'View your statement',
-				condition: (appealCase) => !!appealCase.LPAStatementSubmittedDate
+				condition: (appealCase) =>
+					representationExists(appealCase.Representations, REPRESENTATION_TYPES.STATEMENT, true)
 			},
 			{
 				url: '/other-party-statements',
@@ -66,7 +70,8 @@ exports.sections = [
 			{
 				url: '/final-comments',
 				text: 'View your final comments',
-				condition: (appealCase) => !!appealCase.LPACommentsSubmittedDate
+				condition: (appealCase) =>
+					representationExists(appealCase.Representations, REPRESENTATION_TYPES.FINAL_COMMENT, true)
 			},
 			{
 				url: '/appellant-final-comments',
@@ -96,7 +101,12 @@ exports.sections = [
 			{
 				url: '/proof-evidence',
 				text: 'View your proof of evidence and witnesses',
-				condition: (appealCase) => !!appealCase.LPAProofsSubmittedDate
+				condition: (appealCase) =>
+					representationExists(
+						appealCase.Representations,
+						REPRESENTATION_TYPES.PROOFS_OF_EVIDENCE,
+						true
+					)
 			},
 			{
 				url: '/appellant-proof-evidence',

--- a/packages/forms-web-app/src/controllers/selected-appeal/user-sections.test.js
+++ b/packages/forms-web-app/src/controllers/selected-appeal/user-sections.test.js
@@ -91,15 +91,28 @@ describe('LPA and Appellant Sections', () => {
 		});
 
 		describe('Statements', () => {
-			it('should show "View your statement" when LPAStatementSubmittedDate is set', () => {
-				appealCase.LPAStatementSubmittedDate = new Date();
+			it('should show "View your statement" when user owned statement is present', () => {
+				appealCase.Representations = [
+					{
+						representationStatus: APPEAL_REPRESENTATION_STATUS.PUBLISHED,
+						userOwnsRepresentation: true,
+						representationType: REPRESENTATION_TYPES.STATEMENT
+					}
+				];
 				const section = findSectionByHeading(lpaSections, 'Statements');
 				const link = findLinkByUrl(section, '/statement');
 				expect(link?.condition(appealCase)).toBe(true);
 				expect(link?.text).toBe('View your statement');
 			});
 
-			it('should not show "View your statement" when LPAStatementSubmittedDate is absent', () => {
+			it('should not show "View your statement" when user owned statement is not present', () => {
+				appealCase.Representations = [
+					{
+						representationStatus: APPEAL_REPRESENTATION_STATUS.PUBLISHED,
+						userOwnsRepresentation: false,
+						representationType: REPRESENTATION_TYPES.STATEMENT
+					}
+				];
 				const section = findSectionByHeading(lpaSections, 'Statements');
 				const link = findLinkByUrl(section, '/statement');
 				expect(link?.condition(appealCase)).toBe(false);
@@ -167,8 +180,14 @@ describe('LPA and Appellant Sections', () => {
 		});
 
 		describe('Final comments', () => {
-			it('should show "View your final comments" when LPACommentsSubmittedDate is set', () => {
-				appealCase.LPACommentsSubmittedDate = new Date();
+			it('should show "View your final comments" when owned FINAL_COMMENT is present', () => {
+				appealCase.Representations = [
+					{
+						representationStatus: APPEAL_REPRESENTATION_STATUS.PUBLISHED,
+						userOwnsRepresentation: true,
+						representationType: REPRESENTATION_TYPES.FINAL_COMMENT
+					}
+				];
 				const section = findSectionByHeading(lpaSections, 'Final comments');
 				const link = findLinkByUrl(section, '/final-comments');
 				expect(link?.condition(appealCase)).toBe(true);
@@ -176,6 +195,13 @@ describe('LPA and Appellant Sections', () => {
 			});
 
 			it('should not show "View your final comments" when LPACommentsSubmittedDate is absent', () => {
+				appealCase.Representations = [
+					{
+						representationStatus: APPEAL_REPRESENTATION_STATUS.PUBLISHED,
+						userOwnsRepresentation: false,
+						representationType: REPRESENTATION_TYPES.FINAL_COMMENT
+					}
+				];
 				const section = findSectionByHeading(lpaSections, 'Final comments');
 				const link = findLinkByUrl(section, '/final-comments');
 				expect(link?.condition(appealCase)).toBe(false);
@@ -205,16 +231,28 @@ describe('LPA and Appellant Sections', () => {
 		});
 
 		describe('Proof of evidence and witnesses', () => {
-			it('should show "View your proof of evidence and witnesses" when LPAProofsSubmittedDate is set', () => {
-				appealCase.LPAProofsSubmittedDate = new Date();
+			it('should show "View your proof of evidence and witnesses" when owned PROOFS_OF_EVIDENCE is present', () => {
+				appealCase.Representations = [
+					{
+						representationStatus: APPEAL_REPRESENTATION_STATUS.PUBLISHED,
+						userOwnsRepresentation: true,
+						representationType: REPRESENTATION_TYPES.PROOFS_OF_EVIDENCE
+					}
+				];
 				const section = findSectionByHeading(lpaSections, 'Proof of evidence and witnesses');
 				const link = findLinkByUrl(section, '/proof-evidence');
 				expect(link?.condition(appealCase)).toBe(true);
 				expect(link?.text).toBe('View your proof of evidence and witnesses');
 			});
 
-			it('should not show "View your proof of evidence and witnesses" when lpaProofEvidencePublished is absent', () => {
-				appealCase.LPAProofsSubmittedDate = null;
+			it('should not show "View your proof of evidence and witnesses" when no owned PROOFS_OF_EVIDENCE is present', () => {
+				appealCase.Representations = [
+					{
+						representationStatus: APPEAL_REPRESENTATION_STATUS.PUBLISHED,
+						userOwnsRepresentation: false,
+						representationType: REPRESENTATION_TYPES.PROOFS_OF_EVIDENCE
+					}
+				];
 				const section = findSectionByHeading(lpaSections, 'Proof of evidence and witnesses');
 				const link = findLinkByUrl(section, '/proof-evidence');
 				expect(link?.condition(appealCase)).toBe(false);
@@ -375,16 +413,28 @@ describe('LPA and Appellant Sections', () => {
 		});
 
 		describe('Final comments', () => {
-			it('should show "View your final comments" when appellantCommentsSubmittedDate is set', () => {
-				appealCase.appellantCommentsSubmittedDate = new Date();
+			it('should show "View your final comments" when user has owned final comment', () => {
+				appealCase.Representations = [
+					{
+						representationStatus: APPEAL_REPRESENTATION_STATUS.PUBLISHED,
+						userOwnsRepresentation: true,
+						representationType: REPRESENTATION_TYPES.FINAL_COMMENT
+					}
+				];
 				const section = findSectionByHeading(appellantSections, 'Final comments');
 				const link = findLinkByUrl(section, '/final-comments');
 				expect(link?.condition(appealCase)).toBe(true);
 				expect(link?.text).toBe('View your final comments');
 			});
 
-			it('should not show "View your final comments" when appellantCommentsSubmittedDate is absent', () => {
-				appealCase.appellantCommentsSubmittedDate = null;
+			it('should not show "View your final comments" when user has no owned final comments', () => {
+				appealCase.Representations = [
+					{
+						representationStatus: APPEAL_REPRESENTATION_STATUS.PUBLISHED,
+						userOwnsRepresentation: false,
+						representationType: REPRESENTATION_TYPES.FINAL_COMMENT
+					}
+				];
 				const section = findSectionByHeading(appellantSections, 'Final comments');
 				const link = findLinkByUrl(section, '/final-comments');
 				expect(link?.condition(appealCase)).toBe(false);
@@ -414,16 +464,28 @@ describe('LPA and Appellant Sections', () => {
 		});
 
 		describe('Proof of evidence and witnesses', () => {
-			it('should show "View your proof of evidence and witnesses" when appellantProofsSubmittedDate is set', () => {
-				appealCase.appellantProofsSubmittedDate = new Date();
+			it('should show "View your proof of evidence and witnesses" when owned PROOFS_OF_EVIDENCE is present', () => {
+				appealCase.Representations = [
+					{
+						representationStatus: APPEAL_REPRESENTATION_STATUS.PUBLISHED,
+						userOwnsRepresentation: true,
+						representationType: REPRESENTATION_TYPES.PROOFS_OF_EVIDENCE
+					}
+				];
 				const section = findSectionByHeading(appellantSections, 'Proof of evidence and witnesses');
 				const link = findLinkByUrl(section, '/proof-evidence');
 				expect(link?.condition(appealCase)).toBe(true);
 				expect(link?.text).toBe('View your proof of evidence and witnesses');
 			});
 
-			it('should not show "View your proof of evidence and witnesses" when appellantProofsSubmittedDate is absent', () => {
-				appealCase.appellantProofsSubmittedDate = null;
+			it('should not show "View your proof of evidence and witnesses" when no owned PROOFS_OF_EVIDENCE is present', () => {
+				appealCase.Representations = [
+					{
+						representationStatus: APPEAL_REPRESENTATION_STATUS.PUBLISHED,
+						userOwnsRepresentation: false,
+						representationType: REPRESENTATION_TYPES.PROOFS_OF_EVIDENCE
+					}
+				];
 				const section = findSectionByHeading(appellantSections, 'Proof of evidence and witnesses');
 				const link = findLinkByUrl(section, '/proof-evidence');
 				expect(link?.condition(appealCase)).toBe(false);

--- a/packages/forms-web-app/src/lib/representation-functions.js
+++ b/packages/forms-web-app/src/lib/representation-functions.js
@@ -1,3 +1,4 @@
+const { APPEAL_REPRESENTATION_STATUS } = require('pins-data-model');
 const {
 	LPA_USER_ROLE,
 	APPEAL_USER_ROLES,
@@ -42,12 +43,14 @@ const filterRepresentationsForDisplay = (caseData, representationParams) => {
 			!!rule6OwnRepresentations
 		).filter(
 			(representation) =>
-				representation.userOwnsRepresentation || representation.representationStatus == 'published'
+				representation.userOwnsRepresentation ||
+				representation.representationStatus == APPEAL_REPRESENTATION_STATUS.PUBLISHED
 		);
 	} else {
 		return representationsFilteredBySubmittingParty.filter(
 			(representation) =>
-				representation.userOwnsRepresentation || representation.representationStatus == 'published'
+				representation.userOwnsRepresentation ||
+				representation.representationStatus == APPEAL_REPRESENTATION_STATUS.PUBLISHED
 		);
 	}
 };


### PR DESCRIPTION
…mitted set

## Description of change

https://pins-ds.atlassian.net/browse/A2-2064

- Display own representations based on existence of owned rep rather than submitted date being set - some dates are not coming through from back office, this resolves issue temporarily but also makes it more consistent

https://pins-ds.atlassian.net/browse/A2-2056

- Only update service user when update is for same case - service users were being overwritten by updates on another case
- Use const for published status

## Checklist

<!-- Put an `x` in all the boxes that apply: -->

- [ ] Requires infrastructure changes
- [ ] I have updated the documentation accordingly
- [x] My commit history in this PR is linear
- [x] New features have tests
- [ ] Breaking change (team conversation required)

## Important

Please do not merge from `main` (please only [rebase](https://github.com/Planning-Inspectorate/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
