### PR TITLE
feat: a2-3242 update upload screening direction conditional logic

### DIFF
--- a/packages/forms-web-app/src/dynamic-forms/docs/s20-lpaq-journey.md
+++ b/packages/forms-web-app/src/dynamic-forms/docs/s20-lpaq-journey.md
@@ -159,7 +159,16 @@ condition: (response) => questionHasAnswer(response, questions.submitEnvironment
 - multi-file-upload `/upload-screening-direction/` Upload the screening direction
 
 ```js
-condition: (response) => questionHasAnswer(response, questions.submitEnvironmentalStatement, 'no');
+condition: (response) =>
+	questionsHaveAnswers(
+		response,
+		[
+			[questions.submitEnvironmentalStatement, 'no'],
+			[questions.environmentalImpactSchedule, 'schedule-2'],
+			[questions.screeningOpinion, 'yes']
+		],
+		{ logicalCombinator: 'and' }
+	);
 ```
 
 ## Notifying relevant parties

--- a/packages/forms-web-app/src/dynamic-forms/docs/s78-lpaq-journey.md
+++ b/packages/forms-web-app/src/dynamic-forms/docs/s78-lpaq-journey.md
@@ -151,7 +151,16 @@ condition: (response) => questionHasAnswer(response, questions.submitEnvironment
 - multi-file-upload `/upload-screening-direction/` Upload the screening direction
 
 ```js
-condition: (response) => questionHasAnswer(response, questions.submitEnvironmentalStatement, 'no');
+condition: (response) =>
+	questionsHaveAnswers(
+		response,
+		[
+			[questions.submitEnvironmentalStatement, 'no'],
+			[questions.environmentalImpactSchedule, 'schedule-2'],
+			[questions.screeningOpinion, 'yes']
+		],
+		{ logicalCombinator: 'and' }
+	);
 ```
 
 ## Notifying relevant parties

--- a/packages/forms-web-app/src/dynamic-forms/questions.js
+++ b/packages/forms-web-app/src/dynamic-forms/questions.js
@@ -1188,7 +1188,7 @@ exports.questionProps = {
 				value: 'yes'
 			},
 			{
-				text: 'No, they have a negative screening direction',
+				text: 'No',
 				value: 'no'
 			}
 		],

--- a/packages/forms-web-app/src/dynamic-forms/s20-lpa-questionnaire/journey.js
+++ b/packages/forms-web-app/src/dynamic-forms/s20-lpa-questionnaire/journey.js
@@ -135,7 +135,15 @@ const sections = [
 		)
 		.addQuestion(questions.uploadScreeningDirection)
 		.withCondition((response) =>
-			questionHasAnswer(response, questions.submitEnvironmentalStatement, 'no')
+			questionsHaveAnswers(
+				response,
+				[
+					[questions.submitEnvironmentalStatement, 'no'],
+					[questions.environmentalImpactSchedule, 'schedule-2'],
+					[questions.screeningOpinion, 'yes']
+				],
+				{ logicalCombinator: 'and' }
+			)
 		),
 	new Section('Notifying relevant parties', 'notified')
 		.addQuestion(questions.whoWasNotified)

--- a/packages/forms-web-app/src/dynamic-forms/s78-questionnaire/journey.js
+++ b/packages/forms-web-app/src/dynamic-forms/s78-questionnaire/journey.js
@@ -129,7 +129,15 @@ const sections = [
 		)
 		.addQuestion(questions.uploadScreeningDirection)
 		.withCondition((response) =>
-			questionHasAnswer(response, questions.submitEnvironmentalStatement, 'no')
+			questionsHaveAnswers(
+				response,
+				[
+					[questions.submitEnvironmentalStatement, 'no'],
+					[questions.environmentalImpactSchedule, 'schedule-2'],
+					[questions.screeningOpinion, 'yes']
+				],
+				{ logicalCombinator: 'and' }
+			)
 		),
 	new Section('Notifying relevant parties', 'notified')
 		.addQuestion(questions.whoWasNotified)


### PR DESCRIPTION
### Description of change

* add extra logic to determine whether or not to display upload screening direction
* update docs
* small content change

Ticket: https://pins-ds.atlassian.net/browse/A2-

### Checklist

- [ ] Feature complete and ready for users, or behind feature-flag
- [ ] Commit history is linear with no merge commits
- [ ] Requires infrastructure changes

### Important

Please do not merge from `main` (please only [rebase](https://github.com/Planning-Inspectorate/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
