### PR TITLE
feat: updating document rows to match S78 for S20 (A2-3849)

### DIFF
--- a/packages/forms-web-app/src/controllers/selected-appeal/appeal-details/appeal-documents-rows.js
+++ b/packages/forms-web-app/src/controllers/selected-appeal/appeal-details/appeal-documents-rows.js
@@ -25,19 +25,25 @@ exports.documentsRows = (caseData) => {
 		{
 			keyText: 'Plans, drawings and supporting documents',
 			valueText: formatDocumentDetails(documents, APPEAL_DOCUMENT_TYPE.PLANS_DRAWINGS),
-			condition: () => caseData.appealTypeCode === CASE_TYPES.S78.processCode,
+			condition: () =>
+				caseData.appealTypeCode === CASE_TYPES.S78.processCode ||
+				caseData.appealTypeCode === CASE_TYPES.S20.processCode,
 			isEscaped: true
 		},
 		{
 			keyText: 'Separate ownership certificate in application',
 			valueText: formatDocumentDetails(documents, APPEAL_DOCUMENT_TYPE.OWNERSHIP_CERTIFICATE),
-			condition: () => caseData.appealTypeCode === CASE_TYPES.S78.processCode,
+			condition: () =>
+				caseData.appealTypeCode === CASE_TYPES.S78.processCode ||
+				caseData.appealTypeCode === CASE_TYPES.S20.processCode,
 			isEscaped: true
 		},
 		{
 			keyText: 'Design and access statement in application',
 			valueText: formatDocumentDetails(documents, APPEAL_DOCUMENT_TYPE.DESIGN_ACCESS_STATEMENT),
-			condition: () => caseData.appealTypeCode === CASE_TYPES.S78.processCode,
+			condition: () =>
+				caseData.appealTypeCode === CASE_TYPES.S78.processCode ||
+				caseData.appealTypeCode === CASE_TYPES.S20.processCode,
 			isEscaped: true
 		},
 		{
@@ -55,7 +61,9 @@ exports.documentsRows = (caseData) => {
 		{
 			keyText: 'New plans or drawings',
 			valueText: formatDocumentDetails(documents, APPEAL_DOCUMENT_TYPE.NEW_PLANS_DRAWINGS),
-			condition: () => caseData.appealTypeCode === CASE_TYPES.S78.processCode,
+			condition: () =>
+				caseData.appealTypeCode === CASE_TYPES.S78.processCode ||
+				caseData.appealTypeCode === CASE_TYPES.S20.processCode,
 			isEscaped: true
 		},
 		{
@@ -66,20 +74,25 @@ exports.documentsRows = (caseData) => {
 		{
 			keyText: 'Planning obligation',
 			valueText: formatDocumentDetails(documents, APPEAL_DOCUMENT_TYPE.PLANNING_OBLIGATION),
-			condition: () => caseData.appealTypeCode === CASE_TYPES.S78.processCode,
+			condition: () =>
+				caseData.appealTypeCode === CASE_TYPES.S78.processCode ||
+				caseData.appealTypeCode === CASE_TYPES.S20.processCode,
 			isEscaped: true
 		},
 		{
 			keyText: 'New supporting documents',
 			valueText: formatDocumentDetails(documents, APPEAL_DOCUMENT_TYPE.OTHER_NEW_DOCUMENTS),
-			condition: () => caseData.appealTypeCode === CASE_TYPES.S78.processCode,
+			condition: () =>
+				caseData.appealTypeCode === CASE_TYPES.S78.processCode ||
+				caseData.appealTypeCode === CASE_TYPES.S20.processCode,
 			isEscaped: true
 		},
 		{
 			keyText: 'Draft statement of common ground',
 			valueText: formatDocumentDetails(documents, APPEAL_DOCUMENT_TYPE.STATEMENT_COMMON_GROUND),
 			condition: () =>
-				caseData.appealTypeCode === CASE_TYPES.S78.processCode &&
+				(caseData.appealTypeCode === CASE_TYPES.S78.processCode ||
+					caseData.appealTypeCode === CASE_TYPES.S20.processCode) &&
 				caseData.appellantProcedurePreference !== APPEAL_APPELLANT_PROCEDURE_PREFERENCE.WRITTEN,
 			isEscaped: true
 		},

--- a/packages/forms-web-app/src/controllers/selected-appeal/appeal-details/appeal-documents-rows.test.js
+++ b/packages/forms-web-app/src/controllers/selected-appeal/appeal-details/appeal-documents-rows.test.js
@@ -30,40 +30,76 @@ describe('appeal-documents-rows', () => {
 		);
 	});
 
-	describe('Plans, drawings and supporting documents', () => {
-		const plansRow = 1;
-		it('should display field if S78', () => {
-			const rows = documentsRows({ appealTypeCode: CASE_TYPES.S78.processCode });
-			expect(rows[plansRow].keyText).toEqual('Plans, drawings and supporting documents');
-			expect(rows[plansRow].valueText).toEqual('No');
-			expect(rows[plansRow].condition()).toEqual(true);
-			expect(rows[plansRow].isEscaped).toEqual(true);
-		});
-		it('should not display field if not S78', () => {
-			const rows = documentsRows({ appealTypeCode: CASE_TYPES.HAS.processCode });
-			expect(rows[plansRow].keyText).toEqual('Plans, drawings and supporting documents');
-			expect(rows[plansRow].valueText).toEqual('No');
-			expect(rows[plansRow].condition()).toEqual(false);
-			expect(rows[plansRow].isEscaped).toEqual(true);
+	// displayed for all appeal types
+	describe.each([
+		['Application form', 0],
+		['Decision letter', 4],
+		['Appeal statement', 5]
+	])('%s', (rowName, rowNumber) => {
+		test.each([
+			['HAS', CASE_TYPES.HAS.processCode],
+			['S78', CASE_TYPES.S78.processCode],
+			['S20', CASE_TYPES.S20.processCode]
+		])('should display field for %s', (_, processCode) => {
+			const rows = documentsRows({ appealTypeCode: processCode });
+			expect(rows[rowNumber].keyText).toEqual(rowName);
+			expect(rows[rowNumber].valueText).toEqual('No');
+			expect(rows[rowNumber].condition()).toEqual(true);
+			expect(rows[rowNumber].isEscaped).toEqual(true);
 		});
 	});
 
+	// depends on the appeal type
+	describe.each([
+		['Plans, drawings and supporting documents', 1],
+		['Separate ownership certificate in application', 2],
+		['Design and access statement in application', 3],
+		['New plans or drawings', 6],
+		['Planning obligation', 8],
+		['New supporting documents', 9]
+	])('%s', (rowName, rowNumber) => {
+		it('should not display field if HAS', () => {
+			const rows = documentsRows({ appealTypeCode: CASE_TYPES.HAS.processCode });
+			expect(rows[rowNumber].keyText).toEqual(rowName);
+			expect(rows[rowNumber].valueText).toEqual('No');
+			expect(rows[rowNumber].condition()).toEqual(false);
+			expect(rows[rowNumber].isEscaped).toEqual(true);
+		});
+
+		test.each([
+			['S78', CASE_TYPES.S78.processCode],
+			['S20', CASE_TYPES.S20.processCode]
+		])('should display field if %s', (_, processCode) => {
+			const rows = documentsRows({ appealTypeCode: processCode });
+			expect(rows[rowNumber].keyText).toEqual(rowName);
+			expect(rows[rowNumber].valueText).toEqual('No');
+			expect(rows[rowNumber].condition()).toEqual(true);
+			expect(rows[rowNumber].isEscaped).toEqual(true);
+		});
+	});
+
+	// depends on the appeal type and whether it is written or not
 	describe('Draft statement of common ground', () => {
 		const draftRow = 10;
-		it('should display field if S78 and not written', () => {
-			const rows = documentsRows({ appealTypeCode: CASE_TYPES.S78.processCode });
+		test.each([
+			['S78', CASE_TYPES.S78.processCode],
+			['S20', CASE_TYPES.S20.processCode]
+		])('should display field if %s and not written', (_, processCode) => {
+			const rows = documentsRows({ appealTypeCode: processCode });
 			expect(rows[draftRow].keyText).toEqual('Draft statement of common ground');
 			expect(rows[draftRow].valueText).toEqual('No');
 			expect(rows[draftRow].condition()).toEqual(true);
 			expect(rows[draftRow].isEscaped).toEqual(true);
 		});
-		it('should not display field if not S78', () => {
+
+		it('should not display field if HAS', () => {
 			const rows = documentsRows({ appealTypeCode: CASE_TYPES.HAS.processCode });
 			expect(rows[draftRow].keyText).toEqual('Draft statement of common ground');
 			expect(rows[draftRow].valueText).toEqual('No');
 			expect(rows[draftRow].condition()).toEqual(false);
 			expect(rows[draftRow].isEscaped).toEqual(true);
 		});
+
 		it('should not display field if Written', () => {
 			const rows = documentsRows({
 				appealTypeCode: CASE_TYPES.S78.processCode,


### PR DESCRIPTION
### Description of change

Updating the conditions on the document row fields so those that show for S78 show for S20 too
Updating the tests to cover the rows which have been included in this change

Ticket: https://pins-ds.atlassian.net/browse/A2-3849

### Checklist

- [x] Feature complete and ready for users, or behind feature-flag
- [x] Commit history is linear with no merge commits
- [ ] Requires infrastructure changes

### Important

Please do not merge from `main` (please only [rebase](https://github.com/Planning-Inspectorate/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
