### PR TITLE
Fix/a2 2242 ensuring unused field are made null when ownsAllLand is set to YES

### DIFF
--- a/packages/forms-web-app/__tests__/unit/controllers/full-appeal/submit-appeal/own-all-the-land.test.js
+++ b/packages/forms-web-app/__tests__/unit/controllers/full-appeal/submit-appeal/own-all-the-land.test.js
@@ -90,7 +90,18 @@ describe('controllers/full-appeal/submit-appeal/own-all-the-land', () => {
 		it('should redirect to the correct page if `yes` has been selected', async () => {
 			const submittedAppeal = {
 				...appeal,
-				state: 'SUBMITTED'
+				state: 'SUBMITTED',
+				appealSiteSection: {
+					...appeal.appealSiteSection,
+					siteOwnership: {
+						ownsAllTheLand: true,
+						ownsSomeOfTheLand: null,
+						knowsTheOwners: null,
+						hasIdentifiedTheOwners: null,
+						tellingTheLandowners: null,
+						advertisingYourAppeal: null
+					}
+				}
 			};
 
 			createOrUpdateAppeal.mockReturnValue(submittedAppeal);
@@ -103,8 +114,7 @@ describe('controllers/full-appeal/submit-appeal/own-all-the-land', () => {
 			};
 
 			await postOwnAllTheLand(req, res);
-
-			expect(createOrUpdateAppeal).toHaveBeenCalledWith(appeal);
+			expect(createOrUpdateAppeal).toHaveBeenCalledWith(req.session.appeal);
 			expect(res.redirect).toHaveBeenCalledWith(`/${AGRICULTURAL_HOLDING}`);
 			expect(req.session.appeal).toEqual(submittedAppeal);
 		});

--- a/packages/forms-web-app/src/controllers/full-appeal/submit-appeal/own-all-the-land.js
+++ b/packages/forms-web-app/src/controllers/full-appeal/submit-appeal/own-all-the-land.js
@@ -36,6 +36,13 @@ const postOwnAllTheLand = async (req, res) => {
 	appeal[sectionName][taskName].ownsAllTheLand = ownsAllTheLand;
 
 	try {
+		if (ownsAllTheLand) {
+			appeal[sectionName][taskName].advertisingYourAppeal = null;
+			appeal[sectionName][taskName].tellingTheLandowners = null;
+			appeal[sectionName][taskName].hasIdentifiedTheOwners = null;
+			appeal[sectionName][taskName].knowsTheOwners = null;
+			appeal[sectionName][taskName].ownsSomeOfTheLand = null;
+		}
 		if (req.body['save-and-return'] !== '') {
 			appeal.sectionStates[sectionName].ownsAllTheLand = COMPLETED;
 			req.session.appeal = await createOrUpdateAppeal(appeal);


### PR DESCRIPTION
## Ticket Number

A2-2242

https://pins-ds.atlassian.net/browse/A2-2242

## Description of change


## Checklist

<!-- Put an `x` in all the boxes that apply: -->

- [ ] Requires infrastructure changes
- [ ] I have updated the documentation accordingly
- [ ] My commit history in this PR is linear
- [ ] New features have tests
- [ ] Breaking change (team conversation required)

## Important

Please do not merge from `main` (please only [rebase](https://github.com/Planning-Inspectorate/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
