### PR TITLE
chore(a2-3208): use nunjucks template engine for notify templates

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -5,3 +5,4 @@ README.md
 tmp
 *.njk
 *.bundle.js
+packages/common/src/lib/notify/templates/**/*.md

--- a/packages/common/src/lib/notify/notify-service.js
+++ b/packages/common/src/lib/notify/notify-service.js
@@ -1,33 +1,31 @@
 const path = require('path');
-const fs = require('fs');
-
-/** @type {Record<string, string>} */
-const templateCache = {};
+const nunjucks = require('nunjucks');
+const templatesDir = path.join(__dirname, 'templates');
 
 class NotifyService {
 	static templates = {
 		appealSubmission: {
-			v1SaveAndReturnContinueAppeal: '/appeal-submission/v1-save-and-return-continue-appeal.md',
-			v1Initial: '/appeal-submission/v1-submission-email.md',
-			v1FollowUp: '/appeal-submission/v1-follow-up-email.md',
-			v1LPANotification: '/appeal-submission/v1-lpa-notification.md',
-			v2Initial: '/appeal-submission/v2-submission-email.md',
-			v2FollowUp: '/appeal-submission/v2-follow-up-email.md',
-			v2LPANotification: '/appeal-submission/v2-lpa-notification.md',
-			v2registrationConfirmation: '/appeal-submission/v2-registration-confirmation.md'
+			v1SaveAndReturnContinueAppeal: 'appeal-submission/v1-save-and-return-continue-appeal.md',
+			v1Initial: 'appeal-submission/v1-submission-email.md',
+			v1FollowUp: 'appeal-submission/v1-follow-up-email.md',
+			v1LPANotification: 'appeal-submission/v1-lpa-notification.md',
+			v2Initial: 'appeal-submission/v2-submission-email.md',
+			v2FollowUp: 'appeal-submission/v2-follow-up-email.md',
+			v2LPANotification: 'appeal-submission/v2-lpa-notification.md',
+			v2registrationConfirmation: 'appeal-submission/v2-registration-confirmation.md'
 		},
 		lpaq: {
-			v2LPAQSubmitted: '/lpaq/v2-lpaq-submitted.md'
+			v2LPAQSubmitted: 'lpaq/v2-lpaq-submitted.md'
 		},
 		representations: {
-			v2LpaStatement: '/representations/v2-lpa-statement.md',
-			v2AppellantFinalComment: '/representations/v2-appellant-final-comments.md',
-			v2LpaFinalComment: '/representations/v2-lpa-final-comments.md',
-			v2ProofOfEvidenceSubmitted: '/representations/v2-proof-of-evidence-submitted.md',
-			v2IpCommentSubmitted: '/representations/v2-ip-comment-submitted.md',
-			v2LpaProofsEvidence: '/representations/v2-lpa-proofs-evidence.md',
-			v2R6ProofsEvidence: '/representations/v2-r6-proofs-evidence.md',
-			v2Rule6StatementSubmission: '/representations/v2-rule6-statement-submission.md'
+			v2LpaStatement: 'representations/v2-lpa-statement.md',
+			v2AppellantFinalComment: 'representations/v2-appellant-final-comments.md',
+			v2LpaFinalComment: 'representations/v2-lpa-final-comments.md',
+			v2ProofOfEvidenceSubmitted: 'representations/v2-proof-of-evidence-submitted.md',
+			v2IpCommentSubmitted: 'representations/v2-ip-comment-submitted.md',
+			v2LpaProofsEvidence: 'representations/v2-lpa-proofs-evidence.md',
+			v2R6ProofsEvidence: 'representations/v2-r6-proofs-evidence.md',
+			v2Rule6StatementSubmission: 'representations/v2-rule6-statement-submission.md'
 		}
 	};
 
@@ -35,8 +33,8 @@ class NotifyService {
 	#client;
 	/** @type {import('pino').Logger} */
 	#logger;
-
-	#personalisationRegex = /\((\w+)\)/g;
+	/** @type {import('nunjucks').Environment} */
+	nunjucksEnv;
 
 	/**
 	 * @param {Object} options
@@ -47,6 +45,10 @@ class NotifyService {
 		logger.info('creating new NotifyService');
 		this.#client = notifyClient;
 		this.#logger = logger;
+		this.nunjucksEnv = nunjucks.configure([templatesDir], {
+			throwOnUndefined: true,
+			autoescape: true
+		});
 	}
 
 	/**
@@ -117,46 +119,40 @@ class NotifyService {
 	}
 
 	/**
-	 * replaces personalisation in local template
+	 * replaces personalisation in local template using nunjucks rendering engine
 	 * @param {string} templateName
 	 * @param {Object<string, string>} personalisation
 	 * @returns {string} populated template
 	 */
 	populateTemplate(templateName, personalisation) {
-		const template = this.#getLocalTemplate(templateName);
-		const content = Object.keys(personalisation).reduce((result, key) => {
-			const value = personalisation[key];
-			if (typeof value !== 'string' && typeof value !== 'number')
-				throw new TypeError('value must be a string or number');
-			return result.replaceAll(`((${key}))`, value);
-		}, template);
+		try {
+			return this.nunjucksEnv.render(templateName, personalisation).trim();
+		} catch (/** @type {any} */ e) {
+			this.#logger.error({ error: e, template: templateName }, 'failed to render template');
+			const message = e?.message || '';
 
-		if (content.includes('((') && content.includes('))')) {
-			const message =
-				'missing personalisation parameters: ' + content.match(this.#personalisationRegex);
-			throw new Error(
-				`populateTemplate: personalisation parameters for ${templateName} ${message}`
-			);
-		}
-
-		return content.trim();
-	}
-
-	/**
-	 * Retrieves template, stores templates in a cache
-	 * @param {string} templateName
-	 * @returns {string} template content
-	 */
-	#getLocalTemplate(templateName) {
-		if (!templateCache[templateName]) {
-			const templatePath = path.join(__dirname, 'templates', `${templateName}`);
-			try {
-				templateCache[templateName] = fs.readFileSync(templatePath, { encoding: 'utf8' }).trim();
-			} catch {
-				throw new Error(`getLocalTemplate: missing template "${templateName}`);
+			// notify error messages are in the form:
+			// [template path] [Line X, Column Y]
+			// error message
+			const matches = message.match(/\[Line (\d+), Column (\d+)\]\s+(.*)/);
+			if (matches) {
+				const line = matches[1];
+				const column = matches[2];
+				const errorMessage = matches[3] || 'issue';
+				if (message.includes('attempted to output null or undefined value')) {
+					throw new Error(
+						`populateTemplate error: missing parameter at line #${line} and column #${column} in template: ${templateName}`
+					);
+				}
+				throw new Error(
+					`populateTemplate error: '${errorMessage}' at line #${line} and column #${column} in template: ${templateName}`
+				);
+			} else if (message.includes('template not found')) {
+				throw new Error(`populateTemplate error: template not found: ${templateName}`);
 			}
+
+			throw new Error(`populateTemplate error: ${message}`);
 		}
-		return templateCache[templateName];
 	}
 }
 

--- a/packages/common/src/lib/notify/notify-service.test.js
+++ b/packages/common/src/lib/notify/notify-service.test.js
@@ -9,6 +9,7 @@ const loggerMock = jest.fn().mockImplementation(() => ({
 	debug: jest.fn(),
 	error: jest.fn()
 }));
+const escape = require('escape-html');
 
 describe('NotifyService', () => {
 	let notifyService;
@@ -93,46 +94,6 @@ describe('NotifyService', () => {
 		});
 	});
 
-	describe('populateTemplate', () => {
-		it('should populate the template with personalisation', () => {
-			const templateName = 'test template 1';
-			const templateContent = 'Hello ((name)) ((number)) [link title](((linkUrl)))';
-			const personalisation = { name: 'John', number: 1, linkUrl: 'https://example.com' };
-			const fsSpy = jest.spyOn(fs, 'readFileSync');
-			fsSpy.mockReturnValueOnce(templateContent);
-
-			const result = notifyService.populateTemplate(templateName, personalisation);
-
-			expect(result).toBe('Hello John 1 [link title](https://example.com)');
-		});
-
-		it('should throw an error if personalisation value is not a string', () => {
-			const templateName = 'test template 2';
-			const templateContent = 'Hello ((name))';
-			const personalisation = { name: [1, 2] };
-
-			const fsSpy = jest.spyOn(fs, 'readFileSync');
-			fsSpy.mockReturnValueOnce(templateContent);
-
-			expect(() => notifyService.populateTemplate(templateName, personalisation)).toThrow(
-				'value must be a string or number'
-			);
-		});
-
-		it('should throw an error if personalisation parameters are missing', () => {
-			const templateName = 'test template 3';
-			const templateContent = 'Hello ((name))';
-			const personalisation = {};
-
-			const fsSpy = jest.spyOn(fs, 'readFileSync');
-			fsSpy.mockReturnValueOnce(templateContent);
-
-			expect(() => notifyService.populateTemplate(templateName, personalisation)).toThrow(
-				'populateTemplate: personalisation parameters for test template 3 missing personalisation parameters: (name)'
-			);
-		});
-	});
-
 	describe('templates', () => {
 		it('should verify all templates exist', () => {
 			const templates = NotifyService.templates;
@@ -151,10 +112,16 @@ describe('NotifyService', () => {
 			templateNames.forEach((templateName) => {
 				expect(() => notifyService.populateTemplate(templateName, {})).toThrow(
 					new RegExp(
-						`^populateTemplate: personalisation parameters for ${templateName} missing personalisation parameters: `
+						`^populateTemplate error: missing parameter at line #\\d+ and column #\\d+ in template: ${templateName}`
 					)
 				);
 			});
+		});
+
+		it('should error for missing template', () => {
+			expect(() => notifyService.populateTemplate('nope.njk', {})).toThrow(
+				'populateTemplate error: template not found: nope.njk'
+			);
 		});
 
 		const whiteSpaceReplace = /\s+/g;
@@ -163,6 +130,26 @@ describe('NotifyService', () => {
 				expected.replace(whiteSpaceReplace, ' ')
 			);
 		};
+
+		it('should escape html', () => {
+			const template = NotifyService.templates.appealSubmission.v1Initial;
+			const personalisation = { name: '<script>alert(1)</script>', contactEmail: '<tag>' };
+			const result = notifyService.populateTemplate(template, personalisation);
+			expectMessage(
+				result,
+				`To ${escape(personalisation.name)}
+
+			We have received your appeal.
+
+			We will process your appeal and send a confirmation email. This will include:
+
+			*your appeal reference number
+			*a copy of your appeal form
+
+			The Planning Inspectorate
+			${escape(personalisation.contactEmail)}`
+			);
+		});
 
 		it('should populate appealSubmission.v1SaveAndReturnContinueAppeal ', () => {
 			const template = NotifyService.templates.appealSubmission.v1SaveAndReturnContinueAppeal;

--- a/packages/common/src/lib/notify/templates/appeal-submission/v1-follow-up-email.md
+++ b/packages/common/src/lib/notify/templates/appeal-submission/v1-follow-up-email.md
@@ -1,21 +1,21 @@
 We have processed your appeal.
 
 #Appeal details
-^Appeal reference number: ((appealReferenceNumber))
-Site address: ((appealSiteAddress))
-Planning application reference: ((lpaReference))
+^Appeal reference number: {{appealReferenceNumber}}
+Site address: {{appealSiteAddress}}
+Planning application reference: {{lpaReference}}
 
 #What happens next
 
-1. Download a copy of your appeal form ((pdfLink)).
+1. Download a copy of your appeal form {{pdfLink}}.
 2. [Find the email address for your local planning authority.](https://www.gov.uk/government/publications/sending-a-copy-of-the-appeal-form-to-the-council/sending-a-copy-to-the-council)
-3. Email the copy of your appeal form and the documents you uploaded to: ((lpaName)).
+3. Email the copy of your appeal form and the documents you uploaded to: {{lpaName}}.
 4. We will check and confirm that your appeal form has everything that we need.
 
 You must send a copy of your appeal form and documents to the local planning authority, it’s a legal requirement.
 
 #Give feedback
-[Give feedback on the appeals service](((feedbackUrl))) (takes 2 minutes)
+[Give feedback on the appeals service]({{feedbackUrl}}) (takes 2 minutes)
 
 The Planning Inspectorate
-((contactEmail))
+{{contactEmail}}

--- a/packages/common/src/lib/notify/templates/appeal-submission/v1-lpa-notification.md
+++ b/packages/common/src/lib/notify/templates/appeal-submission/v1-lpa-notification.md
@@ -1,15 +1,15 @@
-Dear ((lpaName))
+Dear {{lpaName}}
 
-We’ve received a ((appealType)) appeal against ((applicationDecision)) planning application ((lpaReference)).
+We’ve received a {{appealType}} appeal against {{applicationDecision}} planning application {{lpaReference}}.
 
 #Appeal reference:
-((appealReferenceNumber))
+{{appealReferenceNumber}}
 
 #Appeal site:
-((appealSiteAddress))
+{{appealSiteAddress}}
 
 #Appeal received on:
-((submissionDate))
+{{submissionDate}}
 
 #What happens next?
 The appellant will send you a copy of their appeal. If you do not receive this, contact the appellant to request it.
@@ -17,4 +17,4 @@ The appellant will send you a copy of their appeal. If you do not receive this, 
 We’ll contact you again when we start the appeal.
 
 The Planning Inspectorate
-((contactEmail))
+{{contactEmail}}

--- a/packages/common/src/lib/notify/templates/appeal-submission/v1-save-and-return-continue-appeal.md
+++ b/packages/common/src/lib/notify/templates/appeal-submission/v1-save-and-return-continue-appeal.md
@@ -1,6 +1,6 @@
-We’ve saved your appeal. You have until ((date)) to submit the appeal.
+We’ve saved your appeal. You have until {{date}} to submit the appeal.
 
-Sign in to view your appeals and continue: ((link))
+Sign in to view your appeals and continue: {{link}}
 
 The Planning Inspectorate
-((contactEmail))
+{{contactEmail}}

--- a/packages/common/src/lib/notify/templates/appeal-submission/v1-submission-email.md
+++ b/packages/common/src/lib/notify/templates/appeal-submission/v1-submission-email.md
@@ -1,4 +1,4 @@
-To ((name))
+To {{name}}
 
 We have received your appeal.
 
@@ -8,4 +8,4 @@ We will process your appeal and send a confirmation email. This will include:
 *a copy of your appeal form
 
 The Planning Inspectorate
-((contactEmail))
+{{contactEmail}}

--- a/packages/common/src/lib/notify/templates/appeal-submission/v2-follow-up-email.md
+++ b/packages/common/src/lib/notify/templates/appeal-submission/v2-follow-up-email.md
@@ -1,13 +1,13 @@
 We have processed your appeal.
 
 #Appeal details
-^Appeal reference number: ((appealReferenceNumber))
-Address: ((appealSiteAddress))
-Planning application reference: ((lpaReference))
+^Appeal reference number: {{appealReferenceNumber}}
+Address: {{appealSiteAddress}}
+Planning application reference: {{lpaReference}}
 
 #What happens next
 
-1. Download a copy of your appeal form ((pdfLink)).
+1. Download a copy of your appeal form {{pdfLink}}.
 2. [Find the email address for your local planning authority.](https://www.gov.uk/government/publications/sending-a-copy-of-the-appeal-form-to-the-council/sending-a-copy-to-the-council)
 3. Email the copy of your appeal form and the documents you uploaded to your local planning authority.
 4. We will check and confirm that your appeal form has everything that we need.
@@ -15,7 +15,7 @@ Planning application reference: ((lpaReference))
 You must send a copy of your appeal form and documents to the local planning authority, it’s a legal requirement.
 
 #Give feedback
-[Give feedback on the appeals service](((feedbackUrl))) (takes 2 minutes)
+[Give feedback on the appeals service]({{feedbackUrl}}) (takes 2 minutes)
 
 The Planning Inspectorate
-[Contact us](((contactForm)))
+[Contact us]({{contactForm}})

--- a/packages/common/src/lib/notify/templates/appeal-submission/v2-lpa-notification.md
+++ b/packages/common/src/lib/notify/templates/appeal-submission/v2-lpa-notification.md
@@ -1,8 +1,8 @@
-^ LPA reference: ((lpaReference))
+^ LPA reference: {{lpaReference}}
 
 We have received an appeal against this decision.
 
-When we start the appeal, you can [view the appeal in the manage your appeals service](((loginUrl))). We will contact you when we start the appeal.
+When we start the appeal, you can [view the appeal in the manage your appeals service]({{loginUrl}}). We will contact you when we start the appeal.
 
 Planning Inspectorate
-((contactEmail))
+{{contactEmail}}

--- a/packages/common/src/lib/notify/templates/appeal-submission/v2-registration-confirmation.md
+++ b/packages/common/src/lib/notify/templates/appeal-submission/v2-registration-confirmation.md
@@ -1,6 +1,6 @@
-Sign in to appeal a planning decision: ((link))
+Sign in to appeal a planning decision: {{link}}
 
 We will send a code to your email address, so that you can sign in to the service.
 
 Planning Inspectorate
-((contactEmail))
+{{contactEmail}}

--- a/packages/common/src/lib/notify/templates/appeal-submission/v2-submission-email.md
+++ b/packages/common/src/lib/notify/templates/appeal-submission/v2-submission-email.md
@@ -1,14 +1,14 @@
 We have received your appeal.
 
 #Appeal details
-^Address: ((appealSiteAddress))
-Planning application reference: ((lpaReference))
+^Address: {{appealSiteAddress}}
+Planning application reference: {{lpaReference}}
 
 #What happens next
 We will process your appeal and send a confirmation email. This will include your appeal reference number.
 
 #Give feedback
-[Give feedback on the appeals service](((feedbackUrl))) (takes 2 minutes)
+[Give feedback on the appeals service]({{feedbackUrl}}) (takes 2 minutes)
 
 The Planning Inspectorate
-((contactEmail))
+{{contactEmail}}

--- a/packages/common/src/lib/notify/templates/lpaq/v2-lpaq-submitted.md
+++ b/packages/common/src/lib/notify/templates/lpaq/v2-lpaq-submitted.md
@@ -1,19 +1,19 @@
-To ((lpaName))
+To {{lpaName}}
 
-We’ve received your questionnaire for the planning application ((lpaReference)).
+We’ve received your questionnaire for the planning application {{lpaReference}}.
 
 #Appeal details
 
-^Appeal reference number: ((appealReferenceNumber))
-Address: ((siteAddress))
-Planning application reference: ((lpaReference))
-Start date: ((appealStartDate))
+^Appeal reference number: {{appealReferenceNumber}}
+Address: {{siteAddress}}
+Planning application reference: {{lpaReference}}
+Start date: {{appealStartDate}}
 
 # What happens next
 
-1. Download a copy of your questionnaire at ((questionnaireLink))
-2. Email a copy of the questionnaire and any documents to the appellant: ((appellantEmailAddress))
+1. Download a copy of your questionnaire at {{questionnaireLink}}
+2. Email a copy of the questionnaire and any documents to the appellant: {{appellantEmailAddress}}
 3. We will review your questionnaire and contact you if we need any further information.
 
 The Planning Inspectorate
-((contactEmail))
+{{contactEmail}}

--- a/packages/common/src/lib/notify/templates/representations/v2-appellant-final-comments.md
+++ b/packages/common/src/lib/notify/templates/representations/v2-appellant-final-comments.md
@@ -2,12 +2,12 @@ We have received your final comments.
 
 #Appeal details
 
-^Appeal reference number: ((appealReferenceNumber))
-Address: ((appealSiteAddress))
+^Appeal reference number: {{appealReferenceNumber}}
+Address: {{appealSiteAddress}}
 
 ##What happens next
 
-We will contact you if the local planning authority submits final comments. The deadline for the local planning authority’s final comments is ((deadlineDate)).
+We will contact you if the local planning authority submits final comments. The deadline for the local planning authority’s final comments is {{deadlineDate}}.
 
 The Planning Inspectorate
-((contactEmail))
+{{contactEmail}}

--- a/packages/common/src/lib/notify/templates/representations/v2-ip-comment-submitted.md
+++ b/packages/common/src/lib/notify/templates/representations/v2-ip-comment-submitted.md
@@ -1,10 +1,10 @@
-To ((name))
+To {{name}}
 
-We’ve received your comment for the appeal: ((appealReferenceNumber)).
+We’ve received your comment for the appeal: {{appealReferenceNumber}}.
 
 # What happens next
 
 The inspector will review all of the evidence. We will contact you by email when we make a decision.
 
 The Planning Inspectorate
-((contactEmail))
+{{contactEmail}}

--- a/packages/common/src/lib/notify/templates/representations/v2-lpa-final-comments.md
+++ b/packages/common/src/lib/notify/templates/representations/v2-lpa-final-comments.md
@@ -1,13 +1,13 @@
-To ((LPA))
+To {{LPA}}
 
 We’ve received your final comments.
 
 #Appeal details
-^Appeal reference number: ((appealReferenceNumber))
-Appeal site: ((appealSiteAddress))
+^Appeal reference number: {{appealReferenceNumber}}
+Appeal site: {{appealSiteAddress}}
 
 ##What happens next
-We will contact you when the appellant submits their final comments. The deadline for the appellant’s final comments is ((deadlineDate)).
+We will contact you when the appellant submits their final comments. The deadline for the appellant’s final comments is {{deadlineDate}}.
 
 The Planning Inspectorate
-((contactEmail))
+{{contactEmail}}

--- a/packages/common/src/lib/notify/templates/representations/v2-lpa-proofs-evidence.md
+++ b/packages/common/src/lib/notify/templates/representations/v2-lpa-proofs-evidence.md
@@ -2,13 +2,13 @@ We’ve received your proof of evidence and witnesses.
 
 #Appeal details
 
-^Appeal reference number: ((appealReferenceNumber))
-Address: ((appealSiteAddress))
-Planning application reference: ((lpaReference))
+^Appeal reference number: {{appealReferenceNumber}}
+Address: {{appealSiteAddress}}
+Planning application reference: {{lpaReference}}
 
 ## What happens next
 
-We will contact you when the appellant and any other parties submit their proof of evidence and witnesses. The deadline is ((deadlineDate)).
+We will contact you when the appellant and any other parties submit their proof of evidence and witnesses. The deadline is {{deadlineDate}}.
 
 The Planning Inspectorate
-((contactEmail))
+{{contactEmail}}

--- a/packages/common/src/lib/notify/templates/representations/v2-lpa-statement.md
+++ b/packages/common/src/lib/notify/templates/representations/v2-lpa-statement.md
@@ -2,12 +2,12 @@ We’ve received your statement.
 
 #Appeal details
 
-^Appeal reference number: ((appealReferenceNumber))
-Address: ((appealSiteAddress))
+^Appeal reference number: {{appealReferenceNumber}}
+Address: {{appealSiteAddress}}
 
 ## What happens next
 
-We will contact you when the appellant has submitted their final comments. The deadline is ((deadlineDate)).
+We will contact you when the appellant has submitted their final comments. The deadline is {{deadlineDate}}.
 
 The Planning Inspectorate
-((contactEmail))
+{{contactEmail}}

--- a/packages/common/src/lib/notify/templates/representations/v2-proof-of-evidence-submitted.md
+++ b/packages/common/src/lib/notify/templates/representations/v2-proof-of-evidence-submitted.md
@@ -2,13 +2,13 @@ We have received your proof of evidence and witnesses.
 
 # Appeal details
 
-^Appeal reference number: ((appealReferenceNumber))
-Address: ((siteAddress))
-Planning application reference: ((lpaReference))
+^Appeal reference number: {{appealReferenceNumber}}
+Address: {{siteAddress}}
+Planning application reference: {{lpaReference}}
 
 # What happens next
 
-We will contact you when the local planning authority and any other parties submit their proof of evidence and witnesses. The deadline is ((deadlineDate)).
+We will contact you when the local planning authority and any other parties submit their proof of evidence and witnesses. The deadline is {{deadlineDate}}.
 
 The Planning Inspectorate
-((contactEmail))
+{{contactEmail}}

--- a/packages/common/src/lib/notify/templates/representations/v2-r6-proofs-evidence.md
+++ b/packages/common/src/lib/notify/templates/representations/v2-r6-proofs-evidence.md
@@ -1,15 +1,15 @@
-((rule6RecipientLine))
+{{rule6RecipientLine}}
 
 We’ve received your proof of evidence and witnesses.
 
 # Appeal details
 
-^Appeal reference number: ((appealReferenceNumber))
-Site address: ((siteAddress))
+^Appeal reference number: {{appealReferenceNumber}}
+Site address: {{siteAddress}}
 
 ## What happens next
 
-We will contact you when the appellant and any other parties submit their proof of evidence and witnesses. The deadline is ((deadlineDate)).
+We will contact you when the appellant and any other parties submit their proof of evidence and witnesses. The deadline is {{deadlineDate}}.
 
 The Planning Inspectorate
-((contactEmail))
+{{contactEmail}}

--- a/packages/common/src/lib/notify/templates/representations/v2-rule6-statement-submission.md
+++ b/packages/common/src/lib/notify/templates/representations/v2-rule6-statement-submission.md
@@ -2,9 +2,9 @@ We have received your statement.
 
 # Appeal details
 
-^Appeal reference number: ((appealReferenceNumber))
-Address: ((siteAddress))
-Planning application reference: ((lpaReference))
+^Appeal reference number: {{appealReferenceNumber}}
+Address: {{siteAddress}}
+Planning application reference: {{lpaReference}}
 
 # What happens next
 
@@ -14,4 +14,4 @@ We will contact you when:
 - we have received comments from interested parties
 
 The Planning Inspectorate
-((contactEmail))
+{{contactEmail}}


### PR DESCRIPTION
## Ticket Number

<!-- Add the number from the Jira board -->

https://pins-ds.atlassian.net/browse/A2-3208

## Description of change

Switches to uses nunjucks templating engine for notify template construction
Based off of: https://github.com/Planning-Inspectorate/appeals-back-office/pull/1301/files

## Checklist

<!-- Put an `x` in all the boxes that apply: -->

- [ ] Requires infrastructure changes
- [ ] I have updated the documentation accordingly
- [x] My commit history in this PR is linear
- [x] New features have tests
- [ ] Breaking change (team conversation required)

## Important

Please do not merge from `main` (please only [rebase](https://github.com/Planning-Inspectorate/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
