### PR TITLE
fix: revert commit lint due to conflict with commitizen

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -73,7 +73,7 @@
 			},
 			"devDependencies": {
 				"@commitlint/cli": "^17.0.0",
-				"@commitlint/config-conventional": "^19.8.0",
+				"@commitlint/config-conventional": "^17.8.1",
 				"@commitlint/cz-commitlint": "^17.0.0",
 				"@shelf/jest-mongodb": "^1.3.4",
 				"@testing-library/dom": "^10.4.0",
@@ -1158,25 +1158,27 @@
 			}
 		},
 		"node_modules/@babel/helpers": {
-			"version": "7.26.0",
-			"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.26.0.tgz",
-			"integrity": "sha512-tbhNuIxNcVb21pInl3ZSjksLCvgdZy9KwJ8brv993QtIVKJBBkYXz4q4ZbAv31GdnC+R90np23L5FbEBlthAEw==",
+			"version": "7.26.10",
+			"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.26.10.tgz",
+			"integrity": "sha512-UPYc3SauzZ3JGgj87GgZ89JVdC5dj0AoetR5Bw6wj4niittNyFh6+eOGonYvJ1ao6B8lEa3Q3klS7ADZ53bc5g==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@babel/template": "^7.25.9",
-				"@babel/types": "^7.26.0"
+				"@babel/template": "^7.26.9",
+				"@babel/types": "^7.26.10"
 			},
 			"engines": {
 				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@babel/parser": {
-			"version": "7.26.2",
+			"version": "7.26.10",
+			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.26.10.tgz",
+			"integrity": "sha512-6aQR2zGE/QFi8JpDLjUZEPYOs7+mhKXm86VaKFiLP35JQwQb6bwUE+XbvkH0EptsYhbNBSUGaUBLKqxH1xSgsA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@babel/types": "^7.26.0"
+				"@babel/types": "^7.26.10"
 			},
 			"bin": {
 				"parser": "bin/babel-parser.js"
@@ -1361,13 +1363,15 @@
 			}
 		},
 		"node_modules/@babel/template": {
-			"version": "7.25.9",
+			"version": "7.26.9",
+			"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.26.9.tgz",
+			"integrity": "sha512-qyRplbeIpNZhmzOysF/wFMuP9sctmh2cFzRAZOn1YapxBsE1i9bJIY586R/WBLfLcmcBlM8ROBiQURnnNy+zfA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@babel/code-frame": "^7.25.9",
-				"@babel/parser": "^7.25.9",
-				"@babel/types": "^7.25.9"
+				"@babel/code-frame": "^7.26.2",
+				"@babel/parser": "^7.26.9",
+				"@babel/types": "^7.26.9"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -1391,7 +1395,9 @@
 			}
 		},
 		"node_modules/@babel/types": {
-			"version": "7.26.0",
+			"version": "7.26.10",
+			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.26.10.tgz",
+			"integrity": "sha512-emqcG3vHrpxUKTrxcblR36dcrcoRDvKmnL/dCL6ZsHaShW80qxCAcNhzQZrpeM765VzEos+xOi4s+r4IXzTwdQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -1445,44 +1451,16 @@
 			}
 		},
 		"node_modules/@commitlint/config-conventional": {
-			"version": "19.8.0",
-			"resolved": "https://registry.npmjs.org/@commitlint/config-conventional/-/config-conventional-19.8.0.tgz",
-			"integrity": "sha512-9I2kKJwcAPwMoAj38hwqFXG0CzS2Kj+SAByPUQ0SlHTfb7VUhYVmo7G2w2tBrqmOf7PFd6MpZ/a1GQJo8na8kw==",
+			"version": "17.8.1",
+			"resolved": "https://registry.npmjs.org/@commitlint/config-conventional/-/config-conventional-17.8.1.tgz",
+			"integrity": "sha512-NxCOHx1kgneig3VLauWJcDWS40DVjg7nKOpBEEK9E5fjJpQqLCilcnKkIIjdBH98kEO1q3NpE5NSrZ2kl/QGJg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@commitlint/types": "^19.8.0",
-				"conventional-changelog-conventionalcommits": "^7.0.2"
+				"conventional-changelog-conventionalcommits": "^6.1.0"
 			},
 			"engines": {
-				"node": ">=v18"
-			}
-		},
-		"node_modules/@commitlint/config-conventional/node_modules/@commitlint/types": {
-			"version": "19.8.0",
-			"resolved": "https://registry.npmjs.org/@commitlint/types/-/types-19.8.0.tgz",
-			"integrity": "sha512-LRjP623jPyf3Poyfb0ohMj8I3ORyBDOwXAgxxVPbSD0unJuW2mJWeiRfaQinjtccMqC5Wy1HOMfa4btKjbNxbg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@types/conventional-commits-parser": "^5.0.0",
-				"chalk": "^5.3.0"
-			},
-			"engines": {
-				"node": ">=v18"
-			}
-		},
-		"node_modules/@commitlint/config-conventional/node_modules/chalk": {
-			"version": "5.4.1",
-			"resolved": "https://registry.npmjs.org/chalk/-/chalk-5.4.1.tgz",
-			"integrity": "sha512-zgVZuo2WcZgfUEmsn6eO3kINexW8RAE4maiQ8QNs8CtpPCSyMiYsULR3HQYkm3w8FIA3SberyMJMSldGsW+U3w==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": "^12.17.0 || ^14.13 || >=16.0.0"
-			},
-			"funding": {
-				"url": "https://github.com/chalk/chalk?sponsor=1"
+				"node": ">=v14"
 			}
 		},
 		"node_modules/@commitlint/config-validator": {
@@ -5107,16 +5085,6 @@
 				"@types/node": "*"
 			}
 		},
-		"node_modules/@types/conventional-commits-parser": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/@types/conventional-commits-parser/-/conventional-commits-parser-5.0.1.tgz",
-			"integrity": "sha512-7uz5EHdzz2TqoMfV7ee61Egf5y6NkcO4FB/1iCCQnbeiI1F3xzv3vK5dBCXUCLQgGYS+mUeigK1iKQzvED+QnQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@types/node": "*"
-			}
-		},
 		"node_modules/@types/docker-modem": {
 			"version": "3.0.6",
 			"dev": true,
@@ -6287,7 +6255,9 @@
 			}
 		},
 		"node_modules/axios": {
-			"version": "1.7.4",
+			"version": "1.8.3",
+			"resolved": "https://registry.npmjs.org/axios/-/axios-1.8.3.tgz",
+			"integrity": "sha512-iP4DebzoNlP/YN2dpwCgb8zoCmhtkajzS48JvwmkSkXvPI3DHc7m+XYL5tGnSlJtR6nImXZmdCuN5aP8dh1d8A==",
 			"license": "MIT",
 			"dependencies": {
 				"follow-redirects": "^1.15.6",
@@ -7507,16 +7477,16 @@
 			}
 		},
 		"node_modules/conventional-changelog-conventionalcommits": {
-			"version": "7.0.2",
-			"resolved": "https://registry.npmjs.org/conventional-changelog-conventionalcommits/-/conventional-changelog-conventionalcommits-7.0.2.tgz",
-			"integrity": "sha512-NKXYmMR/Hr1DevQegFB4MwfM5Vv0m4UIxKZTTYuD98lpTknaZlSRrDOG4X7wIXpGkfsYxZTghUN+Qq+T0YQI7w==",
+			"version": "6.1.0",
+			"resolved": "https://registry.npmjs.org/conventional-changelog-conventionalcommits/-/conventional-changelog-conventionalcommits-6.1.0.tgz",
+			"integrity": "sha512-3cS3GEtR78zTfMzk0AizXKKIdN4OvSh7ibNz6/DPbhWWQu7LqE/8+/GqSodV+sywUR2gpJAdP/1JFf4XtN7Zpw==",
 			"dev": true,
 			"license": "ISC",
 			"dependencies": {
 				"compare-func": "^2.0.0"
 			},
 			"engines": {
-				"node": ">=16"
+				"node": ">=14"
 			}
 		},
 		"node_modules/conventional-commit-types": {

--- a/package.json
+++ b/package.json
@@ -147,7 +147,7 @@
 	},
 	"devDependencies": {
 		"@commitlint/cli": "^17.0.0",
-		"@commitlint/config-conventional": "^19.8.0",
+		"@commitlint/config-conventional": "^17.8.1",
 		"@commitlint/cz-commitlint": "^17.0.0",
 		"@shelf/jest-mongodb": "^1.3.4",
 		"@testing-library/dom": "^10.4.0",


### PR DESCRIPTION
## Ticket Number

<!-- Add the number from the Jira board -->

## Description of change

Reverts https://github.com/Planning-Inspectorate/appeal-planning-decision/pull/4141
Due to conflict with commitizen

## Checklist

<!-- Put an `x` in all the boxes that apply: -->

- [ ] Requires infrastructure changes
- [ ] I have updated the documentation accordingly
- [ ] My commit history in this PR is linear
- [ ] New features have tests
- [ ] Breaking change (team conversation required)

## Important

Please do not merge from `main` (please only [rebase](https://github.com/Planning-Inspectorate/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
