### PR TITLE
feat(appeals-service-api): cas planning lpaq integrations a2-3461

### DIFF
--- a/packages/appeals-service-api/src/routes/v2/appeal-cases/_caseReference/lpa-questionnaire-submission/submit/controller.js
+++ b/packages/appeals-service-api/src/routes/v2/appeal-cases/_caseReference/lpa-questionnaire-submission/submit/controller.js
@@ -12,6 +12,10 @@ const {
 const {
 	formatter: s20Formatter
 } = require('../../../../../../services/back-office-v2/formatters/s20/questionnaire');
+const {
+	formatter: casPlanningFormatter
+} = require('../../../../../../services/back-office-v2/formatters/cas-planning/questionnaire');
+
 const { getLPAQuestionnaireByAppealId } = require('../service');
 
 const backOfficeV2Service = new BackOfficeV2Service();
@@ -32,6 +36,8 @@ const getFormatter = (appealTypeCode) => {
 			return s78Formatter;
 		case CASE_TYPES.S20.processCode:
 			return s20Formatter;
+		case CASE_TYPES.CAS_PLANNING.processCode:
+			return casPlanningFormatter;
 		default:
 			throw new Error('unknown formatter');
 	}

--- a/packages/appeals-service-api/src/routes/v2/appeal-cases/service.js
+++ b/packages/appeals-service-api/src/routes/v2/appeal-cases/service.js
@@ -258,6 +258,17 @@ const mapHASDataModelToAppealCase = (
  * @param {AppealS78Case} dataModel
  * @returns {Omit<AppealCaseCreateInput, 'Appeal'>}
  */
+const mapCASPlanningDataModelToAppealCase = (caseProcessCode, dataModel) => ({
+	...mapHASDataModelToAppealCase(caseProcessCode, dataModel),
+	statutoryConsultees: dataModel.hasStatutoryConsultees, // todo: rename
+	consultedBodiesDetails: dataModel.consultedBodiesDetails
+});
+
+/**
+ * @param {String} caseProcessCode
+ * @param {AppealS78Case} dataModel
+ * @returns {Omit<AppealCaseCreateInput, 'Appeal'>}
+ */
 const mapS78DataModelToAppealCase = (caseProcessCode, dataModel) => ({
 	...mapHASDataModelToAppealCase(caseProcessCode, dataModel),
 	agriculturalHolding: dataModel.agriculturalHolding,
@@ -384,6 +395,11 @@ const getMappedData = (data) => {
 			const hasValidator = getValidator('appeal-has');
 			if (!hasValidator(data)) throw ApiError.badRequest('Payload was invalid');
 			return mapHASDataModelToAppealCase(CASE_TYPES.HAS.processCode, data);
+		}
+		case CASE_TYPES.CAS_PLANNING.key: {
+			const hasValidator = getValidator('appeal-has');
+			if (!hasValidator(data)) throw ApiError.badRequest('Payload was invalid');
+			return mapCASPlanningDataModelToAppealCase(CASE_TYPES.S20.processCode, data);
 		}
 		case CASE_TYPES.S78.key: {
 			const s78Validator = getValidator('appeal-s78');

--- a/packages/appeals-service-api/src/services/back-office-v2/formatters/cas-planning/questionnaire.js
+++ b/packages/appeals-service-api/src/services/back-office-v2/formatters/cas-planning/questionnaire.js
@@ -1,0 +1,32 @@
+/**
+ * @typedef {import('../../../../routes/v2/appeal-cases/_caseReference/lpa-questionnaire-submission/questionnaire-submission').LPAQuestionnaireSubmission} LPAQuestionnaireSubmission
+ * @typedef {import ('@planning-inspectorate/data-model').Schemas.LPAQuestionnaireCommand} LPAQuestionnaireCommand
+ */
+
+const {
+	getDocuments,
+	getCommonLPAQSubmissionFields,
+	getCASLPAQSubmissionFields
+} = require('../utils');
+const { documentTypes } = require('@pins/common/src/document-types');
+const { CASE_TYPES } = require('@pins/common/src/database/data-static');
+const CAS_PLANNING = CASE_TYPES.CAS_PLANNING.key;
+
+/**
+ * @param {string} caseReference
+ * @param {LPAQuestionnaireSubmission} questionnaireResponse
+ * @returns {Promise<LPAQuestionnaireCommand>}
+ */
+exports.formatter = async (caseReference, { ...answers }) => {
+	return {
+		casedata: {
+			// Root
+			caseType: CAS_PLANNING,
+			// Common
+			...getCommonLPAQSubmissionFields(caseReference, answers),
+			//CAS
+			...getCASLPAQSubmissionFields(answers)
+		},
+		documents: await getDocuments(answers, documentTypes.planningOfficersReportUpload.dataModelName)
+	};
+};

--- a/packages/appeals-service-api/src/services/back-office-v2/formatters/cas-planning/questionnaire.test.js
+++ b/packages/appeals-service-api/src/services/back-office-v2/formatters/cas-planning/questionnaire.test.js
@@ -1,0 +1,118 @@
+const { formatter } = require(`./questionnaire`);
+const { CASE_TYPES } = require('@pins/common/src/database/data-static');
+const CAS_PLANNING = CASE_TYPES.CAS_PLANNING.key;
+
+jest.mock('../../../../services/object-store');
+
+// Mock getDocuments
+jest.mock('../utils', () => {
+	const originalModule = jest.requireActual('../utils');
+	return {
+		...originalModule,
+		getDocuments: jest.fn(() => [1])
+	};
+});
+
+describe('formatter', () => {
+	const caseReference = '12345';
+	const answers = {
+		correctAppealType: true,
+		SubmissionListedBuilding: [{ reference: 'LB123', fieldName: 'affectedListedBuildingNumber' }],
+		conservationArea: true,
+		greenBelt: false,
+		notificationMethod: 'site-notice,letters-or-emails,advert',
+		lpaSiteAccess_lpaSiteAccessDetails: 'Access details',
+		lpaSiteSafetyRisks_lpaSiteSafetyRiskDetails: 'Safety details',
+		SubmissionAddress: [
+			{
+				fieldName: 'neighbourSiteAddress',
+				addressLine1: 'Line 1',
+				addressLine2: 'Line 2',
+				townCity: 'Town',
+				county: 'County',
+				postcode: 'Postcode'
+			}
+		],
+		neighbourSiteAccess_neighbourSiteAccessDetails: 'check the impact',
+		SubmissionLinkedCase: [{ caseReference: 'CASE123' }],
+		newConditions_newConditionDetails: 'New condition details',
+		statutoryConsultees: true,
+		statutoryConsultees_consultedBodiesDetails: 'body 1, body 2',
+		consultationResponses: true
+	};
+
+	beforeEach(() => {
+		jest.clearAllMocks();
+	});
+
+	it('should format the data correctly', async () => {
+		const result = await formatter(caseReference, answers);
+
+		expect(result).toEqual({
+			casedata: {
+				caseType: CAS_PLANNING,
+				caseReference: '12345',
+				lpaQuestionnaireSubmittedDate: expect.any(String),
+				isCorrectAppealType: true,
+				affectedListedBuildingNumbers: ['LB123'],
+				inConservationArea: true,
+				isGreenBelt: false,
+				notificationMethod: ['notice', 'letter', 'advert'],
+				siteAccessDetails: ['Access details'],
+				siteSafetyDetails: ['Safety details'],
+				neighbouringSiteAddresses: [
+					{
+						neighbouringSiteAddressLine1: 'Line 1',
+						neighbouringSiteAddressLine2: 'Line 2',
+						neighbouringSiteAddressTown: 'Town',
+						neighbouringSiteAddressCounty: 'County',
+						neighbouringSiteAddressPostcode: 'Postcode',
+						neighbouringSiteAccessDetails: null,
+						neighbouringSiteSafetyDetails: null
+					}
+				],
+				reasonForNeighbourVisits: 'check the impact',
+				nearbyCaseReferences: ['CASE123'],
+				newConditionDetails: 'New condition details',
+				lpaStatement: '',
+				lpaCostsAppliedFor: null,
+				consultedBodiesDetails: 'body 1, body 2',
+				hasConsultationResponses: true,
+				hasStatutoryConsultees: false
+			},
+			documents: [1]
+		});
+	});
+
+	it('should handle missing optional fields', async () => {
+		const minimalAnswers = {
+			correctAppealType: true
+		};
+		const result = await formatter(caseReference, minimalAnswers);
+
+		expect(result).toEqual({
+			casedata: {
+				caseType: CAS_PLANNING,
+				caseReference: '12345',
+				lpaQuestionnaireSubmittedDate: expect.any(String),
+				isCorrectAppealType: true,
+				affectedListedBuildingNumbers: [],
+				inConservationArea: undefined,
+				isGreenBelt: undefined,
+				notificationMethod: null,
+				siteAccessDetails: null,
+				siteSafetyDetails: null,
+				neighbouringSiteAddresses: undefined,
+				reasonForNeighbourVisits: null,
+				nearbyCaseReferences: undefined,
+				newConditionDetails: null,
+				lpaStatement: '',
+				lpaCostsAppliedFor: null,
+				consultedBodiesDetails: null,
+				hasConsultationResponses: undefined,
+				hasStatutoryConsultees: false
+			},
+			documents: [1]
+		});
+	});
+});

--- a/packages/appeals-service-api/src/services/back-office-v2/formatters/utils.js
+++ b/packages/appeals-service-api/src/services/back-office-v2/formatters/utils.js
@@ -523,6 +523,30 @@ exports.getHASLPAQSubmissionFields = (answers) => {
  * @param {LPAQAnswers} answers
  * @returns {LPAQS78SubmissionProperties}
  */
+exports.getCASLPAQSubmissionFields = (answers) => {
+	return {
+		isCorrectAppealType: answers.correctAppealType,
+		affectedListedBuildingNumbers: getListedBuildingByType(
+			answers.SubmissionListedBuilding,
+			fieldNames.affectedListedBuildingNumber
+		),
+		inConservationArea: answers.conservationArea,
+		isGreenBelt: answers.greenBelt,
+		notificationMethod: exports.howYouNotifiedPeople(answers),
+		newConditionDetails: answers.newConditions_newConditionDetails ?? null,
+		lpaStatement: '', // not asked
+		lpaCostsAppliedFor: null, // not asked
+		// Consultation responses and representations
+		hasStatutoryConsultees: exports.toBool(answers.statutoryConsultees),
+		consultedBodiesDetails: answers.statutoryConsultees_consultedBodiesDetails || null,
+		hasConsultationResponses: answers.consultationResponses
+	};
+};
+
+/**
+ * @param {LPAQAnswers} answers
+ * @returns {LPAQS78SubmissionProperties}
+ */
 exports.getS78LPAQSubmissionFields = (answers) => {
 	const levy = getInfrastructureLevy(answers);
 	const preference = getLPAProcedurePreference(answers);


### PR DESCRIPTION
### Description of change

Adds integration mapping for cas planning lpaq 

Ticket: https://pins-ds.atlassian.net/browse/A2-3461

### Checklist

- [x] Feature complete and ready for users, or behind feature-flag
- [x] Commit history is linear with no merge commits
- [ ] Requires infrastructure changes

### Important

Please do not merge from `main` (please only [rebase](https://github.com/Planning-Inspectorate/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
