### PR TITLE
fix: remove unredacted documents from zip

### DIFF
--- a/packages/document-service-api/src/routes/v2/back-office/_caseReference/case_stage/_caseStage/controller.js
+++ b/packages/document-service-api/src/routes/v2/back-office/_caseReference/case_stage/_caseStage/controller.js
@@ -25,6 +25,7 @@ async function getBlobCollection(caseStage, caseReference) {
 		)
 	)
 		.flat()
+		.filter((doc) => doc.redacted)
 		.map((document) => {
 			const { filename, documentURI, documentType } = document;
 			return {

--- a/packages/document-service-api/src/routes/v2/back-office/_caseReference/case_stage/_caseStage/controller.test.js
+++ b/packages/document-service-api/src/routes/v2/back-office/_caseReference/case_stage/_caseStage/controller.test.js
@@ -31,7 +31,14 @@ jest.mock('../../../../../../db/repos/repository', () => ({
 			{
 				documentURI,
 				documentType,
-				filename: 'document.pdf'
+				filename: 'document.pdf',
+				redacted: true
+			},
+			{
+				documentURI,
+				documentType,
+				filename: 'document2.pdf',
+				redacted: false
 			}
 		])
 	}))
@@ -76,7 +83,7 @@ describe('/v2/back-office/{caseReference}/case_stage/{caseStage}', () => {
 		expect(res.status).toHaveBeenCalledWith(200);
 	});
 
-	it('should expect 3 blob streams to be appended', async () => {
+	it('should expect 3 blob streams to be appended instead of 6 due to one document being unredacted', async () => {
 		await getDocumentsByCaseReferenceAndCaseStage(req, res);
 
 		// Testing archive append was called correctly 3 times


### PR DESCRIPTION
### Description of change

Removed unredacted documents from zip download file

Ticket: https://pins-ds.atlassian.net/browse/A2-1664

### Checklist

- [ ] Feature complete and ready for users, or behind feature-flag
- [ ] Commit history is linear with no merge commits
- [ ] Requires infrastructure changes

### Important

Please do not merge from `main` (please only [rebase](https://github.com/Planning-Inspectorate/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
