### PR TITLE
Fix/a2 4029 decision date month format

### DIFF
--- a/packages/common/src/lib/format-date.js
+++ b/packages/common/src/lib/format-date.js
@@ -7,7 +7,7 @@ const ukTimeZone = 'Europe/London';
  * Display the date in Europe/London
  * @param {Date|string} [date]
  * @param {Object} [options]
- * @param {string} [options.format] date formatting string
+ * @param {string} [options.format] date formatting string, defaults to shortened month
  * @returns {string} formatted date string or empty string if invalid value passed in
  */
 const formatDateForDisplay = (date, { format = 'd MMM yyyy' } = { format: 'd MMM yyyy' }) => {

--- a/packages/common/src/lib/format-date.js
+++ b/packages/common/src/lib/format-date.js
@@ -7,7 +7,7 @@ const ukTimeZone = 'Europe/London';
  * Display the date in Europe/London
  * @param {Date|string} [date]
  * @param {Object} [options]
- * @param {string} [options.format] date formatting string, defaults to shortened month
+ * @param {string} [options.format] date formatting string
  * @returns {string} formatted date string or empty string if invalid value passed in
  */
 const formatDateForDisplay = (date, { format = 'd MMM yyyy' } = { format: 'd MMM yyyy' }) => {

--- a/packages/forms-web-app/src/controllers/selected-appeal/index.js
+++ b/packages/forms-web-app/src/controllers/selected-appeal/index.js
@@ -117,7 +117,9 @@ exports.get = (layoutTemplate = 'layouts/no-banner-link/main.njk') => {
 				sections: formatSections({ caseData, sections }),
 				baseUrl: userRouteUrl,
 				decision: mapDecisionTag(caseData.caseDecisionOutcome),
-				decisionDate: formatDateForDisplay(caseData.caseDecisionOutcomeDate),
+				decisionDate: formatDateForDisplay(caseData.caseDecisionOutcomeDate, {
+					format: 'd MMMM yyyy'
+				}),
 				decisionDocuments: filterDecisionDocuments(caseData.Documents ?? []),
 				lpaQuestionnaireDueDate: formatDateForNotification(caseData.lpaQuestionnaireDueDate),
 				statementDueDate: formatDateForNotification(caseData.statementDueDate),

--- a/packages/forms-web-app/src/routes/file-based-router/comment-planning-appeal/decided-appeals/controller.js
+++ b/packages/forms-web-app/src/routes/file-based-router/comment-planning-appeal/decided-appeals/controller.js
@@ -26,7 +26,9 @@ const decidedAppeals = async (req, res) => {
 	if (decidedAppeals) {
 		decidedAppeals.forEach((appeal) => {
 			appeal.formattedAddress = formatAddress(appeal);
-			appeal.formattedCaseDecisionDate = formatDateForDisplay(appeal.caseDecisionOutcomeDate);
+			appeal.formattedCaseDecisionDate = formatDateForDisplay(appeal.caseDecisionOutcomeDate, {
+				format: 'd MMMM yyyy'
+			});
 			appeal.formattedDecisionColour = mapDecisionColour(appeal.caseDecisionOutcome);
 			appeal.appealTypeName = caseTypeNameWithDefault(appeal.appealTypeCode);
 			appeal.caseDecisionOutcome =

--- a/packages/forms-web-app/src/routes/file-based-router/comment-planning-appeal/decided-appeals/controller.test.js
+++ b/packages/forms-web-app/src/routes/file-based-router/comment-planning-appeal/decided-appeals/controller.test.js
@@ -44,7 +44,7 @@ describe('decidedAppeals', () => {
 				{
 					...appeal,
 					formattedAddress: 'a, b, c, d',
-					formattedCaseDecisionDate: '31 Dec 2024',
+					formattedCaseDecisionDate: '31 December 2024',
 					formattedDecisionColour: 'green',
 					appealTypeName: 'Householder',
 					caseDecisionOutcome: 'Allowed'
@@ -90,7 +90,7 @@ describe('decidedAppeals', () => {
 				{
 					...appeal,
 					formattedAddress: 'a, b, c, d',
-					formattedCaseDecisionDate: '31 Dec 2024',
+					formattedCaseDecisionDate: '31 December 2024',
 					formattedDecisionColour: 'green',
 					appealTypeName: 'Householder',
 					caseDecisionOutcome: 'Allowed'


### PR DESCRIPTION
Ticket: https://pins-ds.atlassian.net/browse/A2-4029

Amends date format for the display of decision date month (moving from shortened eg 'Sep' to full eg 'September') for decided appeals details page

### Checklist

- [ ] Feature complete and ready for users, or behind feature-flag
- [ ] Commit history is linear with no merge commits
- [ ] Requires infrastructure changes

### Important

Please do not merge from `main` (please only [rebase](https://github.com/Planning-Inspectorate/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
