### PR TITLE
feat(web): removing error message for non user (A2-1450)

### DIFF
--- a/packages/forms-web-app/__tests__/unit/controllers/common/enter-code.test.js
+++ b/packages/forms-web-app/__tests__/unit/controllers/common/enter-code.test.js
@@ -267,7 +267,7 @@ describe('controllers/common/enter-code', () => {
 			const returnedFunction = postEnterCode({ ENTER_CODE }, { isGeneralLogin: true });
 			await returnedFunction(req, res);
 
-			const errorMessage = 'Enter the correct code';
+			const errorMessage = 'Enter the code we sent to your email address';
 
 			expect(res.render).toHaveBeenCalledWith(`${ENTER_CODE}`, {
 				token: req.body['email-code'],

--- a/packages/forms-web-app/__tests__/unit/controllers/common/your-email-address.test.js
+++ b/packages/forms-web-app/__tests__/unit/controllers/common/your-email-address.test.js
@@ -3,9 +3,12 @@ const {
 	postYourEmailAddress
 } = require('../../../../src/controllers/common/your-email-address');
 
+const mapCache = require('../../../../src/lib/map-cache');
+
 const { mockReq, mockRes } = require('../../mocks');
 const views = require('#lib/views');
 const lpaViews = views.VIEW.LPA_DASHBOARD;
+const mockEmailUUIDcache = new mapCache(5);
 
 describe('controllers/full-appeal/submit-appeal/enter-code', () => {
 	let req;
@@ -51,10 +54,74 @@ describe('controllers/full-appeal/submit-appeal/enter-code', () => {
 			);
 
 			req.body['email-address'] = testEmail;
-			const returnedFunction = postYourEmailAddress(lpaViews);
+			const returnedFunction = postYourEmailAddress(lpaViews, mockEmailUUIDcache);
 			await returnedFunction(req, res);
 			expect(res.redirect).toHaveBeenCalledWith(`/${lpaViews.ENTER_CODE}/${testId}`);
 		});
+
+		it('redirect to enter code when a non LPA email which exists in the database is used', async () => {
+			const testId = '64c789bf8672ef00122fe30c';
+			const testEmail = 'iamnoone@planninginspectorate.gov.uk';
+			req.appealsApiClient.getUserByEmailV2.mockImplementation(() =>
+				Promise.resolve({
+					id: '64c789bf8672ef00122fe30c',
+					email: 'appellant1@planninginspectorate.gov.uk',
+					isLpaAdmin: false,
+					status: '',
+					lpaCode: ''
+				})
+			);
+
+			req.body['email-address'] = testEmail;
+			const returnedFunction = postYourEmailAddress(lpaViews, mockEmailUUIDcache);
+			await returnedFunction(req, res);
+			expect(res.redirect).toHaveBeenCalledWith(`/${lpaViews.ENTER_CODE}/${testId}`);
+		});
+
+		it('redirect to enter code when an email is used which is not in the database', async () => {
+			const testEmail = 'iamnoone@planninginspectorate.gov.uk';
+			req.appealsApiClient.getUserByEmailV2.mockImplementation(() =>
+				Promise.reject(new Error('No user found'))
+			);
+
+			req.body['email-address'] = testEmail;
+			const returnedFunction = postYourEmailAddress(lpaViews, mockEmailUUIDcache);
+			await returnedFunction(req, res);
+			// we want to check that we have a UUID in the redirect URL, but as it is generated at runtime, we use a regex to match it
+			const expectedURLRegex = new RegExp(
+				`${lpaViews.ENTER_CODE}/[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}`
+			);
+			expect(res.redirect).toHaveBeenCalledWith(expect.stringMatching(expectedURLRegex));
+		});
+
+		it('redirect to enter code when an email is used which is not in the database should be called with the same id within 5 minutes', async () => {
+			const testEmail = 'iamnoone@planninginspectorate.gov.uk';
+
+			jest.useFakeTimers().setSystemTime(new Date('2025-01-30T00:00:00.000Z'));
+
+			req.appealsApiClient.getUserByEmailV2.mockImplementation(() =>
+				Promise.reject(new Error('No user found'))
+			);
+
+			req.body['email-address'] = testEmail;
+
+			let laterReq = mockReq();
+			laterReq = { ...req };
+			let laterRes = mockRes();
+
+			const returnedFunction = postYourEmailAddress(lpaViews, mockEmailUUIDcache);
+			await returnedFunction(req, res);
+			const redirectURL = res.redirect.mock.calls[0][0];
+
+			// 5 minutes later, we expect to call the same redirect URL
+			jest.setSystemTime(new Date('2025-01-30T00:04:00.000Z'));
+			const laterReturnedFunction = postYourEmailAddress(lpaViews, mockEmailUUIDcache);
+			await laterReturnedFunction(laterReq, laterRes);
+			expect(laterRes.redirect).toHaveBeenCalledWith(redirectURL);
+
+			jest.useRealTimers();
+		});
+
 		it('should error with missing email address', async () => {
 			const customErrorSummary = [
 				{
@@ -62,7 +129,7 @@ describe('controllers/full-appeal/submit-appeal/enter-code', () => {
 					href: '#your-email-address'
 				}
 			];
-			const returnedFunction = postYourEmailAddress(lpaViews);
+			const returnedFunction = postYourEmailAddress(lpaViews, mockEmailUUIDcache);
 			await returnedFunction(req, res);
 			expect(res.render).toHaveBeenCalledWith(lpaViews.YOUR_EMAIL_ADDRESS, {
 				errors: {},

--- a/packages/forms-web-app/src/controllers/common/enter-code.js
+++ b/packages/forms-web-app/src/controllers/common/enter-code.js
@@ -182,7 +182,7 @@ const postEnterCode = (views, { isGeneralLogin = true }) => {
 		const tokenValid = await isTokenValid(token, sessionEmail, action);
 		if (tokenValid.tooManyAttempts) return res.redirect(`/${views.NEED_NEW_CODE}`);
 		if (tokenValid.expired) return res.redirect(`/${views.CODE_EXPIRED}`);
-		if (!tokenValid.valid) return renderError('Enter the correct code');
+		if (!tokenValid.valid) return renderError('Enter the code we sent to your email address');
 
 		// is valid so set user in session
 		createAppealUserSession(
@@ -303,7 +303,7 @@ const lpaTokenVerification = (res, token, views, id) => {
 		res.redirect(`/${views.CODE_EXPIRED}/${id}`);
 		return false;
 	} else if (!token.valid) {
-		const errorMessage = 'Enter the code';
+		const errorMessage = 'Enter the code we sent to your email address';
 
 		renderErrorPageLPA(res, views.ENTER_CODE, {
 			lpaUserId: id,

--- a/packages/forms-web-app/src/lib/map-cache.js
+++ b/packages/forms-web-app/src/lib/map-cache.js
@@ -1,0 +1,45 @@
+/**
+ * @typedef {Object} CacheEntry
+ * @property {Date} updated
+ * @property {*} value
+ */
+
+class MapCache {
+	/** @type {Map<string, CacheEntry>} */
+	cache = new Map();
+	/** @type {number} */
+	#ttl;
+
+	/**
+	 * @param {number} ttlMinutes
+	 */
+	constructor(ttlMinutes) {
+		this.#ttl = ttlMinutes * 60 * 1000; // to ms
+	}
+
+	/**
+	 * @param {string} id
+	 * @returns {undefined|*}
+	 */
+	get(id) {
+		const entry = this.cache.get(id);
+		if (!entry) {
+			return undefined;
+		}
+		if (new Date() - entry.updated > this.#ttl) {
+			this.cache.delete(id);
+			return undefined;
+		}
+		return entry.value;
+	}
+
+	/**
+	 * @param {string} id
+	 * @param {*} value
+	 */
+	set(id, value) {
+		this.cache.set(id, { updated: new Date(), value });
+	}
+}
+
+module.exports = MapCache;

--- a/packages/forms-web-app/src/lib/map-cache.test.js
+++ b/packages/forms-web-app/src/lib/map-cache.test.js
@@ -1,0 +1,55 @@
+const MapCache = require('./map-cache.js');
+
+const now = new Date('2025-01-30T00:00:00.000Z');
+
+describe('MapCache', () => {
+	beforeEach(() => {
+		jest.useFakeTimers().setSystemTime(now);
+	});
+
+	afterEach(() => {
+		jest.useRealTimers();
+	});
+
+	it('should add entries with the current date', () => {
+		const cache = new MapCache(5);
+
+		cache.set('id-1', true);
+
+		expect(cache.cache.get('id-1').updated).toEqual(now);
+	});
+
+	it(`should return values that aren't expired`, () => {
+		const cache = new MapCache(5);
+		cache.set('id-1', true);
+		cache.set('id-2', 'value 2');
+
+		expect(cache.get('id-1')).toBe(true);
+		expect(cache.get('id-2')).toBe('value 2');
+	});
+
+	it(`should return undefined if no entry`, () => {
+		const cache = new MapCache(5);
+
+		expect(cache.get('id-1')).toBe(undefined);
+	});
+
+	it(`should not return expired values`, () => {
+		const cache = new MapCache(5);
+		cache.set('id-1', true);
+		cache.set('id-2', 'value 2');
+
+		expect(cache.get('id-1')).toBe(true);
+		expect(cache.get('id-2')).toBe('value 2');
+
+		// 5 minutes later, still not expired
+		jest.setSystemTime(new Date('2025-01-30T00:05:00.000Z'));
+		expect(cache.get('id-1')).toBe(true);
+		expect(cache.get('id-2')).toBe('value 2');
+
+		// 10 minutes later, now expired
+		jest.setSystemTime(new Date('2025-01-30T00:10:00.000Z'));
+		expect(cache.get('id-1')).toBe(undefined);
+		expect(cache.get('id-2')).toBe(undefined);
+	});
+});

--- a/packages/forms-web-app/src/routes/lpa-dashboard/your-email-address.js
+++ b/packages/forms-web-app/src/routes/lpa-dashboard/your-email-address.js
@@ -1,6 +1,7 @@
 const express = require('express');
 
 const router = express.Router();
+const MapCache = require('../../lib/map-cache');
 
 const { rules: emailAddressValidationRules } = require('../../validators/common/email-address');
 const { validationErrorHandler } = require('../../validators/validation-error-handler');
@@ -16,6 +17,8 @@ const {
 	}
 } = require('../../lib/views');
 
+const emailUUIDcache = new MapCache(5);
+
 const views = { YOUR_EMAIL_ADDRESS, ENTER_CODE };
 
 router.get('/your-email-address', getYourEmailAddress(views));
@@ -23,7 +26,7 @@ router.post(
 	'/your-email-address',
 	emailAddressValidationRules('email-address'),
 	validationErrorHandler,
-	postYourEmailAddress(views)
+	postYourEmailAddress(views, emailUUIDcache)
 );
 
 module.exports = router;


### PR DESCRIPTION
### Description of change

Making it so that all emails entered for the LPA login redirect to the enter code page but only LPA emails get sent a code and are able to login, in order to obscure information about the database.

Emails not in the database are given a UUID which is cached for 5 minutes

Updated inconsistent error code message

Ticket: https://pins-ds.atlassian.net/browse/A2-1450

### Checklist

- [x] Feature complete and ready for users, or behind feature-flag
- [x] Commit history is linear with no merge commits
- [ ] Requires infrastructure changes

### Important

Please do not merge from `main` (please only [rebase](https://github.com/Planning-Inspectorate/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
