### PR TITLE
fix: a2-2814 updated section length display

### DIFF
--- a/packages/forms-web-app/src/dynamic-forms/dynamic-components/task-list/questionnaire.njk
+++ b/packages/forms-web-app/src/dynamic-forms/dynamic-components/task-list/questionnaire.njk
@@ -29,7 +29,7 @@
     <div class="govuk-grid-column-three-quarters-from-desktop">
       <hr class="govuk-section-break govuk-section-break--visible govuk-section-break--l">
       <h2 class="govuk-heading-s">Complete the questionnaire</h2>
-      <p class="govuk-!-margin-bottom-7">You have completed {{summaryListData.completedSectionCount}} of {{summaryListData.sections.length}} sections.</p>
+      <p class="govuk-!-margin-bottom-7">You have completed {{summaryListData.completedSectionCount}} of {{summaryListData.sections.length + 1}} sections.</p>
     </div>
   </div>
 {% endblock %}


### PR DESCRIPTION
## Ticket Number

A2-2814

https://pins-ds.atlassian.net/browse/A2-2814

## Description of change

As per the CD the Paragraph  content under   h2 "Complete the questionnaire"  should be displayed as  You have completed [number of sections completed] of 8 sections instead it is displaying as  You have completed 0 of 7 sections.

Fixed issue for display purposes only.

## Checklist

<!-- Put an `x` in all the boxes that apply: -->

- [ ] Requires infrastructure changes
- [ ] I have updated the documentation accordingly
- [ ] My commit history in this PR is linear
- [ ] New features have tests
- [ ] Breaking change (team conversation required)

## Important

Please do not merge from `main` (please only [rebase](https://github.com/Planning-Inspectorate/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
