### PR TITLE
fix: removed published flag check

### DIFF
--- a/packages/forms-web-app/src/controllers/selected-appeal/representations/index.js
+++ b/packages/forms-web-app/src/controllers/selected-appeal/representations/index.js
@@ -69,10 +69,7 @@ exports.get = (representationParams, layoutTemplate = 'layouts/no-banner-link/ma
 		let pdfDownloadUrl;
 		let zipDownloadUrl;
 		const ipDocuments = caseData?.Documents?.filter(
-			(doc) =>
-				doc.documentType === documentTypes.interestedPartyComment.name &&
-				doc.published &&
-				doc.redacted
+			(doc) => doc.documentType === documentTypes.interestedPartyComment.name && doc.redacted
 		);
 		if (
 			(userType === APPEAL_USER_ROLES.APPELLANT || userType === LPA_USER_ROLE) &&


### PR DESCRIPTION
## Ticket Number

A2-1644

https://pins-ds.atlassian.net/browse/A2-1644

## Description of change

Removed the published check because the flag is not returned in the query but all documents returned are all published. So there is no need for the flag and if we include it, it returns published=false.

## Checklist

<!-- Put an `x` in all the boxes that apply: -->

- [ ] Requires infrastructure changes
- [ ] I have updated the documentation accordingly
- [x] My commit history in this PR is linear
- [x] New features have tests
- [ ] Breaking change (team conversation required)

## Important

Please do not merge from `main` (please only [rebase](https://github.com/Planning-Inspectorate/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
