### PR TITLE
chore: use sql-2022 image as azure-edge deprecated arm support

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -56,8 +56,10 @@ services:
       # - 9229:9229
     working_dir: /opt/app
     depends_on:
-      - mock-notify
-      - mssql
+      mock-notify:
+        condition: service_started
+      mssql:
+        condition: service_healthy
     volumes:
       # mount the root node_modules for shared packages
       - ./node_modules:/opt/node_modules
@@ -322,7 +324,7 @@ services:
 
   mssql:
     profiles: ['all', 'api', 'appeals', 'comment', 'database']
-    image: mcr.microsoft.com/azure-sql-edge:latest
+    image: mcr.microsoft.com/mssql/server:2022-latest
     platform: 'linux/amd64' # force platform, ARM machines to use emulation
     container_name: appeals-mssql
     cap_add: ['SYS_PTRACE']
@@ -336,7 +338,12 @@ services:
     hostname: mssql
     volumes:
       - ./dev/mssql.conf:/var/opt/mssql/mssql.conf
-      - ./tmp/mssql-data:/var/opt/mssql/data
+      - ./tmp/mssql-data-2022:/var/opt/mssql/
+    healthcheck:
+      test: ['CMD', 'bash', '-c', 'echo > /dev/tcp/localhost/1433']
+      interval: 5s
+      timeout: 10s
+      retries: 10
 
   c4:
     profiles: ['c4']

--- a/packages/appeals-service-api/__tests__/developer/external-dependencies/database/test-database.js
+++ b/packages/appeals-service-api/__tests__/developer/external-dependencies/database/test-database.js
@@ -24,13 +24,13 @@ async function startMongo() {
 }
 
 async function startSql() {
-	const container = await new GenericContainer('mcr.microsoft.com/azure-sql-edge:latest')
+	const container = await new GenericContainer('mcr.microsoft.com/mssql/server:2022-latest')
 		.withName('appeals-mssql-integration-tests')
 		.withExposedPorts(1433)
 		.withAddedCapabilities('SYS_PTRACE')
 		.withUser('root')
 		.withEnvironment({ ACCEPT_EULA: '1', MSSQL_SA_PASSWORD: 'DockerDatabaseP@22word!' })
-		.withWaitStrategy(Wait.forListeningPorts())
+		.withWaitStrategy(Wait.forLogMessage('SQL Server is now ready for client connections'))
 		.start();
 
 	containers.push(container);

--- a/packages/auth-server/__tests__/external-dependencies/database/test-database.js
+++ b/packages/auth-server/__tests__/external-dependencies/database/test-database.js
@@ -4,24 +4,23 @@ import { GenericContainer, Wait } from 'testcontainers';
 const containers = [];
 
 async function startSql() {
-	const container = await new GenericContainer('mcr.microsoft.com/azure-sql-edge:latest')
+	const container = await new GenericContainer('mcr.microsoft.com/mssql/server:2022-latest')
 		.withName('appeals-auth-mssql-integration-tests')
-		.withExposedPorts(1434)
+		.withExposedPorts(1433)
 		.withAddedCapabilities('SYS_PTRACE')
 		.withUser('root')
 		.withEnvironment({
 			ACCEPT_EULA: '1',
-			MSSQL_SA_PASSWORD: 'DockerDatabaseP@22word!',
-			MSSQL_TCP_PORT: '1434'
+			MSSQL_SA_PASSWORD: 'DockerDatabaseP@22word!'
 		})
-		.withWaitStrategy(Wait.forListeningPorts())
+		.withWaitStrategy(Wait.forLogMessage('SQL Server is now ready for client connections'))
 		.start();
 
 	containers.push(container);
 
 	const sqlDbName = 'pins_front_office_integration_test';
 	const connectionString = [
-		`sqlserver://localhost:${container.getMappedPort(1434)}`,
+		`sqlserver://localhost:${container.getMappedPort(1433)}`,
 		`database=${sqlDbName}`,
 		`user=sa`,
 		`password=DockerDatabaseP@22word!`,

--- a/packages/document-service-api/test/developer/testcontainer-helpers/test-database.js
+++ b/packages/document-service-api/test/developer/testcontainer-helpers/test-database.js
@@ -12,22 +12,21 @@ const create = async () => {
 async function startSql() {
 	const container = await new GenericContainer('mcr.microsoft.com/azure-sql-edge:latest')
 		.withName('docs-mssql-integration-tests')
-		.withExposedPorts(1435)
+		.withExposedPorts(1433)
 		.withAddedCapabilities('SYS_PTRACE')
 		.withUser('root')
 		.withEnvironment({
 			ACCEPT_EULA: '1',
-			MSSQL_SA_PASSWORD: 'DockerDatabaseP@22word!',
-			MSSQL_TCP_PORT: '1435'
+			MSSQL_SA_PASSWORD: 'DockerDatabaseP@22word!'
 		})
-		.withWaitStrategy(Wait.forListeningPorts())
+		.withWaitStrategy(Wait.forLogMessage('SQL Server is now ready for client connections'))
 		.start();
 
 	containers.push(container);
 
 	const sqlDbName = 'pins_front_office_integration_test';
 	const connectionString = [
-		`sqlserver://localhost:${container.getMappedPort(1435)}`,
+		`sqlserver://localhost:${container.getMappedPort(1433)}`,
 		`database=${sqlDbName}`,
 		`user=sa`,
 		`password=DockerDatabaseP@22word!`,


### PR DESCRIPTION
### Description of change

<!-- Please describe the change -->

Ticket: https://pins-ds.atlassian.net/browse/A2-

### Checklist

- [ ] Feature complete and ready for users, or behind feature-flag
- [ ] Commit history is linear with no merge commits
- [ ] Requires infrastructure changes

### Important

Please do not merge from `main` (please only [rebase](https://github.com/Planning-Inspectorate/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
