### PR TITLE
fix(a2-3237): only provide lpa details for lpa dashboard login

### DIFF
--- a/packages/auth-server/src/account/account.js
+++ b/packages/auth-server/src/account/account.js
@@ -1,6 +1,7 @@
 import { UnknownUserId } from 'oidc-provider/lib/helpers/errors.js';
 import { sendConfirmRegistrationEmailToAppellant } from '../lib/notify.js';
 import { isEmailLike } from '../validators/email.js';
+import consts from '@pins/common/src/constants.js';
 
 import Repository from './repository.js';
 const repo = new Repository();
@@ -44,7 +45,9 @@ class Account {
 			email: this.user.email
 		};
 
-		if (this.user.isLpaUser) {
+		const lpaScope = scope?.split(' ').includes(consts.AUTH.SCOPES.USER_DETAILS.LPA);
+
+		if (lpaScope && this.user.isLpaUser) {
 			details.lpaCode = this.user.lpaCode;
 			details.isLpaAdmin = this.user.isLpaAdmin;
 			details.lpaStatus = this.user.lpaStatus;

--- a/packages/common/src/client/auth-client.js
+++ b/packages/common/src/client/auth-client.js
@@ -72,19 +72,25 @@ exports.createOTPGrant = async (email, action) => {
 /**
  * @param {string} email
  * @param {string} token
+ * @param {string[]} [additionalScopes]
  * @returns {Promise<Token>}
  */
-exports.createROPCGrant = async (email, token) => {
+exports.createROPCGrant = async (email, token, additionalScopes) => {
 	if (!authClientConfig || !authClient) {
 		throw new Error(
 			'Auth client configuration is not initialized. Call getAuthClientConfig first.'
 		);
 	}
 
+	const scopes = [AUTH.SCOPES.USER_DETAILS.OPENID, AUTH.SCOPES.USER_DETAILS.EMAIL];
+	if (additionalScopes && additionalScopes.length > 0) {
+		scopes.push(...additionalScopes);
+	}
+
 	return authClient.genericGrantRequest(authClientConfig, AUTH.GRANT_TYPE.ROPC, {
 		email: email,
 		otp: token,
-		scope: 'openid email',
+		scope: scopes.join(' '),
 		resource: AUTH.RESOURCE
 	});
 };

--- a/packages/common/src/client/auth-client.test.js
+++ b/packages/common/src/client/auth-client.test.js
@@ -2,14 +2,8 @@ const mockDiscovery = jest.fn();
 const mockGenericGrantRequest = jest.fn();
 const mockClientCredentialsGrant = jest.fn();
 const mockAllowInsecureRequests = Symbol('allowInsecureRequests');
-const mockAUTH = {
-	GRANT_TYPE: { OTP: 'otp', ROPC: 'ropc' },
-	RESOURCE: 'test-resource'
-};
+const { AUTH } = require('../constants');
 
-jest.mock('../constants', () => ({
-	AUTH: mockAUTH
-}));
 jest.unstable_mockModule('openid-client', () => {
 	return {
 		discovery: mockDiscovery,
@@ -136,10 +130,10 @@ describe('Auth Client', () => {
 			const email = 'test@example.com';
 			const action = 'test-action';
 			await createOTPGrant(email, action);
-			expect(mockGenericGrantRequest).toHaveBeenCalledWith(authClientConfig, 'otp', {
+			expect(mockGenericGrantRequest).toHaveBeenCalledWith(authClientConfig, AUTH.GRANT_TYPE.OTP, {
 				email,
 				action,
-				resource: mockAUTH.RESOURCE
+				resource: AUTH.RESOURCE
 			});
 		});
 
@@ -148,10 +142,10 @@ describe('Auth Client', () => {
 			const email = 'test@example.com';
 			const action = 'test-action';
 			await createOTPGrant(email, action);
-			expect(mockGenericGrantRequest).toHaveBeenCalledWith(authClientConfig, 'otp', {
+			expect(mockGenericGrantRequest).toHaveBeenCalledWith(authClientConfig, AUTH.GRANT_TYPE.OTP, {
 				email,
 				action,
-				resource: mockAUTH.RESOURCE
+				resource: AUTH.RESOURCE
 			});
 		});
 	});
@@ -180,11 +174,11 @@ describe('Auth Client', () => {
 			const email = 'test@example.com';
 			const token = 'test-token';
 			await createROPCGrant(email, token);
-			expect(mockGenericGrantRequest).toHaveBeenCalledWith(authClientConfig, 'ropc', {
+			expect(mockGenericGrantRequest).toHaveBeenCalledWith(authClientConfig, AUTH.GRANT_TYPE.ROPC, {
 				email,
 				otp: token,
 				scope: 'openid email',
-				resource: mockAUTH.RESOURCE
+				resource: AUTH.RESOURCE
 			});
 		});
 
@@ -196,11 +190,24 @@ describe('Auth Client', () => {
 			const token = 'test-token';
 			const result = await createROPCGrant(email, token);
 			expect(result).toEqual(mockToken);
-			expect(mockGenericGrantRequest).toHaveBeenCalledWith(authClientConfig, 'ropc', {
+			expect(mockGenericGrantRequest).toHaveBeenCalledWith(authClientConfig, AUTH.GRANT_TYPE.ROPC, {
 				email,
 				otp: token,
 				scope: 'openid email',
-				resource: mockAUTH.RESOURCE
+				resource: AUTH.RESOURCE
+			});
+		});
+
+		it('calls genericGrantRequest with additional scopes', async () => {
+			await getAuthClientConfig('https://example.com', 'test-client-id', 'test-client-secret');
+			const email = 'test@example.com';
+			const token = 'test-token';
+			await createROPCGrant(email, token, ['custom-scope']);
+			expect(mockGenericGrantRequest).toHaveBeenCalledWith(authClientConfig, AUTH.GRANT_TYPE.ROPC, {
+				email,
+				otp: token,
+				scope: 'openid email custom-scope',
+				resource: AUTH.RESOURCE
 			});
 		});
 	});
@@ -228,7 +235,7 @@ describe('Auth Client', () => {
 			await getAuthClientConfig('https://example.com', 'test-client-id', 'test-client-secret');
 			await createClientCredentialsGrant();
 			expect(mockClientCredentialsGrant).toHaveBeenCalledWith(authClientConfig, {
-				resource: mockAUTH.RESOURCE
+				resource: AUTH.RESOURCE
 			});
 		});
 	});

--- a/packages/common/src/constants.js
+++ b/packages/common/src/constants.js
@@ -76,18 +76,8 @@ module.exports = {
 			USER_DETAILS: {
 				OPENID: 'openid',
 				USER_INFO: 'userinfo',
-				EMAIL: 'email'
-			},
-			// APPEALS_API: {
-			// 	READ: 'appeals:read',
-			// 	WRITE: 'appeals:write'
-			// },
-			// DOCS_API: {
-			// 	READ: 'documents:read',
-			// 	WRITE: 'documents:write'
-			// },
-			BO_DOCS_API: {
-				READ: 'bo-documents:read'
+				EMAIL: 'email',
+				LPA: 'lpa'
 			}
 		},
 		GRANT_TYPE: {

--- a/packages/forms-web-app/__tests__/unit/controllers/common/enter-code.test.js
+++ b/packages/forms-web-app/__tests__/unit/controllers/common/enter-code.test.js
@@ -19,7 +19,7 @@ const {
 } = require('../../../../src/services/user.service');
 const { isTokenValid } = require('#lib/is-token-valid');
 const { enterCodeConfig } = require('@pins/common');
-const { STATUS_CONSTANTS } = require('@pins/common/src/constants');
+const { STATUS_CONSTANTS, AUTH } = require('@pins/common/src/constants');
 const { isFeatureActive } = require('../../../../src/featureFlag');
 const { ApiClientError } = require('@pins/common/src/client/api-client-error');
 let { createOTPGrant } = require('@pins/common/src/client/auth-client');
@@ -609,6 +609,9 @@ describe('controllers/common/enter-code', () => {
 			};
 			getLPAUserStatus.mockResolvedValue(STATUS_CONSTANTS.ADDED);
 			await returnedFunction(req, res);
+			expect(isTokenValid).toHaveBeenCalledWith(code, mockUser.email, undefined, [
+				AUTH.SCOPES.USER_DETAILS.LPA
+			]);
 			expect(getLPAUserStatus).toHaveBeenCalledWith(req, userId);
 			expect(setLPAUserStatus).toHaveBeenCalledWith(req, userId, STATUS_CONSTANTS.CONFIRMED);
 			expect(res.redirect).toHaveBeenCalledWith('/manage-appeals/your-appeals');

--- a/packages/forms-web-app/__tests__/unit/lib/is-token-valid.test.js
+++ b/packages/forms-web-app/__tests__/unit/lib/is-token-valid.test.js
@@ -54,6 +54,17 @@ describe('lib/is-token-valid', () => {
 			});
 		});
 
+		it('should pass through scopes', async () => {
+			const action = 'testAction';
+			createROPCGrant.mockResolvedValue({
+				access_token: 'access_token',
+				id_token: 'id_token',
+				expires_in: 3600
+			});
+			await isTokenValid(code, email, action, ['scope1', 'scope2']);
+			expect(createROPCGrant).toHaveBeenCalledWith(email, code, ['scope1', 'scope2']);
+		});
+
 		it('should return throw unhandled error', async () => {
 			const errorMessage = 'error';
 			createROPCGrant.mockRejectedValueOnce(new Error(errorMessage));

--- a/packages/forms-web-app/src/controllers/common/enter-code.js
+++ b/packages/forms-web-app/src/controllers/common/enter-code.js
@@ -11,7 +11,7 @@ const { createAppealUserSession } = require('../../services/user.service');
 const { isTokenValid } = require('#lib/is-token-valid');
 const { enterCodeConfig } = require('@pins/common');
 const logger = require('#lib/logger');
-const { STATUS_CONSTANTS } = require('@pins/common/src/constants');
+const { STATUS_CONSTANTS, AUTH } = require('@pins/common/src/constants');
 
 const { getSessionEmail, setSessionEmail, getSessionAppealSqlId } = require('#lib/session-helper');
 const { getAuthClientConfig, createOTPGrant } = require('@pins/common/src/client/auth-client');
@@ -416,7 +416,9 @@ const postEnterCodeLPA = (views) => {
 		}
 
 		// check token
-		const tokenResult = await isTokenValid(emailCode, user.email);
+		const tokenResult = await isTokenValid(emailCode, user.email, undefined, [
+			AUTH.SCOPES.USER_DETAILS.LPA
+		]);
 
 		if (!lpaTokenVerification(res, tokenResult, views, id)) return;
 

--- a/packages/forms-web-app/src/lib/is-token-valid.js
+++ b/packages/forms-web-app/src/lib/is-token-valid.js
@@ -18,9 +18,10 @@ const logger = require('#lib/logger');
  * @param {string} token
  * @param {string} [emailAddress]
  * @param {string} [action]
+ * @param {string[]} [additionalScopes]
  * @returns {Promise<TokenValidResult>}
  */
-const getAuthToken = async (token, emailAddress, action) => {
+const getAuthToken = async (token, emailAddress, action, additionalScopes) => {
 	const tooManyAttempts = {
 		valid: false,
 		action: action,
@@ -43,7 +44,7 @@ const getAuthToken = async (token, emailAddress, action) => {
 	await getAuthClientConfig(config.oauth.baseUrl, config.oauth.clientID, config.oauth.clientSecret);
 
 	try {
-		const authResult = await createROPCGrant(emailAddress, token);
+		const authResult = await createROPCGrant(emailAddress, token, additionalScopes);
 
 		valid.access_token = authResult.access_token;
 		valid.id_token = authResult.id_token;
@@ -69,9 +70,10 @@ const getAuthToken = async (token, emailAddress, action) => {
  * @param {string} token
  * @param {string} [emailAddress] - user's email
  * @param {string} [action] - token action
+ * @param {string[]} [additionalScopes]
  * @returns {Promise<TokenValidResult>}
  */
-const isTokenValid = async (token, emailAddress, action) => {
+const isTokenValid = async (token, emailAddress, action, additionalScopes) => {
 	/** @type {TokenValidResult} */
 	let result = {
 		valid: false
@@ -88,7 +90,7 @@ const isTokenValid = async (token, emailAddress, action) => {
 	if (!isNonEmptyString(token)) return result;
 	if (!isNonEmptyString(emailAddress)) return result;
 
-	return await getAuthToken(token, emailAddress, action);
+	return await getAuthToken(token, emailAddress, action, additionalScopes);
 };
 
 module.exports = {


### PR DESCRIPTION
### Description of change

<!-- Please describe the change -->

Ticket: https://pins-ds.atlassian.net/browse/A2-3237

### Checklist

- [x] Feature complete and ready for users, or behind feature-flag
- [x] Commit history is linear with no merge commits
- [ ] Requires infrastructure changes

### Important

Please do not merge from `main` (please only [rebase](https://github.com/Planning-Inspectorate/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
