### PR TITLE
fix: consultHistoricEngland naming to match data model

### DIFF
--- a/packages/appeals-service-api/src/routes/v2/appeal-cases/_caseReference/lpa-questionnaire-submission/submit/index.test.js
+++ b/packages/appeals-service-api/src/routes/v2/appeal-cases/_caseReference/lpa-questionnaire-submission/submit/index.test.js
@@ -389,7 +389,7 @@ const formattedS20 = [
 			changedListedBuildingNumbers: [],
 			designatedSitesNames: ['yes', 'other designations'],
 			preserveGrantLoan: true,
-			historicEnglandConsultation: true,
+			consultHistoricEngland: true,
 			eiaColumnTwoThreshold: true,
 			eiaCompletedEnvironmentalStatement: false,
 			consultedBodiesDetails: 'consultation details',

--- a/packages/appeals-service-api/src/services/back-office-v2/formatters/s20/questionnaire.test.js
+++ b/packages/appeals-service-api/src/services/back-office-v2/formatters/s20/questionnaire.test.js
@@ -169,7 +169,7 @@ describe('formatter', () => {
 				isGypsyOrTravellerSite: s20Answers.gypsyTraveller,
 				isPublicRightOfWay: s20Answers.publicRightOfWay,
 				preserveGrantLoan: s20Answers.section3aGrant,
-				historicEnglandConsultation: s20Answers.consultHistoricEngland,
+				consultHistoricEngland: s20Answers.consultHistoricEngland,
 
 				// Environmental impact assessment
 				eiaEnvironmentalImpactSchedule: s20Answers.environmentalImpactSchedule,
@@ -292,7 +292,7 @@ describe('formatter', () => {
 				isGypsyOrTravellerSite: undefined,
 				isPublicRightOfWay: undefined,
 				preserveGrantLoan: undefined,
-				historicEnglandConsultation: undefined,
+				consultHistoricEngland: undefined,
 
 				// Environmental impact assessment
 				eiaEnvironmentalImpactSchedule: null,

--- a/packages/appeals-service-api/src/services/back-office-v2/formatters/utils.js
+++ b/packages/appeals-service-api/src/services/back-office-v2/formatters/utils.js
@@ -613,7 +613,7 @@ exports.getS20LPAQSubmissionFields = (answers) => {
 		designatedSitesNames,
 		hasTreePreservationOrder: answers.treePreservationOrder,
 		preserveGrantLoan: answers.section3aGrant,
-		historicEnglandConsultation: answers.consultHistoricEngland,
+		consultHistoricEngland: answers.consultHistoricEngland,
 		isGypsyOrTravellerSite: answers.gypsyTraveller,
 		isPublicRightOfWay: answers.publicRightOfWay,
 


### PR DESCRIPTION
### Description of change

<!-- Please describe the change -->

Ticket: https://pins-ds.atlassian.net/browse/A2-

### Checklist

- [ ] Feature complete and ready for users, or behind feature-flag
- [ ] Commit history is linear with no merge commits
- [ ] Requires infrastructure changes

### Important

Please do not merge from `main` (please only [rebase](https://github.com/Planning-Inspectorate/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
