### PR TITLE
feat: A2-1217 added lpa table and endpoints including seeding

### DIFF
--- a/packages/appeals-service-api/data/populate-db.sh
+++ b/packages/appeals-service-api/data/populate-db.sh
@@ -1,1 +1,3 @@
 curl -X POST -d @lpa-list.csv http://localhost:3000/api/v1/local-planning-authorities
+
+curl -X POST -d @lpa-list.csv http://localhost:3000/api/v2/lpa

--- a/packages/appeals-service-api/src/errors/apiError.js
+++ b/packages/appeals-service-api/src/errors/apiError.js
@@ -105,6 +105,10 @@ class ApiError {
 		return new ApiError(404, { errors: [`LPA was not found`] });
 	}
 
+	static lpaUpsertFailure() {
+		return new ApiError(400, { errors: [`LPA list insert failed`] });
+	}
+
 	// Users/LPA Dashboard
 	static noLpaCodeProvided() {
 		return new ApiError(400, { errors: [`No LPA was provided`] });

--- a/packages/appeals-service-api/src/mappers/lpa-mapper.js
+++ b/packages/appeals-service-api/src/mappers/lpa-mapper.js
@@ -1,29 +1,32 @@
-const LpaEntity = require('../models/entities/lpa-entity')
+const LpaEntity = require('../models/entities/lpa-entity');
 
 class LpaMapper {
-    static #CSV_SEPARATOR = ';';
+	static #CSV_SEPARATOR = ';';
 
-    csvJsonToLpaEntities(csvJson) {
-        return JSON
-            .stringify(csvJson)
-            .replace('{', '')
-            .replace('}', '')
-            .replace(':""', '')
-            .replace('OBJECTID,LPA19CD,LPA CODE,LPA19NM,EMAIL,DOMAIN,LPA ONBOARDED','')
-            .trim()
-            .split(/\r?\\n/)
-            .slice(1) // Removes CSV header line and leaves the value lines
-            .map(lpaRow => {
-                const lpaElements = lpaRow.trim().split(LpaMapper.#CSV_SEPARATOR)
-                return new LpaEntity(
-                    null,
-                    lpaElements[0], lpaElements[1], lpaElements[2], 
-                    lpaElements[3], lpaElements[4], lpaElements[5], 
-                    lpaElements[6] && !!lpaElements[6].includes('TRUE')
-                );
-            })
-        ;
-    }
+	csvJsonToLpaEntities(csvJson) {
+		return JSON.stringify(csvJson)
+			.replace('{', '')
+			.replace('}', '')
+			.replace(':""', '')
+			.replace('OBJECTID,LPA19CD,LPA CODE,LPA19NM,EMAIL,DOMAIN,LPA ONBOARDED', '')
+			.trim()
+			.split(/\r?\\n/)
+			.slice(1) // Removes CSV header line and leaves the value lines
+			.filter((lpaRow) => lpaRow.trim().length > 6)
+			.map((lpaRow) => {
+				const lpaElements = lpaRow.trim().split(LpaMapper.#CSV_SEPARATOR);
+				return new LpaEntity(
+					null,
+					lpaElements[0],
+					lpaElements[1],
+					lpaElements[2],
+					lpaElements[3],
+					lpaElements[4],
+					lpaElements[5],
+					lpaElements[6] && !!lpaElements[6].includes('TRUE')
+				);
+			});
+	}
 }
 
 module.exports = LpaMapper;

--- a/packages/appeals-service-api/src/routes/v2/lpa/controller.js
+++ b/packages/appeals-service-api/src/routes/v2/lpa/controller.js
@@ -1,0 +1,93 @@
+const ApiError = require('#errors/apiError');
+const logger = require('#lib/logger');
+const service = require('./service');
+
+/**
+ * @type {import('express').RequestHandler}
+ */
+exports.getAll = async (req, res) => {
+	try {
+		const result = await service.getAll();
+		res.status(200).send(result);
+	} catch (err) {
+		if (err instanceof ApiError) {
+			throw err; // re-throw service errors
+		}
+		logger.error({ error: err }, 'error getting LPA List');
+		throw ApiError.withMessage(500, 'unexpected error');
+	}
+};
+
+/**
+ * @type {import('express').RequestHandler}
+ */
+exports.getById = async (req, res) => {
+	if (!req.params.id) {
+		throw ApiError.badRequest('No LPA id provided');
+	}
+
+	const id = req.params.id;
+
+	try {
+		const result = await service.get(id, null, null);
+		res.status(200).send(result);
+	} catch (err) {
+		if (err instanceof ApiError) {
+			throw err; // re-throw service errors
+		}
+		logger.error({ error: err, id }, 'error getting LPA');
+		throw ApiError.withMessage(500, 'unexpected error');
+	}
+};
+
+/**
+ * @type {import('express').RequestHandler}
+ */
+exports.getBylpaCode = async (req, res) => {
+	if (!req.params.lpaCode) {
+		throw ApiError.badRequest('No LPA code provided');
+	}
+
+	const lpaCode = req.params.lpaCode;
+
+	try {
+		const result = await service.get(null, lpaCode, null);
+		res.status(200).send(result);
+	} catch (err) {
+		if (err instanceof ApiError) {
+			throw err; // re-throw service errors
+		}
+		logger.error({ error: err, lpaCode }, 'error getting LPA code');
+		throw ApiError.withMessage(500, 'unexpected error');
+	}
+};
+
+/**
+ * @type {import('express').RequestHandler}
+ */
+exports.getBylpa19CD = async (req, res) => {
+	if (!req.params.lpa19CD) {
+		throw ApiError.badRequest('No lpa19CD provided');
+	}
+
+	const lpa19CD = req.params.lpa19CD;
+
+	try {
+		const result = await service.get(null, null, lpa19CD);
+		res.status(200).send(result);
+	} catch (err) {
+		if (err instanceof ApiError) {
+			throw err; // re-throw service errors
+		}
+		logger.error({ error: err, lpa19CD }, 'error getting LPA by lpa19CD');
+		throw ApiError.withMessage(500, 'unexpected error');
+	}
+};
+
+/**
+ * @type {import('express').RequestHandler}
+ */
+exports.post = async (req, res) => {
+	const doc = await service.createLpaList(req.body);
+	res.send(doc);
+};

--- a/packages/appeals-service-api/src/routes/v2/lpa/index.js
+++ b/packages/appeals-service-api/src/routes/v2/lpa/index.js
@@ -1,0 +1,21 @@
+const express = require('express');
+const router = express.Router();
+const asyncHandler = require('@pins/common/src/middleware/async-handler');
+const controller = require('./controller');
+const { openApiValidatorMiddleware } = require('../../../validators/validate-open-api');
+
+router.get('/', openApiValidatorMiddleware(), asyncHandler(controller.getAll));
+router.get('/:id', openApiValidatorMiddleware(), asyncHandler(controller.getById));
+router.get(
+	'/lpaCode/:lpaCode',
+	openApiValidatorMiddleware(),
+	asyncHandler(controller.getBylpaCode)
+);
+router.get(
+	'/lpa19CD/:lpa19CD',
+	openApiValidatorMiddleware(),
+	asyncHandler(controller.getBylpa19CD)
+);
+router.post('/', openApiValidatorMiddleware(), asyncHandler(controller.post));
+
+module.exports = { router };

--- a/packages/appeals-service-api/src/routes/v2/lpa/index.spec.js
+++ b/packages/appeals-service-api/src/routes/v2/lpa/index.spec.js
@@ -1,0 +1,208 @@
+const http = require('http');
+const supertest = require('supertest');
+
+const app = require('../../../app');
+const { createPrismaClient } = require('../../../db/db-client');
+
+const { isFeatureActive } = require('../../../configuration/featureFlag');
+
+/** @type {import('@prisma/client').PrismaClient} */
+let sqlClient;
+/** @type {import('supertest').SuperTest<import('supertest').Test>} */
+let lpaApi;
+
+jest.mock('../../../configuration/featureFlag');
+jest.mock('../../../../src/services/object-store');
+jest.mock('express-oauth2-jwt-bearer', () => {
+	let currentSub = '';
+
+	return {
+		auth: jest.fn(() => {
+			return (req, _res, next) => {
+				req.auth = {
+					payload: {
+						sub: currentSub
+					}
+				};
+				next();
+			};
+		})
+	};
+});
+
+jest.setTimeout(10000);
+
+const csvMock = `OBJECTID;LPA19CD;LPA CODE;LPA19NM;EMAIL;DOMAIN;LPA ONBOARDED
+8;E00000151;A0001;Test 1 County;test@test1county.gov.uk;test1county.gov.uk;TRUE
+9;E00000152;A0002;Test 2 County;test@test2county.gov.uk;test2county.gov.uk;TRUE
+10;E00000153;A0003;Test 3 County;test@test3county.gov.uk;test3county.gov.uk;TRUE
+11;E00000154;A0004;Test 4 County;test@test4county.gov.uk;test4county.gov.uk;TRUE
+12;E00000155;A0005;Test 5 County;test@test5county.gov.u;test5county.gov.uk;TRUE`;
+
+beforeAll(async () => {
+	///////////////////////////////
+	///// SETUP TEST DATABASE ////
+	/////////////////////////////
+	sqlClient = createPrismaClient();
+
+	/////////////////////
+	///// SETUP APP ////
+	///////////////////
+	let server = http.createServer(app);
+	lpaApi = supertest(server);
+});
+
+beforeEach(async () => {
+	// turn all feature flags on
+	isFeatureActive.mockImplementation(() => {
+		return true;
+	});
+});
+
+afterEach(async () => {
+	jest.clearAllMocks();
+});
+
+afterAll(async () => {
+	await sqlClient.$disconnect();
+});
+
+function containsAny(arr1, arr2) {
+	return arr1.some((item) => arr2.includes(item));
+}
+
+describe('LPAs v2', () => {
+	describe('upload LPAs', () => {
+		it('should upload upload all LPAs to the DB without error', async () => {
+			const response = await lpaApi.post('/api/v2/lpa').send({
+				csvMock
+			});
+			const getResponse = await lpaApi.get(`/api/v2/lpa`);
+			expect(response.status).toBe(200);
+			expect(getResponse.status).toBe(200);
+			expect(getResponse.body.length).toBe(5);
+		});
+
+		it('should delete existing data and reupload without error', async () => {
+			const response1 = await lpaApi.post('/api/v2/lpa').send({
+				csvMock
+			});
+			const getResponse1 = await lpaApi.get(`/api/v2/lpa`);
+			const response2 = await lpaApi.post('/api/v2/lpa').send({
+				csvMock
+			});
+			const getResponse2 = await lpaApi.get(`/api/v2/lpa`);
+
+			expect(response1.status).toBe(200);
+			expect(response2.status).toBe(200);
+			expect(getResponse1.status).toBe(200);
+			expect(getResponse2.status).toBe(200);
+			const doesContain = containsAny(
+				getResponse1.body.map((x) => x.id),
+				getResponse2.body.map((y) => y.id)
+			);
+			expect(doesContain).toBeFalsy();
+			expect(getResponse2.body.length).toBe(5);
+		});
+	});
+
+	describe('get LPA', () => {
+		beforeAll(async () => {
+			await sqlClient.lPA.deleteMany({});
+			await sqlClient.lPA.createMany({
+				data: [
+					{
+						domain: 'test.com',
+						email: 'test1@test.com',
+						inTrial: true,
+						lpa19CD: 'E60000001',
+						name: 'Test1',
+						lpaCode: 'A1355',
+						objectId: '1'
+					},
+					{
+						domain: 'test.com',
+						email: 'test2@test.com',
+						inTrial: false,
+						lpa19CD: 'E60000002',
+						name: 'Test2',
+						lpaCode: 'B1355',
+						objectId: '2'
+					}
+				]
+			});
+		});
+
+		it('should get all LPAs', async () => {
+			const response = await lpaApi.get(`/api/v2/lpa`);
+			expect(response.status).toBe(200);
+			expect(response.body.length).toBe(2);
+		});
+
+		it('should get LPA by id', async () => {
+			const allResponse = await lpaApi.get(`/api/v2/lpa`);
+			let testId = allResponse.body[0].id;
+			let testinTrial = allResponse.body[0].inTrial;
+			let testEmail = allResponse.body[0].email;
+			let testLpa19CD = allResponse.body[0].lpa19CD;
+			let testLpaCode = allResponse.body[0].lpaCode;
+			let testObjectId = allResponse.body[0].objectId;
+
+			const response = await lpaApi.get(`/api/v2/lpa/${testId}`);
+
+			expect(response.status).toBe(200);
+			expect(response.body).toHaveProperty('id', testId);
+			expect(response.body).toHaveProperty('inTrial', testinTrial);
+			expect(response.body).toHaveProperty('email', testEmail);
+			expect(response.body).toHaveProperty('lpa19CD', testLpa19CD);
+			expect(response.body).toHaveProperty('lpaCode', testLpaCode);
+			expect(response.body).toHaveProperty('objectId', testObjectId);
+		});
+
+		it('should fail to get LPA by id', async () => {
+			const testId = '00000000-0000-00000-00000-0000000002';
+			const response = await lpaApi.get(`/api/v2/lpa/${testId}`);
+
+			expect(response.status).toBe(404);
+		});
+
+		it('should get LPA by lpaCode', async () => {
+			const testCode = 'A1355';
+
+			const response = await lpaApi.get(`/api/v2/lpa/lpaCode/${testCode}`);
+
+			expect(response.status).toBe(200);
+			expect(response.body).toHaveProperty('inTrial', true);
+			expect(response.body).toHaveProperty('email', 'test1@test.com');
+			expect(response.body).toHaveProperty('lpa19CD', 'E60000001');
+			expect(response.body).toHaveProperty('lpaCode', testCode);
+			expect(response.body).toHaveProperty('objectId', '1');
+		});
+
+		it('should fail to get LPA by lpaCode', async () => {
+			const testCode = 'A1356';
+
+			const response = await lpaApi.get(`/api/v2/lpa/lpaCode/${testCode}`);
+			expect(response.status).toBe(404);
+		});
+
+		it('should get LPA by lpa19CD', async () => {
+			const testlpa19CD = 'E60000001';
+
+			const response = await lpaApi.get(`/api/v2/lpa/lpa19CD/${testlpa19CD}`);
+			expect(response.status).toBe(200);
+			expect(response.body).toHaveProperty('email', 'test1@test.com');
+			expect(response.body).toHaveProperty('lpa19CD', testlpa19CD);
+			expect(response.body).toHaveProperty('lpaCode', 'A1355');
+			expect(response.body).toHaveProperty('objectId', '1');
+			expect(response.body).toHaveProperty('inTrial', true);
+		});
+
+		it('should fail to get LPA by lpa19CD', async () => {
+			const testlpa19CD = 'E60000003';
+			const response = await lpaApi.get(`/api/v2/lpa/lpa19CD/${testlpa19CD}`);
+
+			expect(response.status).toBe(404);
+		});
+	});
+});

--- a/packages/appeals-service-api/src/routes/v2/lpa/repo.js
+++ b/packages/appeals-service-api/src/routes/v2/lpa/repo.js
@@ -1,0 +1,86 @@
+const { createPrismaClient } = require('#db-client');
+const { PrismaClientValidationError } = require('@prisma/client/runtime/library');
+const ApiError = require('#errors/apiError');
+
+/**
+ * @typedef {import('pins-data-model/src/schemas').AppealDocument} DataModelDocument
+ * @typedef {import('@prisma/client').LPA} PrismaLPA
+ */
+
+/**
+ * @param {any} lpaDataModel
+ * @returns {PrismaLPA}
+ */
+const mapDataModelToEntity = ({
+	_id,
+	objectId,
+	lpa19CD,
+	lpaCode,
+	name,
+	email,
+	domain,
+	inTrial
+}) => ({
+	objectId: objectId,
+	lpa19CD: lpa19CD,
+	lpaCode: lpaCode,
+	name: name,
+	email: email,
+	domain: domain,
+	inTrial: inTrial
+});
+
+module.exports = class Repo {
+	dbClient;
+
+	constructor() {
+		this.dbClient = createPrismaClient();
+	}
+
+	/**
+	 * @returns {Promise<PrismaLPA[]>}
+	 */
+	async getAll() {
+		return await this.dbClient.lPA.findMany({});
+	}
+
+	/**
+	 * @param {string?} id
+	 * @param {string?} lpaCode
+	 * @param {string?} lpa19CD
+	 * @returns {Promise<PrismaLPA>}
+	 */
+	async get(id, lpaCode, lpa19CD) {
+		const whereClause = {};
+		if (id) whereClause.id = id;
+		if (lpaCode) whereClause.lpaCode = lpaCode;
+		if (lpa19CD) whereClause.lpa19CD = lpa19CD;
+
+		return await this.dbClient.lPA.findFirstOrThrow({
+			where: whereClause
+		});
+	}
+
+	async remove() {
+		await this.dbClient.lPA.deleteMany();
+	}
+
+	/**
+	 * @param {any[]} data
+	 */
+	async upsertMany(data) {
+		const mappedData = data.map((record) => {
+			return mapDataModelToEntity(record);
+		});
+		try {
+			await this.dbClient.lPA.createMany({
+				data: mappedData
+			});
+		} catch (e) {
+			if (e instanceof PrismaClientValidationError) {
+				throw ApiError.badRequest(e.message);
+			}
+			throw e;
+		}
+	}
+};

--- a/packages/appeals-service-api/src/routes/v2/lpa/service.js
+++ b/packages/appeals-service-api/src/routes/v2/lpa/service.js
@@ -1,0 +1,59 @@
+const ApiError = require('#errors/apiError');
+const Repo = require('./repo');
+const repo = new Repo();
+const LpaMapper = require('../../../mappers/lpa-mapper');
+const logger = require('#lib/logger');
+const { chunkArray } = require('@pins/common/src/database/chunk-array');
+
+const chunckSize = 10;
+/**
+ * @typedef {import('@prisma/client').LPA} PrismaLPA
+ */
+
+/**
+ * @returns {Promise<PrismaLPA[]>}
+ */
+exports.getAll = async () => {
+	try {
+		return await repo.getAll();
+	} catch (error) {
+		throw ApiError.lpaNotFound();
+	}
+};
+
+/**
+ * @param {string?} id
+ * @param {string?} lpaCode
+ * * @param {string?} lpa19CD
+ * @returns {Promise<PrismaLPA>}
+ */
+exports.get = async (id, lpaCode, lpa19CD) => {
+	try {
+		return await repo.get(id, lpaCode, lpa19CD);
+	} catch (error) {
+		throw ApiError.lpaNotFound();
+	}
+};
+
+/**
+ * @param {any} csv
+ * @returns {Promise<void>}
+ */
+exports.createLpaList = async (csv) => {
+	const mapper = new LpaMapper();
+	const lpaEntities = mapper.csvJsonToLpaEntities(csv).map((lpaEntity) => lpaEntity.toJson());
+	logger.debug(lpaEntities, 'LPA entities as JSON');
+
+	try {
+		await repo.remove();
+		const lpaChunks = chunkArray(lpaEntities, chunckSize);
+
+		for (let chunk in lpaChunks) {
+			await new Promise((res) => setTimeout(res, 1000));
+			await repo.upsertMany(lpaChunks[chunk]);
+		}
+	} catch (err) {
+		logger.error(err);
+		throw ApiError.lpaUpsertFailure();
+	}
+};

--- a/packages/appeals-service-api/src/routes/v2/lpa/spec.yaml
+++ b/packages/appeals-service-api/src/routes/v2/lpa/spec.yaml
@@ -1,0 +1,131 @@
+paths:
+  /api/v2/lpa/:
+    get:
+      summary: Get all LPA records
+      operationId: getAll
+      tags:
+        - LPA
+      responses:
+        "200":
+          description: Successfully retrieved all LPA records
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/LpaRecord"
+        "400":
+          description: Bad request
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorBody"
+
+    post:
+      summary: Upload a CSV file
+      operationId: post
+      tags:
+        - LPA
+      requestBody:
+        required: true
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              properties:
+                file:
+                  type: string
+                  format: binary
+      responses:
+        "204":
+          description: CSV file processed successfully
+        "400":
+          description: Bad request
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorBody"
+
+  /api/v2/lpa/{id}:
+    get:
+      summary: Get LPA record by ID
+      operationId: getById
+      tags:
+        - LPA
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Successfully retrieved LPA record
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/LpaRecord"
+        "400":
+          description: Bad request
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorBody"
+        "404":
+          description: LPA record not found
+
+  /api/v2/lpa/lpaCode/{lpaCode}:
+    get:
+      summary: Get LPA record by LPA Code
+      operationId: getBylpaCode
+      tags:
+        - LPA
+      parameters:
+        - name: lpaCode
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Successfully retrieved LPA record
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/LpaRecord"
+        "400":
+          description: Bad request
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorBody"
+        "404":
+          description: LPA record not found
+
+  /api/v2/lpa/lpa19CD/{lpa19CD}:
+    get:
+      summary: Get LPA record by LPA19CD
+      operationId: getBylpa19CD
+      tags:
+        - LPA
+      parameters:
+        - name: lpa19CD
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Successfully retrieved LPA record
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/LpaRecord"
+        "400":
+          description: Bad request
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorBody"
+        "404":
+          description: LPA record not found

--- a/packages/appeals-service-api/src/spec/api-types.d.ts
+++ b/packages/appeals-service-api/src/spec/api-types.d.ts
@@ -1062,6 +1062,17 @@ export interface LPAQuestionnaireSubmission {
 	section3aGrant?: boolean;
 }
 
+export interface LpaRecord {
+	id?: string;
+	objectId?: string;
+	lpa19CD?: string;
+	lpaCode?: string;
+	name?: string;
+	email?: string;
+	domain?: string;
+	inTrial?: boolean;
+}
+
 /** A statement submitted by an LPA */
 export interface LPAStatementSubmission {
 	/** @format uuid */

--- a/packages/appeals-service-api/src/spec/lpa-record.yaml
+++ b/packages/appeals-service-api/src/spec/lpa-record.yaml
@@ -1,0 +1,21 @@
+components:
+  schemas:
+    LpaRecord:
+      type: object
+      properties:
+        id:
+          type: string
+        objectId:
+          type: string
+        lpa19CD:
+          type: string
+        lpaCode:
+          type: string
+        name:
+          type: string
+        email:
+          type: string
+        domain:
+          type: string
+        inTrial:
+          type: boolean

--- a/packages/common/src/database/chunk-array.js
+++ b/packages/common/src/database/chunk-array.js
@@ -1,0 +1,21 @@
+/**
+ * @param {any} myArray
+ * @param {number} chunk_size
+ * @returns {Promise<any>}
+ */
+const chunkArray = (myArray, chunk_size) => {
+	let index = 0;
+	const arrayLength = myArray.length;
+	const tempArray = [];
+
+	for (index = 0; index < arrayLength; index += chunk_size) {
+		const myChunk = myArray.slice(index, index + chunk_size);
+		tempArray.push(myChunk);
+	}
+
+	return tempArray;
+};
+
+module.exports = {
+	chunkArray
+};

--- a/packages/database/src/migrations/20250318091501_add_lpa_collection_table/migration.sql
+++ b/packages/database/src/migrations/20250318091501_add_lpa_collection_table/migration.sql
@@ -1,0 +1,35 @@
+BEGIN TRY
+
+BEGIN TRAN;
+
+-- CreateTable
+CREATE TABLE [dbo].[LPA] (
+    [id] UNIQUEIDENTIFIER NOT NULL CONSTRAINT [LPA_id_df] DEFAULT newid(),
+    [objectId] NVARCHAR(1000),
+    [lpa19CD] NVARCHAR(1000),
+    [lpaCode] NVARCHAR(1000),
+    [name] NVARCHAR(1000),
+    [email] NVARCHAR(1000),
+    [domain] NVARCHAR(1000),
+    [inTrial] BIT NOT NULL,
+    CONSTRAINT [LPA_pkey] PRIMARY KEY CLUSTERED ([id])
+);
+
+-- CreateIndex
+CREATE NONCLUSTERED INDEX [LPA_lpaCode_idx] ON [dbo].[LPA]([lpaCode]);
+
+-- CreateIndex
+CREATE NONCLUSTERED INDEX [LPA_lpa19CD_idx] ON [dbo].[LPA]([lpa19CD]);
+
+COMMIT TRAN;
+
+END TRY
+BEGIN CATCH
+
+IF @@TRANCOUNT > 0
+BEGIN
+    ROLLBACK TRAN;
+END;
+THROW
+
+END CATCH

--- a/packages/database/src/schema.prisma
+++ b/packages/database/src/schema.prisma
@@ -1229,3 +1229,21 @@ model RepresentationDocument {
   @@index([representationId])
   @@index([documentId])
 }
+
+/// Proofs of Evidence, Final Comments, Statements, Planning Obligations and Interested Party Comments
+/// Received from BO will share this model and table
+model LPA {
+  id String @id @default(dbgenerated("newid()")) @db.UniqueIdentifier
+
+  objectId String?
+  lpa19CD  String?
+  lpaCode  String?
+  name     String?
+  email    String?
+  domain   String?
+  inTrial  Boolean
+
+  // indexes
+  @@index([lpaCode])
+  @@index([lpa19CD])
+}

--- a/packages/database/src/seed/data-dev.js
+++ b/packages/database/src/seed/data-dev.js
@@ -13,6 +13,7 @@ const { CASE_TYPES } = require('@pins/common/src/database/data-static');
 const { testLPACode2 } = require('@pins/common/src/utils');
 const { CASE_RELATION_TYPES } = require('@pins/common/src/database/data-static');
 const config = require('../configuration/config.js');
+const { lpasDev } = require('./lpa-dev');
 
 // some data here so we can reference in multiple places
 // IDs have no specific meaning, just valid UUIDs and used for upsert/relations
@@ -1565,6 +1566,14 @@ async function seedDev(dbClient) {
 			create: representationDocument,
 			update: representationDocument,
 			where: { id: representationDocument.id }
+		});
+	}
+
+	for (const lpa of lpasDev) {
+		await dbClient.lPA.upsert({
+			create: lpa,
+			update: lpa,
+			where: { id: lpa.id }
 		});
 	}
 

--- a/packages/database/src/seed/lpa-dev.js
+++ b/packages/database/src/seed/lpa-dev.js
@@ -1,0 +1,26 @@
+const lpasDev = [
+	{
+		id: '319612c2-9cad-48b3-bfde-faeffba61556',
+		objectId: '0',
+		lpa19CD: 'E69999999',
+		lpaCode: 'Q9999',
+		name: 'System Test Borough Council',
+		email: 'appealplanningdecisiontest@planninginspectorate.gov.uk',
+		domain: 'planninginspectorate.gov.uk',
+		inTrial: true
+	},
+	{
+		id: '319612c2-9cad-48b3-bfde-faeffba61527',
+		objectId: '1',
+		lpa19CD: 'E69999991',
+		lpaCode: 'Q1111',
+		name: 'System Test 2 Borough Council',
+		email: 'appealplanningdecisiontest@planninginspectorate.gov.uk',
+		domain: 'planninginspectorate.gov.uk',
+		inTrial: true
+	}
+];
+
+module.exports = {
+	lpasDev
+};


### PR DESCRIPTION
## Ticket Number

A2-1217

https://pins-ds.atlassian.net/browse/A2-1217

## Description of change

Create an LPA model prisma model + migration that uses the same fields as Mongo

V2 API endpoint that returns retrieves all lpas from sql

V2 API endpoint that fetches single LPA by lpaCode

V2 API endpoint that fetches single LPA by lpa19CD

V2 API endpoint that replaces the existing list of lpas with a new one
POST, takes a semi colon separated csv file, deletes all records and adds all new ones

## Checklist

<!-- Put an `x` in all the boxes that apply: -->

- [ ] Requires infrastructure changes
- [ ] I have updated the documentation accordingly
- [ ] My commit history in this PR is linear
- [ ] New features have tests
- [ ] Breaking change (team conversation required)

## Important

Please do not merge from `main` (please only [rebase](https://github.com/Planning-Inspectorate/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
