### PR TITLE
fix: lpaq due date set in seeded data

### DIFF
--- a/packages/database/src/seed/seed-appeal.js
+++ b/packages/database/src/seed/seed-appeal.js
@@ -95,7 +95,6 @@ module.exports.getAppealInState = ({
 		case APPEAL_CASE_STATUS.LPA_QUESTIONNAIRE:
 			appeal.lpaQuestionnaireDueDate = pickRandom(datesNMonthsAhead(1));
 			appeal.caseStartedDate = new Date();
-			appeal.lpaQuestionnaireDueDate = null;
 			break;
 		// Statements
 		case APPEAL_CASE_STATUS.STATEMENTS:


### PR DESCRIPTION
### Description of change

Overwritten lpaq date stops lpaq link from appearing on seeded data

### Checklist

- [x] Feature complete and ready for users, or behind feature-flag
- [x] Commit history is linear with no merge commits
- [ ] Requires infrastructure changes

### Important

Please do not merge from `main` (please only [rebase](https://github.com/Planning-Inspectorate/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
