### PR TITLE
fix(a2-2648): sets axios timeout for horizon calls

### DIFF
--- a/packages/appeals-service-api/src/configuration/config.js
+++ b/packages/appeals-service-api/src/configuration/config.js
@@ -61,7 +61,7 @@ let config = {
 	},
 	services: {
 		horizon: {
-			timeout: parseInt(process.env.SRV_HORIZON_TIMEOUT, 10) || 30 * 1000, // 30s by default
+			timeout: parseInt(process.env.SRV_HORIZON_TIMEOUT, 10) || 10 * 60 * 1000, // 10 mins in ms
 			url: process.env.SRV_HORIZON_URL,
 			logRequestTime: process.env.SRV_HORIZON_LOG_REQUEST_TIME === 'true'
 		},

--- a/packages/appeals-service-api/src/gateway/horizon-gateway.js
+++ b/packages/appeals-service-api/src/gateway/horizon-gateway.js
@@ -207,9 +207,8 @@ class HorizonGateway {
 		const url = `${config.services.horizon.url}/${endpoint}`;
 		logger.debug(body, `Sending ${descriptionOfRequest} request to ${url} with body`);
 
-		// set request timeout
-		// TODO: enable this when we know how long requests need, document updates could be slow
-		// options.timeout = config.services.horizon.timeout;
+		// set request timeout in milliseconds
+		options.timeout = config.services.horizon.timeout;
 
 		try {
 			const requestStart = Date.now();


### PR DESCRIPTION
## Ticket Number

<!-- Add the number from the Jira board -->

https://pins-ds.atlassian.net/browse/A2-2648

## Description of change

- Sets a timeout on the axios calls to the horizon wrapper
- Will update wrapper timeout manually when I have approval

## Checklist

<!-- Put an `x` in all the boxes that apply: -->

- [ ] Requires infrastructure changes
- [ ] I have updated the documentation accordingly
- [x] My commit history in this PR is linear
- [ ] New features have tests
- [ ] Breaking change (team conversation required)

## Important

Please do not merge from `main` (please only [rebase](https://github.com/Planning-Inspectorate/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
