### PR TITLE
fix(a2-3639): handle openid-client expiry breaking change

### DIFF
--- a/packages/forms-web-app/src/middleware/create-api-clients.js
+++ b/packages/forms-web-app/src/middleware/create-api-clients.js
@@ -17,8 +17,12 @@ const TEN_MINS_IN_SECONDS = 600;
  * @returns {Promise<string|undefined>}
  */
 const getClientCredentials = async () => {
-	if (clientCredentials && clientCredentials.expires_in) {
-		if (clientCredentials.expires_in > TEN_MINS_IN_SECONDS) {
+	const now = Math.floor(Date.now() / 1000);
+
+	if (clientCredentials && clientCredentials.expiry) {
+		const secondsUntilExpiry = clientCredentials.expiry - now;
+
+		if (secondsUntilExpiry > TEN_MINS_IN_SECONDS) {
 			return clientCredentials.access_token;
 		}
 	}
@@ -26,6 +30,7 @@ const getClientCredentials = async () => {
 	await getAuthClientConfig(config.oauth.baseUrl, config.oauth.clientID, config.oauth.clientSecret);
 
 	clientCredentials = await createClientCredentialsGrant();
+	clientCredentials.expiry = now + clientCredentials.expires_in;
 
 	return clientCredentials.access_token;
 };

--- a/packages/integration-functions/src/common/api-client.js
+++ b/packages/integration-functions/src/common/api-client.js
@@ -18,9 +18,9 @@ const getClientCredentials = async () => {
 	const now = Math.floor(Date.now() / 1000);
 
 	if (clientCredentials && clientCredentials.expiry) {
-		const secondsUntiExpiry = clientCredentials.expiry - now;
+		const secondsUntilExpiry = clientCredentials.expiry - now;
 
-		if (secondsUntiExpiry > TEN_MINS_IN_SECONDS) {
+		if (secondsUntilExpiry > TEN_MINS_IN_SECONDS) {
 			return clientCredentials.access_token;
 		}
 	}

--- a/packages/integration-functions/src/common/api-client.js
+++ b/packages/integration-functions/src/common/api-client.js
@@ -15,8 +15,12 @@ const TEN_MINS_IN_SECONDS = 600;
  * @returns {Promise<string|undefined>}
  */
 const getClientCredentials = async () => {
-	if (clientCredentials && clientCredentials.expires_in) {
-		if (clientCredentials.expires_in > TEN_MINS_IN_SECONDS) {
+	const now = Math.floor(Date.now() / 1000);
+
+	if (clientCredentials && clientCredentials.expiry) {
+		const secondsUntiExpiry = clientCredentials.expiry - now;
+
+		if (secondsUntiExpiry > TEN_MINS_IN_SECONDS) {
 			return clientCredentials.access_token;
 		}
 	}
@@ -24,6 +28,7 @@ const getClientCredentials = async () => {
 	await getAuthClientConfig(config.oauth.baseUrl, config.oauth.clientID, config.oauth.clientSecret);
 
 	clientCredentials = await createClientCredentialsGrant();
+	clientCredentials.expiry = now + clientCredentials.expires_in;
 
 	return clientCredentials.access_token;
 };


### PR DESCRIPTION
### Description of change

Ticket: https://pins-ds.atlassian.net/browse/A2-3639

OpenId client used to provide a relative expiry, it is now just the expires_in from the token, meaning we never know it's expired

This restores the expiry checking functionality

We don't share code between the app and functions which is why there is duplication

### Checklist

- [x] Feature complete and ready for users, or behind feature-flag
- [x] Commit history is linear with no merge commits
- [ ] Requires infrastructure changes

### Important

Please do not merge from `main` (please only [rebase](https://github.com/Planning-Inspectorate/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
