### PR TITLE
fix(a2-3527): apply truncation toggle only to Appeal statement on check your answers page

### DIFF
--- a/packages/forms-web-app/src/dynamic-forms/dynamic-components/task-list/statement.njk
+++ b/packages/forms-web-app/src/dynamic-forms/dynamic-components/task-list/statement.njk
@@ -20,7 +20,8 @@
 						{% for row in summaryListData.sections[0].list.rows %}
 							{% set rawHtml = row.value.html | default('') %}
 							{% set plainText = rawHtml | trim %}
-							{% set needsTruncation = plainText | length > 150 %}
+							{% set isAppealStatement = (row.key.text or row.key) == "Appeal statement" %}
+							{% set needsTruncation = isAppealStatement and (plainText | length > 150) %}
 							{% set truncatedText = plainText | truncate(150, true, '...') %}
 							<div class="govuk-summary-list__row">
 								<dt class="govuk-summary-list__key">


### PR DESCRIPTION
### Description of change

Updated the Nunjucks file to apply truncation of long appeal statements only when the first column text is "Appeal statement", ensuring other fields remain unaffected.

Ticket:
[A2-3527](https://pins-ds.atlassian.net/browse/A2-3527)

Minor content fixes for notify templates

### Checklist

- [x] Feature complete and ready for users, or behind feature-flag
- [x] Commit history is linear with no merge commits
- [ ] Requires infrastructure changes

### Important

Please do not merge from `main` (please only [rebase](https://github.com/Planning-Inspectorate/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.

[A2-3527]: https://pins-ds.atlassian.net/browse/A2-3527?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ