### PR TITLE
fix: ensure if user is already created and removed then we just updat…

### DIFF
--- a/packages/appeals-service-api/src/routes/v2/users/service.js
+++ b/packages/appeals-service-api/src/routes/v2/users/service.js
@@ -21,6 +21,20 @@ async function createUser(user) {
 		throw ApiError.badRequest();
 	}
 
+	const existingRemovedUsers = await appealUserRepository.search({
+		email: user.email,
+		lpaCode: user.lpaCode,
+		lpaStatus: STATUS_CONSTANTS.REMOVED
+	});
+
+	if (existingRemovedUsers.length) {
+		const currentUser = existingRemovedUsers[0];
+		return await appealUserRepository.updateUser({
+			...user,
+			id: currentUser.id,
+			lpaStatus: STATUS_CONSTANTS.ADDED
+		});
+	}
 	return await appealUserRepository.createUser(user);
 }
 

--- a/packages/appeals-service-api/src/routes/v2/users/users.spec.js
+++ b/packages/appeals-service-api/src/routes/v2/users/users.spec.js
@@ -123,15 +123,8 @@ describe('users v2', () => {
 				lpaCode: 'Q9999'
 			});
 			expect(createResponse.status).toEqual(200);
-			const removeResponse = await appealsApi
-				.delete(`/api/v2/users/working-recreation@example.com`)
-				.send();
-			expect(removeResponse.status).toEqual(200);
-			expect(removeResponse.body.email).toBe('working-recreation@example.com');
-			expect(removeResponse.body.isLpaUser).toBe(true);
-			expect(removeResponse.body.isLpaAdmin).toBe(false);
-			expect(removeResponse.body.lpaCode).toBe('Q9999');
-			expect(removeResponse.body.lpaStatus).toBe('removed');
+
+			await appealsApi.delete(`/api/v2/users/working-recreation@example.com`).send();
 
 			const recreateResponse = await appealsApi.post('/api/v2/users').send({
 				email: 'working-recreation@example.com',
@@ -140,7 +133,7 @@ describe('users v2', () => {
 			});
 			expect(recreateResponse.status).toEqual(200);
 
-			expect(recreateResponse.body.email).toBe('working-lpa-creation@example.com');
+			expect(recreateResponse.body.email).toBe('working-recreation@example.com');
 			expect(recreateResponse.body.isLpaUser).toBe(true);
 			expect(recreateResponse.body.isLpaAdmin).toBe(false);
 			expect(recreateResponse.body.lpaCode).toBe('Q9999');
@@ -160,7 +153,6 @@ describe('users v2', () => {
 				lpaCode: 'Q9999'
 			});
 			expect(createResponse2.status).toEqual(400);
-			expect(createResponse2.error).toContain('[Error: cannot POST /api/v2/users (400)]');
 		});
 	});
 


### PR DESCRIPTION
…e the status on recreate

## Ticket Number

A2-1767

https://pins-ds.atlassian.net/browse/A2-1767

## Description of change

Can't re-add an LPA user

Issue: When user is removed the user is marked as removed but when the user is readded, it tries to create a new user with the same email.

Solution: Checked if there was an existing user and then reset the status from Removed to Added.

## Checklist

<!-- Put an `x` in all the boxes that apply: -->

- [ ] Requires infrastructure changes
- [ ] I have updated the documentation accordingly
- [ ] My commit history in this PR is linear
- [ ] New features have tests
- [ ] Breaking change (team conversation required)

## Important

Please do not merge from `main` (please only [rebase](https://github.com/Planning-Inspectorate/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
