### PR TITLE
chore(deps): use workspace imports

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23915,9 +23915,9 @@
 			"dependencies": {
 				"@azure/identity": "*",
 				"@azure/service-bus": "*",
-				"@pins/business-rules": "file:../business-rules",
-				"@pins/common": "file:../common",
-				"@pins/database": "file:../database",
+				"@pins/business-rules": "^0.0.0",
+				"@pins/common": "^0.0.0",
+				"@pins/database": "^0.0.0",
 				"@prisma/client": "*",
 				"ajv": "*",
 				"ajv-errors": "*",
@@ -23965,8 +23965,8 @@
 			"name": "appeals-auth-server",
 			"version": "1.0.0",
 			"dependencies": {
-				"@pins/common": "file:../common",
-				"@pins/database": "file:../database",
+				"@pins/common": "^0.0.0",
+				"@pins/database": "^0.0.0",
 				"@prisma/client": "*",
 				"applicationinsights": "*",
 				"express": "*",
@@ -23992,7 +23992,7 @@
 			"name": "@pins/business-rules",
 			"version": "0.0.0",
 			"dependencies": {
-				"@pins/common": "file:../common",
+				"@pins/common": "^0.0.0",
 				"date-fns": "*",
 				"date-fns-tz": "*",
 				"pins-data-model": "*",
@@ -24041,7 +24041,7 @@
 			"version": "0.0.0",
 			"license": "ISC",
 			"dependencies": {
-				"@pins/common": "file:../common",
+				"@pins/common": "^0.0.0",
 				"@prisma/client": "*",
 				"pins-data-model": "*"
 			},
@@ -24056,8 +24056,8 @@
 			"version": "0.0.0",
 			"dependencies": {
 				"@azure/storage-blob": "*",
-				"@pins/common": "file:../common",
-				"@pins/database": "file:../database",
+				"@pins/common": "^0.0.0",
+				"@pins/database": "^0.0.0",
 				"@prisma/client": "*",
 				"applicationinsights": "*",
 				"archiver": "*",
@@ -24089,12 +24089,31 @@
 				"node": ">=22.0.0 <23.0.0"
 			}
 		},
+		"packages/dynamic-forms": {
+			"name": "@pins/dynamic-forms",
+			"version": "0.0.0",
+			"dependencies": {
+				"date-fns": "*",
+				"date-fns-tz": "*",
+				"escape-html": "*",
+				"express-validator": "*",
+				"nunjucks": "*"
+			},
+			"devDependencies": {
+				"jest": "*",
+				"jest-fetch-mock": "*",
+				"jest-junit": "*"
+			},
+			"engines": {
+				"node": ">=22.0.0 <23.0.0"
+			}
+		},
 		"packages/forms-web-app": {
 			"version": "1.19.0",
 			"dependencies": {
 				"@ministryofjustice/frontend": "*",
-				"@pins/business-rules": "file:../business-rules",
-				"@pins/common": "file:../common",
+				"@pins/business-rules": "^0.0.0",
+				"@pins/common": "^0.0.0",
 				"accessible-autocomplete": "*",
 				"applicationinsights": "*",
 				"compression": "*",
@@ -24160,7 +24179,7 @@
 				"@azure/identity": "*",
 				"@azure/service-bus": "*",
 				"@azure/storage-blob": "*",
-				"@pins/common": "file:../common",
+				"@pins/common": "^0.0.0",
 				"stream-json": "*"
 			},
 			"devDependencies": {

--- a/packages/appeals-service-api/package.json
+++ b/packages/appeals-service-api/package.json
@@ -25,9 +25,9 @@
 	"dependencies": {
 		"@azure/identity": "*",
 		"@azure/service-bus": "*",
-		"@pins/business-rules": "file:../business-rules",
-		"@pins/common": "file:../common",
-		"@pins/database": "file:../database",
+		"@pins/business-rules": "^0.0.0",
+		"@pins/common": "^0.0.0",
+		"@pins/database": "^0.0.0",
 		"@prisma/client": "*",
 		"ajv": "*",
 		"ajv-errors": "*",

--- a/packages/auth-server/package.json
+++ b/packages/auth-server/package.json
@@ -22,8 +22,8 @@
 		"test:cov": "npm run db:generate && cross-env NODE_OPTIONS=--experimental-vm-modules jest --ci --verbose --coverage"
 	},
 	"dependencies": {
-		"@pins/common": "file:../common",
-		"@pins/database": "file:../database",
+		"@pins/common": "^0.0.0",
+		"@pins/database": "^0.0.0",
 		"@prisma/client": "*",
 		"applicationinsights": "*",
 		"express": "*",

--- a/packages/business-rules/README.md
+++ b/packages/business-rules/README.md
@@ -7,5 +7,5 @@ npm repository. To use it, add this line to your `package.json` `dependencies`
 and run`npm install`.
 
 ```
-"@pins/business-rules": "file:../business-rules",
+"@pins/business-rules": "^0.0.0",
 ```

--- a/packages/business-rules/package.json
+++ b/packages/business-rules/package.json
@@ -16,7 +16,7 @@
 	},
 	"author": "",
 	"dependencies": {
-		"@pins/common": "file:../common",
+		"@pins/common": "^0.0.0",
 		"date-fns": "*",
 		"date-fns-tz": "*",
 		"pins-data-model": "*",

--- a/packages/common/README.md
+++ b/packages/common/README.md
@@ -7,7 +7,7 @@ npm repository. To use it, add this line to your `package.json` `dependencies`
 and run`npm install`.
 
 ```
-"@pins/common": "file:../common",
+"@pins/common": "^0.0.0",
 ```
 
 ## Engineering Backlog

--- a/packages/database/package.json
+++ b/packages/database/package.json
@@ -22,7 +22,7 @@
 	"license": "ISC",
 	"dependencies": {
 		"@prisma/client": "*",
-		"@pins/common": "file:../common",
+		"@pins/common": "^0.0.0",
 		"pins-data-model": "*"
 	},
 	"devDependencies": {

--- a/packages/document-service-api/package.json
+++ b/packages/document-service-api/package.json
@@ -22,8 +22,8 @@
 	"author": "Planning-Inspectorate <https://gov.uk/pins>",
 	"dependencies": {
 		"@azure/storage-blob": "*",
-		"@pins/common": "file:../common",
-		"@pins/database": "file:../database",
+		"@pins/common": "^0.0.0",
+		"@pins/database": "^0.0.0",
 		"@prisma/client": "*",
 		"applicationinsights": "*",
 		"archiver": "*",

--- a/packages/forms-web-app/package.json
+++ b/packages/forms-web-app/package.json
@@ -28,8 +28,8 @@
 	},
 	"dependencies": {
 		"@ministryofjustice/frontend": "*",
-		"@pins/business-rules": "file:../business-rules",
-		"@pins/common": "file:../common",
+		"@pins/business-rules": "^0.0.0",
+		"@pins/common": "^0.0.0",
 		"accessible-autocomplete": "*",
 		"applicationinsights": "*",
 		"compression": "*",

--- a/packages/integration-functions/package.json
+++ b/packages/integration-functions/package.json
@@ -24,7 +24,7 @@
 		"@azure/identity": "*",
 		"@azure/service-bus": "*",
 		"@azure/storage-blob": "*",
-		"@pins/common": "file:../common",
+		"@pins/common": "^0.0.0",
 		"stream-json": "*"
 	}
 }


### PR DESCRIPTION
### Description of change

Use workspace imports instead of file references

Tested in [dev](https://dev.azure.com/planninginspectorate/appeal-planning-decision/_build/results?buildId=120528&view=results)

### Checklist

- [x] Feature complete and ready for users, or behind feature-flag
- [x] Commit history is linear with no merge commits
- [ ] Requires infrastructure changes

### Important

Please do not merge from `main` (please only [rebase](https://github.com/Planning-Inspectorate/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
