### PR TITLE
fix(forms-web-app): don't remove easy-auth cookie (AppServiceAuthSession)

### DIFF
--- a/packages/forms-web-app/__tests__/unit/lib/remove-unwanted-cookies.test.js
+++ b/packages/forms-web-app/__tests__/unit/lib/remove-unwanted-cookies.test.js
@@ -2,6 +2,7 @@ const {
 	defaultKeepMeCookies,
 	removeUnwantedCookies
 } = require('../../../src/lib/remove-unwanted-cookies');
+const { CONSTS } = require('../../../src/consts');
 const { mockReq, mockRes } = require('../mocks');
 const cookieConfig = require('../../../src/lib/client-side/cookie/cookie-config');
 const {
@@ -13,7 +14,11 @@ jest.mock('../../../src/lib/extract-root-domain-name-from-full-domain-name');
 describe('lib/remove-unwanted-cookies', () => {
 	describe('defaultKeepMeCookies', () => {
 		it('should have the expected cookie names', () => {
-			expect(defaultKeepMeCookies).toEqual(['connect.sid', cookieConfig.COOKIE_POLICY_KEY]);
+			expect(defaultKeepMeCookies).toEqual([
+				CONSTS.SESSION_COOKIE_NAME,
+				cookieConfig.COOKIE_POLICY_KEY,
+				CONSTS.EASY_AUTH_COOKIE_NAME
+			]);
 		});
 	});
 

--- a/packages/forms-web-app/__tests__/unit/middleware/remove-unwanted-cookies.test.js
+++ b/packages/forms-web-app/__tests__/unit/middleware/remove-unwanted-cookies.test.js
@@ -2,6 +2,7 @@ const { mockReq, mockRes } = require('../mocks');
 const removeUnwantedCookiesMiddelware = require('../../../src/middleware/remove-unwanted-cookies');
 const { removeUnwantedCookies } = require('../../../src/lib/remove-unwanted-cookies');
 const cookieConfig = require('../../../src/lib/client-side/cookie/cookie-config');
+const { CONSTS } = require('../../../src/consts');
 
 jest.mock('../../../src/lib/remove-unwanted-cookies');
 
@@ -36,7 +37,10 @@ describe('middleware/remove-unwanted-cookies', () => {
 				}
 			}),
 			expected: (req, res, next) => {
-				expect(removeUnwantedCookies).toHaveBeenCalledWith(req, res, ['connect.sid']);
+				expect(removeUnwantedCookies).toHaveBeenCalledWith(req, res, [
+					CONSTS.SESSION_COOKIE_NAME,
+					CONSTS.EASY_AUTH_COOKIE_NAME
+				]);
 				expect(next).toHaveBeenCalled();
 			}
 		},

--- a/packages/forms-web-app/src/consts.js
+++ b/packages/forms-web-app/src/consts.js
@@ -1,4 +1,5 @@
 const CONSTS = {
+	EASY_AUTH_COOKIE_NAME: 'AppServiceAuthSession',
 	SESSION_COOKIE_NAME: 'connect.sid'
 };
 

--- a/packages/forms-web-app/src/lib/remove-unwanted-cookies.js
+++ b/packages/forms-web-app/src/lib/remove-unwanted-cookies.js
@@ -4,7 +4,7 @@ const {
 } = require('./extract-root-domain-name-from-full-domain-name');
 const { CONSTS } = require('../consts');
 
-const defaultKeepMeCookies = [CONSTS.SESSION_COOKIE_NAME, cookieConfig.COOKIE_POLICY_KEY];
+const defaultKeepMeCookies = [CONSTS.SESSION_COOKIE_NAME, cookieConfig.COOKIE_POLICY_KEY, CONSTS.EASY_AUTH_COOKIE_NAME];
 
 /**
  * This is a brute force attempt at removing any unwanted cookies.

--- a/packages/forms-web-app/src/middleware/remove-unwanted-cookies.js
+++ b/packages/forms-web-app/src/middleware/remove-unwanted-cookies.js
@@ -26,7 +26,7 @@ module.exports = (req, res, next) => {
 		activeCookiePolicy = JSON.parse(req.cookies[cookieConfig.COOKIE_POLICY_KEY]);
 	} catch (e) {
 		// something went wrong decoding the cookie policy JSON, so lets wipe it and start again
-		removeUnwantedCookies(req, res, [CONSTS.SESSION_COOKIE_NAME]);
+		removeUnwantedCookies(req, res, [CONSTS.SESSION_COOKIE_NAME, CONSTS.EASY_AUTH_COOKIE_NAME]);
 		req.log.warn(e, 'Erasing all cookies due to JSON decoding error in the stored cookie policy.');
 		return next();
 	}


### PR DESCRIPTION
The easy auth in dev is not working because subsequent requests to the service (include all assets) don't include the auth session cookie. This is because they were explicitly removed. This PR adds `AppServiceAuthSession` to the list of "cookies to keep".