### PR TITLE
Feature/a2 3633 - Added hearing event cancellation message to be displayed to the users

### DIFF
--- a/packages/common/src/view-model-maps/events.js
+++ b/packages/common/src/view-model-maps/events.js
@@ -105,7 +105,7 @@ const formatHearings = (events, role) => {
 			if (role === LPA_USER_ROLE || role === APPEAL_USER_ROLES.APPELLANT) {
 				if (hearing.status === 'withdrawn') {
 					return {
-						lineOne: `We have cancelled your hearing on ${formattedStartTime}. We will contact you when we rearrange your hearing.`,
+						lineOne: `We have cancelled ${role === APPEAL_USER_ROLES.APPELLANT ? 'your' : 'the'} hearing on ${formattedStartDate}. We will contact you when we rearrange your hearing.`,
 						lineTwo: null
 					};
 				}

--- a/packages/common/src/view-model-maps/events.js
+++ b/packages/common/src/view-model-maps/events.js
@@ -103,6 +103,12 @@ const formatHearings = (events, role) => {
 				getFormattedTimeAndDate(hearing.startDate);
 			const address = formatEventAddress(hearing);
 			if (role === LPA_USER_ROLE || role === APPEAL_USER_ROLES.APPELLANT) {
+				if (hearing.status === 'withdrawn') {
+					return {
+						lineOne: `We have cancelled your hearing on ${formattedStartTime}. We will contact you when we rearrange your hearing.`,
+						lineTwo: null
+					};
+				}
 				return {
 					lineOne:
 						`${role === APPEAL_USER_ROLES.APPELLANT ? `Your` : `The`} hearing will start at ${formattedStartTime} on ${formattedStartDate}. ` +

--- a/packages/common/src/view-model-maps/events.test.js
+++ b/packages/common/src/view-model-maps/events.test.js
@@ -331,5 +331,39 @@ describe('view-model-maps/events', () => {
 				}
 			]);
 		});
+
+		it('returns correct string array if valid cancel hearing event & LPA user', () => {
+			const events = [
+				{
+					...hearingEvent,
+					status: 'withdrawn'
+				}
+			];
+			const role = LPA_USER_ROLE;
+			expect(formatHearings(events, role)).toEqual([
+				{
+					lineOne:
+						'We have cancelled the hearing on 29 December 2025. We will contact you when we rearrange your hearing.',
+					lineTwo: null
+				}
+			]);
+		});
+
+		it('returns correct string array if valid cancel hearing event & Appellant user', () => {
+			const events = [
+				{
+					...hearingEvent,
+					status: 'withdrawn'
+				}
+			];
+			const role = APPEAL_USER_ROLES.APPELLANT;
+			expect(formatHearings(events, role)).toEqual([
+				{
+					lineOne:
+						'We have cancelled your hearing on 29 December 2025. We will contact you when we rearrange your hearing.',
+					lineTwo: null
+				}
+			]);
+		});
 	});
 });


### PR DESCRIPTION
### Description of change

Added hearing event cancellation message to be displayed to users.

Ticket: https://pins-ds.atlassian.net/browse/A2-3633

### Checklist

- [ ] Feature complete and ready for users, or behind feature-flag
- [ ] Commit history is linear with no merge commits
- [ ] Requires infrastructure changes

### Important

Please do not merge from `main` (please only [rebase](https://github.com/Planning-Inspectorate/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
