### PR TITLE
feat(forms-web-app): a2-3653 cas adverts appeal form

### DIFF
--- a/packages/common/src/dynamic-forms/journey-types.js
+++ b/packages/common/src/dynamic-forms/journey-types.js
@@ -76,6 +76,13 @@ exports.JOURNEY_TYPES = Object.freeze({
 		userType: LPA_USER_ROLE,
 		caseType: CASE_TYPES.CAS_PLANNING.processCode
 	},
+	CAS_ADVERTS_APPEAL_FORM: {
+		id: 'cas-adverts-appeal-form',
+		type: exports.JOURNEY_TYPE.appealForm,
+		userType: APPEAL_USER_ROLES.APPELLANT,
+		caseType: CASE_TYPES.CAS_ADVERTS.processCode
+	},
+
 	ADVERTS_APPEAL_FORM: {
 		id: 'adverts-appeal-form',
 		type: exports.JOURNEY_TYPE.appealForm,

--- a/packages/forms-web-app/src/dynamic-forms/cas-adverts-appeal-form/journey.js
+++ b/packages/forms-web-app/src/dynamic-forms/cas-adverts-appeal-form/journey.js
@@ -1,0 +1,122 @@
+const { getQuestions } = require('../questions');
+const questions = getQuestions();
+const { Section } = require('../section');
+const { JOURNEY_TYPES } = require('@pins/common/src/dynamic-forms/journey-types');
+const {
+	CASE_TYPES: { CAS_ADVERTS }
+} = require('@pins/common/src/database/data-static');
+const config = require('../../config');
+const {
+	questionHasAnswer,
+	questionsHaveAnswers
+} = require('../dynamic-components/utils/question-has-answer');
+const {
+	shouldDisplayTellingLandowners,
+	shouldDisplayIdentifyingLandowners
+} = require('../display-questions');
+
+/**
+ * @typedef {import('../journey-response').JourneyResponse} JourneyResponse
+ * @typedef {Omit<ConstructorParameters<typeof import('../journey').Journey>[0], 'response'>} JourneyParameters
+ */
+
+/**
+ * @param {JourneyResponse} response
+ * @returns {Section[]}
+ */
+const sections = [
+	new Section('Prepare appeal', 'prepare-appeal')
+		.addQuestion(questions.applicationName)
+		.addQuestion(questions.applicantName)
+		.withCondition((response) => questionHasAnswer(response, questions.applicationName, 'no'))
+		.addQuestion(questions.contactDetails)
+		.addQuestion(questions.contactPhoneNumber)
+		.addQuestion(questions.appealSiteAddress)
+		.addQuestion(questions.siteArea)
+		.addQuestion(questions.appellantGreenBelt)
+		.addQuestion(questions.ownsAllLand)
+		.addQuestion(questions.ownsSomeLand)
+		.withCondition((response) => questionHasAnswer(response, questions.ownsAllLand, 'no'))
+		.addQuestion(questions.knowsWhoOwnsRestOfLand)
+		.withCondition((response) =>
+			questionsHaveAnswers(
+				response,
+				[
+					[questions.ownsSomeLand, 'yes'],
+					[questions.ownsAllLand, 'no']
+				],
+				{ logicalCombinator: 'and' }
+			)
+		)
+		.addQuestion(questions.knowsWhoOwnsLandInvolved)
+		.withCondition((response) =>
+			questionsHaveAnswers(
+				response,
+				[
+					[questions.ownsSomeLand, 'no'],
+					[questions.ownsAllLand, 'no']
+				],
+				{ logicalCombinator: 'and' }
+			)
+		)
+		.addQuestion(questions.identifyingLandowners)
+		.withCondition((response) => shouldDisplayIdentifyingLandowners(response, questions))
+		.addQuestion(questions.advertisingAppeal)
+		.withCondition(
+			(response) =>
+				shouldDisplayIdentifyingLandowners(response, questions) &&
+				questionHasAnswer(response, questions.identifyingLandowners, 'yes')
+		)
+		.addQuestion(questions.tellingLandowners)
+		.withCondition((response) => shouldDisplayTellingLandowners(response, questions))
+		.addQuestion(questions.inspectorAccess)
+		.addQuestion(questions.healthAndSafety)
+		.addQuestion(questions.enterApplicationReference)
+		.addQuestion(questions.planningApplicationDate)
+		.addQuestion(questions.enterDevelopmentDescription)
+		.addQuestion(questions.updateDevelopmentDescription)
+		.addQuestion(questions.anyOtherAppeals)
+		.addQuestion(questions.linkAppeals)
+		.withCondition((response) => questionHasAnswer(response, questions.anyOtherAppeals, 'yes')),
+	new Section('Upload documents', 'upload-documents')
+		.addQuestion(questions.uploadOriginalApplicationForm)
+		.addQuestion(questions.uploadChangeOfDescriptionEvidence)
+		.withCondition((response) =>
+			questionHasAnswer(response, questions.updateDevelopmentDescription, 'yes')
+		)
+		.addQuestion(questions.uploadApplicationDecisionLetter)
+		.addQuestion(questions.uploadAppellantStatement)
+		.addQuestion(questions.costApplication)
+		.addQuestion(questions.uploadCostApplication)
+		.withCondition((response) => questionHasAnswer(response, questions.costApplication, 'yes'))
+		.addQuestion(questions.uploadPlansDrawingsDocuments)
+];
+
+const baseAdvertsSubmissionUrl = `/appeals/${CAS_ADVERTS.friendlyUrl}`;
+
+/**
+ * @param {JourneyResponse} response
+ * @returns {string}
+ */
+const makeBaseUrl = (response) => `${baseAdvertsSubmissionUrl}?id=${response.referenceId}`;
+
+/** @type {JourneyParameters} */
+const params = {
+	journeyId: JOURNEY_TYPES.CAS_ADVERTS_APPEAL_FORM.id,
+	sections,
+	taskListUrl: 'appeal-form/your-appeal',
+	journeyTemplate: 'submission-form-template.njk',
+	listingPageViewPath: 'dynamic-components/task-list/submission',
+	informationPageViewPath: 'dynamic-components/submission-information/index',
+	journeyTitle: 'Appeal a planning decision',
+	returnToListing: true,
+	makeBaseUrl,
+	bannerHtmlOverride:
+		config.betaBannerText +
+		config.generateBetaBannerFeedbackLink(config.getAppealTypeFeedbackUrl(CAS_ADVERTS.processCode))
+};
+
+module.exports = {
+	...params,
+	baseAdvertsSubmissionUrl
+};

--- a/packages/forms-web-app/src/dynamic-forms/cas-adverts-appeal-form/journey.test.js
+++ b/packages/forms-web-app/src/dynamic-forms/cas-adverts-appeal-form/journey.test.js
@@ -1,0 +1,36 @@
+const { Journey } = require('../journey');
+const { baseAdvertsSubmissionUrl, ...params } = require('./journey');
+
+const mockResponse = {
+	journeyId: 'ADVERTS',
+	LPACode: 'Q9999',
+	referenceId: '123',
+	answers: {}
+};
+
+describe('ADVERTS Appeal Form Journey', () => {
+	it('should error if no response', () => {
+		expect(() => {
+			new Journey(params);
+		}).toThrow("Cannot read properties of undefined (reading 'referenceId')");
+	});
+	it('should set baseUrl', () => {
+		const journey = new Journey({ ...params, response: mockResponse });
+		expect(journey.baseUrl).toEqual(expect.stringContaining(baseAdvertsSubmissionUrl));
+		expect(journey.baseUrl).toEqual(expect.stringContaining(mockResponse.referenceId));
+	});
+
+	it('should set taskListUrl', () => {
+		const journey = new Journey({ ...params, response: mockResponse });
+		expect(journey.taskListUrl).toEqual('/appeals/adverts/appeal-form/your-appeal?id=123');
+	});
+
+	it('should set template', () => {
+		const journey = new Journey({ ...params, response: mockResponse });
+		expect(journey.journeyTemplate).toBe('submission-form-template.njk');
+	});
+	it('should set journeyTitle', () => {
+		const journey = new Journey({ ...params, response: mockResponse });
+		expect(journey.journeyTitle).toBe('Appeal a planning decision');
+	});
+});


### PR DESCRIPTION
### Description of change

Adds cas adverts appeal form

Ticket: https://pins-ds.atlassian.net/browse/A2-3653

### Checklist

- [x] Feature complete and ready for users, or behind feature-flag
- [x] Commit history is linear with no merge commits
- [ ] Requires infrastructure changes

### Important

Please do not merge from `main` (please only [rebase](https://github.com/Planning-Inspectorate/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
