### PR TITLE
feat: display cost decision docs

### DIFF
--- a/packages/common/src/document-types.js
+++ b/packages/common/src/document-types.js
@@ -17,7 +17,7 @@ const { APPEAL_DOCUMENT_TYPE } = require('@planning-inspectorate/data-model');
 /**
  * @typedef {Object} DocType
  * @property {string} name internal name for the doc type
- * @property {string} [dataModelName] the value used in the @planning-inspectorate/data-model
+ * @property {string} [dataModelName] the value used in the \@planning-inspectorate/data-model
  * @property {boolean} multiple if this is a multi-file or single-file upload
  * @property {string} [displayName] a user friendly name for the doc type, has been defined on all docs
  * @property {'LPA'|'Appellant'|''} involvement currently unsure what this is used for?
@@ -800,12 +800,34 @@ const documentTypes = {
 		publiclyAccessible: false,
 		horizonDocumentType: '', // Does not exist in horizon
 		horizonDocumentGroupType: '' // Does not exist in horizon
+	},
+	appellantCostsDecisionLetter: {
+		name: 'appellantCostsDecisionLetter',
+		dataModelName: APPEAL_DOCUMENT_TYPE.APPELLANT_COSTS_DECISION_LETTER,
+		multiple: false,
+		displayName: '',
+		involvement: '',
+		owner: (_appealTypeCode) => pinsOwner,
+		publiclyAccessible: false,
+		horizonDocumentType: '', // Does not exist in horizon
+		horizonDocumentGroupType: '' // Does not exist in horizon
+	},
+	lpaCostsDecisionLetter: {
+		name: 'lpaCostsDecisionLetter',
+		dataModelName: APPEAL_DOCUMENT_TYPE.LPA_COSTS_DECISION_LETTER,
+		multiple: false,
+		displayName: '',
+		involvement: '',
+		owner: (_appealTypeCode) => pinsOwner,
+		publiclyAccessible: false,
+		horizonDocumentType: '', // Does not exist in horizon
+		horizonDocumentGroupType: '' // Does not exist in horizon
 	}
 };
 
 /**
  * @param {any} value value to lookup
- * @param {string} lookupProp property to check
+ * @param {keyof DocType} lookupProp property to check
  * @returns {DocType|null} result based on the returnProp
  */
 const getDocType = (value, lookupProp) => {

--- a/packages/common/src/frontend/pins/components/appeal-decision-block.njk
+++ b/packages/common/src/frontend/pins/components/appeal-decision-block.njk
@@ -7,10 +7,16 @@
             text: caseDecisionOutcome,
             classes: "govuk-tag--" + formattedDecisionColour + " govuk-!-margin-bottom-3"
         }) }}
-        <p class="govuk-body">Decision issued on {{formattedCaseDecisionDate}}</p>
-        {% for document in decisionDocuments %}
-            <p class="govuk-body"><a href="/published-document/{{document.id}}" class="govuk-link">{{document.filename}}</a></p>
-        {% endfor %}
+        <p class="govuk-body">Decision issued on {{formattedCaseDecisionDate}}.</p>
+        {% if decisionDocuments | length === 1 %}
+            <p class="govuk-body"><a href="/published-document/{{decisionDocuments[0].id}}" class="govuk-link">{{decisionDocuments[0].filename}}</a></p>
+        {% else %}
+            <ul class="govuk-list govuk-list--bullet">
+            {% for document in decisionDocuments %}
+                <li><a href="/published-document/{{document.id}}" class="govuk-link">{{document.filename}}</a></li>
+            {% endfor %}
+            </ul>
+        {% endif %}
         <hr class="govuk-section-break govuk-section-break--m">
     </div>
 {% endmacro %}

--- a/packages/common/src/view-model-maps/sections/def.d.ts
+++ b/packages/common/src/view-model-maps/sections/def.d.ts
@@ -20,4 +20,4 @@ export type Sections = Array<Section>;
 
 export type UserType = AppealToUserRoles | LpaUserRole;
 
-export type UserSectionsDict = { [userType: UserType]: Sections };
+export type UserSectionsDict = { [Key in UserType]: Sections };

--- a/packages/forms-web-app/src/controllers/selected-appeal/index.js
+++ b/packages/forms-web-app/src/controllers/selected-appeal/index.js
@@ -35,7 +35,7 @@ const logger = require('#lib/logger');
 const config = require('../../config');
 const { formatDateForDisplay } = require('@pins/common/src/lib/format-date');
 
-/** @type {import('@pins/common/src/view-model-maps/sections/def').UserSectionsDict} */
+/** @type {Partial<import('@pins/common/src/view-model-maps/sections/def').UserSectionsDict>} */
 const userSectionsDict = {
 	[APPEAL_USER_ROLES.APPELLANT]: appellantSections,
 	[LPA_USER_ROLE]: lpaUserSections,
@@ -118,7 +118,7 @@ exports.get = (layoutTemplate = 'layouts/no-banner-link/main.njk') => {
 				baseUrl: userRouteUrl,
 				decision: mapDecisionTag(caseData.caseDecisionOutcome),
 				decisionDate: formatDateForDisplay(caseData.caseDecisionOutcomeDate),
-				decisionDocuments: filterDecisionDocuments(caseData.Documents),
+				decisionDocuments: filterDecisionDocuments(caseData.Documents ?? []),
 				lpaQuestionnaireDueDate: formatDateForNotification(caseData.lpaQuestionnaireDueDate),
 				statementDueDate: formatDateForNotification(caseData.statementDueDate),
 				rule6StatementDueDate: formatDateForNotification(caseData.statementDueDate),
@@ -149,9 +149,16 @@ const formatTitleSuffix = (userType) => {
  * @return {import('appeals-service-api').Api.Document[]}
  */
 const filterDecisionDocuments = (documents) =>
-	documents.filter(
-		(document) => document.documentType === APPEAL_DOCUMENT_TYPE.CASE_DECISION_LETTER
-	);
+	documents.filter((document) => {
+		if (
+			document.documentType === APPEAL_DOCUMENT_TYPE.CASE_DECISION_LETTER ||
+			document.documentType === APPEAL_DOCUMENT_TYPE.LPA_COSTS_DECISION_LETTER ||
+			document.documentType === APPEAL_DOCUMENT_TYPE.APPELLANT_COSTS_DECISION_LETTER
+		) {
+			return true;
+		}
+		return false;
+	});
 
 /**
  *


### PR DESCRIPTION
### Description of change

Displaying appellant and LPA cost decision letters as part of appeals decision

Ticket: https://pins-ds.atlassian.net/browse/A2-3528

### Checklist

- [X] Feature complete and ready for users, or behind feature-flag
- [X] Commit history is linear with no merge commits
- [ ] Requires infrastructure changes

### Important

Please do not merge from `main` (please only [rebase](https://github.com/Planning-Inspectorate/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
