### PR TITLE
feat/display hearing date and time

### DIFF
--- a/packages/common/src/view-model-maps/events.js
+++ b/packages/common/src/view-model-maps/events.js
@@ -74,38 +74,16 @@ const formatInquiries = (events, role) => {
 
 			if (
 				role === LPA_USER_ROLE ||
+				role === APPEAL_USER_ROLES.APPELLANT ||
 				role === APPEAL_USER_ROLES.AGENT ||
 				role === APPEAL_USER_ROLES.RULE_6_PARTY
 			) {
-				if (address) {
-					return {
-						lineOne:
-							`The inquiry will start at ${formattedStartTime} on ${formattedStartDate}. ` +
-							`You must attend the inquiry at ${address}.`
-					};
-				} else {
-					return {
-						lineOne:
-							`The inquiry will start at ${formattedStartTime} on ${formattedStartDate}. ` +
-							`We will contact you when we confirm the venue address.`,
-						lineTwo: 'You must attend the inquiry.'
-					};
-				}
-			} else if (role === APPEAL_USER_ROLES.APPELLANT) {
-				if (address) {
-					return {
-						lineOne:
-							`Your inquiry will start at ${formattedStartTime} on ${formattedStartDate}. ` +
-							`You must attend the inquiry at ${address}.`
-					};
-				} else {
-					return {
-						lineOne:
-							`Your inquiry will start at ${formattedStartTime} on ${formattedStartDate}. ` +
-							`We will contact you when we confirm the venue address.`,
-						lineTwo: 'You must attend the inquiry.'
-					};
-				}
+				return {
+					lineOne:
+						`${role === APPEAL_USER_ROLES.APPELLANT ? `Your` : `The`} inquiry will start at ${formattedStartTime} on ${formattedStartDate}. ` +
+						`${address ? `You must attend the inquiry at ${address}.` : 'We will contact you when we confirm the venue address.'}`,
+					lineTwo: address ? null : 'You must attend the inquiry.'
+				};
 			}
 			return;
 		})
@@ -124,36 +102,13 @@ const formatHearings = (events, role) => {
 			const { formattedTime: formattedStartTime, formattedDate: formattedStartDate } =
 				getFormattedTimeAndDate(hearing.startDate);
 			const address = formatEventAddress(hearing);
-			if (role === LPA_USER_ROLE) {
-				if (address) {
-					return {
-						lineOne:
-							`The hearing will start at ${formattedStartTime} on ${formattedStartDate}. ` +
-							`You must attend the hearing at ${address}.`
-					};
-				} else {
-					return {
-						lineOne:
-							`The hearing will start at ${formattedStartTime} on ${formattedStartDate}. ` +
-							`We will contact you when we confirm the venue address.`,
-						lineTwo: 'You must attend the hearing.'
-					};
-				}
-			} else if (role === APPEAL_USER_ROLES.APPELLANT) {
-				if (address) {
-					return {
-						lineOne:
-							`Your hearing will start at ${formattedStartTime} on ${formattedStartDate}. ` +
-							`You must attend the hearing at ${address}.`
-					};
-				} else {
-					return {
-						lineOne:
-							`Your hearing will start at ${formattedStartTime} on ${formattedStartDate}. ` +
-							`We will contact you when we confirm the venue address.`,
-						lineTwo: 'You must attend the hearing.'
-					};
-				}
+			if (role === LPA_USER_ROLE || role === APPEAL_USER_ROLES.APPELLANT) {
+				return {
+					lineOne:
+						`${role === APPEAL_USER_ROLES.APPELLANT ? `Your` : `The`} hearing will start at ${formattedStartTime} on ${formattedStartDate}. ` +
+						`${address ? `You must attend the hearing at ${address}.` : 'We will contact you when we confirm the venue address.'}`,
+					lineTwo: address ? null : 'You must attend the hearing.'
+				};
 			}
 			return;
 		})

--- a/packages/common/src/view-model-maps/events.js
+++ b/packages/common/src/view-model-maps/events.js
@@ -74,7 +74,6 @@ const formatInquiries = (events, role) => {
 
 			if (
 				role === LPA_USER_ROLE ||
-				role === APPEAL_USER_ROLES.APPELLANT ||
 				role === APPEAL_USER_ROLES.AGENT ||
 				role === APPEAL_USER_ROLES.RULE_6_PARTY
 			) {
@@ -88,6 +87,21 @@ const formatInquiries = (events, role) => {
 					return {
 						lineOne:
 							`The inquiry will start at ${formattedStartTime} on ${formattedStartDate}. ` +
+							`We will contact you when we confirm the venue address.`,
+						lineTwo: 'You must attend the inquiry.'
+					};
+				}
+			} else if (role === APPEAL_USER_ROLES.APPELLANT) {
+				if (address) {
+					return {
+						lineOne:
+							`Your inquiry will start at ${formattedStartTime} on ${formattedStartDate}. ` +
+							`You must attend the inquiry at ${address}.`
+					};
+				} else {
+					return {
+						lineOne:
+							`Your inquiry will start at ${formattedStartTime} on ${formattedStartDate}. ` +
 							`We will contact you when we confirm the venue address.`,
 						lineTwo: 'You must attend the inquiry.'
 					};
@@ -121,6 +135,21 @@ const formatHearings = (events, role) => {
 					return {
 						lineOne:
 							`The hearing will start at ${formattedStartTime} on ${formattedStartDate}. ` +
+							`We will contact you when we confirm the venue address.`,
+						lineTwo: 'You must attend the hearing.'
+					};
+				}
+			} else if (role === APPEAL_USER_ROLES.APPELLANT) {
+				if (address) {
+					return {
+						lineOne:
+							`Your hearing will start at ${formattedStartTime} on ${formattedStartDate}. ` +
+							`You must attend the hearing at ${address}.`
+					};
+				} else {
+					return {
+						lineOne:
+							`Your hearing will start at ${formattedStartTime} on ${formattedStartDate}. ` +
 							`We will contact you when we confirm the venue address.`,
 						lineTwo: 'You must attend the hearing.'
 					};

--- a/packages/common/src/view-model-maps/events.js
+++ b/packages/common/src/view-model-maps/events.js
@@ -78,9 +78,53 @@ const formatInquiries = (events, role) => {
 				role === APPEAL_USER_ROLES.AGENT ||
 				role === APPEAL_USER_ROLES.RULE_6_PARTY
 			) {
-				return `The inquiry will start at ${formattedStartTime} on ${formattedStartDate}. You must attend the inquiry ${
-					address ? `at ${address}.` : '- address to be confirmed.'
-				}`;
+				if (address) {
+					return {
+						lineOne:
+							`The inquiry will start at ${formattedStartTime} on ${formattedStartDate}. ` +
+							`You must attend the inquiry at ${address}.`
+					};
+				} else {
+					return {
+						lineOne:
+							`The inquiry will start at ${formattedStartTime} on ${formattedStartDate}. ` +
+							`We will contact you when we confirm the venue address.`,
+						lineTwo: 'You must attend the inquiry.'
+					};
+				}
+			}
+			return;
+		})
+		.filter(Boolean);
+};
+
+/**
+ * @param {Array<Event>} events
+ * @param {string} role
+ * @returns {Array<string|undefined>}
+ */
+const formatHearings = (events, role) => {
+	let hearings = events.filter((item) => item.type === EVENT_TYPES.HEARING);
+	return hearings
+		.map((hearing) => {
+			const { formattedTime: formattedStartTime, formattedDate: formattedStartDate } =
+				getFormattedTimeAndDate(hearing.startDate);
+			const address = formatEventAddress(hearing);
+			if (role === LPA_USER_ROLE) {
+				if (address) {
+					return {
+						lineOne:
+							`The hearing will start at ${formattedStartTime} on ${formattedStartDate}. ` +
+							`You must attend the hearing at ${address}.`
+					};
+				} else {
+					return {
+						lineOne:
+							`The hearing will start at ${formattedStartTime} on ${formattedStartDate}. ` +
+							`We will contact you when we confirm the venue address.`,
+						lineTwo: 'You must attend the hearing.'
+					};
+				}
 			}
 			return;
 		})
@@ -107,4 +151,4 @@ function getFormattedTimeAndDate(date) {
 	};
 }
 
-module.exports = { formatSiteVisits, formatInquiries };
+module.exports = { formatSiteVisits, formatInquiries, formatHearings };

--- a/packages/common/src/view-model-maps/events.test.js
+++ b/packages/common/src/view-model-maps/events.test.js
@@ -157,7 +157,8 @@ describe('view-model-maps/events', () => {
 			expect(formatInquiries(events, role)).toEqual([
 				{
 					lineOne:
-						'The inquiry will start at 9am on 29 December 2024. You must attend the inquiry at 101 The Street, Flat 2, Town, County, AB1 2CD.'
+						'The inquiry will start at 9am on 29 December 2024. You must attend the inquiry at 101 The Street, Flat 2, Town, County, AB1 2CD.',
+					lineTwo: null
 				}
 			]);
 		});
@@ -169,7 +170,8 @@ describe('view-model-maps/events', () => {
 			expect(formatInquiries(events, role)).toEqual([
 				{
 					lineOne:
-						'The inquiry will start at 9am on 29 December 2024. You must attend the inquiry at 101 The Street, Flat 2, Town, County, AB1 2CD.'
+						'The inquiry will start at 9am on 29 December 2024. You must attend the inquiry at 101 The Street, Flat 2, Town, County, AB1 2CD.',
+					lineTwo: null
 				}
 			]);
 		});
@@ -181,7 +183,8 @@ describe('view-model-maps/events', () => {
 			expect(formatInquiries(events, role)).toEqual([
 				{
 					lineOne:
-						'Your inquiry will start at 9am on 29 December 2024. You must attend the inquiry at 101 The Street, Flat 2, Town, County, AB1 2CD.'
+						'Your inquiry will start at 9am on 29 December 2024. You must attend the inquiry at 101 The Street, Flat 2, Town, County, AB1 2CD.',
+					lineTwo: null
 				}
 			]);
 		});
@@ -193,7 +196,8 @@ describe('view-model-maps/events', () => {
 			expect(formatInquiries(events, role)).toEqual([
 				{
 					lineOne:
-						'The inquiry will start at 9am on 29 December 2024. You must attend the inquiry at 101 The Street, Flat 2, Town, County, AB1 2CD.'
+						'The inquiry will start at 9am on 29 December 2024. You must attend the inquiry at 101 The Street, Flat 2, Town, County, AB1 2CD.',
+					lineTwo: null
 				}
 			]);
 		});
@@ -267,7 +271,8 @@ describe('view-model-maps/events', () => {
 			expect(formatHearings(events, role)).toEqual([
 				{
 					lineOne:
-						'Your hearing will start at 9am on 29 December 2025. You must attend the hearing at 101 The Street, Flat 2, Town, County, AB1 2CD.'
+						'Your hearing will start at 9am on 29 December 2025. You must attend the hearing at 101 The Street, Flat 2, Town, County, AB1 2CD.',
+					lineTwo: null
 				}
 			]);
 		});
@@ -279,7 +284,8 @@ describe('view-model-maps/events', () => {
 			expect(formatHearings(events, role)).toEqual([
 				{
 					lineOne:
-						'The hearing will start at 9am on 29 December 2025. You must attend the hearing at 101 The Street, Flat 2, Town, County, AB1 2CD.'
+						'The hearing will start at 9am on 29 December 2025. You must attend the hearing at 101 The Street, Flat 2, Town, County, AB1 2CD.',
+					lineTwo: null
 				}
 			]);
 		});

--- a/packages/common/src/view-model-maps/events.test.js
+++ b/packages/common/src/view-model-maps/events.test.js
@@ -181,7 +181,7 @@ describe('view-model-maps/events', () => {
 			expect(formatInquiries(events, role)).toEqual([
 				{
 					lineOne:
-						'The inquiry will start at 9am on 29 December 2024. You must attend the inquiry at 101 The Street, Flat 2, Town, County, AB1 2CD.'
+						'Your inquiry will start at 9am on 29 December 2024. You must attend the inquiry at 101 The Street, Flat 2, Town, County, AB1 2CD.'
 				}
 			]);
 		});
@@ -198,7 +198,7 @@ describe('view-model-maps/events', () => {
 			]);
 		});
 
-		it('returns correct string array if inquiry missing address', () => {
+		it('returns correct string array if inquiry missing address & appellant user', () => {
 			const events = [
 				siteVisitEvent,
 				{
@@ -210,16 +210,39 @@ describe('view-model-maps/events', () => {
 					addressPostcode: null
 				}
 			];
-			const role = LPA_USER_ROLE;
+			const role = APPEAL_USER_ROLES.APPELLANT;
 
 			expect(formatInquiries(events, role)).toEqual([
 				{
 					lineOne:
-						'The inquiry will start at 9am on 29 December 2024. We will contact you when we confirm the venue address.',
+						'Your inquiry will start at 9am on 29 December 2024. We will contact you when we confirm the venue address.',
 					lineTwo: 'You must attend the inquiry.'
 				}
 			]);
 		});
+	});
+
+	it('returns correct string array if inquiry missing address & LPA user', () => {
+		const events = [
+			siteVisitEvent,
+			{
+				...inquiryEvent,
+				addressLine1: null,
+				addressLine2: null,
+				addressTown: null,
+				addressCounty: null,
+				addressPostcode: null
+			}
+		];
+		const role = LPA_USER_ROLE;
+
+		expect(formatInquiries(events, role)).toEqual([
+			{
+				lineOne:
+					'The inquiry will start at 9am on 29 December 2024. We will contact you when we confirm the venue address.',
+				lineTwo: 'You must attend the inquiry.'
+			}
+		]);
 	});
 
 	describe('formatHearings', () => {
@@ -237,7 +260,19 @@ describe('view-model-maps/events', () => {
 			expect(formatHearings(events, role)).toHaveLength(0);
 		});
 
-		it('returns only hearingEvent not inquiry or site visit when user is valid', () => {
+		it('returns correct string array if valid hearing & appellant user', () => {
+			const events = [siteVisitEvent, inquiryEvent, hearingEvent];
+			const role = APPEAL_USER_ROLES.APPELLANT;
+
+			expect(formatHearings(events, role)).toEqual([
+				{
+					lineOne:
+						'Your hearing will start at 9am on 29 December 2025. You must attend the hearing at 101 The Street, Flat 2, Town, County, AB1 2CD.'
+				}
+			]);
+		});
+
+		it('returns correct string array if valid hearing & LPA user', () => {
 			const events = [siteVisitEvent, inquiryEvent, hearingEvent];
 			const role = LPA_USER_ROLE;
 
@@ -249,7 +284,28 @@ describe('view-model-maps/events', () => {
 			]);
 		});
 
-		it('returns correct object string array if valid user and hearing missing address', () => {
+		it('returns correct string array if valid hearing without an address & appellant user', () => {
+			const events = [
+				{
+					...hearingEvent,
+					addressLine1: null,
+					addressLine2: null,
+					addressTown: null,
+					addressCounty: null,
+					addressPostcode: null
+				}
+			];
+			const role = APPEAL_USER_ROLES.APPELLANT;
+			expect(formatHearings(events, role)).toEqual([
+				{
+					lineOne:
+						'Your hearing will start at 9am on 29 December 2025. We will contact you when we confirm the venue address.',
+					lineTwo: 'You must attend the hearing.'
+				}
+			]);
+		});
+
+		it('returns correct string array if valid hearing without an address & LPA user', () => {
 			const events = [
 				{
 					...hearingEvent,

--- a/packages/common/src/view-model-maps/events.test.js
+++ b/packages/common/src/view-model-maps/events.test.js
@@ -1,5 +1,5 @@
 const { LPA_USER_ROLE, APPEAL_USER_ROLES, EVENT_SUB_TYPES } = require('../constants');
-const { formatInquiries, formatSiteVisits } = require('./events');
+const { formatInquiries, formatSiteVisits, formatHearings } = require('./events');
 
 describe('view-model-maps/events', () => {
 	const siteVisitEvent = {
@@ -27,6 +27,19 @@ describe('view-model-maps/events', () => {
 		addressCounty: 'County',
 		addressPostcode: 'AB1 2CD'
 	};
+	const hearingEvent = {
+		internalId: 'test123',
+		published: true,
+		type: 'hearing',
+		subtype: null,
+		startDate: new Date(2025, 11, 29, 9),
+		endDate: new Date(2025, 11, 30, 9),
+		addressLine1: '101 The Street',
+		addressLine2: 'Flat 2',
+		addressTown: 'Town',
+		addressCounty: 'County',
+		addressPostcode: 'AB1 2CD'
+	};
 
 	describe('formatSiteVisits', () => {
 		it('returns empty array if not a valid user', () => {
@@ -37,7 +50,7 @@ describe('view-model-maps/events', () => {
 		});
 
 		it('returns empty array if valid user and no site visit in events array', () => {
-			const events = [inquiryEvent, inquiryEvent];
+			const events = [inquiryEvent, inquiryEvent, hearingEvent];
 			const role = APPEAL_USER_ROLES.APPELLANT;
 
 			expect(formatSiteVisits(events, role)).toHaveLength(0);
@@ -131,7 +144,7 @@ describe('view-model-maps/events', () => {
 		});
 
 		it('returns empty array if valid user and no inquiries in events', () => {
-			const events = [siteVisitEvent];
+			const events = [siteVisitEvent, hearingEvent];
 			const role = LPA_USER_ROLE;
 
 			expect(formatInquiries(events, role)).toHaveLength(0);
@@ -142,7 +155,10 @@ describe('view-model-maps/events', () => {
 			const role = LPA_USER_ROLE;
 
 			expect(formatInquiries(events, role)).toEqual([
-				'The inquiry will start at 9am on 29 December 2024. You must attend the inquiry at 101 The Street, Flat 2, Town, County, AB1 2CD.'
+				{
+					lineOne:
+						'The inquiry will start at 9am on 29 December 2024. You must attend the inquiry at 101 The Street, Flat 2, Town, County, AB1 2CD.'
+				}
 			]);
 		});
 
@@ -151,7 +167,10 @@ describe('view-model-maps/events', () => {
 			const role = APPEAL_USER_ROLES.RULE_6_PARTY;
 
 			expect(formatInquiries(events, role)).toEqual([
-				'The inquiry will start at 9am on 29 December 2024. You must attend the inquiry at 101 The Street, Flat 2, Town, County, AB1 2CD.'
+				{
+					lineOne:
+						'The inquiry will start at 9am on 29 December 2024. You must attend the inquiry at 101 The Street, Flat 2, Town, County, AB1 2CD.'
+				}
 			]);
 		});
 
@@ -160,7 +179,10 @@ describe('view-model-maps/events', () => {
 			const role = APPEAL_USER_ROLES.APPELLANT;
 
 			expect(formatInquiries(events, role)).toEqual([
-				'The inquiry will start at 9am on 29 December 2024. You must attend the inquiry at 101 The Street, Flat 2, Town, County, AB1 2CD.'
+				{
+					lineOne:
+						'The inquiry will start at 9am on 29 December 2024. You must attend the inquiry at 101 The Street, Flat 2, Town, County, AB1 2CD.'
+				}
 			]);
 		});
 
@@ -169,7 +191,10 @@ describe('view-model-maps/events', () => {
 			const role = APPEAL_USER_ROLES.AGENT;
 
 			expect(formatInquiries(events, role)).toEqual([
-				'The inquiry will start at 9am on 29 December 2024. You must attend the inquiry at 101 The Street, Flat 2, Town, County, AB1 2CD.'
+				{
+					lineOne:
+						'The inquiry will start at 9am on 29 December 2024. You must attend the inquiry at 101 The Street, Flat 2, Town, County, AB1 2CD.'
+				}
 			]);
 		});
 
@@ -188,7 +213,60 @@ describe('view-model-maps/events', () => {
 			const role = LPA_USER_ROLE;
 
 			expect(formatInquiries(events, role)).toEqual([
-				'The inquiry will start at 9am on 29 December 2024. You must attend the inquiry - address to be confirmed.'
+				{
+					lineOne:
+						'The inquiry will start at 9am on 29 December 2024. We will contact you when we confirm the venue address.',
+					lineTwo: 'You must attend the inquiry.'
+				}
+			]);
+		});
+	});
+
+	describe('formatHearings', () => {
+		it('returns empty array if not a valid user', () => {
+			const events = [hearingEvent];
+			const role = 'not a valid user';
+
+			expect(formatHearings(events, role)).toHaveLength(0);
+		});
+
+		it('returns empty array if valid user and no hearings in events', () => {
+			const events = [siteVisitEvent, inquiryEvent];
+			const role = LPA_USER_ROLE;
+
+			expect(formatHearings(events, role)).toHaveLength(0);
+		});
+
+		it('returns only hearingEvent not inquiry or site visit when user is valid', () => {
+			const events = [siteVisitEvent, inquiryEvent, hearingEvent];
+			const role = LPA_USER_ROLE;
+
+			expect(formatHearings(events, role)).toEqual([
+				{
+					lineOne:
+						'The hearing will start at 9am on 29 December 2025. You must attend the hearing at 101 The Street, Flat 2, Town, County, AB1 2CD.'
+				}
+			]);
+		});
+
+		it('returns correct object string array if valid user and hearing missing address', () => {
+			const events = [
+				{
+					...hearingEvent,
+					addressLine1: null,
+					addressLine2: null,
+					addressTown: null,
+					addressCounty: null,
+					addressPostcode: null
+				}
+			];
+			const role = LPA_USER_ROLE;
+			expect(formatHearings(events, role)).toEqual([
+				{
+					lineOne:
+						'The hearing will start at 9am on 29 December 2025. We will contact you when we confirm the venue address.',
+					lineTwo: 'You must attend the hearing.'
+				}
 			]);
 		});
 	});

--- a/packages/forms-web-app/src/controllers/selected-appeal/index.js
+++ b/packages/forms-web-app/src/controllers/selected-appeal/index.js
@@ -16,6 +16,7 @@ const {
 	formatSections,
 	formatSiteVisits,
 	formatInquiries,
+	formatHearings,
 	isSection,
 	displayHeadlinesByUser
 } = require('@pins/common');
@@ -111,6 +112,7 @@ exports.get = (layoutTemplate = 'layouts/no-banner-link/main.njk') => {
 				headlineData,
 				siteVisits: formatSiteVisits(events, userType),
 				inquiries: formatInquiries(events, userType),
+				hearings: formatHearings(events, userType),
 				sections: formatSections({ caseData, sections }),
 				baseUrl: userRouteUrl,
 				decision: mapDecisionTag(caseData.caseDecisionOutcome),

--- a/packages/forms-web-app/src/views/selected-appeal/appeal.njk
+++ b/packages/forms-web-app/src/views/selected-appeal/appeal.njk
@@ -228,8 +228,26 @@
 			{% for inquiry in appeal.inquiries %}
 				<div class="govuk-inset-text">
 					<p class="govuk-body">
-						{{inquiry}}
+						{{inquiry.lineOne}}
 					</p>
+					{% if inquiry.lineTwo %}
+						<p class="govuk-body">
+							{{inquiry.lineTwo}}
+						</p>
+					{% endif %}
+				</div>
+			{% endfor %}
+
+			{% for hearing in appeal.hearings %}
+				<div class="govuk-inset-text">
+					<p class="govuk-body">
+						{{hearing.lineOne}}
+					</p>
+					{% if hearing.lineTwo %}
+						<p class="govuk-body">
+							{{hearing.lineTwo}}
+						</p>
+					{% endif %}
 				</div>
 			{% endfor %}
 


### PR DESCRIPTION
### Description of change

Adding the display of hearing date and time for both LPAs and appellants, as well as changing inquiries to match.

Ticket (LPA): https://pins-ds.atlassian.net/browse/A2-1175
Ticket (Appellant): https://pins-ds.atlassian.net/browse/A2-1154

### Checklist

- [x] Feature complete and ready for users, or behind feature-flag
- [x] Commit history is linear with no merge commits
- [ ] Requires infrastructure changes

### Important

Please do not merge from `main` (please only [rebase](https://github.com/Planning-Inspectorate/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
