### PR TITLE
fix(A2-2705): change column width for appeal page to two thirds

### DIFF
--- a/packages/forms-web-app/src/views/selected-appeal/appeal.njk
+++ b/packages/forms-web-app/src/views/selected-appeal/appeal.njk
@@ -199,7 +199,7 @@
       		<h1 class="govuk-heading-l">Appeal {{appeal.appealNumber}}</h1>
 		</div>
 
-		<div class="govuk-grid-column-full">
+		<div class="govuk-grid-column-two-thirds">
 			{% if appeal.decision %}
 				<h2 class="govuk-heading-2">Appeal decision</h2>
 				{{ govukTag({


### PR DESCRIPTION
### Description of change

<!-- Please describe the change -->

Updated column width to two thirds for appeal page

Ticket: https://pins-ds.atlassian.net/browse/A2-2705

### Checklist

- [x] Feature complete and ready for users, or behind feature-flag
- [x] Commit history is linear with no merge commits
- [ ] Requires infrastructure changes

### Important

Please do not merge from `main` (please only [rebase](https://github.com/Planning-Inspectorate/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
