### PR TITLE
A2 2941 - fixing s78 and s20 question flow

### DIFF
--- a/packages/forms-web-app/src/dynamic-forms/docs/s20-lpaq-journey.md
+++ b/packages/forms-web-app/src/dynamic-forms/docs/s20-lpaq-journey.md
@@ -131,32 +131,29 @@ condition: (response) =>
 
 ```js
 condition: (response) =>
-	questionHasAnswer(response, questions.screeningOpinionEnvironmentalStatement, 'yes') &&
 	questionsHaveAnswers(
 		response,
 		[
-			[questions.environmentalImpactSchedule, 'schedule-2'],
-			[questions.environmentalImpactSchedule, 'no']
+			[questions.screeningOpinion, 'yes'],
+			[questions.screeningOpinionEnvironmentalStatement, 'yes']
 		],
-		{ logicalCombinator: 'or' }
-	) &&
-	config.featureFlag.scopingOpinionEnabled;
+		{ logicalCombinator: 'and' }
+	) && config.featureFlag.scopingOpinionEnabled;
 ```
 
 - multi-file-upload `/upload-scoping-opinion/` Upload your scoping opinion
 
 ```js
 condition: (response) =>
-	questionHasAnswer(response, questions.scopingOpinion, 'yes') &&
 	questionsHaveAnswers(
 		response,
 		[
-			[questions.environmentalImpactSchedule, 'schedule-2'],
-			[questions.environmentalImpactSchedule, 'no']
+			[questions.scopingOpinion, 'yes'],
+			[questions.screeningOpinion, 'yes'],
+			[questions.screeningOpinionEnvironmentalStatement, 'yes']
 		],
-		{ logicalCombinator: 'or' }
-	) &&
-	config.featureFlag.scopingOpinionEnabled;
+		{ logicalCombinator: 'and' }
+	) && config.featureFlag.scopingOpinionEnabled;
 ```
 
 - radio `/environmental-statement/` Did the applicant submit an environmental statement?

--- a/packages/forms-web-app/src/dynamic-forms/docs/s78-lpaq-journey.md
+++ b/packages/forms-web-app/src/dynamic-forms/docs/s78-lpaq-journey.md
@@ -116,32 +116,29 @@ condition: (response) =>
 
 ```js
 condition: (response) =>
-	questionHasAnswer(response, questions.screeningOpinionEnvironmentalStatement, 'yes') &&
 	questionsHaveAnswers(
 		response,
 		[
-			[questions.environmentalImpactSchedule, 'schedule-2'],
-			[questions.environmentalImpactSchedule, 'no']
+			[questions.screeningOpinion, 'yes'],
+			[questions.screeningOpinionEnvironmentalStatement, 'yes']
 		],
-		{ logicalCombinator: 'or' }
-	) &&
-	config.featureFlag.scopingOpinionEnabled;
+		{ logicalCombinator: 'and' }
+	) && config.featureFlag.scopingOpinionEnabled;
 ```
 
 - multi-file-upload `/upload-scoping-opinion/` Upload your scoping opinion
 
 ```js
 condition: (response) =>
-	questionHasAnswer(response, questions.scopingOpinion, 'yes') &&
 	questionsHaveAnswers(
 		response,
 		[
-			[questions.environmentalImpactSchedule, 'schedule-2'],
-			[questions.environmentalImpactSchedule, 'no']
+			[questions.scopingOpinion, 'yes'],
+			[questions.screeningOpinion, 'yes'],
+			[questions.screeningOpinionEnvironmentalStatement, 'yes']
 		],
-		{ logicalCombinator: 'or' }
-	) &&
-	config.featureFlag.scopingOpinionEnabled;
+		{ logicalCombinator: 'and' }
+	) && config.featureFlag.scopingOpinionEnabled;
 ```
 
 - radio `/environmental-statement/` Did the applicant submit an environmental statement?

--- a/packages/forms-web-app/src/dynamic-forms/s20-lpa-questionnaire/journey.js
+++ b/packages/forms-web-app/src/dynamic-forms/s20-lpa-questionnaire/journey.js
@@ -109,30 +109,27 @@ const sections = [
 		.addQuestion(questions.scopingOpinion)
 		.withCondition(
 			(response) =>
-				questionHasAnswer(response, questions.screeningOpinionEnvironmentalStatement, 'yes') &&
 				questionsHaveAnswers(
 					response,
 					[
-						[questions.environmentalImpactSchedule, 'schedule-2'],
-						[questions.environmentalImpactSchedule, 'no']
+						[questions.screeningOpinion, 'yes'],
+						[questions.screeningOpinionEnvironmentalStatement, 'yes']
 					],
-					{ logicalCombinator: 'or' }
-				) &&
-				config.featureFlag.scopingOpinionEnabled
+					{ logicalCombinator: 'and' }
+				) && config.featureFlag.scopingOpinionEnabled
 		)
 		.addQuestion(questions.scopingOpinionUpload)
 		.withCondition(
 			(response) =>
-				questionHasAnswer(response, questions.scopingOpinion, 'yes') &&
 				questionsHaveAnswers(
 					response,
 					[
-						[questions.environmentalImpactSchedule, 'schedule-2'],
-						[questions.environmentalImpactSchedule, 'no']
+						[questions.scopingOpinion, 'yes'],
+						[questions.screeningOpinion, 'yes'],
+						[questions.screeningOpinionEnvironmentalStatement, 'yes']
 					],
-					{ logicalCombinator: 'or' }
-				) &&
-				config.featureFlag.scopingOpinionEnabled
+					{ logicalCombinator: 'and' }
+				) && config.featureFlag.scopingOpinionEnabled
 		)
 		.addQuestion(questions.submitEnvironmentalStatement)
 		.addQuestion(questions.uploadEnvironmentalStatement)

--- a/packages/forms-web-app/src/dynamic-forms/s78-questionnaire/journey.js
+++ b/packages/forms-web-app/src/dynamic-forms/s78-questionnaire/journey.js
@@ -100,30 +100,27 @@ const sections = [
 		.addQuestion(questions.scopingOpinion)
 		.withCondition(
 			(response) =>
-				questionHasAnswer(response, questions.screeningOpinionEnvironmentalStatement, 'yes') &&
 				questionsHaveAnswers(
 					response,
 					[
-						[questions.environmentalImpactSchedule, 'schedule-2'],
-						[questions.environmentalImpactSchedule, 'no']
+						[questions.screeningOpinion, 'yes'],
+						[questions.screeningOpinionEnvironmentalStatement, 'yes']
 					],
-					{ logicalCombinator: 'or' }
-				) &&
-				config.featureFlag.scopingOpinionEnabled
+					{ logicalCombinator: 'and' }
+				) && config.featureFlag.scopingOpinionEnabled
 		)
 		.addQuestion(questions.scopingOpinionUpload)
 		.withCondition(
 			(response) =>
-				questionHasAnswer(response, questions.scopingOpinion, 'yes') &&
 				questionsHaveAnswers(
 					response,
 					[
-						[questions.environmentalImpactSchedule, 'schedule-2'],
-						[questions.environmentalImpactSchedule, 'no']
+						[questions.scopingOpinion, 'yes'],
+						[questions.screeningOpinion, 'yes'],
+						[questions.screeningOpinionEnvironmentalStatement, 'yes']
 					],
-					{ logicalCombinator: 'or' }
-				) &&
-				config.featureFlag.scopingOpinionEnabled
+					{ logicalCombinator: 'and' }
+				) && config.featureFlag.scopingOpinionEnabled
 		)
 		.addQuestion(questions.submitEnvironmentalStatement)
 		.addQuestion(questions.uploadEnvironmentalStatement)


### PR DESCRIPTION
### Description of change

Fixed the s20 and s78 question flow so that the scoping opinion screen is not shown when the screening opinion question is changed to 'no'

Ticket: https://pins-ds.atlassian.net/browse/A2-2941

### Checklist

- [x] Feature complete and ready for users, or behind feature-flag
- [x] Commit history is linear with no merge commits
- [ ] Requires infrastructure changes

### Important

Please do not merge from `main` (please only [rebase](https://github.com/Planning-Inspectorate/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
