### PR TITLE
Relevant policies from statutory development plan boolean and upload pages missing from HAS LPAQ

### DIFF
--- a/packages/forms-web-app/src/dynamic-forms/has-questionnaire/journey.js
+++ b/packages/forms-web-app/src/dynamic-forms/has-questionnaire/journey.js
@@ -56,7 +56,11 @@ const sections = [
 	new Section("Planning officer's report and supporting documents", 'planning-officer-report')
 		.addQuestion(questions.planningOfficersReportUpload)
 		.addQuestion(questions.uploadPlansDrawingsHAS)
+		.addQuestion(questions.developmentPlanPolicies)
 		.addQuestion(questions.uploadDevelopmentPlanPolicies)
+		.withCondition((response) =>
+			questionHasAnswer(response, questions.developmentPlanPolicies, 'yes')
+		)
 		.addQuestion(questions.emergingPlan)
 		.addQuestion(questions.emergingPlanUpload)
 		.withCondition((response) => questionHasAnswer(response, questions.emergingPlan, 'yes'))


### PR DESCRIPTION
### Description of change

Adds relevant policies from statutory development plan boolean and upload pages to HAS LPAQ

Ticket: https://pins-ds.atlassian.net.mcas.ms/jira/software/c/projects/A2/boards/246?assignee=712020%3A04186e0f-84cf-4604-835a-10ec7cfafa90&selectedIssue=A2-3421

### Checklist

- [x] Feature complete and ready for users, or behind feature-flag
- [x] Commit history is linear with no merge commits
- [ ] Requires infrastructure changes

### Important

Please do not merge from `main` (please only [rebase](https://github.com/Planning-Inspectorate/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
