### PR TITLE
fix: remove service user from appealUser and lookup via email and type

### DIFF
--- a/packages/appeals-service-api/__tests__/unit/repositories/sql/service-user-repository.test.js
+++ b/packages/appeals-service-api/__tests__/unit/repositories/sql/service-user-repository.test.js
@@ -13,58 +13,74 @@ describe('ServiceUserRepository', () => {
 		mockReset(mockPrismaClient);
 	});
 
-	describe('getServiceUserByIdAndCaseReference', () => {
-		it('should return service user when found', async () => {
-			const serviceUserId = 'user-id';
+	describe('getForEmailCaseAndType', () => {
+		it('should return service users for given email, case reference and types', async () => {
+			const email = 'test@example.com';
 			const caseReference = 'case-ref';
-			const expectedUser = { firstName: 'John', lastName: 'Doe' };
+			const serviceUserTypes = [SERVICE_USER_TYPE.APPELLANT, SERVICE_USER_TYPE.AGENT];
+			const expectedUsers = {
+				firstName: 'John',
+				lastName: 'Doe',
+				emailAddress: email,
+				serviceUserType: SERVICE_USER_TYPE.APPELLANT,
+				id: '123'
+			};
 
-			mockPrismaClient.serviceUser.findFirst.mockResolvedValue(expectedUser);
+			mockPrismaClient.serviceUser.findFirst.mockResolvedValue(expectedUsers);
 
-			const result = await repository.getServiceUserByIdAndCaseReference(
-				serviceUserId,
-				caseReference
+			const result = await repository.getForEmailCaseAndType(
+				email,
+				caseReference,
+				serviceUserTypes
 			);
 
-			expect(result).toEqual(expectedUser);
+			expect(result).toEqual(expectedUsers);
 			expect(mockPrismaClient.serviceUser.findFirst).toHaveBeenCalledWith({
 				where: {
-					AND: {
-						id: serviceUserId,
-						caseReference
-					}
+					OR: serviceUserTypes.map((type) => ({
+						emailAddress: email,
+						caseReference,
+						serviceUserType: type
+					}))
 				},
 				select: {
+					emailAddress: true,
+					serviceUserType: true,
+					id: true,
 					firstName: true,
-					lastName: true,
-					serviceUserType: true
+					lastName: true
 				}
 			});
 		});
 
-		it('should return null when service user not found', async () => {
-			const serviceUserId = 'user-id';
+		it('should return null when no service user found', async () => {
+			const email = 'test@example.com';
 			const caseReference = 'case-ref';
+			const serviceUserTypes = [SERVICE_USER_TYPE.APPELLANT, SERVICE_USER_TYPE.AGENT];
 
 			mockPrismaClient.serviceUser.findFirst.mockResolvedValue(null);
 
-			const result = await repository.getServiceUserByIdAndCaseReference(
-				serviceUserId,
-				caseReference
+			const result = await repository.getForEmailCaseAndType(
+				email,
+				caseReference,
+				serviceUserTypes
 			);
 
-			expect(result).toBeNull();
+			expect(result).toEqual(null);
 			expect(mockPrismaClient.serviceUser.findFirst).toHaveBeenCalledWith({
 				where: {
-					AND: {
-						id: serviceUserId,
-						caseReference
-					}
+					OR: serviceUserTypes.map((type) => ({
+						emailAddress: email,
+						caseReference,
+						serviceUserType: type
+					}))
 				},
 				select: {
+					emailAddress: true,
+					serviceUserType: true,
+					id: true,
 					firstName: true,
-					lastName: true,
-					serviceUserType: true
+					lastName: true
 				}
 			});
 		});

--- a/packages/appeals-service-api/src/routes/v2/appeal-cases/_caseReference/appellant-final-comment-submission/submit/index.spec.js
+++ b/packages/appeals-service-api/src/routes/v2/appeal-cases/_caseReference/appellant-final-comment-submission/submit/index.spec.js
@@ -4,6 +4,8 @@ const { createPrismaClient } = require('../../../../../../db/db-client');
 const { seedStaticData } = require('@pins/database/src/seed/data-static');
 const { sendEvents } = require('../../../../../../../src/infrastructure/event-client');
 const { APPEAL_USER_ROLES } = require('@pins/common/src/constants');
+const { SERVICE_USER_TYPE } = require('pins-data-model');
+
 const crypto = require('crypto');
 const {
 	createTestAppealCase
@@ -18,6 +20,9 @@ let appealsApi;
 
 let validUser;
 const validLpa = 'Q9999';
+
+const testCase1 = '001';
+const testCase2 = '002';
 
 jest.mock('../../../../../../configuration/featureFlag');
 jest.mock('../../../../../../../src/services/object-store');
@@ -78,11 +83,29 @@ beforeAll(async () => {
 
 	await seedStaticData(sqlClient);
 
+	const email = crypto.randomUUID() + '@example.com';
 	const user = await sqlClient.appealUser.create({
 		data: {
-			email: crypto.randomUUID() + '@example.com',
-			serviceUserId: 'userID1'
+			email
 		}
+	});
+	await sqlClient.serviceUser.createMany({
+		data: [
+			{
+				internalId: crypto.randomUUID(),
+				emailAddress: email,
+				id: crypto.randomUUID(),
+				serviceUserType: SERVICE_USER_TYPE.APPELLANT,
+				caseReference: testCase1
+			},
+			{
+				internalId: crypto.randomUUID(),
+				emailAddress: email,
+				id: crypto.randomUUID(),
+				serviceUserType: SERVICE_USER_TYPE.APPELLANT,
+				caseReference: testCase2
+			}
+		]
 	});
 	validUser = user.id;
 });
@@ -131,24 +154,24 @@ const createAppeal = async (caseRef) => {
 };
 
 const formattedFinalComment1 = {
-	caseReference: '001',
+	caseReference: testCase1,
 	representation: 'This is a test comment',
 	representationSubmittedDate: expect.any(String),
 	representationType: 'final_comment',
-	serviceUserId: 'userID1',
+	serviceUserId: expect.any(String),
 	documents: []
 };
 
 const formattedFinalComment2 = {
-	caseReference: '002',
+	caseReference: testCase2,
 	representation: 'Another final comment text for appellant case 002',
 	representationSubmittedDate: expect.any(String),
 	representationType: 'final_comment',
-	serviceUserId: 'userID1',
+	serviceUserId: expect.any(String),
 	documents: [
 		{
 			dateCreated: expect.any(String),
-			documentId: '002',
+			documentId: testCase2,
 			documentType: 'appellantFinalComment',
 			documentURI: 'https://example.com',
 			filename: 'doc.pdf',
@@ -162,7 +185,7 @@ const formattedFinalComment2 = {
 describe('/api/v2/appeal-cases/:caseReference/appellant-final-comment-submissions/submit', () => {
 	it('Formats S78 appellant final comment submission without docs for case 001', async () => {
 		utils.getDocuments.mockReturnValue([]);
-		await createAppeal('001');
+		await createAppeal(testCase1);
 
 		const { setCurrentLpa } = require('@pins/common/src/middleware/validate-token');
 		setCurrentLpa(validLpa);
@@ -192,7 +215,7 @@ describe('/api/v2/appeal-cases/:caseReference/appellant-final-comment-submission
 	it('Formats S78 appellant final comment submission with docs for case 002', async () => {
 		utils.getDocuments.mockReturnValue([
 			{
-				documentId: '002',
+				documentId: testCase2,
 				filename: 'doc.pdf',
 				originalFilename: 'mydoc.pdf',
 				documentType: 'appellantFinalComment',
@@ -203,7 +226,7 @@ describe('/api/v2/appeal-cases/:caseReference/appellant-final-comment-submission
 			}
 		]);
 
-		await createAppeal('002');
+		await createAppeal(testCase2);
 		const { setCurrentLpa } = require('@pins/common/src/middleware/validate-token');
 		setCurrentLpa(validLpa);
 		const { setCurrentSub } = require('express-oauth2-jwt-bearer');

--- a/packages/appeals-service-api/src/routes/v2/appeal-cases/_caseReference/representations/representations.spec.js
+++ b/packages/appeals-service-api/src/routes/v2/appeal-cases/_caseReference/representations/representations.spec.js
@@ -3,6 +3,8 @@ const app = require('../../../../../app');
 const { createPrismaClient } = require('../../../../../db/db-client');
 const { seedStaticData } = require('@pins/database/src/seed/data-static');
 const { APPEAL_USER_ROLES, REPRESENTATION_TYPES } = require('@pins/common/src/constants');
+const { SERVICE_USER_TYPE } = require('pins-data-model');
+
 const crypto = require('crypto');
 const {
 	createTestAppealCase
@@ -59,6 +61,11 @@ jest.mock('@pins/common/src/middleware/validate-token', () => {
 });
 
 jest.setTimeout(30000);
+
+const testCase1 = '7845678';
+const testCase2 = '7834587';
+const testCase3 = '7834588';
+
 beforeAll(async () => {
 	///////////////////////////////
 	///// SETUP TEST DATABASE ////
@@ -69,11 +76,36 @@ beforeAll(async () => {
 	///////////////////
 	appealsApi = supertest(app);
 	await seedStaticData(sqlClient);
+	const email = crypto.randomUUID() + '@example.com';
 	const user = await sqlClient.appealUser.create({
 		data: {
-			email: crypto.randomUUID() + '@example.com',
-			serviceUserId: 'userID'
+			email
 		}
+	});
+	await sqlClient.serviceUser.createMany({
+		data: [
+			{
+				internalId: crypto.randomUUID(),
+				emailAddress: email,
+				id: crypto.randomUUID(),
+				serviceUserType: SERVICE_USER_TYPE.APPELLANT,
+				caseReference: testCase1
+			},
+			{
+				internalId: crypto.randomUUID(),
+				emailAddress: email,
+				id: crypto.randomUUID(),
+				serviceUserType: SERVICE_USER_TYPE.APPELLANT,
+				caseReference: testCase2
+			},
+			{
+				internalId: crypto.randomUUID(),
+				emailAddress: email,
+				id: crypto.randomUUID(),
+				serviceUserType: SERVICE_USER_TYPE.APPELLANT,
+				caseReference: testCase3
+			}
+		]
 	});
 	validUser = user.id;
 });
@@ -116,21 +148,20 @@ describe('/appeal-cases/{caseReference}/representations', () => {
 	describe('put', () => {
 		it('should upsert a representation', async () => {
 			const testRepId = '12345';
-			const testCaseRef = '7845678';
 
-			await createAppeal(testCaseRef);
+			await createAppeal(testCase1);
 
 			const testPutRepresentation = createTestRepresentationPayload(
 				testRepId,
-				testCaseRef,
+				testCase1,
 				REPRESENTATION_TYPES.STATEMENT
 			);
 
 			const response = await appealsApi
-				.put(`/api/v2/appeal-cases/${testCaseRef}/representations/${testRepId}`)
+				.put(`/api/v2/appeal-cases/${testCase1}/representations/${testRepId}`)
 				.send(testPutRepresentation);
 			expect(response.status).toBe(200);
-			expect(response.body).toHaveProperty('caseReference', testCaseRef);
+			expect(response.body).toHaveProperty('caseReference', testCase1);
 			expect(response.body).toHaveProperty('representationId', testRepId);
 			const repDocs = await sqlClient.representationDocument.findMany({
 				where: {
@@ -143,44 +174,43 @@ describe('/appeal-cases/{caseReference}/representations', () => {
 
 	describe('get', () => {
 		it('should retrieve all representations for the given case reference', async () => {
-			const testCaseRef = '7834587';
 			const testRepId1 = '23456';
 			const testRepId2 = '34567';
-			await createAppeal(testCaseRef);
+			await createAppeal(testCase2);
 
 			const testGetRepresentation1 = createTestRepresentationPayload(
 				testRepId1,
-				testCaseRef,
+				testCase2,
 				REPRESENTATION_TYPES.STATEMENT
 			);
 			const testGetRepresentation2 = createTestRepresentationPayload(
 				testRepId2,
-				testCaseRef,
+				testCase2,
 				REPRESENTATION_TYPES.FINAL_COMMENT,
 				'citizen'
 			);
 
 			await appealsApi
-				.put(`/api/v2/appeal-cases/${testCaseRef}/representations/${testRepId1}`)
+				.put(`/api/v2/appeal-cases/${testCase2}/representations/${testRepId1}`)
 				.send(testGetRepresentation1);
 
 			await appealsApi
-				.put(`/api/v2/appeal-cases/${testCaseRef}/representations/${testRepId2}`)
+				.put(`/api/v2/appeal-cases/${testCase2}/representations/${testRepId2}`)
 				.send(testGetRepresentation2);
 
-			const response = await appealsApi.get(`/api/v2/appeal-cases/${testCaseRef}/representations`);
+			const response = await appealsApi.get(`/api/v2/appeal-cases/${testCase2}/representations`);
 			expect(response.status).toEqual(200);
 			expect(response.body.Representations.length).toBe(2);
 			expect(response.body.Representations).toEqual(
 				expect.arrayContaining([
 					expect.objectContaining({
-						caseReference: testCaseRef,
+						caseReference: testCase2,
 						representationId: testRepId1,
 						source: 'lpa',
 						representationType: REPRESENTATION_TYPES.STATEMENT
 					}),
 					expect.objectContaining({
-						caseReference: testCaseRef,
+						caseReference: testCase2,
 						representationId: testRepId2,
 						source: 'citizen',
 						representationType: REPRESENTATION_TYPES.FINAL_COMMENT
@@ -190,38 +220,37 @@ describe('/appeal-cases/{caseReference}/representations', () => {
 		});
 
 		it('should retrieve representations filtered by type', async () => {
-			const testCaseRef = '7834588';
 			const testRepId3 = '45678';
 			const testRepId4 = '56789';
-			await createAppeal(testCaseRef);
+			await createAppeal(testCase3);
 
 			const testGetRepresentation3 = createTestRepresentationPayload(
 				testRepId3,
-				testCaseRef,
+				testCase3,
 				REPRESENTATION_TYPES.STATEMENT
 			);
 			const testGetRepresentation4 = createTestRepresentationPayload(
 				testRepId4,
-				testCaseRef,
+				testCase3,
 				REPRESENTATION_TYPES.FINAL_COMMENT,
 				'citizen'
 			);
 
 			await appealsApi
-				.put(`/api/v2/appeal-cases/${testCaseRef}/representations/${testRepId3}`)
+				.put(`/api/v2/appeal-cases/${testCase3}/representations/${testRepId3}`)
 				.send(testGetRepresentation3);
 
 			await appealsApi
-				.put(`/api/v2/appeal-cases/${testCaseRef}/representations/${testRepId4}`)
+				.put(`/api/v2/appeal-cases/${testCase3}/representations/${testRepId4}`)
 				.send(testGetRepresentation4);
 
 			const response = await appealsApi.get(
-				`/api/v2/appeal-cases/${testCaseRef}/representations?type=statement`
+				`/api/v2/appeal-cases/${testCase3}/representations?type=statement`
 			);
 			expect(response.status).toEqual(200);
 			expect(response.body.Representations.length).toBe(1);
 			expect(response.body.Representations[0]).toMatchObject({
-				caseReference: testCaseRef,
+				caseReference: testCase3,
 				representationId: testRepId3,
 				representationType: REPRESENTATION_TYPES.STATEMENT
 			});

--- a/packages/appeals-service-api/src/routes/v2/appeal-cases/_caseReference/rule-6-proof-evidence-submission/submit/index.spec.js
+++ b/packages/appeals-service-api/src/routes/v2/appeal-cases/_caseReference/rule-6-proof-evidence-submission/submit/index.spec.js
@@ -4,7 +4,7 @@ const { createPrismaClient } = require('../../../../../../db/db-client');
 const { seedStaticData } = require('@pins/database/src/seed/data-static');
 const { sendEvents } = require('../../../../../../../src/infrastructure/event-client');
 const { APPEAL_USER_ROLES } = require('@pins/common/src/constants');
-const { APPEAL_DOCUMENT_TYPE } = require('pins-data-model');
+const { APPEAL_DOCUMENT_TYPE, SERVICE_USER_TYPE } = require('pins-data-model');
 const crypto = require('crypto');
 const {
 	createTestAppealCase
@@ -68,11 +68,29 @@ beforeAll(async () => {
 	///////////////////
 	appealsApi = supertest(app);
 	await seedStaticData(sqlClient);
+	const email = crypto.randomUUID() + '@example.com';
 	const user = await sqlClient.appealUser.create({
 		data: {
-			email: crypto.randomUUID() + '@example.com',
-			serviceUserId: testR6ServiceUser1
+			email
 		}
+	});
+	await sqlClient.serviceUser.createMany({
+		data: [
+			{
+				internalId: crypto.randomUUID(),
+				emailAddress: email,
+				id: testR6ServiceUser1,
+				serviceUserType: SERVICE_USER_TYPE.RULE_6_PARTY,
+				caseReference: '307'
+			},
+			{
+				internalId: crypto.randomUUID(),
+				emailAddress: email,
+				id: testR6ServiceUser1,
+				serviceUserType: SERVICE_USER_TYPE.RULE_6_PARTY,
+				caseReference: '308'
+			}
+		]
 	});
 	validUser = user.id;
 });

--- a/packages/appeals-service-api/src/routes/v2/service-users/index.spec.js
+++ b/packages/appeals-service-api/src/routes/v2/service-users/index.spec.js
@@ -82,48 +82,24 @@ describe('service users v2', () => {
 			expect(serviceUser.serviceUserType).toBe(SERVICE_USER_TYPE.APPELLANT);
 		});
 
-		it('should create an appeal user if non exist with a matching email address', async () => {
+		it('should create an appeal user if none exist with a matching email address', async () => {
+			const email = 'newhuman@example.com';
 			const response = await appealsApi.put('/api/v2/service-users').send({
 				id: 'usr_002',
 				serviceUserType: SERVICE_USER_TYPE.APPELLANT,
 				caseReference: 'ref_002',
-				emailAddress: 'newhuman@example.com'
+				emailAddress: email
 			});
 
 			expect(response.status).toEqual(200);
 
 			const appealUser = await sqlClient.appealUser.findFirst({
 				where: {
-					email: 'newhuman@example.com'
+					email
 				}
 			});
 
-			expect(appealUser.serviceUserId).toBe('usr_002');
-		});
-
-		it('should update an appeal user if one exists with a matching email address', async () => {
-			await sqlClient.appealUser.create({
-				data: {
-					email: 'existinghuman@example.com'
-				}
-			});
-
-			const response = await appealsApi.put('/api/v2/service-users').send({
-				id: 'usr_003',
-				serviceUserType: SERVICE_USER_TYPE.APPELLANT,
-				caseReference: 'ref_003',
-				emailAddress: 'existinghuman@example.com'
-			});
-
-			expect(response.status).toEqual(200);
-
-			const appealUser = await sqlClient.appealUser.findFirst({
-				where: {
-					email: 'existinghuman@example.com'
-				}
-			});
-
-			expect(appealUser.serviceUserId).toBe('usr_003');
+			expect(appealUser.email).toBe(email);
 		});
 
 		it('should add an appealToUser relation if a matching appeal exists', async () => {
@@ -221,8 +197,7 @@ describe('service users v2', () => {
 
 			const appealUser = await sqlClient.appealUser.create({
 				data: {
-					email: email,
-					serviceUserId: userId
+					email: email
 				}
 			});
 
@@ -277,8 +252,7 @@ describe('service users v2', () => {
 
 			const appealUser = await sqlClient.appealUser.create({
 				data: {
-					email: email,
-					serviceUserId: userId
+					email: email
 				}
 			});
 
@@ -335,8 +309,7 @@ describe('service users v2', () => {
 
 			const appealUser = await sqlClient.appealUser.create({
 				data: {
-					email: email,
-					serviceUserId: userId
+					email: email
 				}
 			});
 

--- a/packages/appeals-service-api/src/routes/v2/service-users/service.js
+++ b/packages/appeals-service-api/src/routes/v2/service-users/service.js
@@ -11,12 +11,13 @@ exports.put = (data) => {
 };
 
 /**
- * @param {string} serviceUserId
+ * @param {string} email
  * @param {string} caseReference
- * @returns {Promise<import("#repositories/sql/service-user-repository").ServiceUserName|null>}
+ * @param {Array.<string>} serviceUserTypes
+ * @returns {Promise<import("#repositories/sql/service-user-repository").ServiceUser|null>}
  */
-exports.getServiceUserByIdAndCaseReference = (serviceUserId, caseReference) => {
-	return serviceUserRepository.getServiceUserByIdAndCaseReference(serviceUserId, caseReference);
+exports.getForEmailCaseAndType = (email, caseReference, serviceUserTypes) => {
+	return serviceUserRepository.getForEmailCaseAndType(email, caseReference, serviceUserTypes);
 };
 
 /**

--- a/packages/appeals-service-api/src/services/back-office-v2/index.test.js
+++ b/packages/appeals-service-api/src/services/back-office-v2/index.test.js
@@ -5,7 +5,7 @@ const { SchemaValidator } = require('./validate');
 const { isFeatureActive } = require('../../configuration/featureFlag');
 
 const { getUserById } = require('../../routes/v2/users/service');
-const { getServiceUserByIdAndCaseReference } = require('../../routes/v2/service-users/service');
+const { getForEmailCaseAndType } = require('../../routes/v2/service-users/service');
 
 const { markAppealAsSubmitted } = require('../../routes/v2/appellant-submissions/_id/service');
 const {
@@ -99,7 +99,7 @@ describe('BackOfficeV2Service', () => {
 	beforeEach(() => {
 		backOfficeV2Service = new BackOfficeV2Service();
 		getUserById.mockResolvedValue(mockUser);
-		getServiceUserByIdAndCaseReference.mockResolvedValue(mockServiceUser);
+		getForEmailCaseAndType.mockResolvedValue(mockServiceUser);
 		isFeatureActive.mockResolvedValue(true);
 		mockValidator.mockReturnValue(true);
 	});
@@ -486,32 +486,22 @@ describe('BackOfficeV2Service', () => {
 			);
 		});
 
-		it('should handle no service user details', async () => {
+		it('should error if no service user details', async () => {
 			getAppellantFinalCommentByAppealId.mockResolvedValue(mockAppealFinalComment);
-			getServiceUserByIdAndCaseReference.mockResolvedValue(null);
+			getForEmailCaseAndType.mockResolvedValue(null);
 
-			await backOfficeV2Service.submitAppellantFinalCommentSubmission(
-				testCaseRef,
-				testUserID,
-				mockAppealFinalCommentFormatter
-			);
-
-			expect(getAppellantFinalCommentByAppealId).toHaveBeenCalledWith(testCaseRef);
-			expect(getUserById).toHaveBeenCalledWith(testUserID);
-			expect(markAppellantFinalCommentAsSubmitted).toHaveBeenCalledWith(
-				testCaseRef,
-				expect.any(String)
-			);
-			expect(sendAppellantFinalCommentSubmissionEmailToAppellantV2).toHaveBeenCalledWith(
-				mockAppealFinalComment,
-				mockUser.email,
-				'Appellant'
-			);
+			await expect(
+				backOfficeV2Service.submitAppellantFinalCommentSubmission({
+					testCaseRef,
+					testUserID,
+					mockAppealFinalCommentFormatter
+				})
+			).rejects.toThrow(`cannot find appellant service user`);
 		});
 
 		it('should handle service user with no name', async () => {
 			getAppellantFinalCommentByAppealId.mockResolvedValue(mockAppealFinalComment);
-			getServiceUserByIdAndCaseReference.mockResolvedValue({});
+			getForEmailCaseAndType.mockResolvedValue({});
 
 			await backOfficeV2Service.submitAppellantFinalCommentSubmission(
 				testCaseRef,
@@ -576,32 +566,22 @@ describe('BackOfficeV2Service', () => {
 			);
 		});
 
-		it('should handle no service user details', async () => {
+		it('should error if no service user', async () => {
 			getAppellantProofOfEvidenceByAppealId.mockResolvedValue(mockAppellantProofs);
-			getServiceUserByIdAndCaseReference.mockResolvedValue(null);
+			getForEmailCaseAndType.mockResolvedValue(null);
 
-			await backOfficeV2Service.submitAppellantProofEvidenceSubmission(
-				testCaseRef,
-				testUserID,
-				mockAppellantProofsFormatter
-			);
-
-			expect(getAppellantProofOfEvidenceByAppealId).toHaveBeenCalledWith(testCaseRef);
-			expect(getUserById).toHaveBeenCalledWith(testUserID);
-			expect(markAppellantProofOfEvidenceAsSubmitted).toHaveBeenCalledWith(
-				testCaseRef,
-				expect.any(String)
-			);
-			expect(sendAppellantProofEvidenceSubmissionEmailToAppellantV2).toHaveBeenCalledWith(
-				mockAppellantProofs,
-				mockUser.email,
-				'Appellant'
-			);
+			await expect(
+				backOfficeV2Service.submitAppellantProofEvidenceSubmission(
+					testCaseRef,
+					testUserID,
+					mockAppellantProofsFormatter
+				)
+			).rejects.toThrow(`cannot find appellant service user`);
 		});
 
 		it('should handle service user with no name', async () => {
 			getAppellantProofOfEvidenceByAppealId.mockResolvedValue(mockAppellantProofs);
-			getServiceUserByIdAndCaseReference.mockResolvedValue({});
+			getForEmailCaseAndType.mockResolvedValue({});
 
 			await backOfficeV2Service.submitAppellantProofEvidenceSubmission(
 				testCaseRef,

--- a/packages/appeals-service-api/src/spec/api-types.d.ts
+++ b/packages/appeals-service-api/src/spec/api-types.d.ts
@@ -484,8 +484,6 @@ export interface AppealUser {
 	email: string;
 	/** is this user enrolled? (have they been sent a registration confirmation email) */
 	isEnrolled?: boolean;
-	/** service user ID to map to service users */
-	serviceUserId?: string;
 	/** is this an LPA user? */
 	isLpaUser?: boolean;
 	/** if an LPA user, the LPA this user belongs to */

--- a/packages/appeals-service-api/src/spec/appeal-user.yaml
+++ b/packages/appeals-service-api/src/spec/appeal-user.yaml
@@ -18,9 +18,6 @@ components:
         isEnrolled:
           type: boolean
           description: is this user enrolled? (have they been sent a registration confirmation email)
-        serviceUserId:
-          type: string
-          description: service user ID to map to service users
         isLpaUser:
           type: boolean
           description: is this an LPA user?

--- a/packages/database/src/migrations/20250312114533_drop_serviceuserid_from_appealuser/migration.sql
+++ b/packages/database/src/migrations/20250312114533_drop_serviceuserid_from_appealuser/migration.sql
@@ -1,0 +1,26 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `serviceUserId` on the `AppealUser` table. All the data in the column will be lost.
+
+*/
+BEGIN TRY
+
+BEGIN TRAN;
+
+-- AlterTable
+DROP INDEX [idx_AppealUser_serviceUserId_unique_notnull] ON [dbo].[AppealUser]
+ALTER TABLE [dbo].[AppealUser] DROP COLUMN [serviceUserId];
+
+COMMIT TRAN;
+
+END TRY
+BEGIN CATCH
+
+IF @@TRANCOUNT > 0
+BEGIN
+    ROLLBACK TRAN;
+END;
+THROW
+
+END CATCH

--- a/packages/database/src/schema.prisma
+++ b/packages/database/src/schema.prisma
@@ -48,14 +48,6 @@ model AppealUser {
   /// they need an email sent when they first login
   isEnrolled Boolean @default(false)
 
-  /// a service user entity will be broadcast by the back office. We match them to AppealUser by email
-  /// appeals will be matched to users by serviceUserId.
-  serviceUserId String? // unique, with nulls allowed, is enforced in SQL, see first migration script & https://stackoverflow.com/a/767702
-  // -- unique AppealUser.serviceUserId
-  // CREATE UNIQUE NONCLUSTERED INDEX idx_AppealUser_serviceUserId_unique_notnull
-  // ON [dbo].[AppealUser](serviceUserId)
-  // WHERE serviceUserId IS NOT NULL;
-
   // LPA user fields
   /// is this an LPA user?
   isLpaUser  Boolean  @default(false)

--- a/packages/database/src/seed/data-dev.js
+++ b/packages/database/src/seed/data-dev.js
@@ -31,8 +31,7 @@ const getFutureDate = (daysToAdd, hour = 12) => {
 const appellants = {
 	appellantOne: {
 		id: '29670d0f-c4b4-4047-8ee0-d62b93e91a11',
-		email: 'appellant1@planninginspectorate.gov.uk',
-		serviceUserId: '123475'
+		email: 'appellant1@planninginspectorate.gov.uk'
 	},
 	appellantTwo: {
 		id: '29670d0f-c4b4-4047-8ee0-d62b93e91a12',
@@ -67,13 +66,11 @@ const appellants = {
 const rule6Parties = {
 	r6One: {
 		id: '29670d0f-c4b4-4047-8ee0-d62b93e91b11',
-		email: 'r6-1@planninginspectorate.gov.uk',
-		serviceUserId: '123998'
+		email: 'r6-1@planninginspectorate.gov.uk'
 	},
 	r6Two: {
 		id: '29670d0f-c4b4-4047-8ee0-d62b93e91b12',
-		email: 'r6-2@planninginspectorate.gov.uk',
-		serviceUserId: '123999'
+		email: 'r6-2@planninginspectorate.gov.uk'
 	},
 	r6Three: {
 		id: '29670d0f-c4b4-4047-8ee0-d62b93e91b13',

--- a/packages/forms-web-app/src/lib/selected-appeal-page-setup.js
+++ b/packages/forms-web-app/src/lib/selected-appeal-page-setup.js
@@ -56,17 +56,9 @@ const getFinalCommentUserGroup = (url, user, userType) => {
 		return APPEAL_USER_ROLES.APPELLANT;
 	} else if (user.lpaCode && url.includes('final-comments')) {
 		return LPA_USER_ROLE;
-	} else if (
-		user.serviceUserId &&
-		userType === APPEAL_USER_ROLES.APPELLANT &&
-		url.includes('final-comments')
-	) {
+	} else if (userType === APPEAL_USER_ROLES.APPELLANT && url.includes('final-comments')) {
 		return APPEAL_USER_ROLES.APPELLANT;
-	} else if (
-		user.serviceUserId &&
-		userType === APPEAL_USER_ROLES.RULE_6_PARTY &&
-		url.includes('final-comments') // cant see the copy deck for this
-	) {
+	} else if (userType === APPEAL_USER_ROLES.RULE_6_PARTY && url.includes('final-comments')) {
 		return APPEAL_USER_ROLES.RULE_6_PARTY;
 	} else {
 		throw new Error('Unable to determine final comment type');
@@ -101,11 +93,7 @@ const getStatementType = (url, user, userType) => {
 		return STATEMENT_TYPE.LPA;
 	} else if (user.lpaCode && url.includes('statement')) {
 		return STATEMENT_TYPE.LPA;
-	} else if (
-		user.serviceUserId &&
-		userType === APPEAL_USER_ROLES.RULE_6_PARTY &&
-		url.includes('statement')
-	) {
+	} else if (userType === APPEAL_USER_ROLES.RULE_6_PARTY && url.includes('statement')) {
 		return STATEMENT_TYPE.RULE_6;
 	} else {
 		throw new Error('Unable to determine statement type');

--- a/packages/forms-web-app/src/services/user.service.js
+++ b/packages/forms-web-app/src/services/user.service.js
@@ -142,16 +142,6 @@ const isRule6UserByEmail = async (req, email) => {
 	return req.appealsApiClient.isRule6User(email);
 };
 
-/**
- * @param {import('express').Request} req
- * @returns {Promise<string | undefined>}
- */
-const getServiceUserId = async (req) => {
-	const { email } = getUserFromSession(req);
-	const appealUser = await req.appealsApiClient.getUserByEmailV2(email);
-	return appealUser.serviceUserId;
-};
-
 module.exports = {
 	createAppealUserSession,
 	getUserFromSession,
@@ -161,6 +151,5 @@ module.exports = {
 	setLPAUserStatus,
 	getLPAUser,
 	logoutUser,
-	isRule6UserByEmail,
-	getServiceUserId
+	isRule6UserByEmail
 };


### PR DESCRIPTION
## Ticket Number

<!-- Add the number from the Jira board -->

## Description of change

- Removes service user from appeal user, it cannot be relied upon
- Updates service user only if type is the same, should have a different record for each role on a case

## Checklist

<!-- Put an `x` in all the boxes that apply: -->

- [ ] Requires infrastructure changes
- [ ] I have updated the documentation accordingly
- [x] My commit history in this PR is linear
- [x] New features have tests
- [ ] Breaking change (team conversation required)

## Important

Please do not merge from `main` (please only [rebase](https://github.com/Planning-Inspectorate/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
