### PR TITLE
fix: filter out blank addresses before sending

### DIFF
--- a/packages/appeals-service-api/src/services/back-office-v2/formatters/utils.js
+++ b/packages/appeals-service-api/src/services/back-office-v2/formatters/utils.js
@@ -444,7 +444,12 @@ exports.getCommonLPAQSubmissionFields = (caseReference, answers) => ({
 		? [answers.lpaSiteSafetyRisks_lpaSiteSafetyRiskDetails]
 		: null,
 	neighbouringSiteAddresses: answers.SubmissionAddress?.filter((address) => {
-		return address.fieldName === 'neighbourSiteAddress';
+		return (
+			address.fieldName === 'neighbourSiteAddress' &&
+			address.addressLine1 &&
+			address.townCity &&
+			address.postcode
+		);
 	}).map((address) => {
 		return {
 			neighbouringSiteAddressLine1: address.addressLine1,


### PR DESCRIPTION
## Ticket Number

<!-- Add the number from the Jira board -->

https://pins-ds.atlassian.net/browse/A2-

## Description of change

- Address with empty strings ended up in back office and led to case being stuck as the rebroadcast failed

## Checklist

<!-- Put an `x` in all the boxes that apply: -->

- [ ] Requires infrastructure changes
- [ ] I have updated the documentation accordingly
- [x] My commit history in this PR is linear
- [ ] New features have tests
- [ ] Breaking change (team conversation required)

## Important

Please do not merge from `main` (please only [rebase](https://github.com/Planning-Inspectorate/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
