### PR TITLE
fix: a2-4133 use cas planning appeal formatter

### DIFF
--- a/packages/appeals-service-api/src/routes/v2/appellant-submissions/_id/submit/controller.js
+++ b/packages/appeals-service-api/src/routes/v2/appellant-submissions/_id/submit/controller.js
@@ -8,11 +8,15 @@ const {
 	formatter: hasFormatter
 } = require('../../../../../services/back-office-v2/formatters/has/appeal');
 const {
+	formatter: casPlanningFormatter
+} = require('../../../../../services/back-office-v2/formatters/cas-planning/appeal');
+const {
 	formatter: s78Formatter
 } = require('../../../../../services/back-office-v2/formatters/s78/appeal');
 const {
 	formatter: s20Formatter
 } = require('../../../../../services/back-office-v2/formatters/s20/appeal');
+
 const { getUserById } = require('../../../users/service');
 
 const lpaService = new LpaService();
@@ -43,7 +47,7 @@ const getFormatter = (appealTypeCode) => {
 			return s78Formatter;
 		case CASE_TYPES.CAS_PLANNING.processCode:
 			//TODO: update/ create new formatter when data model confirmed
-			return hasFormatter;
+			return casPlanningFormatter;
 		default:
 			throw new Error('unknown formatter');
 	}


### PR DESCRIPTION
### Description of change

Makes use of cas planning appeal formatter to fix incorrect appeal type being broadcast to BO 

Ticket: https://pins-ds.atlassian.net/browse/A2-4133

### Checklist

- [x] Feature complete and ready for users, or behind feature-flag
- [x] Commit history is linear with no merge commits
- [ ] Requires infrastructure changes

### Important

Please do not merge from `main` (please only [rebase](https://github.com/Planning-Inspectorate/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
