### PR TITLE
Task/refactor inject save function

### DIFF
--- a/packages/forms-web-app/src/dynamic-forms/controller.js
+++ b/packages/forms-web-app/src/dynamic-forms/controller.js
@@ -13,7 +13,7 @@ const { APPEAL_ID } = require('@pins/business-rules/src/constants');
 const { LPA_USER_ROLE } = require('@pins/common/src/constants');
 const { caseTypeLookup } = require('@pins/common/src/database/data-static');
 const { getJourneyTypeById } = require('@pins/common/src/dynamic-forms/journey-types');
-
+const { getSaveFunction } = require('../journeys/get-journey-save');
 const { getDepartmentFromId } = require('../services/department.service');
 const { getLPAById, deleteAppeal } = require('../lib/appeals-api-wrapper');
 const { formatDateForDisplay } = require('@pins/common/src/lib/format-date');
@@ -263,8 +263,19 @@ exports.save = async (req, res) => {
 		return res.redirect(journey.taskListUrl);
 	}
 
+	const journeyType = getJourneyTypeById(journeyResponse.journeyId);
+	if (!journeyType) throw new Error(`Journey type: ${journeyResponse.journeyId} not found`);
+
 	try {
-		return await questionObj.saveAction(req, res, journey, sectionObj, journeyResponse);
+		const saveFunction = getSaveFunction(journeyType, req.appealsApiClient);
+		return await questionObj.saveAction(
+			req,
+			res,
+			saveFunction,
+			journey,
+			sectionObj,
+			journeyResponse
+		);
 	} catch (err) {
 		logger.error(err);
 

--- a/packages/forms-web-app/src/dynamic-forms/controller.test.js
+++ b/packages/forms-web-app/src/dynamic-forms/controller.test.js
@@ -14,6 +14,7 @@ const { SECTION_STATUS } = require('./section');
 const { storePdfQuestionnaireSubmission } = require('../services/pdf.service');
 const { getDepartmentFromId } = require('../services/department.service');
 const { deleteAppeal } = require('#lib/appeals-api-wrapper');
+const { getSaveFunction } = require('../journeys/get-journey-save');
 
 const { CASE_TYPES } = require('@pins/common/src/database/data-static');
 
@@ -205,6 +206,7 @@ jest.mock('../services/pdf.service');
 jest.mock('../services/department.service');
 jest.mock('#lib/appeals-api-wrapper');
 jest.mock('../services/user.service');
+jest.mock('../journeys/get-journey-save');
 
 describe('dynamic-form/controller', () => {
 	let req;
@@ -330,6 +332,14 @@ describe('dynamic-form/controller', () => {
 	});
 
 	describe('save', () => {
+		let mockSaveFn = jest.fn();
+		beforeEach(() => {
+			getSaveFunction.mockReturnValue(mockSaveFn);
+		});
+		afterEach(() => {
+			getSaveFunction.mockReset();
+		});
+
 		it('should use question saveAction', async () => {
 			const journeyId = 'has-questionnaire';
 			const sampleQuestionObjWithSaveAction = { ...sampleQuestionObj, saveAction: jest.fn() };
@@ -341,6 +351,7 @@ describe('dynamic-form/controller', () => {
 			};
 
 			res.locals.journeyResponse = {
+				journeyId,
 				answers: {}
 			};
 
@@ -353,11 +364,12 @@ describe('dynamic-form/controller', () => {
 			mockJourney.getQuestionBySectionAndName = jest.fn();
 			mockJourney.getQuestionBySectionAndName.mockReturnValueOnce(sampleQuestionObjWithSaveAction);
 
-			await save(req, res, journeyId);
+			await save(req, res);
 
 			expect(sampleQuestionObjWithSaveAction.saveAction).toHaveBeenCalledWith(
 				req,
 				res,
+				mockSaveFn,
 				mockJourney,
 				mockJourney.sections[0],
 				res.locals.journeyResponse
@@ -386,6 +398,7 @@ describe('dynamic-form/controller', () => {
 			};
 
 			res.locals.journeyResponse = {
+				journeyId,
 				answers: {}
 			};
 
@@ -398,11 +411,12 @@ describe('dynamic-form/controller', () => {
 			mockJourney.getQuestionBySectionAndName = jest.fn();
 			mockJourney.getQuestionBySectionAndName.mockReturnValueOnce(sampleQuestionObjWithActions);
 
-			await save(req, res, journeyId);
+			await save(req, res);
 
 			expect(sampleQuestionObjWithActions.saveAction).toHaveBeenCalledWith(
 				req,
 				res,
+				mockSaveFn,
 				mockJourney,
 				mockJourney.sections[0],
 				res.locals.journeyResponse

--- a/packages/forms-web-app/src/dynamic-forms/dynamic-components/list-add-more/question.js
+++ b/packages/forms-web-app/src/dynamic-forms/dynamic-components/list-add-more/question.js
@@ -282,12 +282,13 @@ class ListAddMoreQuestion extends Question {
 	 * Save an uploaded file
 	 * @param {import('express').Request} req
 	 * @param {import('express').Response} res
+	 * @param {function(string, Object): Promise<any>} saveFunction
 	 * @param {Journey} journey
 	 * @param {Section} section
 	 * @param {JourneyResponse} journeyResponse
 	 * @returns {Promise<void>}
 	 */
-	saveAction = async (req, res, journey, section, journeyResponse) => {
+	saveAction = async (req, res, saveFunction, journey, section, journeyResponse) => {
 		let isAddMorePage = true;
 		if (!req.body[this.fieldName]) {
 			if (
@@ -356,11 +357,7 @@ class ListAddMoreQuestion extends Question {
 			}
 		};
 
-		await this.saveResponseToDB(
-			req.appealsApiClient,
-			{ ...journey.response, [this.fieldName]: responseToSave.answers[this.fieldName] },
-			responseToSave
-		);
+		await saveFunction(journeyResponse.referenceId, responseToSave.answers);
 
 		// check for saving errors
 		const saveViewModel = this.subQuestion.checkForSavingErrors(req, section, journey);

--- a/packages/forms-web-app/src/dynamic-forms/dynamic-components/list-add-more/question.test.js
+++ b/packages/forms-web-app/src/dynamic-forms/dynamic-components/list-add-more/question.test.js
@@ -1,10 +1,9 @@
 const ListAddMoreQuestion = require('./question');
 const CaseAddMoreQuestion = require('../case-add-more/question');
-const { mockRes } = require('../../../../__tests__/unit/mocks');
-const { JOURNEY_TYPES } = require('@pins/common/src/dynamic-forms/journey-types');
 
-const res = mockRes();
-
+const res = {
+	render: jest.fn()
+};
 const TITLE = 'Question1';
 const QUESTION_STRING = 'What is your favourite colour?';
 const DESCRIPTION = 'A question about your favourite colour';
@@ -100,7 +99,7 @@ describe('./src/dynamic-forms/dynamic-components/question.js', () => {
 		it('should add addMoreAnswers data to model', () => {
 			const question = getTestQuestion();
 			const journey = {
-				journeyId: JOURNEY_TYPES.HAS_QUESTIONNAIRE.id,
+				journeyId: 'appeal',
 				response: {
 					answers: {
 						[question.fieldName]: [
@@ -184,7 +183,7 @@ describe('./src/dynamic-forms/dynamic-components/question.js', () => {
 			const journey = {};
 			const section = {};
 
-			await question.saveAction(req, res, journey, section, journey.response);
+			await question.saveAction(req, res, jest.fn(), journey, section, journey.response);
 
 			expect(res.render).toHaveBeenCalledWith(
 				`dynamic-components/${question.subQuestion.viewFolder}/index`,
@@ -203,14 +202,14 @@ describe('./src/dynamic-forms/dynamic-components/question.js', () => {
 			const expectedBackLink = 'back';
 			const req = { body: { 'add-more-question': 1, [question.fieldName]: 'yes' } };
 			const journey = {
-				journeyId: JOURNEY_TYPES.HAS_QUESTIONNAIRE.id,
+				journeyId: 'appeal',
 				response: { answers: {} },
 				getBackLink: jest.fn(() => expectedBackLink),
 				getCurrentQuestionUrl: jest.fn(() => expectedBackLink)
 			};
 			const section = {};
 
-			await question.saveAction(req, res, journey, section, journey.response);
+			await question.saveAction(req, res, jest.fn(), journey, section, journey.response);
 
 			expect(res.render).toHaveBeenCalledWith(
 				`dynamic-components/${question.subQuestion.viewFolder}/index`,
@@ -234,7 +233,7 @@ describe('./src/dynamic-forms/dynamic-components/question.js', () => {
 			const journey = { response: { answers: {} }, getNextQuestionUrl: jest.fn(() => expectedUrl) };
 			const section = {};
 
-			await question.saveAction(req, res, journey, section, journey.response);
+			await question.saveAction(req, res, jest.fn(), journey, section, journey.response);
 
 			expect(res.redirect).toHaveBeenCalledWith(expectedUrl);
 		});
@@ -255,7 +254,7 @@ describe('./src/dynamic-forms/dynamic-components/question.js', () => {
 			const journey = {};
 			const section = {};
 
-			await question.saveAction(req, res, journey, section, journey.response);
+			await question.saveAction(req, res, jest.fn(), journey, section, journey.response);
 
 			expect(res.render).toHaveBeenCalledWith(
 				`dynamic-components/${question.subQuestion.viewFolder}/index`,
@@ -287,7 +286,7 @@ describe('./src/dynamic-forms/dynamic-components/question.js', () => {
 			};
 			const section = {};
 
-			await question.saveAction(req, res, journey, section, journey.response);
+			await question.saveAction(req, res, jest.fn(), journey, section, journey.response);
 
 			expect(res.render).toHaveBeenCalledWith(
 				`dynamic-components/${question.subQuestion.viewFolder}/index`,
@@ -319,7 +318,7 @@ describe('./src/dynamic-forms/dynamic-components/question.js', () => {
 			}
 			const journey = new TestJourney();
 
-			await question.saveAction(req, res, journey, section, journey.response);
+			await question.saveAction(req, res, jest.fn(), journey, section, journey.response);
 
 			expect(res.redirect).toHaveBeenCalledWith(expectedUrl);
 		});

--- a/packages/forms-web-app/src/journeys/get-journey-save.js
+++ b/packages/forms-web-app/src/journeys/get-journey-save.js
@@ -1,0 +1,81 @@
+const {
+	APPEAL_USER_ROLES: { APPELLANT, RULE_6_PARTY },
+	LPA_USER_ROLE
+} = require('@pins/common/src/constants');
+const {
+	JOURNEY_TYPE: { appealForm, questionnaire, statement, finalComments, proofEvidence }
+} = require('@pins/common/src/dynamic-forms/journey-types');
+
+/**
+ * @param {import('@pins/common/src/dynamic-forms/journey-types').JourneyTypesDefinition} journeyType
+ * @param {import('@pins/common/src/client/appeals-api-client').AppealsApiClient} api
+ * @returns {function(string, object): Promise<any>}
+ */
+exports.getSaveFunction = (journeyType, api) => {
+	const key = `${journeyType.type}_${journeyType.userType}`;
+	const saveMethodMap = {
+		[`${questionnaire}_${LPA_USER_ROLE}`]: api.patchLPAQuestionnaire?.bind(api),
+		[`${appealForm}_${APPELLANT}`]: api.updateAppellantSubmission?.bind(api),
+		[`${statement}_${LPA_USER_ROLE}`]: api.patchLPAStatement?.bind(api),
+		[`${statement}_${RULE_6_PARTY}`]: api.patchRule6StatementSubmission?.bind(api),
+		[`${finalComments}_${APPELLANT}`]: api.patchAppellantFinalCommentSubmission?.bind(api),
+		[`${finalComments}_${LPA_USER_ROLE}`]: api.patchLPAFinalCommentSubmission?.bind(api),
+		[`${proofEvidence}_${APPELLANT}`]: api.patchAppellantProofOfEvidenceSubmission?.bind(api),
+		[`${proofEvidence}_${LPA_USER_ROLE}`]: api.patchLpaProofOfEvidenceSubmission?.bind(api),
+		[`${proofEvidence}_${RULE_6_PARTY}`]: api.patchRule6ProofOfEvidenceSubmission?.bind(api)
+	};
+
+	const save = saveMethodMap[key];
+	if (!save) throw new Error(`No save function found for journey type: ${key}`);
+	return save;
+};
+
+/**
+ * @param {import('@pins/common/src/dynamic-forms/journey-types').JourneyTypesDefinition} journeyType
+ * @param {import('@pins/common/src/client/appeals-api-client').AppealsApiClient} api
+ * @returns {function(string, Object): Promise<any>}
+ */
+exports.getUploadDoumentFunction = (journeyType, api) => {
+	const key = `${journeyType.type}_${journeyType.userType}`;
+
+	const saveMethodMap = {
+		[`${questionnaire}_${LPA_USER_ROLE}`]: api.postLPASubmissionDocumentUpload?.bind(api),
+		[`${appealForm}_${APPELLANT}`]: api.postAppellantSubmissionDocumentUpload?.bind(api),
+		[`${statement}_${LPA_USER_ROLE}`]: api.postLPAStatementDocumentUpload?.bind(api),
+		[`${statement}_${RULE_6_PARTY}`]: api.postRule6StatementDocumentUpload?.bind(api),
+		[`${finalComments}_${APPELLANT}`]: api.postAppellantFinalCommentDocumentUpload?.bind(api),
+		[`${finalComments}_${LPA_USER_ROLE}`]: api.postLPAFinalCommentDocumentUpload?.bind(api),
+		[`${proofEvidence}_${APPELLANT}`]: api.postAppellantProofOfEvidenceDocumentUpload?.bind(api),
+		[`${proofEvidence}_${LPA_USER_ROLE}`]: api.postLpaProofOfEvidenceDocumentUpload?.bind(api),
+		[`${proofEvidence}_${RULE_6_PARTY}`]: api.postRule6ProofOfEvidenceDocumentUpload?.bind(api)
+	};
+
+	const upload = saveMethodMap[key];
+	if (!upload) throw new Error(`No save function found for journey type: ${key}`);
+	return upload;
+};
+
+/**
+ * @param {import('@pins/common/src/dynamic-forms/journey-types').JourneyTypesDefinition} journeyType
+ * @param {import('@pins/common/src/client/appeals-api-client').AppealsApiClient} api
+ * @returns {function(string, string): Promise<any>}
+ */
+exports.getRemoveDocumentFunction = (journeyType, api) => {
+	const key = `${journeyType.type}_${journeyType.userType}`;
+
+	const saveMethodMap = {
+		[`${questionnaire}_${LPA_USER_ROLE}`]: api.deleteLPASubmissionDocumentUpload?.bind(api),
+		[`${appealForm}_${APPELLANT}`]: api.deleteAppellantSubmissionDocumentUpload?.bind(api),
+		[`${statement}_${LPA_USER_ROLE}`]: api.deleteLPAStatementDocumentUpload?.bind(api),
+		[`${statement}_${RULE_6_PARTY}`]: api.deleteRule6StatementDocumentUpload?.bind(api),
+		[`${finalComments}_${APPELLANT}`]: api.deleteAppellantFinalCommentDocumentUpload?.bind(api),
+		[`${finalComments}_${LPA_USER_ROLE}`]: api.deleteLPAFinalCommentDocumentUpload?.bind(api),
+		[`${proofEvidence}_${APPELLANT}`]: api.deleteAppellantProofOfEvidenceDocumentUpload?.bind(api),
+		[`${proofEvidence}_${LPA_USER_ROLE}`]: api.deleteLpaProofOfEvidenceDocumentUpload?.bind(api),
+		[`${proofEvidence}_${RULE_6_PARTY}`]: api.deleteRule6ProofOfEvidenceDocumentUpload?.bind(api)
+	};
+
+	const deleteFile = saveMethodMap[key];
+	if (!deleteFile) throw new Error(`No delete function found for journey type: ${key}`);
+	return deleteFile;
+};

--- a/packages/forms-web-app/src/journeys/get-journey-save.test.js
+++ b/packages/forms-web-app/src/journeys/get-journey-save.test.js
@@ -1,0 +1,328 @@
+const {
+	getSaveFunction,
+	getUploadDoumentFunction,
+	getRemoveDocumentFunction
+} = require('./get-journey-save');
+const { LPA_USER_ROLE, APPEAL_USER_ROLES } = require('@pins/common/src/constants');
+const { JOURNEY_TYPE } = require('@pins/common/src/dynamic-forms/journey-types');
+
+describe('getSaveFunction', () => {
+	const mockApiClient = {
+		patchLPAQuestionnaire: jest.fn(),
+		updateAppellantSubmission: jest.fn(),
+		patchLPAStatement: jest.fn(),
+		patchRule6StatementSubmission: jest.fn(),
+		patchAppellantFinalCommentSubmission: jest.fn(),
+		patchLPAFinalCommentSubmission: jest.fn(),
+		patchAppellantProofOfEvidenceSubmission: jest.fn(),
+		patchLpaProofOfEvidenceSubmission: jest.fn(),
+		patchRule6ProofOfEvidenceSubmission: jest.fn()
+	};
+
+	it('returns patchLPAQuestionnaire for questionnaire LPA', () => {
+		const journeyType = { type: JOURNEY_TYPE.questionnaire, userType: LPA_USER_ROLE };
+		const fn = getSaveFunction(journeyType, mockApiClient);
+		fn();
+		expect(mockApiClient.patchLPAQuestionnaire).toHaveBeenCalled();
+	});
+
+	it('returns updateAppellantSubmission for appealForm appellant', () => {
+		const journeyType = { type: JOURNEY_TYPE.appealForm, userType: APPEAL_USER_ROLES.APPELLANT };
+		const fn = getSaveFunction(journeyType, mockApiClient);
+		fn();
+		expect(mockApiClient.updateAppellantSubmission).toHaveBeenCalled();
+	});
+
+	it('returns patchLPAStatement for statement LPA', () => {
+		const journeyType = { type: JOURNEY_TYPE.statement, userType: LPA_USER_ROLE };
+		const fn = getSaveFunction(journeyType, mockApiClient);
+		fn();
+		expect(mockApiClient.patchLPAStatement).toHaveBeenCalled();
+	});
+
+	it('returns patchRule6StatementSubmission for statement rule6', () => {
+		const journeyType = { type: JOURNEY_TYPE.statement, userType: APPEAL_USER_ROLES.RULE_6_PARTY };
+		const fn = getSaveFunction(journeyType, mockApiClient);
+		fn();
+		expect(mockApiClient.patchRule6StatementSubmission).toHaveBeenCalled();
+	});
+
+	it('returns patchAppellantFinalCommentSubmission for finalComments appellant', () => {
+		const journeyType = { type: JOURNEY_TYPE.finalComments, userType: APPEAL_USER_ROLES.APPELLANT };
+		const fn = getSaveFunction(journeyType, mockApiClient);
+		fn();
+		expect(mockApiClient.patchAppellantFinalCommentSubmission).toHaveBeenCalled();
+	});
+
+	it('returns patchLPAFinalCommentSubmission for finalComments LPA', () => {
+		const journeyType = { type: JOURNEY_TYPE.finalComments, userType: LPA_USER_ROLE };
+		const fn = getSaveFunction(journeyType, mockApiClient);
+		fn();
+		expect(mockApiClient.patchLPAFinalCommentSubmission).toHaveBeenCalled();
+	});
+
+	it('returns patchAppellantProofOfEvidenceSubmission for proofEvidence appellant', () => {
+		const journeyType = { type: JOURNEY_TYPE.proofEvidence, userType: APPEAL_USER_ROLES.APPELLANT };
+		const fn = getSaveFunction(journeyType, mockApiClient);
+		fn();
+		expect(mockApiClient.patchAppellantProofOfEvidenceSubmission).toHaveBeenCalled();
+	});
+
+	it('returns patchLpaProofOfEvidenceSubmission for proofEvidence LPA', () => {
+		const journeyType = { type: JOURNEY_TYPE.proofEvidence, userType: LPA_USER_ROLE };
+		const fn = getSaveFunction(journeyType, mockApiClient);
+		fn();
+		expect(mockApiClient.patchLpaProofOfEvidenceSubmission).toHaveBeenCalled();
+	});
+
+	it('returns patchRule6ProofOfEvidenceSubmission for proofEvidence rule6', () => {
+		const journeyType = {
+			type: JOURNEY_TYPE.proofEvidence,
+			userType: APPEAL_USER_ROLES.RULE_6_PARTY
+		};
+		const fn = getSaveFunction(journeyType, mockApiClient);
+		fn();
+		expect(mockApiClient.patchRule6ProofOfEvidenceSubmission).toHaveBeenCalled();
+	});
+
+	it('throws if no save function found', () => {
+		const journeyType = { type: 'unknown', userType: 'unknown' };
+		expect(() => getSaveFunction(journeyType, mockApiClient)).toThrow(
+			'No save function found for journey type: unknown_unknown'
+		);
+	});
+});
+
+describe('getUploadDoumentFunction', () => {
+	const mockApiClient = {
+		postLPASubmissionDocumentUpload: jest.fn(),
+		postAppellantSubmissionDocumentUpload: jest.fn(),
+		postLPAStatementDocumentUpload: jest.fn(),
+		postRule6StatementDocumentUpload: jest.fn(),
+		postAppellantFinalCommentDocumentUpload: jest.fn(),
+		postLPAFinalCommentDocumentUpload: jest.fn(),
+		postAppellantProofOfEvidenceDocumentUpload: jest.fn(),
+		postLpaProofOfEvidenceDocumentUpload: jest.fn(),
+		postRule6ProofOfEvidenceDocumentUpload: jest.fn()
+	};
+	const baseJourney = { id: 'id', caseType: 'caseType' };
+
+	it('returns postLPASubmissionDocumentUpload for questionnaire LPA', () => {
+		const journeyType = {
+			...baseJourney,
+			type: JOURNEY_TYPE.questionnaire,
+			userType: LPA_USER_ROLE
+		};
+		const fn = getUploadDoumentFunction(journeyType, mockApiClient);
+		fn('fileId', {});
+		expect(mockApiClient.postLPASubmissionDocumentUpload).toHaveBeenCalled();
+	});
+
+	it('returns postAppellantSubmissionDocumentUpload for appealForm appellant', () => {
+		const journeyType = {
+			...baseJourney,
+			type: JOURNEY_TYPE.appealForm,
+			userType: APPEAL_USER_ROLES.APPELLANT
+		};
+		const fn = getUploadDoumentFunction(journeyType, mockApiClient);
+		fn('fileId', {});
+		expect(mockApiClient.postAppellantSubmissionDocumentUpload).toHaveBeenCalled();
+	});
+
+	it('returns postLPAStatementDocumentUpload for statement LPA', () => {
+		const journeyType = { ...baseJourney, type: JOURNEY_TYPE.statement, userType: LPA_USER_ROLE };
+		const fn = getUploadDoumentFunction(journeyType, mockApiClient);
+		fn('fileId', {});
+		expect(mockApiClient.postLPAStatementDocumentUpload).toHaveBeenCalled();
+	});
+
+	it('returns postRule6StatementDocumentUpload for statement rule6', () => {
+		const journeyType = {
+			...baseJourney,
+			type: JOURNEY_TYPE.statement,
+			userType: APPEAL_USER_ROLES.RULE_6_PARTY
+		};
+		const fn = getUploadDoumentFunction(journeyType, mockApiClient);
+		fn('fileId', {});
+		expect(mockApiClient.postRule6StatementDocumentUpload).toHaveBeenCalled();
+	});
+
+	it('returns postAppellantFinalCommentDocumentUpload for finalComments appellant', () => {
+		const journeyType = {
+			...baseJourney,
+			type: JOURNEY_TYPE.finalComments,
+			userType: APPEAL_USER_ROLES.APPELLANT
+		};
+		const fn = getUploadDoumentFunction(journeyType, mockApiClient);
+		fn('fileId', {});
+		expect(mockApiClient.postAppellantFinalCommentDocumentUpload).toHaveBeenCalled();
+	});
+
+	it('returns postLPAFinalCommentDocumentUpload for finalComments LPA', () => {
+		const journeyType = {
+			...baseJourney,
+			type: JOURNEY_TYPE.finalComments,
+			userType: LPA_USER_ROLE
+		};
+		const fn = getUploadDoumentFunction(journeyType, mockApiClient);
+		fn('fileId', {});
+		expect(mockApiClient.postLPAFinalCommentDocumentUpload).toHaveBeenCalled();
+	});
+
+	it('returns postAppellantProofOfEvidenceDocumentUpload for proofEvidence appellant', () => {
+		const journeyType = {
+			...baseJourney,
+			type: JOURNEY_TYPE.proofEvidence,
+			userType: APPEAL_USER_ROLES.APPELLANT
+		};
+		const fn = getUploadDoumentFunction(journeyType, mockApiClient);
+		fn('fileId', {});
+		expect(mockApiClient.postAppellantProofOfEvidenceDocumentUpload).toHaveBeenCalled();
+	});
+
+	it('returns postLpaProofOfEvidenceDocumentUpload for proofEvidence LPA', () => {
+		const journeyType = {
+			...baseJourney,
+			type: JOURNEY_TYPE.proofEvidence,
+			userType: LPA_USER_ROLE
+		};
+		const fn = getUploadDoumentFunction(journeyType, mockApiClient);
+		fn('fileId', {});
+		expect(mockApiClient.postLpaProofOfEvidenceDocumentUpload).toHaveBeenCalled();
+	});
+
+	it('returns postRule6ProofOfEvidenceDocumentUpload for proofEvidence rule6', () => {
+		const journeyType = {
+			...baseJourney,
+			type: JOURNEY_TYPE.proofEvidence,
+			userType: APPEAL_USER_ROLES.RULE_6_PARTY
+		};
+		const fn = getUploadDoumentFunction(journeyType, mockApiClient);
+		fn('fileId', {});
+		expect(mockApiClient.postRule6ProofOfEvidenceDocumentUpload).toHaveBeenCalled();
+	});
+
+	it('throws if no upload function found', () => {
+		const journeyType = { ...baseJourney, type: 'unknown', userType: LPA_USER_ROLE };
+		expect(() => getUploadDoumentFunction(journeyType, mockApiClient)).toThrow(
+			'No save function found for journey type: unknown_LPAUser'
+		);
+	});
+});
+
+describe('getRemoveDocumentFunction', () => {
+	const mockApiClient = {
+		deleteLPASubmissionDocumentUpload: jest.fn(),
+		deleteAppellantSubmissionDocumentUpload: jest.fn(),
+		deleteLPAStatementDocumentUpload: jest.fn(),
+		deleteRule6StatementDocumentUpload: jest.fn(),
+		deleteAppellantFinalCommentDocumentUpload: jest.fn(),
+		deleteLPAFinalCommentDocumentUpload: jest.fn(),
+		deleteAppellantProofOfEvidenceDocumentUpload: jest.fn(),
+		deleteLpaProofOfEvidenceDocumentUpload: jest.fn(),
+		deleteRule6ProofOfEvidenceDocumentUpload: jest.fn()
+	};
+	const baseJourney = { id: 'id', caseType: 'caseType' };
+
+	it('returns deleteLPASubmissionDocumentUpload for questionnaire LPA', () => {
+		const journeyType = {
+			...baseJourney,
+			type: JOURNEY_TYPE.questionnaire,
+			userType: LPA_USER_ROLE
+		};
+		const fn = getRemoveDocumentFunction(journeyType, mockApiClient);
+		fn('fileId', 'docId');
+		expect(mockApiClient.deleteLPASubmissionDocumentUpload).toHaveBeenCalled();
+	});
+
+	it('returns deleteAppellantSubmissionDocumentUpload for appealForm appellant', () => {
+		const journeyType = {
+			...baseJourney,
+			type: JOURNEY_TYPE.appealForm,
+			userType: APPEAL_USER_ROLES.APPELLANT
+		};
+		const fn = getRemoveDocumentFunction(journeyType, mockApiClient);
+		fn('fileId', 'docId');
+		expect(mockApiClient.deleteAppellantSubmissionDocumentUpload).toHaveBeenCalled();
+	});
+
+	it('returns deleteLPAStatementDocumentUpload for statement LPA', () => {
+		const journeyType = { ...baseJourney, type: JOURNEY_TYPE.statement, userType: LPA_USER_ROLE };
+		const fn = getRemoveDocumentFunction(journeyType, mockApiClient);
+		fn('fileId', 'docId');
+		expect(mockApiClient.deleteLPAStatementDocumentUpload).toHaveBeenCalled();
+	});
+
+	it('returns deleteRule6StatementDocumentUpload for statement rule6', () => {
+		const journeyType = {
+			...baseJourney,
+			type: JOURNEY_TYPE.statement,
+			userType: APPEAL_USER_ROLES.RULE_6_PARTY
+		};
+		const fn = getRemoveDocumentFunction(journeyType, mockApiClient);
+		fn('fileId', 'docId');
+		expect(mockApiClient.deleteRule6StatementDocumentUpload).toHaveBeenCalled();
+	});
+
+	it('returns deleteAppellantFinalCommentDocumentUpload for finalComments appellant', () => {
+		const journeyType = {
+			...baseJourney,
+			type: JOURNEY_TYPE.finalComments,
+			userType: APPEAL_USER_ROLES.APPELLANT
+		};
+		const fn = getRemoveDocumentFunction(journeyType, mockApiClient);
+		fn('fileId', 'docId');
+		expect(mockApiClient.deleteAppellantFinalCommentDocumentUpload).toHaveBeenCalled();
+	});
+
+	it('returns deleteLPAFinalCommentDocumentUpload for finalComments LPA', () => {
+		const journeyType = {
+			...baseJourney,
+			type: JOURNEY_TYPE.finalComments,
+			userType: LPA_USER_ROLE
+		};
+		const fn = getRemoveDocumentFunction(journeyType, mockApiClient);
+		fn('fileId', 'docId');
+		expect(mockApiClient.deleteLPAFinalCommentDocumentUpload).toHaveBeenCalled();
+	});
+
+	it('returns deleteAppellantProofOfEvidenceDocumentUpload for proofEvidence appellant', () => {
+		const journeyType = {
+			...baseJourney,
+			type: JOURNEY_TYPE.proofEvidence,
+			userType: APPEAL_USER_ROLES.APPELLANT
+		};
+		const fn = getRemoveDocumentFunction(journeyType, mockApiClient);
+		fn('fileId', 'docId');
+		expect(mockApiClient.deleteAppellantProofOfEvidenceDocumentUpload).toHaveBeenCalled();
+	});
+
+	it('returns deleteLpaProofOfEvidenceDocumentUpload for proofEvidence LPA', () => {
+		const journeyType = {
+			...baseJourney,
+			type: JOURNEY_TYPE.proofEvidence,
+			userType: LPA_USER_ROLE
+		};
+		const fn = getRemoveDocumentFunction(journeyType, mockApiClient);
+		fn('fileId', 'docId');
+		expect(mockApiClient.deleteLpaProofOfEvidenceDocumentUpload).toHaveBeenCalled();
+	});
+
+	it('returns deleteRule6ProofOfEvidenceDocumentUpload for proofEvidence rule6', () => {
+		const journeyType = {
+			...baseJourney,
+			type: JOURNEY_TYPE.proofEvidence,
+			userType: APPEAL_USER_ROLES.RULE_6_PARTY
+		};
+		const fn = getRemoveDocumentFunction(journeyType, mockApiClient);
+		fn('fileId', 'docId');
+		expect(mockApiClient.deleteRule6ProofOfEvidenceDocumentUpload).toHaveBeenCalled();
+	});
+
+	it('throws if no delete function found', () => {
+		const journeyType = { ...baseJourney, type: 'unknown', userType: LPA_USER_ROLE };
+		expect(() => getRemoveDocumentFunction(journeyType, mockApiClient)).toThrow(
+			'No delete function found for journey type: unknown_LPAUser'
+		);
+	});
+});

--- a/packages/forms-web-app/src/journeys/question-overrides/multi-file-upload.test.js
+++ b/packages/forms-web-app/src/journeys/question-overrides/multi-file-upload.test.js
@@ -1,0 +1,221 @@
+const { getDataToSave, saveFilesToBlobStorage, saveAction } = require('./multi-file-upload');
+
+const {
+	isObjectWithUploadedFiles,
+	removeFilesV2,
+	getValidFiles,
+	generateDocumentSubmissionId
+} = require('#lib/multi-file-upload-helpers');
+const { createDocument } = require('#lib/documents-api-wrapper');
+const { conjoinedPromises } = require('@pins/common/src/utils');
+const { mapMultiFileDocumentToSavedDocument } = require('../../mappers/document-mapper');
+const { getUploadDoumentFunction, getRemoveDocumentFunction } = require('../get-journey-save');
+
+jest.mock('#lib/documents-api-wrapper');
+jest.mock('#lib/multi-file-upload-helpers');
+jest.mock('@pins/common/src/utils');
+jest.mock('../../mappers/document-mapper');
+jest.mock('@pins/common/src/dynamic-forms/journey-types', () => ({
+	JOURNEY_TYPE: {
+		questionnaire: 'questionnaire',
+		appealForm: 'appealForm',
+		statement: 'statement',
+		finalComments: 'finalComments',
+		proofEvidence: 'proofEvidence'
+	},
+	getJourneyTypeById: jest.fn().mockReturnValue({ type: 'appealForm', userType: 'APPELLANT' })
+}));
+jest.mock('../get-journey-save');
+
+describe('multi-file-upload', () => {
+	let req, journeyResponse, questionInstance;
+
+	beforeEach(() => {
+		jest.clearAllMocks();
+		conjoinedPromises.mockResolvedValue([]);
+		req = { body: {}, files: {}, appealsApiClient: {} };
+		journeyResponse = {
+			referenceId: 'ref-1',
+			journeyId: 'appealForm',
+			answers: { SubmissionDocumentUpload: [] }
+		};
+		questionInstance = {
+			fieldName: 'SubmissionDocumentUpload',
+			documentType: { name: 'test-doc' },
+			getRelevantUploadedFiles: jest.fn().mockReturnValue([]),
+			checkForSavingErrors: jest.fn(),
+			renderAction: jest.fn(),
+			handleNextQuestion: jest.fn()
+		};
+		getUploadDoumentFunction.mockReturnValue(jest.fn());
+		getRemoveDocumentFunction.mockReturnValue(jest.fn());
+	});
+
+	describe('getDataToSave', () => {
+		it('returns empty uploadedFiles if no files and no removals', async () => {
+			isObjectWithUploadedFiles.mockReturnValue(false);
+			conjoinedPromises.mockResolvedValue([]);
+			const result = await getDataToSave.call(questionInstance, req, journeyResponse);
+			expect(result.uploadedFiles).toEqual([]);
+			expect(result.answers).toEqual({});
+		});
+
+		it('removes files and adds errors if removal fails', async () => {
+			req.body.removedFiles = '';
+			req.body.errorSummary = [];
+			req.body.errors = {};
+			req.body.removedFiles = JSON.stringify([{ name: 'fail.pdf' }]);
+			journeyResponse.answers.SubmissionDocumentUpload = [
+				{ originalFileName: 'fail.pdf', storageId: 'id1' }
+			];
+			questionInstance.getRelevantUploadedFiles = jest
+				.fn()
+				.mockReturnValue([{ originalFileName: 'fail.pdf', storageId: 'id1' }]);
+			removeFilesV2.mockResolvedValue([{ originalFileName: 'fail.pdf', storageId: 'id1' }]);
+			isObjectWithUploadedFiles.mockReturnValue(false);
+			conjoinedPromises.mockResolvedValue([]);
+
+			const result = await getDataToSave.call(questionInstance, req, journeyResponse);
+
+			expect(result.uploadedFiles).toEqual([]);
+			expect(req.body.errors).toBeDefined();
+			expect(req.body.errorSummary).toBeDefined();
+			expect(req.body.errors.id1).toBeDefined();
+			expect(req.body.errorSummary[0].text).toMatch(/Failed to remove file/);
+		});
+
+		it('adds uploaded files to journeyResponse', async () => {
+			req.files = {
+				SubmissionDocumentUpload: [{ name: 'file1.pdf' }]
+			};
+			getValidFiles.mockReturnValue([{ name: 'file1.pdf' }]);
+			isObjectWithUploadedFiles.mockReturnValue(false);
+			mapMultiFileDocumentToSavedDocument.mockReturnValue({
+				name: 'file1.pdf',
+				originalFileName: 'file1.pdf'
+			});
+
+			// Simulate blob upload
+			conjoinedPromises.mockResolvedValue([
+				[{ name: 'file1.pdf' }, { name: 'file1.pdf', originalFileName: 'file1.pdf' }]
+			]);
+
+			const result = await getDataToSave.call(questionInstance, req, journeyResponse);
+
+			expect(result.uploadedFiles).toEqual([{ name: 'file1.pdf', originalFileName: 'file1.pdf' }]);
+		});
+
+		it('merges uploadedFiles with existing uploadedFiles', async () => {
+			journeyResponse.answers.SubmissionDocumentUpload = {
+				uploadedFiles: [{ name: 'existing.pdf', originalFileName: 'existing.pdf' }]
+			};
+			req.files = {
+				SubmissionDocumentUpload: [{ name: 'file2.pdf' }]
+			};
+			getValidFiles.mockReturnValue([{ name: 'file2.pdf' }]);
+			isObjectWithUploadedFiles.mockReturnValue(true);
+			mapMultiFileDocumentToSavedDocument.mockReturnValue({
+				name: 'file2.pdf',
+				originalFileName: 'file2.pdf'
+			});
+
+			conjoinedPromises.mockResolvedValue([
+				[{ name: 'file2.pdf' }, { name: 'file2.pdf', originalFileName: 'file2.pdf' }]
+			]);
+
+			const result = await getDataToSave.call(questionInstance, req, journeyResponse);
+
+			expect(result.uploadedFiles).toEqual([
+				{ name: 'existing.pdf', originalFileName: 'existing.pdf' },
+				{ name: 'file2.pdf', originalFileName: 'file2.pdf' }
+			]);
+		});
+	});
+
+	describe('saveFilesToBlobStorage', () => {
+		it('calls createDocument and maps result', async () => {
+			const files = [{ name: 'file1.pdf' }];
+			const doc = { name: 'doc1', originalFileName: 'file1.pdf' };
+			createDocument.mockResolvedValue(doc);
+			conjoinedPromises.mockResolvedValue([[files[0], doc]]);
+			mapMultiFileDocumentToSavedDocument.mockReturnValue(doc);
+			generateDocumentSubmissionId.mockReturnValue('sub-id');
+
+			const result = await saveFilesToBlobStorage.call(questionInstance, files, journeyResponse);
+			expect(result).toEqual([doc]);
+			expect(conjoinedPromises).toHaveBeenCalled();
+			expect(mapMultiFileDocumentToSavedDocument).toHaveBeenCalledWith(
+				doc,
+				doc.name,
+				files[0].name
+			);
+		});
+	});
+
+	describe('saveAction', () => {
+		it('calls save and handleNextQuestion', async () => {
+			const previouslyUploadedFiles = [];
+			const updatedUploadedFiles = [{ name: 'file1.pdf', originalFileName: 'file1.pdf' }];
+			const mockSaveFn = jest.fn();
+			questionInstance.getRelevantUploadedFiles = jest
+				.fn()
+				.mockReturnValueOnce(previouslyUploadedFiles)
+				.mockReturnValueOnce(updatedUploadedFiles);
+
+			questionInstance.checkForSavingErrors = jest.fn().mockReturnValue(null);
+			questionInstance.handleNextQuestion = jest.fn();
+
+			journeyResponse.answers.SubmissionDocumentUpload = {
+				uploadedFiles: [{ name: 'existing.pdf', originalFileName: 'existing.pdf' }]
+			};
+
+			await saveAction.call(
+				questionInstance,
+				req,
+				{},
+				mockSaveFn,
+				{ segment: 'seg', response: {} },
+				{},
+				journeyResponse
+			);
+
+			expect(mockSaveFn).toHaveBeenCalled();
+			expect(questionInstance.handleNextQuestion).toHaveBeenCalled();
+		});
+
+		it('renders action if checkForSavingErrors returns a view model', async () => {
+			const previouslyUploadedFiles = [];
+			const updatedUploadedFiles = [{ name: 'file1.pdf', originalFileName: 'file1.pdf' }];
+			const mockSaveFn = jest.fn();
+			questionInstance.getRelevantUploadedFiles = jest
+				.fn()
+				.mockReturnValueOnce(previouslyUploadedFiles)
+				.mockReturnValueOnce(updatedUploadedFiles);
+
+			const viewModel = { error: 'err' };
+			questionInstance.checkForSavingErrors = jest.fn().mockReturnValue(viewModel);
+			questionInstance.handleNextQuestion = jest.fn();
+
+			journeyResponse.answers.SubmissionDocumentUpload = {
+				uploadedFiles: [{ name: 'existing.pdf', originalFileName: 'existing.pdf' }]
+			};
+			const res = {
+				render: jest.fn()
+			};
+
+			await saveAction.call(
+				questionInstance,
+				req,
+				res,
+				mockSaveFn,
+				{ segment: 'seg', response: {} },
+				{},
+				journeyResponse
+			);
+
+			expect(mockSaveFn).toHaveBeenCalled();
+			expect(questionInstance.renderAction).toHaveBeenCalledWith(res, viewModel);
+			expect(questionInstance.handleNextQuestion).not.toHaveBeenCalled();
+		});
+	});
+});

--- a/packages/forms-web-app/src/journeys/question-overrides/site-address.js
+++ b/packages/forms-web-app/src/journeys/question-overrides/site-address.js
@@ -12,12 +12,13 @@
  * @this {SiteAddressQuestion}
  * @param {import('express').Request} req
  * @param {import('express').Response} res
+ * @param {function(string, Object): Promise<any>} saveFunction
  * @param {Journey} journey
  * @param {Section} section
  * @param {JourneyResponse} journeyResponse
  * @returns {Promise<void>}
  */
-async function saveAction(req, res, journey, section, journeyResponse) {
+async function saveAction(req, res, saveFunction, journey, section, journeyResponse) {
 	// check for validation errors
 	const errorViewModel = this.checkForValidationErrors(req, section, journey);
 	if (errorViewModel) {
@@ -54,7 +55,7 @@ async function saveAction(req, res, journey, section, journeyResponse) {
 	);
 
 	if (siteAddressSet) {
-		await req.appealsApiClient.updateAppellantSubmission(journeyResponse.referenceId, {
+		await saveFunction(journeyResponse.referenceId, {
 			siteAddress: siteAddressSet
 		});
 		journeyResponse.answers.siteAddress = siteAddressSet;

--- a/packages/forms-web-app/src/journeys/question-overrides/site-address.test.js
+++ b/packages/forms-web-app/src/journeys/question-overrides/site-address.test.js
@@ -15,8 +15,7 @@ describe('site-address-overrides', () => {
 	);
 
 	const mockApi = {
-		postSubmissionAddress: jest.fn().mockResolvedValue({}),
-		updateAppellantSubmission: jest.fn().mockResolvedValue(null)
+		postSubmissionAddress: jest.fn().mockResolvedValue({})
 	};
 
 	const journeyResponse = {
@@ -39,10 +38,12 @@ describe('site-address-overrides', () => {
 
 	describe('saveAction', () => {
 		it('should successfully save the address and call the next question', async () => {
+			const mockSaveAction = jest.fn();
+
 			question.checkForValidationErrors = jest.fn().mockReturnValue(null);
 			question.handleNextQuestion = jest.fn();
 
-			await question.saveAction(req, {}, {}, {}, journeyResponse);
+			await question.saveAction(req, {}, mockSaveAction, {}, {}, journeyResponse);
 
 			expect(mockApi.postSubmissionAddress).toHaveBeenCalledWith(
 				journeyResponse.journeyId,
@@ -56,7 +57,7 @@ describe('site-address-overrides', () => {
 					fieldName: FIELDNAME
 				}
 			);
-			expect(mockApi.updateAppellantSubmission).toHaveBeenCalled();
+			expect(mockSaveAction).toHaveBeenCalled();
 			expect(question.handleNextQuestion).toHaveBeenCalled();
 		});
 	});


### PR DESCRIPTION
### Description of change

Refactoring dynamic forms
- inject save function
- remove some appeals specific code from dynamic forms code in preparation for moving to external package
- remove unused functions: isShortJourney and getDashboardUrl

### Checklist

- [x] Feature complete and ready for users, or behind feature-flag
- [x] Commit history is linear with no merge commits
- [ ] Requires infrastructure changes

### Important

Please do not merge from `main` (please only [rebase](https://github.com/Planning-Inspectorate/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
