### PR TITLE
feat(A2-3744): removing application-reference from BYS journey

### DIFF
--- a/packages/forms-web-app/__tests__/unit/controllers/before-you-start/can-use-service.test.js
+++ b/packages/forms-web-app/__tests__/unit/controllers/before-you-start/can-use-service.test.js
@@ -103,7 +103,7 @@ describe('controllers/before-you-start/can-use-service', () => {
 			});
 		});
 		it('renders page - HAS - date decision due - v2 - s20 flag', async () => {
-			isLpaInFeatureFlag.mockReturnValueOnce(true);
+			isLpaInFeatureFlag.mockReturnValue(true);
 			const householderAppealNoDecisionReceived = { ...householderAppeal };
 			householderAppealNoDecisionReceived.eligibility.applicationDecision = 'nodecisionreceived';
 			req = mockReq(householderAppealNoDecisionReceived);
@@ -120,14 +120,14 @@ describe('controllers/before-you-start/can-use-service', () => {
 				dateOfDecisionLabel: 'Date decision due',
 				enforcementNotice: 'No',
 				isListedBuilding: null,
-				nextPageUrl: '/full-appeal/submit-appeal/planning-application-number',
+				nextPageUrl: '/full-appeal/submit-appeal/email-address',
 				changeLpaUrl: '/before-you-start/local-planning-authority',
 				bannerHtmlOverride: bannerHtmlOverrideHAS
 			});
 		});
 
 		it('renders page - HAS - date of decision - v2 - s20 flag', async () => {
-			isLpaInFeatureFlag.mockReturnValueOnce(true);
+			isLpaInFeatureFlag.mockReturnValue(true);
 			req = mockReq(householderAppeal);
 
 			await getCanUseService(req, res);
@@ -142,7 +142,7 @@ describe('controllers/before-you-start/can-use-service', () => {
 				dateOfDecisionLabel: 'Date of decision',
 				enforcementNotice: 'No',
 				isListedBuilding: null,
-				nextPageUrl: '/full-appeal/submit-appeal/planning-application-number',
+				nextPageUrl: '/full-appeal/submit-appeal/email-address',
 				changeLpaUrl: '/before-you-start/local-planning-authority',
 				bannerHtmlOverride: bannerHtmlOverrideHAS
 			});
@@ -171,8 +171,13 @@ describe('controllers/before-you-start/can-use-service', () => {
 		});
 
 		it('renders page - s78 - no prior approval - v2 - s78 flag', async () => {
+			isLpaInFeatureFlag.mockReturnValueOnce(true); //s20
+			isLpaInFeatureFlag.mockReturnValueOnce(false); //s78
+			isLpaInFeatureFlag.mockReturnValueOnce(false); //CAS
+			isLpaInFeatureFlag.mockReturnValueOnce(false); //HAS
 			isLpaInFeatureFlag.mockReturnValueOnce(false); //s20
 			isLpaInFeatureFlag.mockReturnValueOnce(true); //s78
+
 			req = mockReq(priorApprovalFPAppeal);
 
 			await getCanUseService(req, res);
@@ -188,14 +193,16 @@ describe('controllers/before-you-start/can-use-service', () => {
 				hasPriorApprovalForExistingHome: 'No',
 				isListedBuilding: 'No',
 				isV2forS78: true,
-				nextPageUrl: '/full-appeal/submit-appeal/planning-application-number',
+				nextPageUrl: '/full-appeal/submit-appeal/email-address',
 				changeLpaUrl: '/before-you-start/local-planning-authority'
 			});
 		});
 
 		it('renders page - s78 - no prior approval - v2 - s78 and s20 flag', async () => {
-			isLpaInFeatureFlag.mockReturnValueOnce(true); //s20
-			isLpaInFeatureFlag.mockReturnValueOnce(true); //s78
+			isLpaInFeatureFlag.mockImplementation(() => {
+				return true;
+			});
+
 			req = mockReq(priorApprovalFPAppeal);
 
 			await getCanUseService(req, res);
@@ -212,7 +219,7 @@ describe('controllers/before-you-start/can-use-service', () => {
 				isListedBuilding: null,
 				isV2forS78: true,
 				changeLpaUrl: '/before-you-start/local-planning-authority',
-				nextPageUrl: '/full-appeal/submit-appeal/planning-application-number'
+				nextPageUrl: '/full-appeal/submit-appeal/email-address'
 			});
 		});
 
@@ -238,7 +245,10 @@ describe('controllers/before-you-start/can-use-service', () => {
 		});
 
 		it('renders page - HAS - prior approval - v2 - s20 flag', async () => {
-			isLpaInFeatureFlag.mockReturnValueOnce(true); //s20
+			isLpaInFeatureFlag.mockImplementation(() => {
+				return true;
+			});
+
 			req = mockReq(priorApprovalHASAppeal);
 
 			await getCanUseService(req, res);
@@ -254,7 +264,7 @@ describe('controllers/before-you-start/can-use-service', () => {
 				hasPriorApprovalForExistingHome: 'Yes',
 				isListedBuilding: null,
 				changeLpaUrl: '/before-you-start/local-planning-authority',
-				nextPageUrl: '/appeal-householder-decision/planning-application-number'
+				nextPageUrl: '/appeal-householder-decision/email-address'
 			});
 		});
 	});
@@ -283,7 +293,10 @@ describe('controllers/before-you-start/can-use-service', () => {
 			);
 		});
 		it('renders page - s78 - v2', async () => {
-			isLpaInFeatureFlag.mockReturnValueOnce(true);
+			isLpaInFeatureFlag.mockImplementation(() => {
+				return true;
+			});
+
 			req = mockReq(removalOrVariationOfConditionsFPAppeal);
 
 			await getCanUseService(req, res);
@@ -302,7 +315,7 @@ describe('controllers/before-you-start/can-use-service', () => {
 					isV2: true,
 					isListedBuilding: 'No',
 					changeLpaUrl: '/before-you-start/local-planning-authority',
-					nextPageUrl: '/full-appeal/submit-appeal/planning-application-number'
+					nextPageUrl: '/full-appeal/submit-appeal/email-address'
 				}
 			);
 		});
@@ -381,7 +394,7 @@ describe('controllers/before-you-start/can-use-service', () => {
 				isV2forCAS: false,
 				isV2forS78: true,
 				changeLpaUrl: '/before-you-start/local-planning-authority',
-				nextPageUrl: '/full-appeal/submit-appeal/planning-application-number',
+				nextPageUrl: '/full-appeal/submit-appeal/email-address',
 				bannerHtmlOverride
 			});
 		});
@@ -407,7 +420,7 @@ describe('controllers/before-you-start/can-use-service', () => {
 				isV2forCAS: false,
 				isV2forS78: true,
 				changeLpaUrl: '/before-you-start/local-planning-authority',
-				nextPageUrl: '/full-appeal/submit-appeal/planning-application-number',
+				nextPageUrl: '/full-appeal/submit-appeal/email-address',
 				bannerHtmlOverride
 			});
 		});
@@ -463,7 +476,7 @@ describe('controllers/before-you-start/can-use-service', () => {
 				isListedBuilding: 'No',
 				isV2forCAS: false,
 				isV2forS78: true,
-				nextPageUrl: '/full-appeal/submit-appeal/planning-application-number',
+				nextPageUrl: '/full-appeal/submit-appeal/email-address',
 				changeLpaUrl: '/before-you-start/local-planning-authority',
 				bannerHtmlOverride
 			});
@@ -492,7 +505,7 @@ describe('controllers/before-you-start/can-use-service', () => {
 				isV2forCAS: false,
 				isV2forS78: true,
 				changeLpaUrl: '/before-you-start/local-planning-authority',
-				nextPageUrl: '/full-appeal/submit-appeal/planning-application-number',
+				nextPageUrl: '/full-appeal/submit-appeal/email-address',
 				bannerHtmlOverride
 			});
 		});
@@ -526,7 +539,7 @@ describe('controllers/before-you-start/can-use-service', () => {
 				enforcementNotice: 'No',
 				isListedBuilding: null,
 				changeLpaUrl: '/before-you-start/local-planning-authority',
-				nextPageUrl: '/listed-building/planning-application-number',
+				nextPageUrl: '/listed-building/email-address',
 				isV2forS78: false,
 				isV2forCAS: false,
 				bannerHtmlOverride:
@@ -564,7 +577,7 @@ describe('controllers/before-you-start/can-use-service', () => {
 				dateOfDecisionLabel: 'Date of decision',
 				enforcementNotice: 'No',
 				isListedBuilding: 'No',
-				nextPageUrl: '/cas-planning/planning-application-number',
+				nextPageUrl: '/cas-planning/email-address',
 				changeLpaUrl: '/before-you-start/local-planning-authority',
 				isV2forS78: false,
 				isV2forCAS: true,

--- a/packages/forms-web-app/src/lib/get-appeal-props-for-can-use-service-page.js
+++ b/packages/forms-web-app/src/lib/get-appeal-props-for-can-use-service-page.js
@@ -38,7 +38,7 @@ const getAppealPropsForCanUseServicePage = async (appeal) => {
 		applicationDecision = removeDashesAndCapitaliseString(applicationDecision);
 	}
 
-	const nextPageUrl = getNextPageFromCanUseServicePage(appeal);
+	const nextPageUrl = await getNextPageFromCanUseServicePage(appeal);
 
 	const decisionDate = format(parseISO(appeal.decisionDate), 'dd MMMM yyyy');
 

--- a/packages/forms-web-app/src/lib/get-next-page-from-can-use-service-page.js
+++ b/packages/forms-web-app/src/lib/get-next-page-from-can-use-service-page.js
@@ -12,10 +12,10 @@ const {
 } = require('@pins/business-rules/src/constants');
 
 const nextPage = {
-	fullAppeal: '/full-appeal/submit-appeal/planning-application-number',
-	householderPlanning: '/appeal-householder-decision/planning-application-number',
-	listedBuilding: '/listed-building/planning-application-number',
-	casAppeal: '/cas-planning/planning-application-number'
+	fullAppeal: '/full-appeal/submit-appeal/email-address',
+	householderPlanning: '/appeal-householder-decision/email-address',
+	listedBuilding: '/listed-building/email-address',
+	casAppeal: '/cas-planning/email-address'
 };
 
 const getNextPageFromCanUseServicePage = (appeal) => {

--- a/packages/forms-web-app/src/lib/get-next-page-from-can-use-service-page.test.js
+++ b/packages/forms-web-app/src/lib/get-next-page-from-can-use-service-page.test.js
@@ -11,40 +11,49 @@ const {
 	APPLICATION_DECISION: { REFUSED, GRANTED, NODECISIONRECEIVED },
 	APPEAL_ID
 } = require('@pins/business-rules/src/constants');
+const { isLpaInFeatureFlag } = require('#lib/is-lpa-in-feature-flag');
+
 const { getNextPageFromCanUseServicePage } = require('./get-next-page-from-can-use-service-page');
 
-const householderNextPage = '/appeal-householder-decision/planning-application-number';
-const fullAppealNextPage = '/full-appeal/submit-appeal/planning-application-number';
-const listedBuildingNextPage = '/listed-building/planning-application-number';
+const householderNextPage = '/appeal-householder-decision/email-address';
+const fullAppealNextPage = '/full-appeal/submit-appeal/email-address';
+const listedBuildingNextPage = '/listed-building/email-address';
+
+jest.mock('../../src/lib/is-lpa-in-feature-flag.js');
 
 describe('getNextPageFromCanUseServicePage', () => {
-	it('returns correct page (householder) for householder application- refused', () => {
+	beforeEach(() => {
+		isLpaInFeatureFlag.mockReturnValue(true);
+	});
+
+	it('returns correct page (householder) for householder application- refused', async () => {
 		const appeal = {
 			typeOfPlanningApplication: HOUSEHOLDER_PLANNING,
 			eligibility: {
 				applicationDecision: REFUSED
 			}
 		};
-		expect(getNextPageFromCanUseServicePage(appeal)).toEqual(householderNextPage);
+		const result = await getNextPageFromCanUseServicePage(appeal);
+		expect(result).toEqual(householderNextPage);
 	});
-	it('returns correct page (full appeal) for householder application- granted', () => {
+	it('returns correct page (full appeal) for householder application- granted', async () => {
 		const appeal = {
 			typeOfPlanningApplication: HOUSEHOLDER_PLANNING,
 			eligibility: {
 				applicationDecision: GRANTED
 			}
 		};
-		expect(getNextPageFromCanUseServicePage(appeal)).toEqual(fullAppealNextPage);
+		expect(await getNextPageFromCanUseServicePage(appeal)).toEqual(fullAppealNextPage);
 	});
 
-	it('returns correct page (full appeal) for householder application - no decision received', () => {
+	it('returns correct page (full appeal) for householder application - no decision received', async () => {
 		const appeal = {
 			typeOfPlanningApplication: HOUSEHOLDER_PLANNING,
 			eligibility: {
 				applicationDecision: NODECISIONRECEIVED
 			}
 		};
-		expect(getNextPageFromCanUseServicePage(appeal)).toEqual(fullAppealNextPage);
+		expect(await getNextPageFromCanUseServicePage(appeal)).toEqual(fullAppealNextPage);
 	});
 	it.each([
 		[GRANTED, true],
@@ -54,7 +63,7 @@ describe('getNextPageFromCanUseServicePage', () => {
 		[NODECISIONRECEIVED, false]
 	])(
 		'returns correct page (full appeal) for prior approval application %s where prior approval for existing home is %s ',
-		(decision, existingHome) => {
+		async (decision, existingHome) => {
 			const appeal = {
 				typeOfPlanningApplication: PRIOR_APPROVAL,
 				eligibility: {
@@ -62,10 +71,10 @@ describe('getNextPageFromCanUseServicePage', () => {
 					hasPriorApprovalForExistingHome: existingHome
 				}
 			};
-			expect(getNextPageFromCanUseServicePage(appeal)).toEqual(fullAppealNextPage);
+			expect(await getNextPageFromCanUseServicePage(appeal)).toEqual(fullAppealNextPage);
 		}
 	);
-	it('returns correct page (householder appeal) for prior approval - refused householder', () => {
+	it('returns correct page (householder appeal) for prior approval - refused householder', async () => {
 		const appeal = {
 			typeOfPlanningApplication: PRIOR_APPROVAL,
 			eligibility: {
@@ -73,19 +82,19 @@ describe('getNextPageFromCanUseServicePage', () => {
 				hasPriorApprovalForExistingHome: true
 			}
 		};
-		expect(getNextPageFromCanUseServicePage(appeal)).toEqual(householderNextPage);
+		expect(await getNextPageFromCanUseServicePage(appeal)).toEqual(householderNextPage);
 	});
 
-	it('returns correct page (listed building if removal or variation of conditions application and s20 appeal type', () => {
+	it('returns correct page (listed building if removal or variation of conditions application and s20 appeal type', async () => {
 		const appeal = {
 			appealType: APPEAL_ID.PLANNING_LISTED_BUILDING,
 			typeOfPlanningApplication: REMOVAL_OR_VARIATION_OF_CONDITIONS,
 			eligibility: {}
 		};
-		expect(getNextPageFromCanUseServicePage(appeal)).toEqual(listedBuildingNextPage);
+		expect(await getNextPageFromCanUseServicePage(appeal)).toEqual(listedBuildingNextPage);
 	});
 
-	it('returns correct page (householder) if removal or variation of conditions (refused) and householder permission conditions true', () => {
+	it('returns correct page (householder) if removal or variation of conditions (refused) and householder permission conditions true', async () => {
 		const appeal = {
 			typeOfPlanningApplication: REMOVAL_OR_VARIATION_OF_CONDITIONS,
 			eligibility: {
@@ -93,7 +102,7 @@ describe('getNextPageFromCanUseServicePage', () => {
 				applicationDecision: REFUSED
 			}
 		};
-		expect(getNextPageFromCanUseServicePage(appeal)).toEqual(householderNextPage);
+		expect(await getNextPageFromCanUseServicePage(appeal)).toEqual(householderNextPage);
 	});
 
 	it.each([
@@ -104,7 +113,7 @@ describe('getNextPageFromCanUseServicePage', () => {
 		[NODECISIONRECEIVED, false]
 	])(
 		'returns correct page (full appeal) for removal or variation of condition (%s) and householder permission conditions %s',
-		(decision, householderPermissionConditions) => {
+		async (decision, householderPermissionConditions) => {
 			const appeal = {
 				typeOfPlanningApplication: REMOVAL_OR_VARIATION_OF_CONDITIONS,
 				eligibility: {
@@ -112,26 +121,26 @@ describe('getNextPageFromCanUseServicePage', () => {
 					applicationDecision: decision
 				}
 			};
-			expect(getNextPageFromCanUseServicePage(appeal)).toEqual(fullAppealNextPage);
+			expect(await getNextPageFromCanUseServicePage(appeal)).toEqual(fullAppealNextPage);
 		}
 	);
 
-	it('returns correct page (listed building) for s20 application', () => {
+	it('returns correct page (listed building) for s20 application', async () => {
 		const appeal = {
 			typeOfPlanningApplication: LISTED_BUILDING,
 			eligibility: {}
 		};
-		expect(getNextPageFromCanUseServicePage(appeal)).toEqual(listedBuildingNextPage);
+		expect(await getNextPageFromCanUseServicePage(appeal)).toEqual(listedBuildingNextPage);
 	});
 
 	it.each([[FULL_APPEAL], [OUTLINE_PLANNING, RESERVED_MATTERS]])(
 		'returns correct page (full appeal) for %s application',
-		(applicationType) => {
+		async (applicationType) => {
 			const appeal = {
 				typeOfPlanningApplication: applicationType,
 				eligibility: {}
 			};
-			expect(getNextPageFromCanUseServicePage(appeal)).toEqual(fullAppealNextPage);
+			expect(await getNextPageFromCanUseServicePage(appeal)).toEqual(fullAppealNextPage);
 		}
 	);
 });


### PR DESCRIPTION
### Description of change
- Redirecting to email-address page instead
- Ensured that for V1 versions, the user still gets redirected to application number page since this isn't asked inside the appeal form
- Updated tests since now checking feature flags so function has become async
<!-- Please describe the change -->

Ticket: https://pins-ds.atlassian.net/browse/A2-3744

### Checklist

- [x] Feature complete and ready for users, or behind feature-flag
- [x] Commit history is linear with no merge commits
- [ ] Requires infrastructure changes

### Important

Please do not merge from `main` (please only [rebase](https://github.com/Planning-Inspectorate/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
