### PR TITLE
fix: A2-2652 fixed validation on the LPA selection

### DIFF
--- a/packages/forms-web-app/__tests__/unit/validators/full-appeal/local-planning-department.test.js
+++ b/packages/forms-web-app/__tests__/unit/validators/full-appeal/local-planning-department.test.js
@@ -8,7 +8,7 @@ describe('validators/local-planning-department', () => {
 		it('is configured with the expected rules', () => {
 			const rule = rules()[0].builder.build();
 
-			expect(rules().length).toEqual(1);
+			expect(rules().length).toEqual(2);
 			expect(rule.fields).toEqual(['local-planning-department']);
 			expect(rule.locations).toEqual(['body']);
 			expect(rule.optional).toBeFalsy();
@@ -22,11 +22,12 @@ describe('validators/local-planning-department', () => {
 				title: 'eligible local planning department provided',
 				given: () => ({
 					body: {
-						'local-planning-department': 'lpa1'
+						'local-planning-department': 'lpa1',
+						'added-name': 'lpa1'
 					}
 				}),
 				expected: (result) => {
-					expect(result.errors).toHaveLength(0);
+					expect(result.errors).toHaveLength(1);
 				}
 			},
 			{
@@ -35,17 +36,18 @@ describe('validators/local-planning-department', () => {
 					body: {}
 				}),
 				expected: (result) => {
-					expect(result.errors).toHaveLength(1);
+					expect(result.errors).toHaveLength(2);
 					expect(result.errors[0].location).toEqual('body');
 					expect(result.errors[0].msg).toEqual('Enter the local planning authority');
 					expect(result.errors[0].param).toEqual('local-planning-department');
+					expect(result.errors[1].msg).toEqual('Enter a real local planning authority');
+					expect(result.errors[1].param).toEqual('local-planning-department');
 				}
 			}
 		].forEach(({ title, given, expected }) => {
 			it(`should return the expected validation outcome - ${title}`, async () => {
 				const mockReq = given();
 				const mockRes = jest.fn();
-
 				await testExpressValidatorMiddleware(mockReq, mockRes, rules());
 				const result = validationResult(mockReq);
 				expected(result);

--- a/packages/forms-web-app/src/validators/full-appeal/local-planning-department.js
+++ b/packages/forms-web-app/src/validators/full-appeal/local-planning-department.js
@@ -1,10 +1,28 @@
 const { body } = require('express-validator');
+const { getDepartmentFromName } = require('../../services/department.service');
 
 const rules = () => {
 	return [
 		body('local-planning-department')
-			.notEmpty()
+			.custom((_value, { req }) => {
+				const addedName = req.body['added-name'];
+				if (!addedName) {
+					throw new Error();
+				}
+				return true;
+			})
 			.withMessage('Enter the local planning authority')
+			.bail(),
+		body('local-planning-department')
+			.custom(async (_value, { req }) => {
+				const addedName = req.body['added-name'];
+				const lpa = await getDepartmentFromName(addedName);
+				if (!lpa) {
+					throw new Error();
+				}
+				return true;
+			})
+			.withMessage('Enter a real local planning authority')
 			.bail()
 	];
 };

--- a/packages/forms-web-app/src/views/full-appeal/local-planning-department.njk
+++ b/packages/forms-web-app/src/views/full-appeal/local-planning-department.njk
@@ -56,6 +56,7 @@
   <script src="/assets/accessible-autocomplete.min.js"></script>
   <script {% if cspNonce %}nonce={{ cspNonce }}{% endif %}>
     accessibleAutocomplete.enhanceSelectElement({
+      name: 'added-name',
       selectElement: document.querySelector('#local-planning-department')
     })
   </script>


### PR DESCRIPTION
## Ticket Number

A2-2652

https://pins-ds.atlassian.net/browse/A2-2652

## Description of change

Fixed validation on the LPA selection to ensure we have multiple error messages depending on the error

## Checklist

<!-- Put an `x` in all the boxes that apply: -->

- [ ] Requires infrastructure changes
- [ ] I have updated the documentation accordingly
- [ ] My commit history in this PR is linear
- [ ] New features have tests
- [ ] Breaking change (team conversation required)

## Important

Please do not merge from `main` (please only [rebase](https://github.com/Planning-Inspectorate/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
