### PR TITLE
feat(forms-web-app): display S20 contstraints and designations fields

### DIFF
--- a/packages/forms-web-app/src/controllers/selected-appeal/questionnaire-details/constraints-details-rows.js
+++ b/packages/forms-web-app/src/controllers/selected-appeal/questionnaire-details/constraints-details-rows.js
@@ -20,6 +20,7 @@ exports.constraintsRows = (caseData) => {
 	const documents = caseData.Documents || [];
 
 	const isHASAppeal = caseData.appealTypeCode === CASE_TYPES.HAS.processCode;
+	const isS20Appeal = caseData.appealTypeCode === CASE_TYPES.S20.processCode;
 
 	const affectedListedBuildings = caseData.ListedBuildings?.filter(
 		(x) => x.type === LISTED_RELATION_TYPES.affected
@@ -62,6 +63,30 @@ exports.constraintsRows = (caseData) => {
 			keyText: 'Listed building details',
 			valueText: affectedListedBuildings?.map((x) => x.listedBuildingReference).join('\n') || '',
 			condition: () => showAffectedListed
+		},
+		{
+			keyText: 'Grant or loan made to preserve the listed building at the appeal site',
+			valueText: formatYesOrNo(caseData, 'section3aGrant'),
+			condition: () => isS20Appeal && isNotUndefinedOrNull(caseData.section3aGrant)
+		},
+		{
+			keyText: 'Consulted Historic England',
+			valueText: boolToYesNo(
+				documentExists(documents, APPEAL_DOCUMENT_TYPE.HISTORIC_ENGLAND_CONSULTATION)
+			),
+			condition: () =>
+				isS20Appeal && documentExists(documents, APPEAL_DOCUMENT_TYPE.HISTORIC_ENGLAND_CONSULTATION)
+		},
+		{
+			keyText: 'Uploaded Historic England consultation',
+			valueText: formatDocumentDetails(
+				documents,
+				APPEAL_DOCUMENT_TYPE.HISTORIC_ENGLAND_CONSULTATION
+			),
+			condition: () =>
+				isS20Appeal &&
+				documentExists(documents, APPEAL_DOCUMENT_TYPE.HISTORIC_ENGLAND_CONSULTATION),
+			isEscaped: true
 		},
 		{
 			keyText: 'Affects a scheduled monument',


### PR DESCRIPTION
### Description of change

Displays additional S20 constraints and designations fields in the LPA questionnaire details page

Ticket: https://pins-ds.atlassian.net/jira/software/c/projects/A2/boards/246?assignee=712020%3A04186e0f-84cf-4604-835a-10ec7cfafa90&selectedIssue=A2-3855&sprints=2719

### Checklist

- [ ] Feature complete and ready for users, or behind feature-flag
- [x] Commit history is linear with no merge commits
- [ ] Requires infrastructure changes

### Important

Please do not merge from `main` (please only [rebase](https://github.com/Planning-Inspectorate/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
