### PR TITLE
fix(a2-2909): restore azure auth on build pipeline

### DIFF
--- a/azure-pipelines-build.yml
+++ b/azure-pipelines-build.yml
@@ -53,7 +53,6 @@ extends:
     globalVariables:
       - template: azure-pipelines-variables.yml@self
     gitFetchDepth: 1
-    skipAzureAuth: true
     validationJobs:
       - name: Run Linting & Tests
         condition: ${{ eq(parameters.runValidation, true) }}


### PR DESCRIPTION
### Description of change

<!-- Please describe the change -->

Ticket: https://pins-ds.atlassian.net/browse/A2-2909

Took out azure auth but only tested the build pipeline with tests 

### Checklist

- [x] Feature complete and ready for users, or behind feature-flag
- [x] Commit history is linear with no merge commits
- [ ] Requires infrastructure changes

### Important

Please do not merge from `main` (please only [rebase](https://github.com/Planning-Inspectorate/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
