### PR TITLE
fix(a2-2588): allow submitted page access after submission

### DIFF
--- a/packages/forms-web-app/src/routes/lpa-dashboard/questionnaire.js
+++ b/packages/forms-web-app/src/routes/lpa-dashboard/questionnaire.js
@@ -113,7 +113,7 @@ router.get(
 
 router.get(
 	'/householder/:referenceId/questionnaire-submitted',
-	getJourneyResponse(),
+	getJourneyResponse(false),
 	getJourney(journeys),
 	validationErrorHandler,
 	lpaSubmitted
@@ -127,14 +127,14 @@ router.get(
 // used for PDF generation of submission
 router.get(
 	'/householder/:referenceId/questionnaire-submitted/information',
-	getJourneyResponse(),
+	getJourneyResponse(false),
 	getJourney(journeys),
 	lpaQuestionnaireSubmissionInformation
 );
 
 router.get(
 	'/full-planning/:referenceId/questionnaire-submitted/information',
-	getJourneyResponse(),
+	getJourneyResponse(false),
 	getJourney(journeys),
 	lpaQuestionnaireSubmissionInformation
 );


### PR DESCRIPTION
## Ticket Number

<!-- Add the number from the Jira board -->

https://pins-ds.atlassian.net/browse/A2-2588

## Description of change

Allow submitted pages to be accessed after submission is complete

## Checklist

<!-- Put an `x` in all the boxes that apply: -->

- [ ] Requires infrastructure changes
- [ ] I have updated the documentation accordingly
- [x] My commit history in this PR is linear
- [ ] New features have tests
- [ ] Breaking change (team conversation required)

## Important

Please do not merge from `main` (please only [rebase](https://github.com/Planning-Inspectorate/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
