### PR TITLE
feat(forms-web-app): updates to appeal decision section on dashboards

### DIFF
--- a/packages/common/src/frontend/pins/components/appeal-decision-block.njk
+++ b/packages/common/src/frontend/pins/components/appeal-decision-block.njk
@@ -1,0 +1,16 @@
+{% from "govuk/components/tag/macro.njk" import govukTag %}
+
+{% macro appealDecisionBlock(caseDecisionOutcome, formattedDecisionColour, formattedCaseDecisionDate, decisionDocuments) %}
+    <div class="govuk-inset-text">
+        <h2 class="govuk-heading-2">Appeal decision</h2>
+        {{ govukTag({
+            text: caseDecisionOutcome,
+            classes: "govuk-tag--" + formattedDecisionColour + " govuk-!-margin-bottom-3"
+        }) }}
+        <p class="govuk-body">Decision issued on {{formattedCaseDecisionDate}}</p>
+        {% for document in decisionDocuments %}
+            <p class="govuk-body"><a href="/published-document/{{document.id}}" class="govuk-link">{{document.filename}}</a></p>
+        {% endfor %}
+        <hr class="govuk-section-break govuk-section-break--m">
+    </div>
+{% endmacro %}

--- a/packages/forms-web-app/src/controllers/selected-appeal/index.js
+++ b/packages/forms-web-app/src/controllers/selected-appeal/index.js
@@ -33,6 +33,7 @@ const targetTimezone = 'Europe/London';
 const { getDepartmentFromCode } = require('../../services/department.service');
 const logger = require('#lib/logger');
 const config = require('../../config');
+const { formatDateForDisplay } = require('@pins/common/src/lib/format-date');
 
 /** @type {import('@pins/common/src/view-model-maps/sections/def').UserSectionsDict} */
 const userSectionsDict = {
@@ -116,6 +117,7 @@ exports.get = (layoutTemplate = 'layouts/no-banner-link/main.njk') => {
 				sections: formatSections({ caseData, sections }),
 				baseUrl: userRouteUrl,
 				decision: mapDecisionTag(caseData.caseDecisionOutcome),
+				decisionDate: formatDateForDisplay(caseData.caseDecisionOutcomeDate),
 				decisionDocuments: filterDecisionDocuments(caseData.Documents),
 				lpaQuestionnaireDueDate: formatDateForNotification(caseData.lpaQuestionnaireDueDate),
 				statementDueDate: formatDateForNotification(caseData.statementDueDate),

--- a/packages/forms-web-app/src/routes/file-based-router/comment-planning-appeal/appeals/_appealNumber/index.njk
+++ b/packages/forms-web-app/src/routes/file-based-router/comment-planning-appeal/appeals/_appealNumber/index.njk
@@ -2,9 +2,8 @@
 
 {% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
 {% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
-{% from "govuk/components/tag/macro.njk" import govukTag %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
-{% from "pins/components/appeal-sections-block.njk" import appealSectionsBlock %}
+{% from "pins/components/appeal-decision-block.njk" import appealDecisionBlock %}
 
 {% set title=appeal.headlineText + " - Comment on a planning appeal - GOV.UK" %}
 
@@ -25,16 +24,12 @@
       <h1 class="govuk-heading-l">{{appeal.headlineText}}</h1>
 
 	  {% if appeal.status === 'decided' %}
-		<h2 class="govuk-heading-2">Appeal decision</h2>
-		{{ govukTag({
-			text: appeal.decidedData.caseDecisionOutcome,
-			classes: "govuk-tag--" + appeal.decidedData.formattedDecisionColour + " govuk-!-margin-bottom-3"
-		}) }}
-		<p class="govuk-body">Decision date: {{appeal.decidedData.formattedCaseDecisionDate}}</p>
-		{% for document in appeal.decidedData.decisionDocuments %}
-			<p class="govuk-body"><a href="/published-document/{{document.id}}" class="govuk-link">{{document.filename}}</a></p>
-		{% endfor %}
-		<hr class="govuk-section-break govuk-section-break--visible govuk-section-break--m">
+	  	{{ appealDecisionBlock(
+			appeal.decidedData.caseDecisionOutcome,
+			appeal.decidedData.formattedDecisionColour,
+			appeal.decidedData.formattedCaseDecisionDate,
+			appeal.decidedData.decisionDocument
+		) }}
 	  {% endif %}
 
       {{ govukSummaryList({

--- a/packages/forms-web-app/src/views/selected-appeal/appeal.njk
+++ b/packages/forms-web-app/src/views/selected-appeal/appeal.njk
@@ -2,9 +2,9 @@
 
 {% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
 {% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
-{% from "govuk/components/tag/macro.njk" import govukTag %}
 {% from "govuk/components/notification-banner/macro.njk" import govukNotificationBanner %}
 {% from "pins/components/appeal-sections-block.njk" import appealSectionsBlock %}
+{% from "pins/components/appeal-decision-block.njk" import appealDecisionBlock %}
 
 {% set title="Appeal " + appeal.appealNumber + " - " + titleSuffix + " - GOV.UK" %}
 
@@ -201,15 +201,7 @@
 
 		<div class="govuk-grid-column-two-thirds">
 			{% if appeal.decision %}
-				<h2 class="govuk-heading-2">Appeal decision</h2>
-				{{ govukTag({
-					text: appeal.decision.label,
-					classes: "govuk-tag--" + appeal.decision.color + " govuk-!-margin-bottom-3"
-				}) }}
-				{% for document in appeal.decisionDocuments %}
-				  <p class="govuk-body"><a href="/published-document/{{document.id}}" class="govuk-link">{{document.filename}}</a></p>
-				{% endfor %}
-				<hr class="govuk-section-break govuk-section-break--visible govuk-section-break--m">
+			    {{ appealDecisionBlock(appeal.decision.label, appeal.decision.color, appeal.decisionDate, appeal.decisionDocuments) }}
 			{% endif %}
 
 			{{ govukSummaryList({


### PR DESCRIPTION
### Description of change

Adding text insert formatting and decision date to Appeal Decision section on dashboards

Ticket: https://pins-ds.atlassian.net/browse/A2-3694

### Checklist

- [x] Feature complete and ready for users, or behind feature-flag
- [x] Commit history is linear with no merge commits
- [ ] Requires infrastructure changes

### Important

Please do not merge from `main` (please only [rebase](https://github.com/Planning-Inspectorate/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
