### PR TITLE
chore: skip PR pipeline outside of npm/src code changes

### DIFF
--- a/azure-pipelines-pr.yml
+++ b/azure-pipelines-pr.yml
@@ -1,13 +1,24 @@
-trigger:
-  branches:
-    include:
-      # trigger for merge queue branches
-      - gh-readonly-queue/*
-
+# any PR
 pr:
   branches:
     include:
-      - '*'
+      - '*'  
+  paths:
+    include:
+    - package.json
+    - package-lock.json
+    - packages/**
+
+# trigger for merge queue branches (PR has been approved, pipeline has already run as per above trigger)
+trigger:
+  branches:
+    include:
+      - gh-readonly-queue/*
+  paths:
+    include:
+    - package.json
+    - package-lock.json
+    - packages/**
 
 resources:
   repositories:

--- a/azure-pipelines-pr.yml
+++ b/azure-pipelines-pr.yml
@@ -2,23 +2,13 @@
 pr:
   branches:
     include:
-      - '*'  
-  paths:
-    include:
-    - package.json
-    - package-lock.json
-    - packages/**
-
+      - '*'
+      
 # trigger for merge queue branches (PR has been approved, pipeline has already run as per above trigger)
 trigger:
   branches:
     include:
       - gh-readonly-queue/*
-  paths:
-    include:
-    - package.json
-    - package-lock.json
-    - packages/**
 
 resources:
   repositories:
@@ -33,8 +23,33 @@ extends:
   parameters:
     globalVariables:
       - template: azure-pipelines-variables.yml@self
+    # Checking against main 50 commits back, this might not catch everything
+    gitFetchDepth: 50
     validationJobs:
+      - name: Check Changes
+        steps:
+          - template: ../steps/check_changed_files.yml
+            parameters:
+              pathFilters:
+                - name: source_code
+                  path: packages
+                - name: package_lock
+                  path: package-lock.json
+                - name: package_json
+                  path: package.json
+              stepName: check_files
       - name: Run Linting & Tests
+        dependsOn:
+          - Check Changes
+        condition: >-
+          and(
+            succeeded(),
+            or(
+              eq(dependencies.check_changes.outputs['check_files.source_code'], 'true'),
+              eq(dependencies.check_changes.outputs['check_files.package_lock'], 'true'),
+              eq(dependencies.check_changes.outputs['check_files.package_json'], 'true')
+            )            
+          )
         variables:
         - name: test-script
           ${{ if startsWith(variables['Build.SourceBranch'], 'refs/heads/gh-readonly-queue') }}:


### PR DESCRIPTION
## Description of change

Run PR pipeline only when npm package or source code changes
To reduce run costs on agents when not required

## Checklist

<!-- Put an `x` in all the boxes that apply: -->

- [ ] Requires infrastructure changes
- [ ] I have updated the documentation accordingly
- [ ] My commit history in this PR is linear
- [ ] New features have tests
- [ ] Breaking change (team conversation required)

## Important

Please do not merge from `main` (please only [rebase](https://github.com/Planning-Inspectorate/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
