### PR TITLE
chore: bump prisma to match prisma client

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -104,7 +104,7 @@
 				"pino-pretty": "^11.2.1",
 				"prettier": "^3.5.3",
 				"prettier-plugin-prisma": "^5.0.0",
-				"prisma": "^6.8.2",
+				"prisma": "^6.9.0",
 				"rhea": "^3.0.4",
 				"sass": "^1.89.0",
 				"sinon": "^20.0.0",
@@ -3813,9 +3813,9 @@
 			}
 		},
 		"node_modules/@prisma/config": {
-			"version": "6.8.2",
-			"resolved": "https://registry.npmjs.org/@prisma/config/-/config-6.8.2.tgz",
-			"integrity": "sha512-ZJY1fF4qRBPdLQ/60wxNtX+eu89c3AkYEcP7L3jkp0IPXCNphCYxikTg55kPJLDOG6P0X+QG5tCv6CmsBRZWFQ==",
+			"version": "6.9.0",
+			"resolved": "https://registry.npmjs.org/@prisma/config/-/config-6.9.0.tgz",
+			"integrity": "sha512-Wcfk8/lN3WRJd5w4jmNQkUwhUw0eksaU/+BlAJwPQKW10k0h0LC9PD/6TQFmqKVbHQL0vG2z266r0S1MPzzhbA==",
 			"devOptional": true,
 			"license": "Apache-2.0",
 			"dependencies": {
@@ -3823,53 +3823,53 @@
 			}
 		},
 		"node_modules/@prisma/debug": {
-			"version": "6.8.2",
-			"resolved": "https://registry.npmjs.org/@prisma/debug/-/debug-6.8.2.tgz",
-			"integrity": "sha512-4muBSSUwJJ9BYth5N8tqts8JtiLT8QI/RSAzEogwEfpbYGFo9mYsInsVo8dqXdPO2+Rm5OG5q0qWDDE3nyUbVg==",
+			"version": "6.9.0",
+			"resolved": "https://registry.npmjs.org/@prisma/debug/-/debug-6.9.0.tgz",
+			"integrity": "sha512-bFeur/qi/Q+Mqk4JdQ3R38upSYPebv5aOyD1RKywVD+rAMLtRkmTFn28ZuTtVOnZHEdtxnNOCH+bPIeSGz1+Fg==",
 			"devOptional": true,
 			"license": "Apache-2.0"
 		},
 		"node_modules/@prisma/engines": {
-			"version": "6.8.2",
-			"resolved": "https://registry.npmjs.org/@prisma/engines/-/engines-6.8.2.tgz",
-			"integrity": "sha512-XqAJ//LXjqYRQ1RRabs79KOY4+v6gZOGzbcwDQl0D6n9WBKjV7qdrbd042CwSK0v0lM9MSHsbcFnU2Yn7z8Zlw==",
+			"version": "6.9.0",
+			"resolved": "https://registry.npmjs.org/@prisma/engines/-/engines-6.9.0.tgz",
+			"integrity": "sha512-im0X0bwDLA0244CDf8fuvnLuCQcBBdAGgr+ByvGfQY9wWl6EA+kRGwVk8ZIpG65rnlOwtaWIr/ZcEU5pNVvq9g==",
 			"devOptional": true,
 			"hasInstallScript": true,
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@prisma/debug": "6.8.2",
-				"@prisma/engines-version": "6.8.0-43.2060c79ba17c6bb9f5823312b6f6b7f4a845738e",
-				"@prisma/fetch-engine": "6.8.2",
-				"@prisma/get-platform": "6.8.2"
+				"@prisma/debug": "6.9.0",
+				"@prisma/engines-version": "6.9.0-10.81e4af48011447c3cc503a190e86995b66d2a28e",
+				"@prisma/fetch-engine": "6.9.0",
+				"@prisma/get-platform": "6.9.0"
 			}
 		},
 		"node_modules/@prisma/engines-version": {
-			"version": "6.8.0-43.2060c79ba17c6bb9f5823312b6f6b7f4a845738e",
-			"resolved": "https://registry.npmjs.org/@prisma/engines-version/-/engines-version-6.8.0-43.2060c79ba17c6bb9f5823312b6f6b7f4a845738e.tgz",
-			"integrity": "sha512-Rkik9lMyHpFNGaLpPF3H5q5TQTkm/aE7DsGM5m92FZTvWQsvmi6Va8On3pWvqLHOt5aPUvFb/FeZTmphI4CPiQ==",
+			"version": "6.9.0-10.81e4af48011447c3cc503a190e86995b66d2a28e",
+			"resolved": "https://registry.npmjs.org/@prisma/engines-version/-/engines-version-6.9.0-10.81e4af48011447c3cc503a190e86995b66d2a28e.tgz",
+			"integrity": "sha512-Qp9gMoBHgqhKlrvumZWujmuD7q4DV/gooEyPCLtbkc13EZdSz2RsGUJ5mHb3RJgAbk+dm6XenqG7obJEhXcJ6Q==",
 			"devOptional": true,
 			"license": "Apache-2.0"
 		},
 		"node_modules/@prisma/fetch-engine": {
-			"version": "6.8.2",
-			"resolved": "https://registry.npmjs.org/@prisma/fetch-engine/-/fetch-engine-6.8.2.tgz",
-			"integrity": "sha512-lCvikWOgaLOfqXGacEKSNeenvj0n3qR5QvZUOmPE2e1Eh8cMYSobxonCg9rqM6FSdTfbpqp9xwhSAOYfNqSW0g==",
+			"version": "6.9.0",
+			"resolved": "https://registry.npmjs.org/@prisma/fetch-engine/-/fetch-engine-6.9.0.tgz",
+			"integrity": "sha512-PMKhJdl4fOdeE3J3NkcWZ+tf3W6rx3ht/rLU8w4SXFRcLhd5+3VcqY4Kslpdm8osca4ej3gTfB3+cSk5pGxgFg==",
 			"devOptional": true,
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@prisma/debug": "6.8.2",
-				"@prisma/engines-version": "6.8.0-43.2060c79ba17c6bb9f5823312b6f6b7f4a845738e",
-				"@prisma/get-platform": "6.8.2"
+				"@prisma/debug": "6.9.0",
+				"@prisma/engines-version": "6.9.0-10.81e4af48011447c3cc503a190e86995b66d2a28e",
+				"@prisma/get-platform": "6.9.0"
 			}
 		},
 		"node_modules/@prisma/get-platform": {
-			"version": "6.8.2",
-			"resolved": "https://registry.npmjs.org/@prisma/get-platform/-/get-platform-6.8.2.tgz",
-			"integrity": "sha512-vXSxyUgX3vm1Q70QwzwkjeYfRryIvKno1SXbIqwSptKwqKzskINnDUcx85oX+ys6ooN2ATGSD0xN2UTfg6Zcow==",
+			"version": "6.9.0",
+			"resolved": "https://registry.npmjs.org/@prisma/get-platform/-/get-platform-6.9.0.tgz",
+			"integrity": "sha512-/B4n+5V1LI/1JQcHp+sUpyRT1bBgZVPHbsC4lt4/19Xp4jvNIVcq5KYNtQDk5e/ukTSjo9PZVAxxy9ieFtlpTQ==",
 			"devOptional": true,
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@prisma/debug": "6.8.2"
+				"@prisma/debug": "6.9.0"
 			}
 		},
 		"node_modules/@prisma/prisma-schema-wasm": {
@@ -16673,15 +16673,15 @@
 			}
 		},
 		"node_modules/prisma": {
-			"version": "6.8.2",
-			"resolved": "https://registry.npmjs.org/prisma/-/prisma-6.8.2.tgz",
-			"integrity": "sha512-JNricTXQxzDtRS7lCGGOB4g5DJ91eg3nozdubXze3LpcMl1oWwcFddrj++Up3jnRE6X/3gB/xz3V+ecBk/eEGA==",
+			"version": "6.9.0",
+			"resolved": "https://registry.npmjs.org/prisma/-/prisma-6.9.0.tgz",
+			"integrity": "sha512-resJAwMyZREC/I40LF6FZ6rZTnlrlrYrb63oW37Gq+U+9xHwbyMSPJjKtM7VZf3gTO86t/Oyz+YeSXr3CmAY1Q==",
 			"devOptional": true,
 			"hasInstallScript": true,
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@prisma/config": "6.8.2",
-				"@prisma/engines": "6.8.2"
+				"@prisma/config": "6.9.0",
+				"@prisma/engines": "6.9.0"
 			},
 			"bin": {
 				"prisma": "build/index.js"

--- a/package.json
+++ b/package.json
@@ -190,7 +190,7 @@
 		"pino-pretty": "^11.2.1",
 		"prettier": "^3.5.3",
 		"prettier-plugin-prisma": "^5.0.0",
-		"prisma": "^6.8.2",
+		"prisma": "^6.9.0",
 		"rhea": "^3.0.4",
 		"sass": "^1.89.0",
 		"sinon": "^20.0.0",


### PR DESCRIPTION
### Description of change

Forgot to bump this with prisma client dependabot update

### Checklist

- [x] Feature complete and ready for users, or behind feature-flag
- [x] Commit history is linear with no merge commits
- [ ] Requires infrastructure changes

### Important

Please do not merge from `main` (please only [rebase](https://github.com/Planning-Inspectorate/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
