### PR TITLE
A2-3088(fix): using null access operator for appealType used in banner for email address page

### DIFF
--- a/packages/forms-web-app/src/controllers/common/email-address.js
+++ b/packages/forms-web-app/src/controllers/common/email-address.js
@@ -20,7 +20,7 @@ const getEmailAddress = (views, appealInSession) => {
 	return (req, res) => {
 		const { email } = appealInSession ? req.session.appeal : req.session;
 		const appealType =
-			typeOfPlanningApplicationToAppealTypeMapper[req.session.appeal.typeOfPlanningApplication];
+			typeOfPlanningApplicationToAppealTypeMapper[req.session?.appeal?.typeOfPlanningApplication];
 		res.render(views.EMAIL_ADDRESS, {
 			email,
 			bannerHtmlOverride:
@@ -42,7 +42,7 @@ const postEmailAddress = (views, appealInSession) => {
 			appeal = getSessionAppeal(req.session);
 		}
 		const appealType =
-			typeOfPlanningApplicationToAppealTypeMapper[req.session.appeal.typeOfPlanningApplication];
+			typeOfPlanningApplicationToAppealTypeMapper[req.session?.appeal?.typeOfPlanningApplication];
 		if (Object.keys(errors).length > 0) {
 			res.render(views.EMAIL_ADDRESS, {
 				email,


### PR DESCRIPTION
- Small fix to deal with scenario where appeal is not in session (return to saved appeal journey).
### Description of change

<!-- Please describe the change -->

Ticket: https://pins-ds.atlassian.net/browse/A2-3088

### Checklist

- [ ] Feature complete and ready for users, or behind feature-flag
- [ ] Commit history is linear with no merge commits
- [ ] Requires infrastructure changes

### Important

Please do not merge from `main` (please only [rebase](https://github.com/Planning-Inspectorate/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
