### PR TITLE
fix(a2-2548): direct user to start of statement journey regardless of…

### DIFF
--- a/packages/forms-web-app/src/views/selected-appeal/appeal.njk
+++ b/packages/forms-web-app/src/views/selected-appeal/appeal.njk
@@ -45,7 +45,7 @@
 						You must submit this statement by {{appeal.statementDueDate}}.&nbsp
 							<ul>
 								<li>
-									<a href="/manage-appeals/appeal-statement/{{appeal.appealNumber}}" class="govuk-link">
+									<a href="/manage-appeals/appeal-statement/{{appeal.appealNumber}}/appeal-statement" class="govuk-link">
 										Submit statement
 										<span class="govuk-visually-hidden"> for {{appeal.appealNumber}}</span>
 									</a>.
@@ -66,7 +66,7 @@
 						You must submit this statement by {{appeal.rule6StatementDueDate}}.&nbsp
 							<ul>
 								<li>
-									<a href="/rule-6/appeal-statement/{{appeal.appealNumber}}" class="govuk-link">
+									<a href="/rule-6/appeal-statement/{{appeal.appealNumber}}/appeal-statement" class="govuk-link">
 										Submit statement
 										<span class="govuk-visually-hidden"> for {{appeal.appealNumber}}</span>
 									</a>.


### PR DESCRIPTION
… already answered

## Ticket Number

<!-- Add the number from the Jira board -->

https://pins-ds.atlassian.net/browse/a2-2548

## Description of change

Directs users to the first question of the statement journey to avoid default behaviour of being sent to task list if the journey is completed

## Checklist

<!-- Put an `x` in all the boxes that apply: -->

- [ ] Requires infrastructure changes
- [ ] I have updated the documentation accordingly
- [x] My commit history in this PR is linear
- [ ] New features have tests
- [ ] Breaking change (team conversation required)

## Important

Please do not merge from `main` (please only [rebase](https://github.com/Planning-Inspectorate/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
