### PR TITLE
Revert "chore(deps): bump @ministryofjustice/frontend from 1.8.1 to 5…

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
 				"@azure/identity": "^4.8.0",
 				"@azure/service-bus": "^7.9.1",
 				"@azure/storage-blob": "^12.17.0",
-				"@ministryofjustice/frontend": "^5.1.3",
+				"@ministryofjustice/frontend": "^1.6.4",
 				"@prisma/client": "^6.9.0",
 				"accessible-autocomplete": "^2.0.3",
 				"ajv": "^8.14.0",
@@ -2622,16 +2622,28 @@
 			"license": "MIT"
 		},
 		"node_modules/@ministryofjustice/frontend": {
-			"version": "5.1.3",
-			"resolved": "https://registry.npmjs.org/@ministryofjustice/frontend/-/frontend-5.1.3.tgz",
-			"integrity": "sha512-h6/riC6zDo5scevzZz1RByRo3AnX4k2ywFMTX47Irq9y7keyhalyfO5D0+VAJMpX0ADuNLg3f2tJh+cumH/PBA==",
+			"version": "1.8.1",
+			"resolved": "https://registry.npmjs.org/@ministryofjustice/frontend/-/frontend-1.8.1.tgz",
+			"integrity": "sha512-HNl8XXbNje/NtQRlGM57CTLlAGBTW+ziGTBkxXHDn7VauKNz418PnErDlKRWeaHIyc6V9twI5EbOj4lFCsvasw==",
 			"license": "MIT",
+			"dependencies": {
+				"govuk-frontend": "^3.0.0 || ^4.0.0",
+				"moment": "^2.27.0"
+			},
 			"engines": {
 				"node": ">= 4.2.0"
 			},
 			"peerDependencies": {
-				"govuk-frontend": "^5.8.0",
-				"moment": "2.30.1"
+				"jquery": "^3.6.0"
+			}
+		},
+		"node_modules/@ministryofjustice/frontend/node_modules/govuk-frontend": {
+			"version": "4.9.0",
+			"resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-4.9.0.tgz",
+			"integrity": "sha512-zfX+GBUKpWBeV6JwCIawEuI8VRWlskH8Ok8aNUjKOvzo3zIaNbcrv4IOwgy+oSnMoGh67Eeh+vb7+9GFxN2fNg==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 4.2.0"
 			}
 		},
 		"node_modules/@mongodb-js/saslprep": {
@@ -12714,6 +12726,13 @@
 			"engines": {
 				"node": ">=10"
 			}
+		},
+		"node_modules/jquery": {
+			"version": "3.7.1",
+			"resolved": "https://registry.npmjs.org/jquery/-/jquery-3.7.1.tgz",
+			"integrity": "sha512-m4avr8yL8kmFN8psrbFFFmB/If14iN5o9nw/NgnnM+kybDJpRsAynV2BsfpTYrTRysYUdADVD7CkUUizgkpLfg==",
+			"license": "MIT",
+			"peer": true
 		},
 		"node_modules/js-tokens": {
 			"version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -104,7 +104,7 @@
 		"@azure/identity": "^4.8.0",
 		"@azure/service-bus": "^7.9.1",
 		"@azure/storage-blob": "^12.17.0",
-		"@ministryofjustice/frontend": "^5.1.3",
+		"@ministryofjustice/frontend": "^1.6.4",
 		"@prisma/client": "^6.9.0",
 		"accessible-autocomplete": "^2.0.3",
 		"ajv": "^8.14.0",


### PR DESCRIPTION
….1.3"

This reverts commit 094d715404c4011c0c79f664e31df53c3c09430d.

### Description of change

Reverting dependabot update

### Checklist

- [ ] Feature complete and ready for users, or behind feature-flag
- [ ] Commit history is linear with no merge commits
- [ ] Requires infrastructure changes

### Important

Please do not merge from `main` (please only [rebase](https://github.com/Planning-Inspectorate/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
