### PR TITLE
fix(a2-3205): fix routes using req.app.render - no res.locals

### DIFF
--- a/packages/forms-web-app/src/controllers/selected-appeal/appeal-details/index.js
+++ b/packages/forms-web-app/src/controllers/selected-appeal/appeal-details/index.js
@@ -84,7 +84,7 @@ exports.get = (layoutTemplate = 'layouts/no-banner-link/main.njk') => {
 			pdfDownloadUrl
 		};
 
-		await req.app.render(VIEW.SELECTED_APPEAL.APPEAL_DETAILS, viewContext, async (_, html) => {
+		await res.render(VIEW.SELECTED_APPEAL.APPEAL_DETAILS, viewContext, async (_, html) => {
 			if (!isPagePdfDownload) return res.send(html);
 
 			const pdfHtml = await addCSStoHtml(html);

--- a/packages/forms-web-app/src/controllers/selected-appeal/appeal-details/index.test.js
+++ b/packages/forms-web-app/src/controllers/selected-appeal/appeal-details/index.test.js
@@ -69,7 +69,7 @@ describe('controllers/selected-appeal/appeal-details/index', () => {
 		formatHeadlineData.mockReturnValue('formatted headline data');
 		req.appealsApiClient.getUserByEmailV2.mockReturnValue({ id: '123' });
 		req.appealsApiClient.getUsersAppealCase.mockReturnValue(caseData);
-		req.app.render.mockImplementation(async (view, locals, callback) => {
+		res.render.mockImplementation(async (view, locals, callback) => {
 			/* eslint-disable-next-line no-undef */
 			callback((err = null), (html = testHtml));
 		});
@@ -104,7 +104,7 @@ describe('controllers/selected-appeal/appeal-details/index', () => {
 			expect(generatePDF).not.toHaveBeenCalled();
 			expect(addCSStoHtml).not.toHaveBeenCalled();
 
-			expect(req.app.render).toHaveBeenCalledWith(
+			expect(res.render).toHaveBeenCalledWith(
 				VIEW.SELECTED_APPEAL.APPEAL_DETAILS,
 				expectedViewContext,
 				expect.any(Function)
@@ -141,7 +141,7 @@ describe('controllers/selected-appeal/appeal-details/index', () => {
 			expect(formatRows).toHaveBeenCalledWith('returned details rows', caseData);
 			expect(formatHeadlineData).toHaveBeenCalledWith(caseData, 'Test LPA', LPA_USER_ROLE);
 
-			expect(req.app.render).toHaveBeenCalledWith(
+			expect(res.render).toHaveBeenCalledWith(
 				VIEW.SELECTED_APPEAL.APPEAL_DETAILS,
 				pdfExpectedViewContext,
 				expect.any(Function)

--- a/packages/forms-web-app/src/controllers/selected-appeal/questionnaire-details/index.js
+++ b/packages/forms-web-app/src/controllers/selected-appeal/questionnaire-details/index.js
@@ -115,21 +115,17 @@ exports.get = (layoutTemplate = 'layouts/no-banner-link/main.njk') => {
 			zipDownloadUrl
 		};
 
-		await req.app.render(
-			VIEW.SELECTED_APPEAL.APPEAL_QUESTIONNAIRE,
-			viewContext,
-			async (_, html) => {
-				if (!isPagePdfDownload) return res.send(html);
-				const pdfHtml = await addCSStoHtml(html);
-				const pdf = await generatePDF(pdfHtml);
+		await res.render(VIEW.SELECTED_APPEAL.APPEAL_QUESTIONNAIRE, viewContext, async (_, html) => {
+			if (!isPagePdfDownload) return res.send(html);
+			const pdfHtml = await addCSStoHtml(html);
+			const pdf = await generatePDF(pdfHtml);
 
-				res.set(
-					'Content-disposition',
-					`attachment; filename="Appeal Questionnaire ${appealNumber}.pdf"`
-				);
-				res.set('Content-type', 'application/pdf');
-				return res.send(pdf);
-			}
-		);
+			res.set(
+				'Content-disposition',
+				`attachment; filename="Appeal Questionnaire ${appealNumber}.pdf"`
+			);
+			res.set('Content-type', 'application/pdf');
+			return res.send(pdf);
+		});
 	};
 };

--- a/packages/forms-web-app/src/controllers/selected-appeal/questionnaire-details/index.test.js
+++ b/packages/forms-web-app/src/controllers/selected-appeal/questionnaire-details/index.test.js
@@ -92,7 +92,7 @@ describe('controllers/selected-appeal/questionnaire-details/index', () => {
 		formatQuestionnaireRows.mockReturnValue('some formatted row data');
 		req.appealsApiClient.getUserByEmailV2.mockReturnValue({ id: '123' });
 		req.appealsApiClient.getUsersAppealCase.mockReturnValue(caseData);
-		req.app.render.mockImplementation(async (view, locals, callback) => {
+		res.render.mockImplementation(async (view, locals, callback) => {
 			/* eslint-disable-next-line no-undef */
 			callback((err = null), (html = testHtml));
 		});
@@ -131,7 +131,7 @@ describe('controllers/selected-appeal/questionnaire-details/index', () => {
 			expect(generatePDF).not.toHaveBeenCalled();
 			expect(addCSStoHtml).not.toHaveBeenCalled();
 
-			expect(req.app.render).toHaveBeenCalledWith(
+			expect(res.render).toHaveBeenCalledWith(
 				VIEW.SELECTED_APPEAL.APPEAL_QUESTIONNAIRE,
 				expectedViewContext,
 				expect.any(Function)
@@ -175,7 +175,7 @@ describe('controllers/selected-appeal/questionnaire-details/index', () => {
 			expect(addCSStoHtml).toHaveBeenCalledWith(testHtml);
 			expect(generatePDF).toHaveBeenCalledWith(testHtmlWithCSS);
 
-			expect(req.app.render).toHaveBeenCalledWith(
+			expect(res.render).toHaveBeenCalledWith(
 				VIEW.SELECTED_APPEAL.APPEAL_QUESTIONNAIRE,
 				pdfExpectedViewContext,
 				expect.any(Function)

--- a/packages/forms-web-app/src/controllers/selected-appeal/representations/index.js
+++ b/packages/forms-web-app/src/controllers/selected-appeal/representations/index.js
@@ -123,7 +123,7 @@ exports.get = (representationParams, layoutTemplate = 'layouts/no-banner-link/ma
 			zipDownloadUrl
 		};
 
-		await req.app.render(representationView, viewContext, async (_, html) => {
+		await res.render(representationView, viewContext, async (_, html) => {
 			if (!isPagePdfDownload) return res.send(html);
 
 			const pdfHtml = await addCSStoHtml(html);

--- a/packages/forms-web-app/src/controllers/selected-appeal/representations/representations-controller.test.js
+++ b/packages/forms-web-app/src/controllers/selected-appeal/representations/representations-controller.test.js
@@ -95,7 +95,7 @@ describe('controllers/selected-appeal/representations', () => {
 		filterRepresentationsForDisplay.mockImplementation(() => []);
 		formatRepresentationHeading.mockImplementation(() => 'test representation heading');
 		formatRepresentations.mockImplementation(() => ['test reps']);
-		req.app.render.mockImplementation(async (view, locals, callback) => {
+		res.render.mockImplementation(async (view, locals, callback) => {
 			/* eslint-disable-next-line no-undef */
 			callback((err = null), (html = testHtml));
 		});
@@ -125,7 +125,7 @@ describe('controllers/selected-appeal/representations', () => {
 		expect(formatRepresentations).toHaveBeenCalledWith(testCaseData, []);
 		expect(formatTitleSuffix).toHaveBeenCalledWith(testParams.userType);
 		expect(formatRepresentationHeading).toHaveBeenCalledWith(testParams);
-		expect(req.app.render).toHaveBeenCalledWith(
+		expect(res.render).toHaveBeenCalledWith(
 			VIEW.SELECTED_APPEAL.APPEAL_REPRESENTATIONS,
 			{ ...expectedViewContext, backToAppealOverviewLink: undefined },
 			expect.any(Function)
@@ -157,7 +157,7 @@ describe('controllers/selected-appeal/representations', () => {
 		expect(formatRepresentations).toHaveBeenCalledWith(testCaseData, []);
 		expect(formatTitleSuffix).toHaveBeenCalledWith(testParams.userType);
 		expect(formatRepresentationHeading).toHaveBeenCalledWith(testParams);
-		expect(req.app.render).toHaveBeenCalledWith(
+		expect(res.render).toHaveBeenCalledWith(
 			VIEW.SELECTED_APPEAL.APPEAL_IP_COMMENTS,
 			expectedViewContext,
 			expect.any(Function)
@@ -188,13 +188,14 @@ describe('controllers/selected-appeal/representations', () => {
 		expect(generatePDF).not.toHaveBeenCalled();
 		expect(addCSStoHtml).not.toHaveBeenCalled();
 
-		expect(req.app.render).toHaveBeenCalledWith(
+		expect(res.render).toHaveBeenCalledWith(
 			VIEW.SELECTED_APPEAL.APPEAL_IP_COMMENTS,
 			expectedViewContext,
 			expect.any(Function)
 		);
 		expect(res.send).toHaveBeenCalledWith(testHtml);
 	});
+
 	it('renders page without zip download url if there is no caseData interested party document but another document', async () => {
 		req.appealsApiClient.getAppealCaseWithRepresentationsByType.mockImplementation(() =>
 			Promise.resolve({
@@ -234,7 +235,7 @@ describe('controllers/selected-appeal/representations', () => {
 		expect(generatePDF).not.toHaveBeenCalled();
 		expect(addCSStoHtml).not.toHaveBeenCalled();
 
-		expect(req.app.render).toHaveBeenCalledWith(
+		expect(res.render).toHaveBeenCalledWith(
 			VIEW.SELECTED_APPEAL.APPEAL_IP_COMMENTS,
 			{ ...expectedViewContext, zipDownloadUrl: undefined },
 			expect.any(Function)
@@ -275,7 +276,7 @@ describe('controllers/selected-appeal/representations', () => {
 		expect(generatePDF).not.toHaveBeenCalled();
 		expect(addCSStoHtml).not.toHaveBeenCalled();
 
-		expect(req.app.render).toHaveBeenCalledWith(
+		expect(res.render).toHaveBeenCalledWith(
 			VIEW.SELECTED_APPEAL.APPEAL_IP_COMMENTS,
 			{ ...expectedViewContext, zipDownloadUrl: undefined },
 			expect.any(Function)
@@ -322,7 +323,7 @@ describe('controllers/selected-appeal/representations', () => {
 		expect(generatePDF).not.toHaveBeenCalled();
 		expect(addCSStoHtml).not.toHaveBeenCalled();
 
-		expect(req.app.render).toHaveBeenCalledWith(
+		expect(res.render).toHaveBeenCalledWith(
 			VIEW.SELECTED_APPEAL.APPEAL_IP_COMMENTS,
 			{ ...expectedViewContext, zipDownloadUrl: undefined },
 			expect.any(Function)
@@ -332,6 +333,8 @@ describe('controllers/selected-appeal/representations', () => {
 
 	it('generates and downloads PDF and does not render HTML if URL has ?pdf=true query', async () => {
 		req.query.pdf = 'true';
+
+		getParentPathLink.mockReturnValue('/appeals/ABC123');
 
 		const pdfExpectedViewContext = {
 			...expectedViewContext,
@@ -361,7 +364,7 @@ describe('controllers/selected-appeal/representations', () => {
 		expect(addCSStoHtml).toHaveBeenCalledWith(testHtml);
 		expect(generatePDF).toHaveBeenCalledWith(testHtmlWithCSS);
 
-		expect(req.app.render).toHaveBeenCalledWith(
+		expect(res.render).toHaveBeenCalledWith(
 			VIEW.SELECTED_APPEAL.APPEAL_IP_COMMENTS,
 			pdfExpectedViewContext,
 			expect.any(Function)


### PR DESCRIPTION
## Ticket Number

<!-- Add the number from the Jira board -->

https://pins-ds.atlassian.net/browse/A2-3205
https://pins-ds.atlassian.net/browse/A2-3206

## Description of change

req.app.render doesn't pass through res.locals to the view so is missing csp nonce on scripts
switching to res.render

## Checklist

<!-- Put an `x` in all the boxes that apply: -->

- [ ] Requires infrastructure changes
- [ ] I have updated the documentation accordingly
- [x] My commit history in this PR is linear
- [ ] New features have tests
- [ ] Breaking change (team conversation required)

## Important

Please do not merge from `main` (please only [rebase](https://github.com/Planning-Inspectorate/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
