### PR TITLE
fix(a2-2959): use file lookup rather than web request for rendering css

### DIFF
--- a/packages/forms-web-app/src/lib/add-css-to-html.js
+++ b/packages/forms-web-app/src/lib/add-css-to-html.js
@@ -1,5 +1,6 @@
-const config = require('../config');
-const { default: fetch } = require('node-fetch');
+const fs = require('fs').promises;
+const path = require('path');
+
 /**
  * @param {string} html
  * @returns {Promise<string>} html with added css if <head> valid, otherwise returns unedited html passed in
@@ -8,8 +9,9 @@ const addCSStoHtml = async (html) => {
 	const htmlArray = html.split('<head>');
 	if (htmlArray.length !== 2) return html;
 
-	const response = await fetch(`${config.server.host}/public/stylesheets/main.css`);
-	const css = await response.text();
+	const cssFilePath = path.join(__dirname, '../public/stylesheets', 'main.css');
+	const css = await fs.readFile(cssFilePath, 'utf8');
+
 	return htmlArray[0] + `<head><style>${css}</style>` + htmlArray[1];
 };
 

--- a/packages/forms-web-app/src/lib/add-css-to-html.test.js
+++ b/packages/forms-web-app/src/lib/add-css-to-html.test.js
@@ -1,35 +1,26 @@
-const { enableFetchMocks } = require('jest-fetch-mock');
-enableFetchMocks();
 const { addCSStoHtml } = require('./add-css-to-html');
 
-const config = require('../config');
-const { default: fetch } = require('node-fetch');
-
 describe('lib/add-css-to-html', () => {
-	beforeEach(() => {
-		fetch.resetMocks();
-	});
-	it('fetches and adds main.css to HTML with valid <head> element', async () => {
+	beforeEach(() => {});
+	it('adds main.css to HTML with valid <head> element', async () => {
 		const html =
 			'<head><title>test</title><link rel="stylesheet" href="style.css"></head><body><h1>test html</h2></body>';
-		const css = 'h1 { color: blue; text-align: center;}';
-		fetch.mockResponseOnce(css);
 
 		const result = await addCSStoHtml(html);
 
-		expect(fetch).toHaveBeenCalledWith(`${config.server.host}/public/stylesheets/main.css`);
-		expect(result).toEqual(
-			'<head><style>' +
-				css +
-				'</style><title>test</title><link rel="stylesheet" href="style.css"></head><body><h1>test html</h2></body>'
-		);
+		expect(result.startsWith('<head><style>')).toBe(true);
+		expect(result.includes('.govuk')).toBe(true);
+		expect(
+			result.endsWith(
+				'<title>test</title><link rel="stylesheet" href="style.css"></head><body><h1>test html</h2></body>'
+			)
+		).toBe(true);
 	});
 	it('returns HTML without CSS added if <head> element absent from HTML', async () => {
 		const html = '<body><h1>test html</h2></body>';
 
 		const result = await addCSStoHtml(html);
 
-		expect(fetch).not.toHaveBeenCalled();
 		expect(result).toEqual(html);
 	});
 	it('returns HTML without CSS added if multiple <head> elements found in HTML', async () => {
@@ -38,7 +29,6 @@ describe('lib/add-css-to-html', () => {
 
 		const result = await addCSStoHtml(html);
 
-		expect(fetch).not.toHaveBeenCalled();
 		expect(result).toEqual(html);
 	});
 });


### PR DESCRIPTION
## Ticket Number

<!-- Add the number from the Jira board -->

https://pins-ds.atlassian.net/browse/A2-2959
https://pins-ds.atlassian.net/browse/A2-2960

## Description of change

Pdf generation inlines css, this updates it to not make a web request which is unreliable generally + fails with easy auth

## Checklist

<!-- Put an `x` in all the boxes that apply: -->

- [ ] Requires infrastructure changes
- [ ] I have updated the documentation accordingly
- [x] My commit history in this PR is linear
- [x] New features have tests
- [ ] Breaking change (team conversation required)

## Important

Please do not merge from `main` (please only [rebase](https://github.com/Planning-Inspectorate/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
