### PR TITLE
fix(a2-2813): corrected back link navigation in appellant and LPA final comments flow

### DIFF
--- a/packages/forms-web-app/src/dynamic-forms/controller.js
+++ b/packages/forms-web-app/src/dynamic-forms/controller.js
@@ -917,6 +917,14 @@ exports.shortJourneyEntry = async (req, res) => {
 	return res.redirect(journey.taskListUrl);
 };
 
+/** @type {import('express').RequestHandler } */
+exports.startJourneyFromBeginning = async (req, res) => {
+	const { journey } = res.locals;
+
+	// always go to the first question
+	return res.redirect(journey.getFirstQuestionUrl());
+};
+
 /**
  * @param {import('express').Request} req
  * @param {Journey} journey

--- a/packages/forms-web-app/src/dynamic-forms/controller.test.js
+++ b/packages/forms-web-app/src/dynamic-forms/controller.test.js
@@ -715,6 +715,25 @@ describe('dynamic-form/controller', () => {
 			expect(res.render).toHaveBeenCalledWith('./error/not-found.njk');
 		});
 	});
+
+	describe('startJourneyFromBeginning', () => {
+		it('always redirects to the first question', async () => {
+			req.session = {
+				navigationHistory: ['/previous-page']
+			};
+
+			const mockFirstQuestionUrl = '/some/path/to/first-question';
+			mockJourney.getFirstQuestionUrl = jest.fn(() => mockFirstQuestionUrl);
+
+			res.locals.journey = mockJourney;
+
+			const { startJourneyFromBeginning } = require('./controller');
+			await startJourneyFromBeginning(req, res);
+
+			expect(mockJourney.getFirstQuestionUrl).toHaveBeenCalled();
+			expect(res.redirect).toHaveBeenCalledWith(mockFirstQuestionUrl);
+		});
+	});
 });
 
 const _getmockSummaryListData = (mockJourney) => {

--- a/packages/forms-web-app/src/routes/lpa-dashboard/statement.js
+++ b/packages/forms-web-app/src/routes/lpa-dashboard/statement.js
@@ -6,7 +6,7 @@ const {
 	remove,
 	submitLpaStatement,
 	appealStatementSubmitted,
-	shortJourneyEntry
+	startJourneyFromBeginning
 } = require('../../dynamic-forms/controller');
 const validate = require('../../dynamic-forms/validator/validator');
 const {
@@ -75,7 +75,7 @@ router.get(
 	getJourneyResponse(),
 	getJourney(journeys),
 	checkNotSubmitted(appealOverviewUrl),
-	shortJourneyEntry
+	startJourneyFromBeginning
 );
 
 router.get(


### PR DESCRIPTION
### Description of change

Ensure users re-enter the Final Comments journey at the first question page, rather than resuming mid-journey.

Ticket:
[A2-2813](https://pins-ds.atlassian.net/browse/A2-2813)

Minor content fixes for notify templates

### Checklist

- [x] Feature complete and ready for users, or behind feature-flag
- [x] Commit history is linear with no merge commits
- [ ] Requires infrastructure changes

### Important

Please do not merge from `main` (please only [rebase](https://github.com/Planning-Inspectorate/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.


[A2-2813]: https://pins-ds.atlassian.net/browse/A2-2813?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ