### PR TITLE
fix(a2-3639): handle openid-client expiry breaking change

### DIFF
--- a/packages/forms-web-app/src/middleware/create-api-clients.js
+++ b/packages/forms-web-app/src/middleware/create-api-clients.js
@@ -17,8 +17,12 @@ const TEN_MINS_IN_SECONDS = 600;
  * @returns {Promise<string|undefined>}
  */
 const getClientCredentials = async () => {
-	if (clientCredentials && clientCredentials.expires_in) {
-		if (clientCredentials.expires_in > TEN_MINS_IN_SECONDS) {
+	const now = Math.floor(Date.now() / 1000);
+
+	if (clientCredentials && clientCredentials.expiry) {
+		const secondsUntiExpiry = clientCredentials.expiry - now;
+
+		if (secondsUntiExpiry > TEN_MINS_IN_SECONDS) {
 			return clientCredentials.access_token;
 		}
 	}
@@ -26,6 +30,7 @@ const getClientCredentials = async () => {
 	await getAuthClientConfig(config.oauth.baseUrl, config.oauth.clientID, config.oauth.clientSecret);
 
 	clientCredentials = await createClientCredentialsGrant();
+	clientCredentials.expiry = now + clientCredentials.expires_in;
 
 	return clientCredentials.access_token;
 };

--- a/packages/integration-functions/src/common/api-client.js
+++ b/packages/integration-functions/src/common/api-client.js
@@ -15,8 +15,12 @@ const TEN_MINS_IN_SECONDS = 600;
  * @returns {Promise<string|undefined>}
  */
 const getClientCredentials = async () => {
-	if (clientCredentials && clientCredentials.expires_in) {
-		if (clientCredentials.expires_in > TEN_MINS_IN_SECONDS) {
+	const now = Math.floor(Date.now() / 1000);
+
+	if (clientCredentials && clientCredentials.expiry) {
+		const secondsUntiExpiry = clientCredentials.expiry - now;
+
+		if (secondsUntiExpiry > TEN_MINS_IN_SECONDS) {
 			return clientCredentials.access_token;
 		}
 	}
@@ -24,6 +28,7 @@ const getClientCredentials = async () => {
 	await getAuthClientConfig(config.oauth.baseUrl, config.oauth.clientID, config.oauth.clientSecret);
 
 	clientCredentials = await createClientCredentialsGrant();
+	clientCredentials.expiry = now + clientCredentials.expires_in;
 
 	return clientCredentials.access_token;
 };

--- a/test-packages/platform-feature-tests/cypress/e2e/appellant-aapd/full-appeal-appellant-final-comment-validation.cy.js
+++ b/test-packages/platform-feature-tests/cypress/e2e/appellant-aapd/full-appeal-appellant-final-comment-validation.cy.js
@@ -19,17 +19,16 @@ describe('Appellant Full Planning Final Comment Validation Test Cases', () => {
                 cy.url().then((url) => {
                         if (url.includes('/appeal/email-address')) {
                                 cy.getById(prepareAppealSelector?._selectors?.emailAddress).clear();
-                                cy.getById(prepareAppealSelector?._selectors?.emailAddress).type(prepareAppealData?.email?.emailAddress);
+                                cy.getById(prepareAppealSelector?._selectors?.emailAddress).type(prepareAppealData?.email?.emailAddress1);
                                 cy.advanceToNextPage();
                                 cy.get(prepareAppealSelector?._selectors?.emailCode).type(prepareAppealData?.email?.emailCode);
                                 cy.advanceToNextPage();
                         }
                 });
-
                 let counter = 0;
                 cy.get(basePage?._selectors.trgovukTableRow).each(($row) => {
-                        const rowtext = $row.text();
-                        if (rowtext.includes(prepareAppealData?.FullAppealType) && rowtext.includes(prepareAppealData?.todoFinalComments)) {
+                        const rowtext = $row.text();                       
+                        if (rowtext.toLowerCase().includes(prepareAppealData?.FullAppealType.toLowerCase()) && rowtext.includes(prepareAppealData?.todoFinalComments)) {                              
                                 if (counter === 0) {
                                         cy.wrap($row).within(() => {
                                                 cy.get(basePage?._selectors.trgovukTableCell).contains(prepareAppealData?.FullAppealType).should('be.visible');
@@ -115,28 +114,54 @@ describe('Appellant Full Planning Final Comment Validation Test Cases', () => {
                                 .eq(index)
                                 .should('contain.text', fileName);
                 });
-                cy.get('button.moj-multi-file-upload__delete').each(($buttons) => {
-                        if ($buttons.length) {
-                                cy.get('button.moj-multi-file-upload__delete').eq(0).click();
-                        }
-                })
+                if (cy.get(basePage?._selectors.govukHeadingM).contains('Files added')) {
+                        cy.get('button.moj-multi-file-upload__delete').each(($buttons) => {
+                            if ($buttons.length) {
+                                    cy.get('button.moj-multi-file-upload__delete').eq(0).click();
+                            }
+                        })
+                }
 
                 cy.advanceToNextPage();
                 cy.containsMessage(basePage?._selectors?.govukErrorSummaryBody, 'Select your new supporting documents');
         });
-        it(`Validate user should not be allowed to upload wrong format file`, () => {
+        it(`Validate user should not be allowed to upload wrong format file`, () => {                
+                cy.getByData(basePage?._selectors?.answerYes).click({ force: true });
+                cy.advanceToNextPage();
+                cy.get('#appellantFinalCommentDetails').clear();
+                cy.get('#appellantFinalCommentDetails').type("Final comment test");
+                cy.get('#sensitiveInformationCheckbox').check({ force: true });
+                cy.advanceToNextPage();               
+                cy.getByData(basePage?._selectors?.answerYes).click({ force: true });
+                cy.advanceToNextPage();
                 cy.uploadFileFromFixtureDirectory(finalCommentTestCases[0]?.documents?.uploadWrongFormatFile);
                 cy.advanceToNextPage();
                 cy.shouldHaveErrorMessage('a[href*="#uploadAppellantFinalCommentDocuments"]', `${finalCommentTestCases[0]?.documents?.uploadWrongFormatFile} must be a DOC, DOCX, PDF, TIF, JPG or PNG`);
         });
 
         it(`Validate user should not be able to uploading document(s) greater than 25 MB`, () => {
+                cy.getByData(basePage?._selectors?.answerYes).click({ force: true });
+                cy.advanceToNextPage();
+                cy.get('#appellantFinalCommentDetails').clear();
+                cy.get('#appellantFinalCommentDetails').type("Final comment test");
+                cy.get('#sensitiveInformationCheckbox').check({ force: true });
+                cy.advanceToNextPage();               
+                cy.getByData(basePage?._selectors?.answerYes).click({ force: true });
+                cy.advanceToNextPage();
                 cy.uploadFileFromFixtureDirectory(finalCommentTestCases[0]?.documents?.uploadFileGreaterThan25mb);
                 cy.advanceToNextPage();
                 cy.shouldHaveErrorMessage('a[href*="#uploadAppellantFinalCommentDocuments"]', `${finalCommentTestCases[0]?.documents?.uploadFileGreaterThan25mb} must be smaller than 25MB`);
         });
 
         it(`Validate final comments summary before submit final comments`, () => {
+                cy.getByData(basePage?._selectors?.answerYes).click({ force: true });
+                cy.advanceToNextPage();
+                cy.get('#appellantFinalCommentDetails').clear();
+                cy.get('#appellantFinalCommentDetails').type("Final comment test");
+                cy.get('#sensitiveInformationCheckbox').check({ force: true });
+                cy.advanceToNextPage();               
+                cy.getByData(basePage?._selectors?.answerYes).click({ force: true });
+                cy.advanceToNextPage();
                 const expectedFileNames = [finalCommentTestCases[0]?.documents?.uploadSupportDocsFinalComments, finalCommentTestCases[0]?.documents?.uploadAdditionalDocsSupportFinalComments];
                 expectedFileNames.forEach((fileName) => {
                         cy.uploadFileFromFixtureDirectory(fileName);

--- a/test-packages/platform-feature-tests/cypress/e2e/appellant-aapd/full-appeal-appellant-final-comment-validation.cy.js
+++ b/test-packages/platform-feature-tests/cypress/e2e/appellant-aapd/full-appeal-appellant-final-comment-validation.cy.js
@@ -6,7 +6,6 @@ import { finalCommentTestCases } from "../../helpers/representations/finalCommen
 import { BasePage } from "../../page-objects/base-page";
 const { PrepareAppealSelector } = require("../../page-objects/prepare-appeal/prepare-appeal-selector");
 
-
 describe('Appellant Full Planning Final Comment Validation Test Cases', () => {
         const prepareAppealSelector = new PrepareAppealSelector();
         let prepareAppealData;
@@ -57,7 +56,6 @@ describe('Appellant Full Planning Final Comment Validation Test Cases', () => {
                 cy.get(basePage?._selectors.govukFieldsetHeading).contains('Do you want to submit any final comments?');
                 cy.get('input[name="appellantFinalComment"]:checked').then(($checked) => {
                         if ($checked.length > 0) {
-                                //cy.log("Radio Button already selected");
                                 return;
                         }
                         else {
@@ -112,16 +110,15 @@ describe('Appellant Full Planning Final Comment Validation Test Cases', () => {
                 expectedFileNames.forEach((fileName) => {
                         cy.uploadFileFromFixtureDirectory(fileName);
                 });
-
                 expectedFileNames.forEach((fileName, index) => {
                         cy.get('.moj-multi-file-upload__filename')
                                 .eq(index)
                                 .should('contain.text', fileName);
                 });
-                expectedFileNames.forEach((filename, index) => {
-                        cy.get('.moj-multi-file-upload__delete')
-                                .eq(expectedFileNames.length - 1 - index)
-                                .click()
+                cy.get('button.moj-multi-file-upload__delete').each(($buttons) => {
+                        if ($buttons.length) {
+                                cy.get('button.moj-multi-file-upload__delete').eq(0).click();
+                        }
                 })
 
                 cy.advanceToNextPage();

--- a/test-packages/platform-feature-tests/cypress/e2e/appellant-aapd/full-appeal-appellant-proofs-of-evidence-validation.cy.js
+++ b/test-packages/platform-feature-tests/cypress/e2e/appellant-aapd/full-appeal-appellant-proofs-of-evidence-validation.cy.js
@@ -76,11 +76,13 @@ describe('Appellant Full Planning Proof Of Evidence Validations', () => {
     it(`Validate multiple uploading documents`, () => {
         const expectedFileNames = [appellantFullAppealProofsOfEvidenceTestCases[0]?.documents?.uploadEmergingPlan, appellantFullAppealProofsOfEvidenceTestCases[0]?.documents?.uploadOtherPolicies];
 
-        cy.get('button.moj-multi-file-upload__delete').each(($buttons) => {
-            if ($buttons.length) {
-                cy.get('button.moj-multi-file-upload__delete').eq(0).click();
-            }
-        })
+        if (cy.get(basePage?._selectors.govukHeadingM).contains('Files added')) {
+            cy.get('button.moj-multi-file-upload__delete').each(($buttons) => {
+                if ($buttons.length) {
+                        cy.get('button.moj-multi-file-upload__delete').eq(0).click();
+                }
+            })
+        }
         cy.advanceToNextPage();
         cy.containsMessage(basePage?._selectors?.govukErrorSummaryBody, 'Select your proof of evidence and summary');
 
@@ -143,11 +145,13 @@ describe('Appellant Full Planning Proof Of Evidence Validations', () => {
         const expectedFileNames = [appellantFullAppealProofsOfEvidenceTestCases[0]?.documents?.uploadEmergingPlan, appellantFullAppealProofsOfEvidenceTestCases[0]?.documents?.uploadOtherPolicies];
         cy.advanceToNextPage();
         cy.advanceToNextPage();
-        cy.get('button.moj-multi-file-upload__delete').each(($buttons) => {
-            if ($buttons.length) {
-                cy.get('button.moj-multi-file-upload__delete').eq(0).click();
-            }
-        })
+        if (cy.get(basePage?._selectors.govukHeadingM).contains('Files added')) {
+            cy.get('button.moj-multi-file-upload__delete').each(($buttons) => {
+                if ($buttons.length) {
+                        cy.get('button.moj-multi-file-upload__delete').eq(0).click();
+                }
+            })
+        }
         cy.advanceToNextPage();
         cy.containsMessage(basePage?._selectors?.govukErrorSummaryBody, 'Select your witnesses and their evidence');
 

--- a/test-packages/platform-feature-tests/cypress/e2e/appellant-aapd/full-appeal-appellant-proofs-of-evidence-validation.cy.js
+++ b/test-packages/platform-feature-tests/cypress/e2e/appellant-aapd/full-appeal-appellant-proofs-of-evidence-validation.cy.js
@@ -19,7 +19,7 @@ describe('Appellant Full Planning Proof Of Evidence Validations', () => {
         cy.url().then((url) => {
             if (url.includes('/appeal/email-address')) {
                 cy.getById(prepareAppealSelector?._selectors?.emailAddress).clear();
-                cy.getById(prepareAppealSelector?._selectors?.emailAddress).type(prepareAppealData?.email?.emailAddress);
+                cy.getById(prepareAppealSelector?._selectors?.emailAddress).type(prepareAppealData?.email?.emailAddress1);
                 cy.advanceToNextPage();
                 cy.get(prepareAppealSelector?._selectors?.emailCode).type(prepareAppealData?.email?.emailCode);
                 cy.advanceToNextPage();
@@ -35,7 +35,7 @@ describe('Appellant Full Planning Proof Of Evidence Validations', () => {
                         cy.get('a').each(($link) => {
                             if ($link.attr('href')?.includes(prepareAppealData?.proofsOfEvidenceLink)) {
                                 const parts = $link.attr('href')?.split('/');
-                                appealId = parts?.[parts.length - 2];                               						
+                                appealId = parts?.[parts.length - 2];
                                 cy.wrap($link).scrollIntoView().should('be.visible').click({ force: true });
                                 return false;
                             }
@@ -76,6 +76,14 @@ describe('Appellant Full Planning Proof Of Evidence Validations', () => {
     it(`Validate multiple uploading documents`, () => {
         const expectedFileNames = [appellantFullAppealProofsOfEvidenceTestCases[0]?.documents?.uploadEmergingPlan, appellantFullAppealProofsOfEvidenceTestCases[0]?.documents?.uploadOtherPolicies];
 
+        cy.get('button.moj-multi-file-upload__delete').each(($buttons) => {
+            if ($buttons.length) {
+                cy.get('button.moj-multi-file-upload__delete').eq(0).click();
+            }
+        })
+        cy.advanceToNextPage();
+        cy.containsMessage(basePage?._selectors?.govukErrorSummaryBody, 'Select your proof of evidence and summary');
+
         expectedFileNames.forEach((fileName) => {
             cy.uploadFileFromFixtureDirectory(fileName);
         })
@@ -87,39 +95,20 @@ describe('Appellant Full Planning Proof Of Evidence Validations', () => {
         cy.advanceToNextPage();
     });
 
-    // it(`Validate add witnesses`, () => {
-    //     cy.advanceToNextPage();
-    //     cy.get(basePage?._selectors.govukFieldsetHeading).contains('Do you need to add any witnesses?');
-    //     cy.shouldHaveErrorMessage(basePage?._selectors?.govukErrorSummaryBody, 'Select yes if you need to add any witnesses');
-    //     it(`Validate add witnesses`, () => {
-    //         cy.advanceToNextPage();
-    //         //cy.advanceToNextPage();
-    //         cy.get(basePage?._selectors.govukFieldsetHeading).contains('Do you need to add any witnesses?');
-    //         cy.get('input[name="appellantWitnesses"]:checked').then(($checked) => {
-    //             if ($checked.length > 0) {
-    //                 cy.log("Radio Button already selected");
-    //                 return;
-    //             }
-    //             else {
-    //                 cy.advanceToNextPage();
-    //                 cy.shouldHaveErrorMessage(basePage?._selectors?.govukErrorSummaryBody, 'Select yes if you need to add any witnesses');
-    //             }
-    //         })
-    //     });
-    // });   
     it(`Validate add witnesses`, () => {
         cy.advanceToNextPage();
-        //cy.advanceToNextPage();
         cy.get(basePage?._selectors.govukFieldsetHeading).contains('Do you need to add any witnesses?');
         cy.get('input[name="appellantWitnesses"]').then(($input) => {
             const checked = $input.filter(':checked')
+            cy.log('Check status', checked);
             if (checked.length > 0) {
-                cy.log("Radio Button already selected");
                 cy.getByData(basePage?._selectors?.answerYes).click();
             }
             else {
                 cy.advanceToNextPage();
                 cy.shouldHaveErrorMessage(basePage?._selectors?.govukErrorSummaryBody, 'Select yes if you need to add any witnesses');
+                cy.getByData(basePage?._selectors?.answerYes).click();
+                cy.advanceToNextPage();
             }
         })
     });
@@ -154,6 +143,14 @@ describe('Appellant Full Planning Proof Of Evidence Validations', () => {
         const expectedFileNames = [appellantFullAppealProofsOfEvidenceTestCases[0]?.documents?.uploadEmergingPlan, appellantFullAppealProofsOfEvidenceTestCases[0]?.documents?.uploadOtherPolicies];
         cy.advanceToNextPage();
         cy.advanceToNextPage();
+        cy.get('button.moj-multi-file-upload__delete').each(($buttons) => {
+            if ($buttons.length) {
+                cy.get('button.moj-multi-file-upload__delete').eq(0).click();
+            }
+        })
+        cy.advanceToNextPage();
+        cy.containsMessage(basePage?._selectors?.govukErrorSummaryBody, 'Select your witnesses and their evidence');
+
         expectedFileNames.forEach((fileName) => {
             cy.uploadFileFromFixtureDirectory(fileName);
         })
@@ -170,7 +167,6 @@ describe('Appellant Full Planning Proof Of Evidence Validations', () => {
         cy.advanceToNextPage();
         cy.advanceToNextPage();
         cy.get(basePage?._selectors.govukHeadingOne).contains('Check your answers and submit your proof of evidence');
-        //basePage.verifyPageHeading('Check your answers and submit your proof of evidence');
         const expectedRows = [
             {
                 key: 'Your proof of evidence and summary',

--- a/test-packages/platform-feature-tests/cypress/e2e/appellant-aapd/full-appeal-appellant-proofs-of-evidence.cy.js
+++ b/test-packages/platform-feature-tests/cypress/e2e/appellant-aapd/full-appeal-appellant-proofs-of-evidence.cy.js
@@ -4,7 +4,6 @@ import { appellantFullAppealProofsOfEvidenceTestCases } from "../../helpers/appe
 const { appellantFullAppealProofsOfEvidence } = require('../../support/flows/sections/appellantAAPD/appellantFullAppealProofsOfEvidence');
 const { PrepareAppealSelector } = require("../../page-objects/prepare-appeal/prepare-appeal-selector");
 
-
 describe('Appellant Full Planning Proof Of Evidence Test Cases', () => {
         const prepareAppealSelector = new PrepareAppealSelector();
         let prepareAppealData;
@@ -16,7 +15,7 @@ describe('Appellant Full Planning Proof Of Evidence Test Cases', () => {
                 cy.url().then((url) => {
                         if (url.includes('/appeal/email-address')) {
                                 cy.getById(prepareAppealSelector?._selectors?.emailAddress).clear();
-                                cy.getById(prepareAppealSelector?._selectors?.emailAddress).type(prepareAppealData?.email?.emailAddress);
+                                cy.getById(prepareAppealSelector?._selectors?.emailAddress).type(prepareAppealData?.email?.emailAddress1);
                                 cy.advanceToNextPage();
                                 cy.get(prepareAppealSelector?._selectors?.emailCode).type(prepareAppealData?.email?.emailCode);
                                 cy.advanceToNextPage();

--- a/test-packages/platform-feature-tests/cypress/e2e/appellant-aapd/full-appeal-appellant-statement-validation.cy.js
+++ b/test-packages/platform-feature-tests/cypress/e2e/appellant-aapd/full-appeal-appellant-statement-validation.cy.js
@@ -92,11 +92,13 @@ describe('Full Planning Statement Test Cases', () => {
         cy.getByData(basePage?._selectors?.answerYes).click({ force: true });
         cy.advanceToNextPage();
         basePage?.basePageElements?.pageHeading().contains('Upload your new supporting documents');
-        cy.get('button.moj-multi-file-upload__delete').each(($buttons) => {
-            if ($buttons.length) {
-                cy.get('button.moj-multi-file-upload__delete').eq(0).click();
-            }
-        })
+        if (cy.get(basePage?._selectors.govukHeadingM).contains('Files added')) {
+            cy.get('button.moj-multi-file-upload__delete').each(($buttons) => {
+                if ($buttons.length) {
+                        cy.get('button.moj-multi-file-upload__delete').eq(0).click();
+                }
+            })
+        }
         cy.advanceToNextPage();
         cy.shouldHaveErrorMessage(basePage?._selectors?.govukErrorSummaryBody, 'Select your new supporting documents');
     });

--- a/test-packages/platform-feature-tests/cypress/e2e/ip-comments/ip-comments-validations.cy.js
+++ b/test-packages/platform-feature-tests/cypress/e2e/ip-comments/ip-comments-validations.cy.js
@@ -195,6 +195,6 @@ describe('Comment on a planning appeal validations', () => {
                 expect(href).to.include(expected.hrefContains);
             });
         });
-        cy.get(basePage?._selectors?.govukButton).should('include.text', 'Submit comments').click();
+        cy.contains(basePage?._selectors?.govukButton, 'Submit comments').click();
     });
 });

--- a/test-packages/platform-feature-tests/cypress/e2e/ip-comments/ip-comments.cy.js
+++ b/test-packages/platform-feature-tests/cypress/e2e/ip-comments/ip-comments.cy.js
@@ -17,7 +17,7 @@ describe('Comment on a planning appeal', () => {
 
   })
 
-  it('should allow a user to enter postcode and start the process', () => {
+  it('should allow a user to enter postcode and submit the IP comments', () => {
     // Validate I do not have an appeal reference number
     cy.get('a[href*="enter-postcode"]').click();
     // Validate URL
@@ -59,7 +59,7 @@ describe('Comment on a planning appeal', () => {
     cy.get(basePage?._selectors?.govukButton).should('include.text', 'Submit comments').click();
   });
 
-  it('should allow a user to enter a reference number and start the process', () => {
+  it('should allow a user to enter a reference number and submit the IP comment', () => {
     // Validate reference number text field label   
     cy.visit(`${Cypress.config('appeals_beta_base_url')}/comment-planning-appeal`);
     cy.get(basePage?._selectors?.govukLabelGovukLabel).should('include.text', 'Enter the appeal reference number');

--- a/test-packages/platform-feature-tests/cypress/e2e/lpa-manage-appeals/full-appeal-final-comment-validation.cy.js
+++ b/test-packages/platform-feature-tests/cypress/e2e/lpa-manage-appeals/full-appeal-final-comment-validation.cy.js
@@ -30,7 +30,7 @@ describe('LPA Full Planning Final comment Test Cases', () => {
                 cy.get(basePage?._selectors.trgovukTableRow).each(($row) => {
                         const rowtext = $row.text();
                         if (rowtext.includes(lpaManageAppealsData?.s78AppealType) && rowtext.includes(lpaManageAppealsData?.todoFinalcomment)) {
-                                if (counter === 3) {
+                                if (counter === 4) {
                                         cy.wrap($row).within(() => {
                                                 cy.get(basePage?._selectors.trgovukTableCell).contains(lpaManageAppealsData?.s78AppealType).should('be.visible');
                                                 cy.get('a').each(($link) => {
@@ -119,29 +119,55 @@ describe('LPA Full Planning Final comment Test Cases', () => {
                                 .should('contain.text', fileName);
                 });
 
-                cy.get('button.moj-multi-file-upload__delete').each(($buttons) => {
-                        if ($buttons.length) {
-                                cy.get('button.moj-multi-file-upload__delete').eq(0).click();
-                        }
-                })
+                if (cy.get(basePage?._selectors.govukHeadingM).contains('Files added')) {
+                        cy.get('button.moj-multi-file-upload__delete').each(($buttons) => {
+                            if ($buttons.length) {
+                                    cy.get('button.moj-multi-file-upload__delete').eq(0).click();
+                            }
+                        })
+                }
 
                 cy.advanceToNextPage();
                 cy.containsMessage(basePage?._selectors?.govukErrorSummaryBody, 'Select your new supporting documents');
         });
 
-        it(`Validate user should not be allowed to upload wrong format file`, () => {
+        it(`Validate user should not be allowed to upload wrong format file`, () => {               
+                cy.getByData(basePage?._selectors?.answerYes).click({ force: true });
+                cy.advanceToNextPage();
+                cy.get('#lpaFinalCommentDetails').clear();
+                cy.get('#lpaFinalCommentDetails').type("Final comment test");
+                cy.get('#sensitiveInformationCheckbox').check({ force: true });
+                cy.advanceToNextPage();               
+                cy.getByData(basePage?._selectors?.answerYes).click({ force: true });
+                cy.advanceToNextPage();
                 cy.uploadFileFromFixtureDirectory(fullAppealFinalCommentTestCases[0]?.documents?.uploadWrongFormatFile);
                 cy.advanceToNextPage();
                 cy.shouldHaveErrorMessage('a[href*="#uploadLPAFinalCommentDocuments"]', `${fullAppealFinalCommentTestCases[0]?.documents?.uploadWrongFormatFile} must be a DOC, DOCX, PDF, TIF, JPG or PNG`);
         });
 
         it(`Validate user should not be able to uploading document(s) greater than 25 MB`, () => {
+                cy.getByData(basePage?._selectors?.answerYes).click({ force: true });
+                cy.advanceToNextPage();
+                cy.get('#lpaFinalCommentDetails').clear();
+                cy.get('#lpaFinalCommentDetails').type("Final comment test");
+                cy.get('#sensitiveInformationCheckbox').check({ force: true });
+                cy.advanceToNextPage();               
+                cy.getByData(basePage?._selectors?.answerYes).click({ force: true });
+                cy.advanceToNextPage();
                 cy.uploadFileFromFixtureDirectory(fullAppealFinalCommentTestCases[0]?.documents?.uploadFileGreaterThan25mb);
                 cy.advanceToNextPage();
                 cy.shouldHaveErrorMessage('a[href*="#uploadLPAFinalCommentDocuments"]', `${fullAppealFinalCommentTestCases[0]?.documents?.uploadFileGreaterThan25mb} must be smaller than 25MB`);
         });
 
         it(`Validate final comments summary before submit final comments`, () => {
+                cy.getByData(basePage?._selectors?.answerYes).click({ force: true });
+                cy.advanceToNextPage();
+                cy.get('#lpaFinalCommentDetails').clear();
+                cy.get('#lpaFinalCommentDetails').type("Final comment test");
+                cy.get('#sensitiveInformationCheckbox').check({ force: true });
+                cy.advanceToNextPage();               
+                cy.getByData(basePage?._selectors?.answerYes).click({ force: true });
+                cy.advanceToNextPage();
                 const expectedFileNames = [fullAppealFinalCommentTestCases[0]?.documents?.uploadSupportDocsFinalComments, fullAppealFinalCommentTestCases[0]?.documents?.uploadAdditionalDocsSupportFinalComments];
                 expectedFileNames.forEach((fileName) => {
                         cy.uploadFileFromFixtureDirectory(fileName);

--- a/test-packages/platform-feature-tests/cypress/e2e/lpa-manage-appeals/full-appeal-final-comment-validation.cy.js
+++ b/test-packages/platform-feature-tests/cypress/e2e/lpa-manage-appeals/full-appeal-final-comment-validation.cy.js
@@ -30,7 +30,7 @@ describe('LPA Full Planning Final comment Test Cases', () => {
                 cy.get(basePage?._selectors.trgovukTableRow).each(($row) => {
                         const rowtext = $row.text();
                         if (rowtext.includes(lpaManageAppealsData?.s78AppealType) && rowtext.includes(lpaManageAppealsData?.todoFinalcomment)) {
-                                if (counter === 0) {
+                                if (counter === 3) {
                                         cy.wrap($row).within(() => {
                                                 cy.get(basePage?._selectors.trgovukTableCell).contains(lpaManageAppealsData?.s78AppealType).should('be.visible');
                                                 cy.get('a').each(($link) => {
@@ -52,13 +52,13 @@ describe('LPA Full Planning Final comment Test Cases', () => {
                 cy.url().should('include', `/manage-appeals/final-comments/${appealId}/submit-final-comments`);
         });
         it(`Validate to submit any Final comments error validation`, () => {
-                
+
                 cy.get(basePage?._selectors.govukFieldsetHeading).contains('Do you want to submit any final comments?');
                 cy.get('input[name="lpaFinalComment"]').then(($radoButton) => {
                         const checked = $radoButton.filter(':checked')
                         if (checked.length > 0) {
-                            cy.log("Radio Button already selected");
-                            cy.getByData(basePage?._selectors?.answerYes).click();
+                                cy.log("Radio Button already selected");
+                                cy.getByData(basePage?._selectors?.answerYes).click();
                         } else {
                                 cy.advanceToNextPage();
                                 cy.get(basePage?._selectors.govukErrorSummaryList).find('a').should('have.attr', 'href', '#lpaFinalComment').and('contain.text', 'Select yes if you want to submit any final comments');
@@ -67,7 +67,7 @@ describe('LPA Full Planning Final comment Test Cases', () => {
                 });
         });
 
-        it(`Validate sensitive information text`, () => {           
+        it(`Validate sensitive information text`, () => {
                 cy.get(basePage?._selectors.govukFieldsetHeading).contains('Do you want to submit any final comments?');
                 cy.getByData(basePage?._selectors?.answerYes).click({ force: true });
                 cy.advanceToNextPage();
@@ -119,10 +119,10 @@ describe('LPA Full Planning Final comment Test Cases', () => {
                                 .should('contain.text', fileName);
                 });
 
-                expectedFileNames.forEach((filename, index) => {
-                        cy.get('.moj-multi-file-upload__delete')
-                                .eq(expectedFileNames.length - 1 - index)
-                                .click()
+                cy.get('button.moj-multi-file-upload__delete').each(($buttons) => {
+                        if ($buttons.length) {
+                                cy.get('button.moj-multi-file-upload__delete').eq(0).click();
+                        }
                 })
 
                 cy.advanceToNextPage();

--- a/test-packages/platform-feature-tests/cypress/e2e/lpa-manage-appeals/full-appeal-lpa-proofs-of-evidence-validation.cy.js
+++ b/test-packages/platform-feature-tests/cypress/e2e/lpa-manage-appeals/full-appeal-lpa-proofs-of-evidence-validation.cy.js
@@ -30,7 +30,6 @@ describe('LPA Proof of Evidence Validations', () => {
             if (rowtext.includes(lpaManageAppealsData?.s78AppealType) && rowtext.includes(lpaManageAppealsData?.lpaTodoProofsOfEvidence)) {
                 if (counter === 0) {
                     cy.wrap($row).within(() => {
-                        //cy.log($row);
                         cy.get(basePage?._selectors.trgovukTableCell).contains(lpaManageAppealsData?.s78AppealType).should('be.visible');
                         cy.get('a').each(($link) => {
                             if ($link.attr('href')?.includes(lpaManageAppealsData?.proofsOfEvidenceLink)) {
@@ -78,7 +77,13 @@ describe('LPA Proof of Evidence Validations', () => {
 
     it(`Validate multiple uploading documents`, () => {
         const expectedFileNames = [fullAppealProofsOfEvidenceTestCases[0]?.documents?.uploadEmergingPlan, fullAppealProofsOfEvidenceTestCases[0]?.documents?.uploadOtherPolicies];
-
+        cy.get('button.moj-multi-file-upload__delete').each(($buttons) => {
+            if ($buttons.length) {
+                cy.get('button.moj-multi-file-upload__delete').eq(0).click();
+            }
+        })
+        cy.advanceToNextPage();
+        cy.containsMessage(basePage?._selectors?.govukErrorSummaryBody, 'Select your proof of evidence and summary');
         expectedFileNames.forEach((fileName) => {
             cy.uploadFileFromFixtureDirectory(fileName);
         })
@@ -102,6 +107,8 @@ describe('LPA Proof of Evidence Validations', () => {
             else {
                 cy.advanceToNextPage();
                 cy.shouldHaveErrorMessage(basePage?._selectors?.govukErrorSummaryBody, 'Select yes if you need to add any witnesses');
+                cy.getByData(basePage?._selectors?.answerYes).click();
+                cy.advanceToNextPage();
             }
         })
     });
@@ -136,6 +143,13 @@ describe('LPA Proof of Evidence Validations', () => {
         const expectedFileNames = [fullAppealProofsOfEvidenceTestCases[0]?.documents?.uploadEmergingPlan, fullAppealProofsOfEvidenceTestCases[0]?.documents?.uploadOtherPolicies];
         cy.advanceToNextPage();
         cy.advanceToNextPage();
+        cy.get('button.moj-multi-file-upload__delete').each(($buttons) => {
+            if ($buttons.length) {
+                cy.get('button.moj-multi-file-upload__delete').eq(0).click();
+            }
+        })
+        cy.advanceToNextPage();
+        cy.containsMessage(basePage?._selectors?.govukErrorSummaryBody, 'Select your witnesses and their evidence');
         expectedFileNames.forEach((fileName) => {
             cy.uploadFileFromFixtureDirectory(fileName);
         })
@@ -152,7 +166,6 @@ describe('LPA Proof of Evidence Validations', () => {
         cy.advanceToNextPage();
         cy.advanceToNextPage();
         cy.get(basePage?._selectors.govukHeadingOne).contains('Check your answers and submit your proof of evidence');
-        //basePage.verifyPageHeading('Check your answers and submit your proof of evidence');
         const expectedRows = [
             {
                 key: 'Your proof of evidence and summary',

--- a/test-packages/platform-feature-tests/cypress/e2e/lpa-manage-appeals/full-appeal-lpa-proofs-of-evidence-validation.cy.js
+++ b/test-packages/platform-feature-tests/cypress/e2e/lpa-manage-appeals/full-appeal-lpa-proofs-of-evidence-validation.cy.js
@@ -28,7 +28,7 @@ describe('LPA Proof of Evidence Validations', () => {
         cy.get(basePage?._selectors.trgovukTableRow).each(($row) => {
             const rowtext = $row.text();
             if (rowtext.includes(lpaManageAppealsData?.s78AppealType) && rowtext.includes(lpaManageAppealsData?.lpaTodoProofsOfEvidence)) {
-                if (counter === 0) {
+                if (counter === 1) {
                     cy.wrap($row).within(() => {
                         cy.get(basePage?._selectors.trgovukTableCell).contains(lpaManageAppealsData?.s78AppealType).should('be.visible');
                         cy.get('a').each(($link) => {
@@ -77,11 +77,14 @@ describe('LPA Proof of Evidence Validations', () => {
 
     it(`Validate multiple uploading documents`, () => {
         const expectedFileNames = [fullAppealProofsOfEvidenceTestCases[0]?.documents?.uploadEmergingPlan, fullAppealProofsOfEvidenceTestCases[0]?.documents?.uploadOtherPolicies];
-        cy.get('button.moj-multi-file-upload__delete').each(($buttons) => {
-            if ($buttons.length) {
-                cy.get('button.moj-multi-file-upload__delete').eq(0).click();
-            }
-        })
+        
+        if (cy.get(basePage?._selectors.govukHeadingM).contains('Files added')) {
+            cy.get('button.moj-multi-file-upload__delete').each(($buttons) => {
+                if ($buttons.length) {
+                        cy.get('button.moj-multi-file-upload__delete').eq(0).click();
+                }
+            })
+        }
         cy.advanceToNextPage();
         cy.containsMessage(basePage?._selectors?.govukErrorSummaryBody, 'Select your proof of evidence and summary');
         expectedFileNames.forEach((fileName) => {
@@ -143,11 +146,13 @@ describe('LPA Proof of Evidence Validations', () => {
         const expectedFileNames = [fullAppealProofsOfEvidenceTestCases[0]?.documents?.uploadEmergingPlan, fullAppealProofsOfEvidenceTestCases[0]?.documents?.uploadOtherPolicies];
         cy.advanceToNextPage();
         cy.advanceToNextPage();
-        cy.get('button.moj-multi-file-upload__delete').each(($buttons) => {
-            if ($buttons.length) {
-                cy.get('button.moj-multi-file-upload__delete').eq(0).click();
-            }
-        })
+        if (cy.get(basePage?._selectors.govukHeadingM).contains('Files added')) {
+            cy.get('button.moj-multi-file-upload__delete').each(($buttons) => {
+                if ($buttons.length) {
+                        cy.get('button.moj-multi-file-upload__delete').eq(0).click();
+                }
+            })
+        }        
         cy.advanceToNextPage();
         cy.containsMessage(basePage?._selectors?.govukErrorSummaryBody, 'Select your witnesses and their evidence');
         expectedFileNames.forEach((fileName) => {

--- a/test-packages/platform-feature-tests/cypress/e2e/lpa-manage-appeals/full-appeal-statement-validation.cy.js
+++ b/test-packages/platform-feature-tests/cypress/e2e/lpa-manage-appeals/full-appeal-statement-validation.cy.js
@@ -78,8 +78,9 @@ describe('Full Planning Statement Test Cases', () => {
         cy.get('#lpaStatement').type("Final comment test");
         cy.advanceToNextPage();
         cy.get(basePage?._selectors.govukFieldsetHeading).contains('Do you have additional documents to support your appeal statement?');
-        cy.get('input[name="additionalDocuments"]:checked').then(($checked) => {
-            if ($checked.length > 0) {
+        cy.get('input[name="additionalDocuments"]').then(($input) => {
+            const isChecked = $input.toArray().some(input=>input.checked);
+            if (isChecked) {
                 return;
             }
             else {
@@ -89,22 +90,25 @@ describe('Full Planning Statement Test Cases', () => {
         })
     });
 
-
     it(`Validate upload your new supporting documents Error message and remove if exists`, () => {
         cy.advanceToNextPage();
         cy.getByData(basePage?._selectors?.answerYes).click({ force: true });
         cy.advanceToNextPage();
-        basePage?.basePageElements?.pageHeading().contains('Upload your new supporting documents');
-        cy.get('button.moj-multi-file-upload__delete').each(($buttons) => {
-            if ($buttons.length) {
-                cy.get('button.moj-multi-file-upload__delete').eq(0).click();
-            }
-        })
+        basePage?.basePageElements?.pageHeading().contains('Upload your new supporting documents');        
+        if (cy.get(basePage?._selectors.govukHeadingM).contains('Files added')) {
+            cy.get('button.moj-multi-file-upload__delete').each(($buttons) => {
+                if ($buttons.length) {
+                        cy.get('button.moj-multi-file-upload__delete').eq(0).click();
+                }
+            })
+        }        
         cy.advanceToNextPage();
         cy.shouldHaveErrorMessage(basePage?._selectors?.govukErrorSummaryBody, 'Select your new supporting documents');
     });
 
     it(`Validate user should not be allowed to upload wrong format file`, () => {
+        cy.advanceToNextPage();
+        cy.advanceToNextPage();
         cy.uploadFileFromFixtureDirectory(fullAppealStatementTestCases[0]?.documents?.uploadWrongFormatFile);
         cy.advanceToNextPage();
         cy.shouldHaveErrorMessage('a[href*="#uploadLpaStatementDocuments"]', `${fullAppealStatementTestCases[0]?.documents?.uploadWrongFormatFile} must be a DOC, DOCX, PDF, TIF, JPG or PNG`);
@@ -112,6 +116,8 @@ describe('Full Planning Statement Test Cases', () => {
 
 
     it(`Validate multiple uploading documents`, () => {
+        cy.advanceToNextPage();
+        cy.advanceToNextPage();
         const expectedFileNames = [fullAppealStatementTestCases[0]?.documents?.uploadEmergingPlan, fullAppealStatementTestCases[0]?.documents?.uploadOtherPolicies];
 
         expectedFileNames.forEach((fileName) => {

--- a/test-packages/platform-feature-tests/cypress/e2e/lpa-manage-appeals/full-appeal-statement-validation.cy.js
+++ b/test-packages/platform-feature-tests/cypress/e2e/lpa-manage-appeals/full-appeal-statement-validation.cy.js
@@ -34,7 +34,7 @@ describe('Full Planning Statement Test Cases', () => {
         cy.get(basePage?._selectors.trgovukTableRow).each(($row) => {
             const rowtext = $row.text();
             if (rowtext.includes(lpaManageAppealsData?.s78AppealType) && rowtext.includes(lpaManageAppealsData?.todoStatement)) {
-                if (counter === 2) {
+                if (counter === 5) {
                     cy.log(rowtext);
                     cy.wrap($row).within(() => {
                         cy.get(basePage?._selectors.trgovukTableCell).contains(lpaManageAppealsData?.s78AppealType).should('be.visible');
@@ -80,7 +80,6 @@ describe('Full Planning Statement Test Cases', () => {
         cy.get(basePage?._selectors.govukFieldsetHeading).contains('Do you have additional documents to support your appeal statement?');
         cy.get('input[name="additionalDocuments"]:checked').then(($checked) => {
             if ($checked.length > 0) {
-                //cy.log("Radio Button already selected");
                 return;
             }
             else {
@@ -91,17 +90,16 @@ describe('Full Planning Statement Test Cases', () => {
     });
 
 
-    it(`Validate upload your new supporting documents Error message`, () => {
-        const expectedFileNames = [fullAppealStatementTestCases[0]?.documents?.uploadEmergingPlan, fullAppealStatementTestCases[0]?.documents?.uploadOtherPolicies];
+    it(`Validate upload your new supporting documents Error message and remove if exists`, () => {
         cy.advanceToNextPage();
         cy.getByData(basePage?._selectors?.answerYes).click({ force: true });
         cy.advanceToNextPage();
         basePage?.basePageElements?.pageHeading().contains('Upload your new supporting documents');
-        expectedFileNames.forEach(() => {
-            cy.get('.moj-multi-file-upload__delete')
-                .eq(0)
-                .click()
-        });
+        cy.get('button.moj-multi-file-upload__delete').each(($buttons) => {
+            if ($buttons.length) {
+                cy.get('button.moj-multi-file-upload__delete').eq(0).click();
+            }
+        })
         cy.advanceToNextPage();
         cy.shouldHaveErrorMessage(basePage?._selectors?.govukErrorSummaryBody, 'Select your new supporting documents');
     });

--- a/test-packages/platform-feature-tests/cypress/e2e/lpa-manage-appeals/lpa-decided-appeals.cy.js
+++ b/test-packages/platform-feature-tests/cypress/e2e/lpa-manage-appeals/lpa-decided-appeals.cy.js
@@ -5,7 +5,6 @@ import { decisionAllowedDowloadVerify, decisionAllowedInPartDowloadVerify, decis
 
 const { YourAppealsSelector } = require("../../page-objects/lpa-manage-appeals/your-appeals-selector");
 
-
 describe('LPA Manage Appeals Questionnaire', () => {
     const yourAppealsSelector = new YourAppealsSelector();
     let lpaManageAppealsData;

--- a/test-packages/platform-feature-tests/cypress/e2e/rule-6-appeals/r6-full-appeal-proofs-of-evidence-validation.cy.js
+++ b/test-packages/platform-feature-tests/cypress/e2e/rule-6-appeals/r6-full-appeal-proofs-of-evidence-validation.cy.js
@@ -77,7 +77,13 @@ describe('Rule 6 Proof of Evidence Validations', () => {
 
     it(`Validate multiple uploading documents`, () => {
         const expectedFileNames = [r6FullAppealsProofsOfEvidenceTestCases[0]?.documents?.uploadEmergingPlan, r6FullAppealsProofsOfEvidenceTestCases[0]?.documents?.uploadOtherPolicies];
-
+        cy.get('button.moj-multi-file-upload__delete').each(($buttons) => {
+            if ($buttons.length) {
+                cy.get('button.moj-multi-file-upload__delete').eq(0).click();
+            }
+        })
+        cy.advanceToNextPage();
+        cy.containsMessage(basePage?._selectors?.govukErrorSummaryBody, 'Select your proof of evidence and summary');
         expectedFileNames.forEach((fileName) => {
             cy.uploadFileFromFixtureDirectory(fileName);
         })
@@ -134,6 +140,13 @@ describe('Rule 6 Proof of Evidence Validations', () => {
         const expectedFileNames = [r6FullAppealsProofsOfEvidenceTestCases[0]?.documents?.uploadEmergingPlan, r6FullAppealsProofsOfEvidenceTestCases[0]?.documents?.uploadOtherPolicies];
         cy.advanceToNextPage();
         cy.advanceToNextPage();
+        cy.get('button.moj-multi-file-upload__delete').each(($buttons) => {
+            if ($buttons.length) {
+                cy.get('button.moj-multi-file-upload__delete').eq(0).click();
+            }
+        })
+        cy.advanceToNextPage();
+        cy.containsMessage(basePage?._selectors?.govukErrorSummaryBody, 'Select your witnesses and their evidence');
         expectedFileNames.forEach((fileName) => {
             cy.uploadFileFromFixtureDirectory(fileName);
         })
@@ -179,5 +192,4 @@ describe('Rule 6 Proof of Evidence Validations', () => {
             });
         });
     });
-
 });

--- a/test-packages/platform-feature-tests/cypress/e2e/rule-6-appeals/r6-full-appeal-proofs-of-evidence-validation.cy.js
+++ b/test-packages/platform-feature-tests/cypress/e2e/rule-6-appeals/r6-full-appeal-proofs-of-evidence-validation.cy.js
@@ -29,7 +29,7 @@ describe('Rule 6 Proof of Evidence Validations', () => {
         cy.get(basePage?._selectors.trgovukTableRow).each(($row) => {
             const rowtext = $row.text();
             if (rowtext.includes(lpaManageAppealsData?.s78AppealType) && rowtext.includes(lpaManageAppealsData?.rule6todoProofOfEvidence)) {
-                if (counter === 0) {
+                if (counter === 3) {
                     cy.wrap($row).within(() => {
                         cy.get(basePage?._selectors.trgovukTableCell).contains(lpaManageAppealsData?.s78AppealType).should('be.visible');
                         cy.get('a').each(($link) => {
@@ -77,11 +77,13 @@ describe('Rule 6 Proof of Evidence Validations', () => {
 
     it(`Validate multiple uploading documents`, () => {
         const expectedFileNames = [r6FullAppealsProofsOfEvidenceTestCases[0]?.documents?.uploadEmergingPlan, r6FullAppealsProofsOfEvidenceTestCases[0]?.documents?.uploadOtherPolicies];
-        cy.get('button.moj-multi-file-upload__delete').each(($buttons) => {
-            if ($buttons.length) {
-                cy.get('button.moj-multi-file-upload__delete').eq(0).click();
-            }
-        })
+        if (cy.get(basePage?._selectors.govukHeadingM).contains('Files added')) {
+            cy.get('button.moj-multi-file-upload__delete').each(($buttons) => {
+                if ($buttons.length) {
+                        cy.get('button.moj-multi-file-upload__delete').eq(0).click();
+                }
+            })
+        }
         cy.advanceToNextPage();
         cy.containsMessage(basePage?._selectors?.govukErrorSummaryBody, 'Select your proof of evidence and summary');
         expectedFileNames.forEach((fileName) => {
@@ -140,11 +142,13 @@ describe('Rule 6 Proof of Evidence Validations', () => {
         const expectedFileNames = [r6FullAppealsProofsOfEvidenceTestCases[0]?.documents?.uploadEmergingPlan, r6FullAppealsProofsOfEvidenceTestCases[0]?.documents?.uploadOtherPolicies];
         cy.advanceToNextPage();
         cy.advanceToNextPage();
-        cy.get('button.moj-multi-file-upload__delete').each(($buttons) => {
-            if ($buttons.length) {
-                cy.get('button.moj-multi-file-upload__delete').eq(0).click();
-            }
-        })
+        if (cy.get(basePage?._selectors.govukHeadingM).contains('Files added')) {
+            cy.get('button.moj-multi-file-upload__delete').each(($buttons) => {
+                if ($buttons.length) {
+                        cy.get('button.moj-multi-file-upload__delete').eq(0).click();
+                }
+            })
+        }
         cy.advanceToNextPage();
         cy.containsMessage(basePage?._selectors?.govukErrorSummaryBody, 'Select your witnesses and their evidence');
         expectedFileNames.forEach((fileName) => {

--- a/test-packages/platform-feature-tests/cypress/e2e/rule-6-appeals/r6-full-appeals-statement-validation.cy.js
+++ b/test-packages/platform-feature-tests/cypress/e2e/rule-6-appeals/r6-full-appeals-statement-validation.cy.js
@@ -2,42 +2,46 @@
 /* eslint-disable cypress/unsafe-to-chain-command */
 // @ts-nocheck
 /// <reference types="cypress"/>
-import { statementTestCases } from "../../helpers/representations/statementData";
+//import { fullAppealStatementTestCases } from "../../helpers/lpaManageAppeals/fullAppealStatementData";
+import { r6FullAppealsStatementTestCases } from "../../helpers/rule6Appeals/r6FullAppealsStatementData";
 import { BasePage } from "../../page-objects/base-page";
+import { upload25MBFileValidation } from "../../utils/uploadService";
 import { StringUtils } from "../../utils/StringUtils";
-const { PrepareAppealSelector } = require("../../page-objects/prepare-appeal/prepare-appeal-selector");
+const { fullAppealStatement } = require('../../support/flows/sections/lpaManageAppeals/fullAppealStatement');
+const { YourAppealsSelector } = require("../../page-objects/lpa-manage-appeals/your-appeals-selector");
 
 describe('Full Planning Statement Test Cases', () => {
-    const prepareAppealSelector = new PrepareAppealSelector();
+    const yourAppealsSelector = new YourAppealsSelector();
     const basePage = new BasePage();
     const stringUtils = new StringUtils();
-    let prepareAppealData;
+    let lpaManageAppealsData;
     let appealId;
 
     beforeEach(() => {
-        cy.fixture('prepareAppealData').then(data => {
-            prepareAppealData = data;
+        cy.fixture('lpaManageAppealsData').then(data => {
+            lpaManageAppealsData = data;
         })
-        cy.visit(`${Cypress.config('appeals_beta_base_url')}/appeals/your-email-address`);
+        cy.visit(`${Cypress.config('appeals_beta_base_url')}/rule-6/email-address`);
         cy.url().then((url) => {
-            if (url.includes('/appeals/your-email-address')) {
-                cy.getByData(prepareAppealSelector?._selectors?.emailAddress).clear();
-                cy.getByData(prepareAppealSelector?._selectors?.emailAddress).type(prepareAppealData?.emailAddress);
+            if (url.includes('/rule-6/email-address')) {
+                cy.getByData(yourAppealsSelector?._selectors?.emailAddress).clear();
+                cy.getByData(yourAppealsSelector?._selectors?.emailAddress).type(lpaManageAppealsData?.rule6EmailAddress);
                 cy.advanceToNextPage();
-                cy.get(PrepareAppealSelector?._selectors?.emailCode).type(prepareAppealData?.emailCode);
+                cy.get(yourAppealsSelector?._selectors?.emailCode).type(lpaManageAppealsData?.emailCode);
                 cy.advanceToNextPage();
             }
         });
         let counter = 0;
         cy.get(basePage?._selectors.trgovukTableRow).each(($row) => {
             const rowtext = $row.text();
-            if (rowtext.includes(prepareAppealData?.s78AppealType) && rowtext.includes(prepareAppealData?.todoStatement)) {
+            if (rowtext.includes(lpaManageAppealsData?.s78AppealType) && rowtext.includes(lpaManageAppealsData?.todoStatement)) {
                 if (counter === 0) {
+                    cy.log(rowtext);
                     cy.wrap($row).within(() => {
-                        cy.get(basePage?._selectors.trgovukTableCell).contains(prepareAppealData?.s78AppealType).should('be.visible');
+                        cy.get(basePage?._selectors.trgovukTableCell).contains(lpaManageAppealsData?.s78AppealType).should('be.visible');
                         cy.get('a').each(($link) => {
                             if ($link.attr('href')?.includes('appeal-statement')) {
-                                cy.log(prepareAppealData?.todoStatement);
+                                cy.log(lpaManageAppealsData?.todoStatement);
                                 const parts = $link.attr('href')?.split('/');
                                 appealId = parts?.[parts.length - 2];
                                 cy.log(appealId);
@@ -53,31 +57,30 @@ describe('Full Planning Statement Test Cases', () => {
     })
 
     it(`Statement url`, () => {
-        cy.url().should('include', `appeals/appeal-statement/${appealId}/appeal-statement`);
+        cy.url().should('include', `rule-6/appeal-statement/${appealId}/appeal-statement`);
     });
 
     it(`Validate Appeal statement error validation`, () => {
         basePage?.basePageElements?.pageHeading().contains('Appeal statement');
-        cy.get('#appellantStatement').clear();
+        cy.get('#rule6Statement').clear();
         cy.advanceToNextPage();
         cy.shouldHaveErrorMessage(basePage?._selectors?.govukErrorSummaryBody, 'Enter your statement');
     });
-    
     it(`Validate Appeal statement more than 32500 cahracters validation`, () => {
         const longText = stringUtils.generateLongString(32501);
-        cy.get('#appellantStatement').invoke('val', longText).trigger('input');
+        cy.get('#rule6Statement').invoke('val', longText).trigger('input');
         cy.advanceToNextPage();
         cy.shouldHaveErrorMessage(basePage?._selectors?.govukErrorSummaryBody, 'Your statement must be 32,500 characters or less');
         cy.advanceToNextPage();
     });
 
     it(`Validate Additional Document statement error validation`, () => {
-        cy.get('#appellantStatement').clear();
-        cy.get('#appellantStatement').type("Final comment test");
+        cy.get('#rule6Statement').clear();
+        cy.get('#rule6Statement').type("Final comment test");
         cy.advanceToNextPage();
         cy.get(basePage?._selectors.govukFieldsetHeading).contains('Do you have additional documents to support your appeal statement?');
-        cy.get('input[name="additionalDocuments"]:checked').then(($checked) => {
-            if ($checked.length > 0) {
+        cy.get('input[name="rule6AdditionalDocuments"]:checked').then(($checked) => {
+            if ($checked.length > 0) {               
                 return;
             }
             else {
@@ -87,7 +90,7 @@ describe('Full Planning Statement Test Cases', () => {
         })
     });
 
-    it(`Validate upload your new supporting documents Error message`, () => {
+    it(`Validate upload your new supporting documents Error message and remove if exists`, () => {       
         cy.advanceToNextPage();
         cy.getByData(basePage?._selectors?.answerYes).click({ force: true });
         cy.advanceToNextPage();
@@ -95,20 +98,20 @@ describe('Full Planning Statement Test Cases', () => {
         cy.get('button.moj-multi-file-upload__delete').each(($buttons) => {
             if ($buttons.length) {
                 cy.get('button.moj-multi-file-upload__delete').eq(0).click();
-            }
+            }           
         })
         cy.advanceToNextPage();
         cy.shouldHaveErrorMessage(basePage?._selectors?.govukErrorSummaryBody, 'Select your new supporting documents');
     });
 
     it(`Validate user should not be allowed to upload wrong format file`, () => {
-        cy.uploadFileFromFixtureDirectory(statementTestCases[0]?.documents?.uploadWrongFormatFile);
+        cy.uploadFileFromFixtureDirectory(r6FullAppealsStatementTestCases[0]?.documents?.uploadWrongFormatFile);
         cy.advanceToNextPage();
-        cy.shouldHaveErrorMessage('a[href*="#uploadLpaStatementDocuments"]', `${statementTestCases[0]?.documents?.uploadWrongFormatFile} must be a DOC, DOCX, PDF, TIF, JPG or PNG`);
+        cy.shouldHaveErrorMessage('a[href*="#uploadRule6StatementDocuments"]', `${r6FullAppealsStatementTestCases[0]?.documents?.uploadWrongFormatFile} must be a DOC, DOCX, PDF, TIF, JPG or PNG`);
     });
 
     it(`Validate multiple uploading documents`, () => {
-        const expectedFileNames = [statementTestCases[0]?.documents?.uploadEmergingPlan, statementTestCases[0]?.documents?.uploadOtherPolicies];
+        const expectedFileNames = [r6FullAppealsStatementTestCases[0]?.documents?.uploadEmergingPlan, r6FullAppealsStatementTestCases[0]?.documents?.uploadOtherPolicies];
 
         expectedFileNames.forEach((fileName) => {
             cy.uploadFileFromFixtureDirectory(fileName);
@@ -121,13 +124,13 @@ describe('Full Planning Statement Test Cases', () => {
         cy.advanceToNextPage();
         const expectedData = [
             {
-                key: 'Appeal statement', value: prepareAppealData?.statements?.lpaStatementTextInput
+                key: 'Appeal statement', value: lpaManageAppealsData?.statements?.lpaStatementTextInput
             },
             {
                 key: 'Add supporting documents', value: 'Yes'
             },
             {
-                key: 'Supporting documents', value: statementTestCases[0]?.documents?.uploadEmergingPlan
+                key: 'Supporting documents', value: r6FullAppealsStatementTestCases[0]?.documents?.uploadEmergingPlan
             }
         ]
         cy.get(basePage?._selectors?.govukSummaryListRow).each(($row, index) => {

--- a/test-packages/platform-feature-tests/cypress/e2e/rule-6-appeals/r6-full-appeals-statement-validation.cy.js
+++ b/test-packages/platform-feature-tests/cypress/e2e/rule-6-appeals/r6-full-appeals-statement-validation.cy.js
@@ -95,11 +95,13 @@ describe('Full Planning Statement Test Cases', () => {
         cy.getByData(basePage?._selectors?.answerYes).click({ force: true });
         cy.advanceToNextPage();
         basePage?.basePageElements?.pageHeading().contains('Upload your new supporting documents');
-        cy.get('button.moj-multi-file-upload__delete').each(($buttons) => {
-            if ($buttons.length) {
-                cy.get('button.moj-multi-file-upload__delete').eq(0).click();
-            }           
-        })
+        if (cy.get(basePage?._selectors.govukHeadingM).contains('Files added')) {
+            cy.get('button.moj-multi-file-upload__delete').each(($buttons) => {
+                if ($buttons.length) {
+                        cy.get('button.moj-multi-file-upload__delete').eq(0).click();
+                }
+            })
+        }
         cy.advanceToNextPage();
         cy.shouldHaveErrorMessage(basePage?._selectors?.govukErrorSummaryBody, 'Select your new supporting documents');
     });

--- a/test-packages/platform-feature-tests/cypress/e2e/rule-6-appeals/r6-full-appeals-statement.cy.js
+++ b/test-packages/platform-feature-tests/cypress/e2e/rule-6-appeals/r6-full-appeals-statement.cy.js
@@ -23,7 +23,6 @@ describe('Rule 6 Full Appeal Statement Test Cases', () => {
                 });
         });
         r6FullAppealsStatementTestCases.forEach((context) => {
-
                 it(`
             Should validate Full appeal R6 Statement, Appeal Type: Rule 6 Appeals
             - User selects add witnesses ${context.proofsOfEvidence?.isAddWitness}

--- a/test-packages/platform-feature-tests/cypress/fixtures/prepareAppealData.json
+++ b/test-packages/platform-feature-tests/cypress/fixtures/prepareAppealData.json
@@ -10,6 +10,7 @@
     "todoInvalid": "Invalid",
     "email": {
         "emailAddress": "appellant2@planninginspectorate.gov.uk",
+        "emailAddress1": "appellant1@planninginspectorate.gov.uk",
         "emailCode": "12345"
     },
     "applicationName": {

--- a/test-packages/platform-feature-tests/cypress/fixtures/prepareAppealData.json
+++ b/test-packages/platform-feature-tests/cypress/fixtures/prepareAppealData.json
@@ -1,5 +1,5 @@
 {
-    "FullAppealType": "Full Planning appeal",
+    "FullAppealType": "Full planning appeal",
     "todoProofsOfEvidence": "Proofs of evidence",
     "todoFinalComments": "Final comments",
     "proofsOfEvidenceLink": "proof-evidence",

--- a/test-packages/platform-feature-tests/cypress/helpers/rule6Appeals/r6FullAppealsStatementData.js
+++ b/test-packages/platform-feature-tests/cypress/helpers/rule6Appeals/r6FullAppealsStatementData.js
@@ -1,7 +1,12 @@
-const documents = {
-    uploadStatement: 'upload-proof-evidence.pdf',
-    uploadWitnessesStatement: 'witnesses-evidence.pdf'
-
+const documents = {   
+    uploadWitnessesStatement: 'witnesses-evidence.pdf',
+    uploadStatement: 'upload-statement.pdf',
+    uploadFileGreaterThan25mb:'greater-than-25-mb.docx',
+    uploadWrongFormatFile: 'wrongFormatFile.xps',
+    uploadEmergingPlan: 'emerging-plan.pdf',
+    uploadOtherPolicies: 'other-policies.pdf',
+    uploadSupplementaryPlanningDocs: 'supplementary-planning-docs.pdf',
+    uploadCommunityInfrastructureLevy: 'community-infrastructure-levy.pdf'
 };
 
 export const r6FullAppealsStatementTestCases = [

--- a/test-packages/platform-feature-tests/cypress/support/flows/sections/appellantAAPD/appellantFullAppealProofsOfEvidence.js
+++ b/test-packages/platform-feature-tests/cypress/support/flows/sections/appellantAAPD/appellantFullAppealProofsOfEvidence.js
@@ -17,8 +17,9 @@ export const appellantFullAppealProofsOfEvidence = (context, prepareAppealData) 
 				cy.wrap($row).within(() => {
 					cy.get(basePage?._selectors.trgovukTableCell).contains(prepareAppealData?.FullAppealType).should('be.visible');
 					cy.get('a').each(($link) => {
-						if ($link.attr('href')?.includes(prepareAppealData?.proofsOfEvidenceLink)) {
-							appealId = $link.attr('href')?.split('/').pop();
+						if ($link.attr('href')?.includes(prepareAppealData?.proofsOfEvidenceLink)) {							
+							const parts = $link.attr('href')?.split('/');
+							appealId = parts?.[parts.length - 2];
 							cy.wrap($link).scrollIntoView().should('be.visible').click({ force: true });
 							return false;
 						}

--- a/test-packages/platform-feature-tests/cypress/support/flows/sections/lpaManageAppeals/fullAppealFinalComment.js
+++ b/test-packages/platform-feature-tests/cypress/support/flows/sections/lpaManageAppeals/fullAppealFinalComment.js
@@ -13,7 +13,7 @@ export const fullAppealFinalComment = (context, lpaManageAppealsData) => {
 	cy.get(basePage?._selectors.trgovukTableRow).each(($row) => {
 		const rowtext = $row.text();
 		if (rowtext.includes(lpaManageAppealsData?.s78AppealType) && rowtext.includes(lpaManageAppealsData?.todoFinalcomment)) {
-			if (counter === 3) {
+			if (counter === 0) {
 				cy.wrap($row).within(() => {
 					cy.get(basePage?._selectors.trgovukTableCell).contains(lpaManageAppealsData?.s78AppealType).should('be.visible');
 					cy.get('a').each(($link) => {

--- a/test-packages/platform-feature-tests/cypress/support/flows/sections/lpaManageAppeals/fullAppealProofsOfEvidence.js
+++ b/test-packages/platform-feature-tests/cypress/support/flows/sections/lpaManageAppeals/fullAppealProofsOfEvidence.js
@@ -17,8 +17,9 @@ export const fullAppealProofsOfEvidence = (context, lpaManageAppealsData) => {
 				cy.wrap($row).within(() => {
 					cy.get(basePage?._selectors.trgovukTableCell).contains(lpaManageAppealsData?.s78AppealType).should('be.visible');
 					cy.get('a').each(($link) => {
-						if ($link.attr('href')?.includes(lpaManageAppealsData?.proofsOfEvidenceLink)) {
-							appealId = $link.attr('href')?.split('/').pop();
+						if ($link.attr('href')?.includes(lpaManageAppealsData?.proofsOfEvidenceLink)) {							
+							const parts = $link.attr('href')?.split('/');
+							appealId = parts?.[parts.length - 2];
 							cy.wrap($link).scrollIntoView().should('be.visible').click({ force: true });
 							return false;
 						}

--- a/test-packages/platform-feature-tests/cypress/support/flows/sections/lpaManageAppeals/fullAppealStatement.js
+++ b/test-packages/platform-feature-tests/cypress/support/flows/sections/lpaManageAppeals/fullAppealStatement.js
@@ -13,7 +13,7 @@ export const fullAppealStatement = (context, lpaManageAppealsData) => {
 	cy.get(basePage?._selectors.trgovukTableRow).each(($row) => {
 		const rowtext = $row.text();
 		if (rowtext.includes(lpaManageAppealsData?.s78AppealType) && rowtext.includes(lpaManageAppealsData?.todoStatement)) {
-			if (counter === 0) {
+			if (counter === 5) {
 				cy.wrap($row).within(() => {
 					cy.get(basePage?._selectors.trgovukTableCell).contains(lpaManageAppealsData?.s78AppealType).should('be.visible');
 					cy.get('a').each(($link) => {

--- a/test-packages/platform-feature-tests/cypress/support/flows/sections/representations/finalComment.js
+++ b/test-packages/platform-feature-tests/cypress/support/flows/sections/representations/finalComment.js
@@ -12,7 +12,7 @@ export const finalComment = (context, prepareAppealData) => {
 	let counter = 0;
 	cy.get(basePage?._selectors.trgovukTableRow).each(($row) => {
 		const rowtext = $row.text();
-		if (rowtext.includes(prepareAppealData?.FullAppealType) && rowtext.includes(prepareAppealData?.todoFinalComments)) {
+		if (rowtext.toLowerCase().includes(prepareAppealData?.FullAppealType.toLowerCase()) && rowtext.includes(prepareAppealData?.todoFinalComments)) {
 			if (counter === 0) {
 				cy.wrap($row).within(() => {
 					cy.get(basePage?._selectors.trgovukTableCell).contains(prepareAppealData?.FullAppealType).should('be.visible');

--- a/test-packages/platform-feature-tests/cypress/support/flows/sections/rule6Appeals/r6FullAppealsProofsOfEvidence.js
+++ b/test-packages/platform-feature-tests/cypress/support/flows/sections/rule6Appeals/r6FullAppealsProofsOfEvidence.js
@@ -1,13 +1,8 @@
 /* eslint-disable cypress/unsafe-to-chain-command */
 // @ts-nocheck
 /// <reference types="cypress"/>
-
 import { BasePage } from "../../../../page-objects/base-page";
 import { ProofsOfEvidence } from "../../pages/rule-6-appeals/r6FullAppealsProofsOfEvidence";
-
-
-
-
 export const r6FullAppealsProofsOfEvidence = (context, lpaManageAppealsData) => {
 	const basePage = new BasePage();
 	const proofsOfEvidence = new ProofsOfEvidence();	
@@ -17,16 +12,13 @@ export const r6FullAppealsProofsOfEvidence = (context, lpaManageAppealsData) => 
 		const rowtext = $row.text();
 		cy.log("Test POC r6",rowtext);		
 			if (rowtext.includes(lpaManageAppealsData?.s78AppealType) && rowtext.includes(lpaManageAppealsData?.rule6todoProofOfEvidence)) {
-			if (counter === 0) {
-				cy.log("Test POC",rowtext);			
+			if (counter === 0) {							
 				cy.wrap($row).within(() => {
 					cy.get(basePage?._selectors.trgovukTableCell).contains(lpaManageAppealsData?.s78AppealType).should('be.visible');					
-					cy.log("Test Rows",$row);
-					cy.get('a').each(($link) => {
-					cy.log("Test Link",$link.attr('href'));
-						if ($link.attr('href')?.includes(lpaManageAppealsData?.proofsOfEvidenceLink)) {
-							appealId = $link.attr('href')?.split('/').pop();
-							cy.log("Validate Link",appealId,$link);							
+					cy.get('a').each(($link) => {					
+						if ($link.attr('href')?.includes(lpaManageAppealsData?.proofsOfEvidenceLink)) {							
+							const parts = $link.attr('href')?.split('/');
+							appealId = parts?.[parts.length - 2];														
 							cy.wrap($link).scrollIntoView().should('be.visible').click({ force: true });
 							return false;
 						}

--- a/test-packages/platform-feature-tests/cypress/support/flows/sections/rule6Appeals/r6FullAppealsProofsOfEvidence.js
+++ b/test-packages/platform-feature-tests/cypress/support/flows/sections/rule6Appeals/r6FullAppealsProofsOfEvidence.js
@@ -33,6 +33,6 @@ export const r6FullAppealsProofsOfEvidence = (context, lpaManageAppealsData) => 
 		proofsOfEvidence.selectAddWitnesses(context);		
 	});
 	// commented for test during coding
-	// 	cy.getByData(lpaManageAppealsData?.submitQuestionnaire).click();
-	// 	cy.get(basePage?._selectors.govukPanelTitle).contains(lpaManageAppealsData?.questionnaireSubmitted);
+		cy.getByData(lpaManageAppealsData?.submitQuestionnaire).click();
+		cy.get(basePage?._selectors.govukPanelTitle).contains(lpaManageAppealsData?.questionnaireSubmitted);
 };

--- a/test-packages/platform-feature-tests/cypress/support/flows/sections/rule6Appeals/r6FullAppealsStatement.js
+++ b/test-packages/platform-feature-tests/cypress/support/flows/sections/rule6Appeals/r6FullAppealsStatement.js
@@ -19,7 +19,8 @@ export const r6FullAppealsStatement = (context, lpaManageAppealsData) => {
 					cy.get(basePage?._selectors.trgovukTableCell).contains(lpaManageAppealsData?.s78AppealType).should('be.visible');					
 					cy.get('a').each(($link) => {					
 						if ($link.attr('href')?.includes(lpaManageAppealsData?.statementLink)) {
-							appealId = $link.attr('href')?.split('/').pop();												
+							const parts = $link.attr('href')?.split('/');
+							appealId = parts[parts.length - 2];
 							cy.wrap($link).scrollIntoView().should('be.visible').click({ force: true });
 							return false;
 						}
@@ -29,7 +30,7 @@ export const r6FullAppealsStatement = (context, lpaManageAppealsData) => {
 			counter++;
 		}
 	}).then(() => {
-		cy.url().should('include', `/rule-6/appeal-statement/${appealId}`);
+		cy.url().should('include', `/rule-6/appeal-statement/${appealId}/appeal-statement`);
 		cy.get('#rule6Statement').type('Statement for full appleal');
 		cy.advanceToNextPage();		
 		statement.selectAddWitnesses(context);		


### PR DESCRIPTION
### Description of change

Ticket: https://pins-ds.atlassian.net/browse/A2-3639

OpenId client used to provide a relative expiry, it is now just the expires_in from the token, meaning we never know it's expired

This restores the expiry checking functionality

We don't share code between the app and functions which is why there is duplication

### Checklist

- [x] Feature complete and ready for users, or behind feature-flag
- [x] Commit history is linear with no merge commits
- [ ] Requires infrastructure changes

### Important

Please do not merge from `main` (please only [rebase](https://github.com/Planning-Inspectorate/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
