### PR TITLE
feat(forms-web-app): cas planning lpaq

### DIFF
--- a/packages/forms-web-app/src/dynamic-forms/cas-planning-questionnaire/journey.js
+++ b/packages/forms-web-app/src/dynamic-forms/cas-planning-questionnaire/journey.js
@@ -6,6 +6,7 @@ const { QUESTION_VARIABLES } = require('@pins/common/src/dynamic-forms/question-
 const {
 	CASE_TYPES: { CAS_PLANNING }
 } = require('@pins/common/src/database/data-static');
+const { questionHasAnswer } = require('../dynamic-components/utils/question-has-answer');
 
 /**
  * @typedef {import('../journey-response').JourneyResponse} JourneyResponse
@@ -20,6 +21,77 @@ const sections = [
 	new Section('Constraints, designations and other issues', 'constraints')
 		.addQuestion(questions.appealTypeAppropriate)
 		.withVariables({ [QUESTION_VARIABLES.APPEAL_TYPE]: CAS_PLANNING.type.toLowerCase() })
+		.addQuestion(questions.listedBuildingCheck)
+		.addQuestion(questions.affectedListedBuildings)
+		.withCondition(
+			(response) =>
+				response.answers && response.answers[questions.listedBuildingCheck.fieldName] == 'yes'
+		)
+		.addQuestion(questions.conservationArea)
+		.addQuestion(questions.conservationAreaUpload)
+		.withCondition(
+			(response) =>
+				response.answers && response.answers[questions.conservationArea.fieldName] == 'yes'
+		)
+		.addQuestion(questions.greenBelt),
+	new Section('Notifying relevant parties', 'notified')
+		.addQuestion(questions.whoWasNotified)
+		.addQuestion(questions.howYouNotifiedPeople)
+		.addQuestion(questions.uploadSiteNotice)
+		.withCondition((response) =>
+			questionHasAnswer(response, questions.howYouNotifiedPeople, 'site-notice')
+		)
+		.addQuestion(questions.uploadNeighbourLetterAddresses)
+		.withCondition((response) =>
+			questionHasAnswer(response, questions.howYouNotifiedPeople, 'letters-or-emails')
+		)
+		.addQuestion(questions.pressAdvertUpload)
+		.withCondition((response) =>
+			questionHasAnswer(response, questions.howYouNotifiedPeople, 'advert')
+		)
+		.addQuestion(questions.appealNotification),
+	new Section('Consultation responses and representations', 'consultation')
+		.addQuestion(questions.statutoryConsultees)
+		.addQuestion(questions.consultationResponses)
+		.addQuestion(questions.consultationResponsesUpload)
+		.withCondition((response) =>
+			questionHasAnswer(response, questions.consultationResponses, 'yes')
+		)
+		.addQuestion(questions.representationsFromOthers)
+		.addQuestion(questions.representationUpload)
+		.withCondition(
+			(response) =>
+				response.answers && response.answers[questions.representationsFromOthers.fieldName] == 'yes'
+		),
+	new Section("Planning officer's report and supporting documents", 'planning-officer-report')
+		.addQuestion(questions.planningOfficersReportUpload)
+		.addQuestion(questions.developmentPlanPolicies)
+		.addQuestion(questions.uploadDevelopmentPlanPolicies)
+		.withCondition((response) =>
+			questionHasAnswer(response, questions.developmentPlanPolicies, 'yes')
+		)
+		.addQuestion(questions.supplementaryPlanning)
+		.addQuestion(questions.supplementaryPlanningUpload)
+		.withCondition((response) =>
+			questionHasAnswer(response, questions.supplementaryPlanning, 'yes')
+		),
+	new Section('Site access', 'site-access')
+		.addQuestion(questions.accessForInspection)
+		.addQuestion(questions.neighbouringSite)
+		.addQuestion(questions.neighbouringSitesToBeVisited)
+		.withCondition(
+			(response) =>
+				response.answers && response.answers[questions.neighbouringSite.fieldName] == 'yes'
+		)
+		.addQuestion(questions.potentialSafetyRisks),
+	new Section('Appeal process', 'appeal-process')
+		.addQuestion(questions.appealsNearSite)
+		.addQuestion(questions.nearbyAppeals)
+		.withCondition(
+			(response) =>
+				response.answers && response.answers[questions.appealsNearSite.fieldName] == 'yes'
+		)
+		.addQuestion(questions.addNewConditions)
 ];
 
 const baseCASPlanningUrl = '/manage-appeals/questionnaire';

--- a/packages/forms-web-app/src/dynamic-forms/docs/cas-planning-lpaq-journey.md
+++ b/packages/forms-web-app/src/dynamic-forms/docs/cas-planning-lpaq-journey.md
@@ -3,3 +3,105 @@
 ## Constraints, designations and other issues
 
 - boolean `/correct-appeal-type/` Is a <appeal type> appeal the correct type of appeal?
+- boolean `/affect-listed-building/` Does the proposed development affect the setting of listed buildings?
+- list-add-more `/affected-listed-buildings/` Add another building or site?
+
+```js
+condition: (response) =>
+	response.answers && response.answers[questions.listedBuildingCheck.fieldName] == 'yes';
+```
+
+- boolean `/conservation-area/` Is the site in, or next to a conservation area?
+- multi-file-upload `/upload-conservation-area-map-guidance/` Upload conservation map and guidance
+
+```js
+condition: (response) =>
+	response.answers && response.answers[questions.conservationArea.fieldName] == 'yes';
+```
+
+- boolean `/green-belt/` Is the site in a green belt?
+
+## Notifying relevant parties
+
+- multi-file-upload `/upload-who-you-notified/` Who did you notify about this application?
+- checkbox `/notification-type/` How did you notify relevant parties about the planning application?
+- multi-file-upload `/upload-site-notice/` Upload the site notice
+
+```js
+condition: (response) => questionHasAnswer(response, questions.howYouNotifiedPeople, 'site-notice');
+```
+
+- multi-file-upload `/letters-interested-parties/` Upload letters or emails sent to interested parties with their addresses
+
+```js
+condition: (response) =>
+	questionHasAnswer(response, questions.howYouNotifiedPeople, 'letters-or-emails');
+```
+
+- multi-file-upload `/upload-press-advert/` Upload the press advertisement
+
+```js
+condition: (response) => questionHasAnswer(response, questions.howYouNotifiedPeople, 'advert');
+```
+
+- multi-file-upload `/appeal-notification-letter/` Upload the appeal notification letter and the list of people that you notified
+
+## Consultation responses and representations
+
+- radio `/statutory-consultees/` Did you consult all the relevant statutory consultees about the development?
+- boolean `/consultation-responses/` Do you have any consultation responses or standing advice from statutory consultees to upload?
+- multi-file-upload `/upload-consultation-responses/` Upload the consultation responses and standing advice
+
+```js
+condition: (response) => questionHasAnswer(response, questions.consultationResponses, 'yes');
+```
+
+- boolean `/representations/` Did you receive representations from members of the public or other parties?
+- multi-file-upload `/upload-representations/` Upload the representations
+
+```js
+condition: (response) =>
+	response.answers && response.answers[questions.representationsFromOthers.fieldName] == 'yes';
+```
+
+## Planning officer's report and supporting documents
+
+- multi-file-upload `/upload-planning-officers-report-decision-notice/` Upload the planning officer’s report or what your decision notice would have said
+- boolean `/other-development-plan-policies/` Do you have any relevant policies from your statutory development plan?
+- multi-file-upload `/upload-development-plan-policies/` Upload relevant policies from your statutory development plan
+
+```js
+condition: (response) => questionHasAnswer(response, questions.developmentPlanPolicies, 'yes');
+```
+
+- boolean `/supplementary-planning-documents/` Did any supplementary planning documents inform the outcome of the planning application?
+- multi-file-upload `/upload-policies-supplementary-planning-documents/` Upload relevant policy extracts and supplementary planning documents
+
+```js
+condition: (response) => questionHasAnswer(response, questions.supplementaryPlanning, 'yes');
+```
+
+## Site access
+
+- radio `/inspector-access-appeal-site/` Might the inspector need access to the appellant’s land or property?
+- radio `/inspector-enter-neighbour-site/` Might the inspector need to enter a neighbour’s land or property?
+- list-add-more `/neighbour-address/` Do you want to add another neighbour to be visited?
+
+```js
+condition: (response) =>
+	response.answers && response.answers[questions.neighbouringSite.fieldName] == 'yes';
+```
+
+- radio `/potential-safety-risks/` Add potential safety risks
+
+## Appeal process
+
+- boolean `/ongoing-appeals/` Are there any other ongoing appeals next to, or close to the site?
+- list-add-more `/appeal-reference-number/` Add another appeal?
+
+```js
+condition: (response) =>
+	response.answers && response.answers[questions.appealsNearSite.fieldName] == 'yes';
+```
+
+- radio `/add-new-planning-conditions/` Add new planning conditions to this appeal

--- a/packages/forms-web-app/src/journeys/index.js
+++ b/packages/forms-web-app/src/journeys/index.js
@@ -15,6 +15,7 @@ const s78Rule6StatementParams = require('../dynamic-forms/s78-rule-6-statement/j
 const s20AppealParams = require('../dynamic-forms/s20-appeal-form/journey');
 const s20QuestionnaireParams = require('../dynamic-forms/s20-lpa-questionnaire/journey');
 const casPlanningAppealForm = require('../dynamic-forms/cas-planning-appeal-form/journey');
+const casPlanningQuestionnaireParams = require('../dynamic-forms/cas-planning-questionnaire/journey');
 const advertsAppealForm = require('../dynamic-forms/adverts-appeal-form/journey');
 
 const { Journeys } = require('../dynamic-forms/journeys');
@@ -35,6 +36,7 @@ journeys.registerJourney(s78Rule6StatementParams);
 journeys.registerJourney(s20AppealParams);
 journeys.registerJourney(s20QuestionnaireParams);
 journeys.registerJourney(casPlanningAppealForm);
+journeys.registerJourney(casPlanningQuestionnaireParams);
 journeys.registerJourney(advertsAppealForm);
 
 module.exports = { journeys };


### PR DESCRIPTION
### Description of change

Creates the lpaq for cas planning - no new fields just reuses has and s78 questions

Ticket: https://pins-ds.atlassian.net/browse/A2-3426

### Checklist

- [x] Feature complete and ready for users, or behind feature-flag
- [x] Commit history is linear with no merge commits
- [ ] Requires infrastructure changes

### Important

Please do not merge from `main` (please only [rebase](https://github.com/Planning-Inspectorate/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
