### PR TITLE
feat(a2-2429): add submission date display to lpa appeal details page

### DIFF
--- a/packages/common/src/constants.js
+++ b/packages/common/src/constants.js
@@ -51,6 +51,12 @@ module.exports = {
 		LPA: 'lpa',
 		RULE_6: 'rule6'
 	},
+	SUBMISSIONS: {
+		QUESTIONNAIRE: 'Questionnaire',
+		STATEMENT: 'Statement',
+		FINAL_COMMENT: 'Final comments',
+		PROOFS_EVIDENCE: 'Proofs of evidence'
+	},
 	/**
 	 * not strictly appeal-user role, there is no link between LPA user and an appeal, it's via the lpa-code on the user and appeal
 	 * @type {LpaUserRole}

--- a/packages/common/src/frontend/pins/components/appeal-sections-block.njk
+++ b/packages/common/src/frontend/pins/components/appeal-sections-block.njk
@@ -3,6 +3,9 @@
 		{% if section.links|hasItems %}
 			<h2 class="govuk-heading-l">{{section.heading}}</h2>
 			{%for link in section.links%}
+				{% if link.submissionDate %}
+					<p class="govuk-body">{{link.submissionDate}} </p>
+				{% endif %}
 				<p class="govuk-body">
 					<a href="{{baseUrl}}{{link.url}}"> {{link.text}} </a>
 				</p>

--- a/packages/common/src/lib/format-appeal-details.js
+++ b/packages/common/src/lib/format-appeal-details.js
@@ -1,6 +1,7 @@
 const escape = require('escape-html');
 const { APPEAL_USER_ROLES } = require('../constants');
 const { APPEAL_DEVELOPMENT_TYPE } = require('pins-data-model');
+const { formatDateForDisplay } = require('./format-date');
 
 // NOTE - consider requirement to escape string values from caseData
 
@@ -147,6 +148,15 @@ exports.formatDevelopmentType = (developmentType) => {
 	}
 
 	throw new Error('unhandled developmentType mapping');
+};
+
+/**
+ * @param {string} submission
+ * @param {Date|string|undefined} date
+ * @returns {string}
+ */
+exports.formatSubmissionDate = (submission, date) => {
+	return `${submission} submitted on ${formatDateForDisplay(date)}`;
 };
 
 /**

--- a/packages/common/src/lib/representations.js
+++ b/packages/common/src/lib/representations.js
@@ -61,3 +61,17 @@ exports.representationPublished = (representations, options) => {
 			filterRepresentations(rep, options)
 	);
 };
+
+/**
+ * Return the received date for a specified representation type
+ * @param {Representation[]|undefined} representations
+ * @param {options} options
+ * @returns {Date|string|undefined}
+ */
+exports.getRepresentationSubmissionDate = (representations, options) => {
+	const filteredRepresentations = representations?.filter((rep) =>
+		filterRepresentations(rep, options)
+	);
+
+	return !filteredRepresentations ? '' : filteredRepresentations[0].dateReceived;
+};

--- a/packages/common/src/lib/representations.js
+++ b/packages/common/src/lib/representations.js
@@ -73,5 +73,7 @@ exports.getRepresentationSubmissionDate = (representations, options) => {
 		filterRepresentations(rep, options)
 	);
 
-	return !filteredRepresentations ? '' : filteredRepresentations[0].dateReceived;
+	return !filteredRepresentations || filteredRepresentations.length < 1
+		? undefined
+		: filteredRepresentations[0].dateReceived;
 };

--- a/packages/common/src/lib/representations.test.js
+++ b/packages/common/src/lib/representations.test.js
@@ -1,4 +1,9 @@
-const { representationExists, representationPublished } = require('./representations');
+const { LPA_USER_ROLE } = require('../constants');
+const {
+	representationExists,
+	representationPublished,
+	getRepresentationSubmissionDate
+} = require('./representations');
 const { APPEAL_REPRESENTATION_STATUS, SERVICE_USER_TYPE } = require('pins-data-model');
 
 describe('representationExists', () => {
@@ -97,5 +102,53 @@ describe('representationPublished', () => {
 		expect(
 			representationPublished(undefined, { type: 'type1', submitter: SERVICE_USER_TYPE.APPELLANT })
 		).toBe(false);
+	});
+});
+
+describe('getRepresentationSubmissionDate', () => {
+	it('should return the representation dateReceived if the specified representation type exists', () => {
+		const representations = [
+			{
+				representationType: 'type1',
+				userOwnsRepresentation: true,
+				submittingPartyType: SERVICE_USER_TYPE.APPELLANT,
+				dateReceived: 'today'
+			},
+			{
+				representationType: 'type1',
+				userOwnsRepresentation: false,
+				submittingPartyType: LPA_USER_ROLE,
+				dateReceived: 'last week'
+			},
+			{
+				representationType: 'type2',
+				userOwnsRepresentation: false,
+				submittingPartyType: SERVICE_USER_TYPE.APPELLANT,
+				dateReceived: 'yesterday'
+			}
+		];
+		expect(
+			getRepresentationSubmissionDate(representations, {
+				type: 'type1',
+				owned: true,
+				submitter: SERVICE_USER_TYPE.APPELLANT
+			})
+		).toBe('today');
+	});
+
+	it('should return undefined if no representation exists with the given type and ownership', () => {
+		const representations = [
+			{ representationType: 'type1', userOwnsRepresentation: false },
+			{ representationType: 'type2', userOwnsRepresentation: false }
+		];
+		expect(getRepresentationSubmissionDate(representations, { type: 'type1', owned: true })).toBe(
+			undefined
+		);
+	});
+
+	it('should return undefined if representation array is undefined', () => {
+		expect(getRepresentationSubmissionDate(undefined, { type: 'type1', owned: true })).toBe(
+			undefined
+		);
 	});
 });

--- a/packages/common/src/view-model-maps/sections/def.d.ts
+++ b/packages/common/src/view-model-maps/sections/def.d.ts
@@ -6,6 +6,9 @@ export interface Section {
 	links: Array<{
 		url: string;
 		text: string;
+		submissionDate?: {
+			text: (appealCase: Api.AppealCaseWithRule6Parties) => string;
+		};
 		condition: (
 			appealCase: Api.AppealCaseWithRule6Parties,
 			userEmail?: string

--- a/packages/common/src/view-model-maps/sections/index.js
+++ b/packages/common/src/view-model-maps/sections/index.js
@@ -2,13 +2,32 @@
 exports.isSection = (maybeSections) => !!maybeSections;
 
 /**
+ * @typedef FormattedSection
+ * @property {string} heading
+ * @property {Array<object>} links
+ */
+
+/**
  * @param {{
  *   caseData: import('appeals-service-api').Api.AppealCaseDetailed,
  *	 sections: import('./def').Sections,
- * }} args * @returns {import('./def').Sections}
+ * }} args * @returns {FormattedSection[]}
  */
-exports.formatSections = ({ sections, caseData }) =>
-	sections.map((section) => ({
-		...section,
-		links: section.links.filter(({ condition }) => condition(caseData))
-	}));
+exports.formatSections = ({ sections, caseData }) => {
+	return sections.map((section) => {
+		const filteredLinks = section.links
+			.filter(({ condition }) => condition(caseData))
+			.map((link) => {
+				const submissionDate = link.submissionDate ? link.submissionDate.text(caseData) : null;
+				return {
+					...link,
+					submissionDate
+				};
+			});
+
+		return {
+			...section,
+			links: filteredLinks
+		};
+	});
+};

--- a/packages/forms-web-app/src/controllers/selected-appeal/lpa-user-sections.js
+++ b/packages/forms-web-app/src/controllers/selected-appeal/lpa-user-sections.js
@@ -1,12 +1,15 @@
 const {
 	representationPublished,
-	representationExists
+	representationExists,
+	getRepresentationSubmissionDate
 } = require('@pins/common/src/lib/representations');
 const {
 	LPA_USER_ROLE,
 	APPEAL_USER_ROLES,
-	REPRESENTATION_TYPES
+	REPRESENTATION_TYPES,
+	SUBMISSIONS
 } = require('@pins/common/src/constants');
+const { formatSubmissionDate } = require('@pins/common/src/lib/format-appeal-details');
 
 /**
  * @type {import("@pins/common/src/view-model-maps/sections/def").Sections}
@@ -29,6 +32,13 @@ exports.sections = [
 			{
 				url: '/questionnaire',
 				text: 'View questionnaire',
+				submissionDate: {
+					text: (appealCase) =>
+						formatSubmissionDate(
+							SUBMISSIONS.QUESTIONNAIRE,
+							appealCase.lpaQuestionnaireSubmittedDate
+						)
+				},
 				condition: (appealCase) => !!appealCase.lpaQuestionnaireSubmittedDate
 			}
 		]
@@ -39,6 +49,17 @@ exports.sections = [
 			{
 				url: '/statement',
 				text: 'View your statement',
+				submissionDate: {
+					text: (appealCase) =>
+						formatSubmissionDate(
+							SUBMISSIONS.STATEMENT,
+							getRepresentationSubmissionDate(appealCase.Representations, {
+								type: REPRESENTATION_TYPES.STATEMENT,
+								owned: true,
+								submitter: LPA_USER_ROLE
+							})
+						)
+				},
 				condition: (appealCase) =>
 					representationExists(appealCase.Representations, {
 						type: REPRESENTATION_TYPES.STATEMENT,
@@ -77,6 +98,17 @@ exports.sections = [
 			{
 				url: '/final-comments',
 				text: 'View your final comments',
+				submissionDate: {
+					text: (appealCase) =>
+						formatSubmissionDate(
+							SUBMISSIONS.FINAL_COMMENT,
+							getRepresentationSubmissionDate(appealCase.Representations, {
+								type: REPRESENTATION_TYPES.FINAL_COMMENT,
+								owned: true,
+								submitter: LPA_USER_ROLE
+							})
+						)
+				},
 				condition: (appealCase) =>
 					representationExists(appealCase.Representations, {
 						type: REPRESENTATION_TYPES.FINAL_COMMENT,
@@ -112,6 +144,17 @@ exports.sections = [
 			{
 				url: '/proof-evidence',
 				text: 'View your proof of evidence and witnesses',
+				submissionDate: {
+					text: (appealCase) =>
+						formatSubmissionDate(
+							SUBMISSIONS.PROOFS_EVIDENCE,
+							getRepresentationSubmissionDate(appealCase.Representations, {
+								type: REPRESENTATION_TYPES.PROOFS_OF_EVIDENCE,
+								owned: true,
+								submitter: LPA_USER_ROLE
+							})
+						)
+				},
 				condition: (appealCase) =>
 					representationExists(appealCase.Representations, {
 						type: REPRESENTATION_TYPES.PROOFS_OF_EVIDENCE,


### PR DESCRIPTION
## Ticket Number

https://pins-ds.atlassian.net/browse/A2-2429

## Description of change

Amends the sections used for generating the appeal details page (and appeal-sections-block macro) in order to display submission date for lpa submissions

## Checklist

<!-- Put an `x` in all the boxes that apply: -->

- [ ] Requires infrastructure changes
- [ ] I have updated the documentation accordingly
- [ ] My commit history in this PR is linear
- [ ] New features have tests
- [ ] Breaking change (team conversation required)

## Important

Please do not merge from `main` (please only [rebase](https://github.com/Planning-Inspectorate/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
