### PR TITLE
fix: ensure journey route is strictly for schedule2 and no routes ins…

### DIFF
--- a/packages/forms-web-app/src/dynamic-forms/docs/s20-lpaq-journey.md
+++ b/packages/forms-web-app/src/dynamic-forms/docs/s20-lpaq-journey.md
@@ -100,13 +100,31 @@ condition: (response) =>
 - multi-file-upload `/upload-screening-opinion/` Upload your screening opinion and any correspondence
 
 ```js
-condition: (response) => questionHasAnswer(response, questions.screeningOpinion, 'yes');
+condition: (response) =>
+	questionHasAnswer(response, questions.screeningOpinion, 'yes') &&
+	questionsHaveAnswers(
+		response,
+		[
+			[questions.environmentalImpactSchedule, 'schedule-2'],
+			[questions.environmentalImpactSchedule, 'no']
+		],
+		{ logicalCombinator: 'or' }
+	);
 ```
 
 - boolean `/screening-opinion-environmental-statement/` Did your screening opinion say the development needed an environmental statement?
 
 ```js
-condition: (response) => questionHasAnswer(response, questions.screeningOpinion, 'yes');
+condition: (response) =>
+	questionHasAnswer(response, questions.screeningOpinion, 'yes') &&
+	questionsHaveAnswers(
+		response,
+		[
+			[questions.environmentalImpactSchedule, 'schedule-2'],
+			[questions.environmentalImpactSchedule, 'no']
+		],
+		{ logicalCombinator: 'or' }
+	);
 ```
 
 - radio `/environmental-statement/` Did the applicant submit an environmental statement?

--- a/packages/forms-web-app/src/dynamic-forms/docs/s78-lpaq-journey.md
+++ b/packages/forms-web-app/src/dynamic-forms/docs/s78-lpaq-journey.md
@@ -85,13 +85,31 @@ condition: (response) =>
 - multi-file-upload `/upload-screening-opinion/` Upload your screening opinion and any correspondence
 
 ```js
-condition: (response) => questionHasAnswer(response, questions.screeningOpinion, 'yes');
+condition: (response) =>
+	questionHasAnswer(response, questions.screeningOpinion, 'yes') &&
+	questionsHaveAnswers(
+		response,
+		[
+			[questions.environmentalImpactSchedule, 'schedule-2'],
+			[questions.environmentalImpactSchedule, 'no']
+		],
+		{ logicalCombinator: 'or' }
+	);
 ```
 
 - boolean `/screening-opinion-environmental-statement/` Did your screening opinion say the development needed an environmental statement?
 
 ```js
-condition: (response) => questionHasAnswer(response, questions.screeningOpinion, 'yes');
+condition: (response) =>
+	questionHasAnswer(response, questions.screeningOpinion, 'yes') &&
+	questionsHaveAnswers(
+		response,
+		[
+			[questions.environmentalImpactSchedule, 'schedule-2'],
+			[questions.environmentalImpactSchedule, 'no']
+		],
+		{ logicalCombinator: 'or' }
+	);
 ```
 
 - radio `/environmental-statement/` Did the applicant submit an environmental statement?

--- a/packages/forms-web-app/src/dynamic-forms/s20-lpa-questionnaire/journey.js
+++ b/packages/forms-web-app/src/dynamic-forms/s20-lpa-questionnaire/journey.js
@@ -81,9 +81,31 @@ const sections = [
 			)
 		)
 		.addQuestion(questions.screeningOpinionUpload)
-		.withCondition((response) => questionHasAnswer(response, questions.screeningOpinion, 'yes'))
+		.withCondition(
+			(response) =>
+				questionHasAnswer(response, questions.screeningOpinion, 'yes') &&
+				questionsHaveAnswers(
+					response,
+					[
+						[questions.environmentalImpactSchedule, 'schedule-2'],
+						[questions.environmentalImpactSchedule, 'no']
+					],
+					{ logicalCombinator: 'or' }
+				)
+		)
 		.addQuestion(questions.screeningOpinionEnvironmentalStatement)
-		.withCondition((response) => questionHasAnswer(response, questions.screeningOpinion, 'yes'))
+		.withCondition(
+			(response) =>
+				questionHasAnswer(response, questions.screeningOpinion, 'yes') &&
+				questionsHaveAnswers(
+					response,
+					[
+						[questions.environmentalImpactSchedule, 'schedule-2'],
+						[questions.environmentalImpactSchedule, 'no']
+					],
+					{ logicalCombinator: 'or' }
+				)
+		)
 		.addQuestion(questions.submitEnvironmentalStatement)
 		.addQuestion(questions.uploadEnvironmentalStatement)
 		.withCondition((response) =>

--- a/packages/forms-web-app/src/dynamic-forms/s78-questionnaire/journey.js
+++ b/packages/forms-web-app/src/dynamic-forms/s78-questionnaire/journey.js
@@ -72,9 +72,31 @@ const sections = [
 			)
 		)
 		.addQuestion(questions.screeningOpinionUpload)
-		.withCondition((response) => questionHasAnswer(response, questions.screeningOpinion, 'yes'))
+		.withCondition(
+			(response) =>
+				questionHasAnswer(response, questions.screeningOpinion, 'yes') &&
+				questionsHaveAnswers(
+					response,
+					[
+						[questions.environmentalImpactSchedule, 'schedule-2'],
+						[questions.environmentalImpactSchedule, 'no']
+					],
+					{ logicalCombinator: 'or' }
+				)
+		)
 		.addQuestion(questions.screeningOpinionEnvironmentalStatement)
-		.withCondition((response) => questionHasAnswer(response, questions.screeningOpinion, 'yes'))
+		.withCondition(
+			(response) =>
+				questionHasAnswer(response, questions.screeningOpinion, 'yes') &&
+				questionsHaveAnswers(
+					response,
+					[
+						[questions.environmentalImpactSchedule, 'schedule-2'],
+						[questions.environmentalImpactSchedule, 'no']
+					],
+					{ logicalCombinator: 'or' }
+				)
+		)
 		.addQuestion(questions.submitEnvironmentalStatement)
 		.addQuestion(questions.uploadEnvironmentalStatement)
 		.withCondition((response) =>


### PR DESCRIPTION
…tead of schedule1

## Ticket Number

A2-3030

https://pins-ds.atlassian.net/browse/A2-3030

## Description of change

Ensuring route is strictly for schedule2 and no

## Checklist

<!-- Put an `x` in all the boxes that apply: -->

- [ ] Requires infrastructure changes
- [ ] I have updated the documentation accordingly
- [ ] My commit history in this PR is linear
- [ ] New features have tests
- [ ] Breaking change (team conversation required)

## Important

Please do not merge from `main` (please only [rebase](https://github.com/Planning-Inspectorate/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
