### PR TITLE
fix(a2-2544): remove old row in appeal details

### DIFF
--- a/packages/common/src/lib/format-appeal-documents.js
+++ b/packages/common/src/lib/format-appeal-documents.js
@@ -24,17 +24,6 @@ exports.documentExists = (documents, documentType) => {
 
 /**
  * @param {import("../client/appeals-api-client").AppealCaseDetailed} caseData
- */
-exports.formatNewDescription = (caseData) => {
-	if (caseData.updateDevelopmentDescription && caseData.developmentDescriptionDetails) {
-		return caseData.developmentDescriptionDetails;
-	}
-
-	return 'No';
-};
-
-/**
- * @param {import("../client/appeals-api-client").AppealCaseDetailed} caseData
  * @returns {boolean}
  */
 exports.hasNotificationMethods = (caseData) =>

--- a/packages/forms-web-app/src/controllers/selected-appeal/appeal-details/appeal-documents-rows.js
+++ b/packages/forms-web-app/src/controllers/selected-appeal/appeal-details/appeal-documents-rows.js
@@ -1,4 +1,4 @@
-const { formatDocumentDetails, formatNewDescription } = require('@pins/common');
+const { formatDocumentDetails } = require('@pins/common');
 const { CASE_TYPES } = require('@pins/common/src/database/data-static');
 
 const { APPEAL_DOCUMENT_TYPE, APPEAL_APPELLANT_PROCEDURE_PREFERENCE } = require('pins-data-model');
@@ -21,11 +21,6 @@ exports.documentsRows = (caseData) => {
 			valueText: formatDocumentDetails(documents, APPEAL_DOCUMENT_TYPE.ORIGINAL_APPLICATION_FORM),
 			condition: () => true,
 			isEscaped: true
-		},
-		{
-			keyText: 'New description of development',
-			valueText: formatNewDescription(caseData),
-			condition: () => caseData.appealTypeCode === CASE_TYPES.S78.processCode
 		},
 		{
 			keyText: 'Plans, drawings and supporting documents',

--- a/packages/forms-web-app/src/controllers/selected-appeal/appeal-details/appeal-documents-rows.test.js
+++ b/packages/forms-web-app/src/controllers/selected-appeal/appeal-details/appeal-documents-rows.test.js
@@ -6,7 +6,7 @@ const { APPEAL_DOCUMENT_TYPE, APPEAL_APPELLANT_PROCEDURE_PREFERENCE } = require(
 describe('appeal-documents-rows', () => {
 	it('should create rows', () => {
 		const rows = documentsRows({ Documents: [] });
-		expect(rows.length).toEqual(14);
+		expect(rows.length).toEqual(13);
 	});
 
 	const applicationRow = 0;
@@ -31,7 +31,7 @@ describe('appeal-documents-rows', () => {
 	});
 
 	describe('Plans, drawings and supporting documents', () => {
-		const plansRow = 2;
+		const plansRow = 1;
 		it('should display field if S78', () => {
 			const rows = documentsRows({ appealTypeCode: CASE_TYPES.S78.processCode });
 			expect(rows[plansRow].keyText).toEqual('Plans, drawings and supporting documents');
@@ -49,7 +49,7 @@ describe('appeal-documents-rows', () => {
 	});
 
 	describe('Draft statement of common ground', () => {
-		const draftRow = 11;
+		const draftRow = 10;
 		it('should display field if S78 and not written', () => {
 			const rows = documentsRows({ appealTypeCode: CASE_TYPES.S78.processCode });
 			expect(rows[draftRow].keyText).toEqual('Draft statement of common ground');


### PR DESCRIPTION
## Ticket Number

<!-- Add the number from the Jira board -->

https://pins-ds.atlassian.net/browse/A2-2544

## Description of change

Removes row - data handled in appeal details rows

## Checklist

<!-- Put an `x` in all the boxes that apply: -->

- [ ] Requires infrastructure changes
- [ ] I have updated the documentation accordingly
- [x] My commit history in this PR is linear
- [ ] New features have tests
- [ ] Breaking change (team conversation required)

## Important

Please do not merge from `main` (please only [rebase](https://github.com/Planning-Inspectorate/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
