### PR TITLE
fix(waf): turn windows command injection rules to log due to false po…

### DIFF
--- a/infrastructure/front-door.tf
+++ b/infrastructure/front-door.tf
@@ -422,6 +422,20 @@ resource "azurerm_cdn_frontdoor_firewall_policy" "wfe" {
         enabled = true
         rule_id = "932150"
       }
+
+      rule {
+        # Remote Command Execution: Windows Command Injection
+        action  = "Log"
+        enabled = true
+        rule_id = "932110"
+      }
+
+      rule {
+        # Remote Command Execution: Windows Command Injection
+        action  = "Log"
+        enabled = true
+        rule_id = "932115"
+      }
     }
 
     override {


### PR DESCRIPTION
…sitives

### Description of change

Windows command injection rules triggered with false positives

### Checklist

- [x] Feature complete and ready for users, or behind feature-flag
- [x] Commit history is linear with no merge commits

### Important

Please do not merge from `main` (please only [rebase](https://github.com/Planning-Inspectorate/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
