### PR TITLE
Feat/a2 3911 linked appeal appellant dashboard

### DIFF
--- a/packages/appeals-service-api/src/routes/v2/appeal-cases/_caseReference/representations/service.js
+++ b/packages/appeals-service-api/src/routes/v2/appeal-cases/_caseReference/representations/service.js
@@ -1,5 +1,5 @@
 const { RepresentationsRepository } = require('./repo');
-const { appendAppellantAndAgent } = require('../../service');
+const { appendAppellantAndAgent, appendLinkedCases } = require('../../service');
 const { PrismaClientValidationError } = require('@prisma/client/runtime/library');
 const ApiError = require('#errors/apiError');
 const { REPRESENTATION_TYPES } = require('@pins/common/src/constants');
@@ -36,7 +36,9 @@ async function getAppealCaseWithAllRepresentations(caseReference) {
 
 	const appealCaseWithApplicant = await appendAppellantAndAgent(appealCaseWithRepresentations);
 
-	return appealCaseWithApplicant;
+	const appealCaseWithLinkedCases = await appendLinkedCases(appealCaseWithApplicant);
+
+	return appealCaseWithLinkedCases;
 }
 
 /**
@@ -55,7 +57,9 @@ async function getAppealCaseWithRepresentationsByType(caseReference, type) {
 
 	const appealCaseWithApplicant = await appendAppellantAndAgent(appealCaseWithRepresentations);
 
-	return appealCaseWithApplicant;
+	const appealCaseWithLinkedCases = await appendLinkedCases(appealCaseWithApplicant);
+
+	return appealCaseWithLinkedCases;
 }
 
 /**

--- a/packages/appeals-service-api/src/spec/api-types.d.ts
+++ b/packages/appeals-service-api/src/spec/api-types.d.ts
@@ -29,12 +29,18 @@ export interface AppealCaseRelationship {
 	caseReference2: string;
 }
 
-/** An appeal case from the Back Office, with users, relations and documents */
+/** An appeal case from the Back Office, with users, relations, documents and linkedCase info */
 export type AppealCaseDetailed = AppealCase & {
 	users?: ServiceUser[];
 	relations?: AppealCaseRelationship[];
 	submissionLinkedCases?: SubmissionLinkedCase[];
 	Documents?: Document[];
+	linkedCases?: {
+		/** the child case reference */
+		childCaseReference: string;
+		/** the lead case reference */
+		leadCaseReference: string;
+	}[];
 };
 
 /** An appeal case from the Back Office */

--- a/packages/appeals-service-api/src/spec/appeal-case.yaml
+++ b/packages/appeals-service-api/src/spec/appeal-case.yaml
@@ -1,7 +1,7 @@
 components:
   schemas:
     AppealCaseDetailed:
-      description: An appeal case from the Back Office, with users, relations and documents
+      description: An appeal case from the Back Office, with users, relations, documents and linkedCase info
       allOf:
         - $ref: '#/components/schemas/AppealCase'
         - type: object
@@ -22,6 +22,20 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/Document'
+            linkedCases:
+              type: array
+              items:
+                type: object
+                required:
+                  - childCaseReference
+                  - leadCaseReference
+                properties:
+                  childCaseReference:
+                    type: string
+                    description: the child case reference
+                  leadCaseReference:
+                    type: string
+                    description: the lead case reference
 
     AppealCase:
       description: An appeal case from the Back Office

--- a/packages/common/src/lib/format-linked-cases.js
+++ b/packages/common/src/lib/format-linked-cases.js
@@ -1,0 +1,55 @@
+/**
+ * @typedef {import("appeals-service-api").Api.ServiceUser} ServiceUser
+ * @typedef {import('@pins/common/src/constants').AppealToUserRoles} AppealToUserRoles
+ * @typedef {import('@pins/common/src/constants').LpaUserRole} LpaUserRole
+ */
+
+/**
+ * @typedef {Object} formattedLinkedCases
+ * @property {string} html
+ */
+
+const { APPEAL_USER_ROLES, LPA_USER_ROLE } = require('../constants');
+
+const urlStubDict = {
+	[APPEAL_USER_ROLES.APPELLANT]: 'appeals',
+	[APPEAL_USER_ROLES.AGENT]: 'appeals',
+	[LPA_USER_ROLE]: 'manage-appeals',
+	[APPEAL_USER_ROLES.RULE_6_PARTY]: 'rule-6'
+};
+
+/**
+ * @param {{childCaseReference: string, leadCaseReference: string}[]} linkedCases
+ * @param {string} appealCaseReference
+ * @param {AppealToUserRoles|LpaUserRole|null} userType
+ * @returns {formattedLinkedCases}
+ */
+const formatLinkedCases = (linkedCases, appealCaseReference, userType) => {
+	if (!userType || !linkedCases || !linkedCases.length) return { html: 'No linked cases' };
+	const urlStub = urlStubDict[userType];
+
+	const leadCaseReference = linkedCases[0].leadCaseReference;
+
+	if (leadCaseReference !== appealCaseReference) {
+		return { html: `${linkedCaseHtml(leadCaseReference, urlStub)} (lead)` };
+	}
+
+	return {
+		html: linkedCases
+			.map((linkedCase) => linkedCaseHtml(linkedCase.childCaseReference, urlStub))
+			.join('<br>')
+	};
+};
+
+/**
+ * @param {string} linkedCaseReference // the case reference of the linked case
+ * @param {string} urlStub // ie appeals/manage-appeals/rule-6
+ * @returns {string}
+ */
+const linkedCaseHtml = (linkedCaseReference, urlStub) => {
+	return `<a href="/${urlStub}/${linkedCaseReference}" class="govuk-link">${linkedCaseReference}</a>`;
+};
+
+module.exports = {
+	formatLinkedCases
+};

--- a/packages/common/src/view-model-maps/appeal-headline.js
+++ b/packages/common/src/view-model-maps/appeal-headline.js
@@ -1,6 +1,7 @@
 const { APPEAL_USER_ROLES, LPA_USER_ROLE } = require('../constants');
 const { formatApplicant } = require('../lib/format-applicant');
 const { formatAddress } = require('../lib/format-address');
+const { formatLinkedCases } = require('../lib/format-linked-cases');
 const { PROCEDURE_TYPES } = require('../database/data-static');
 const { caseTypeNameWithDefault } = require('../lib/format-case-type');
 
@@ -16,7 +17,8 @@ const { caseTypeNameWithDefault } = require('../lib/format-case-type');
  * @param {AppealToUserRoles|LpaUserRole|null} role
  */
 const formatHeadlineData = (caseData, lpaName, role = APPEAL_USER_ROLES.INTERESTED_PARTY) => {
-	const { caseReference, appealTypeCode, caseProcedure, users, applicationReference } = caseData;
+	const { caseReference, appealTypeCode, caseProcedure, users, applicationReference, linkedCases } =
+		caseData;
 
 	const address = formatAddress(caseData);
 	const applicant = formatApplicant(users, role);
@@ -57,6 +59,11 @@ const formatHeadlineData = (caseData, lpaName, role = APPEAL_USER_ROLES.INTEREST
 		headlines.unshift({
 			key: { text: 'Appeal reference' },
 			value: { text: caseReference }
+		});
+	} else if (linkedCases && linkedCases.length) {
+		headlines.push({
+			key: { text: 'Linked appeals' },
+			value: formatLinkedCases(linkedCases, caseReference, role)
 		});
 	}
 

--- a/packages/database/src/migrations/20250808161353_add_linked_type_index/migration.sql
+++ b/packages/database/src/migrations/20250808161353_add_linked_type_index/migration.sql
@@ -1,0 +1,19 @@
+BEGIN TRY
+
+BEGIN TRAN;
+
+-- CreateIndex
+CREATE NONCLUSTERED INDEX [AppealCaseRelationship_type_idx] ON [dbo].[AppealCaseRelationship]([type]);
+
+COMMIT TRAN;
+
+END TRY
+BEGIN CATCH
+
+IF @@TRANCOUNT > 0
+BEGIN
+    ROLLBACK TRAN;
+END;
+THROW
+
+END CATCH

--- a/packages/database/src/schema.prisma
+++ b/packages/database/src/schema.prisma
@@ -429,6 +429,7 @@ model AppealCaseRelationship {
   // indexes
   @@index([caseReference])
   @@index([caseReference2])
+  @@index([type])
 }
 
 /// Lookup table for types of appeals processes, and appeal types such as D (Householder) and W (S78).

--- a/packages/database/src/seed/data-dev.js
+++ b/packages/database/src/seed/data-dev.js
@@ -1186,6 +1186,16 @@ const caseRelations = [
 		caseReference: caseReferences.caseReferenceNine,
 		caseReference2: caseReferences.caseReferenceOne,
 		type: CASE_RELATION_TYPES.nearby
+	},
+	{
+		caseReference: '0000666',
+		caseReference2: '0000066',
+		type: CASE_RELATION_TYPES.linked
+	},
+	{
+		caseReference: '0006666',
+		caseReference2: '0000066',
+		type: CASE_RELATION_TYPES.linked
 	}
 ];
 

--- a/packages/forms-web-app/__tests__/unit/controllers/appeals/your-appeals.test.js
+++ b/packages/forms-web-app/__tests__/unit/controllers/appeals/your-appeals.test.js
@@ -4,7 +4,8 @@ const { VIEW } = require('../../../../src/lib/views');
 const { mockReq, mockRes } = require('../../mocks');
 const {
 	mapToAppellantDashboardDisplayData,
-	isToDoAppellantDashboard
+	isToDoAppellantDashboard,
+	updateChildAppealDisplayData
 } = require('../../../../src/lib/dashboard-functions');
 
 jest.mock('../../../../src/lib/dashboard-functions');
@@ -82,6 +83,7 @@ describe('controllers/appeals/your-appeals', () => {
 	describe('Get - To Do appeals', () => {
 		it('Displays appeal in to do list if it passes all criteria', async () => {
 			mapToAppellantDashboardDisplayData.mockReturnValue(toDoData);
+			updateChildAppealDisplayData.mockReturnValue([toDoData]);
 			isToDoAppellantDashboard.mockReturnValue(true);
 			await get(req, res);
 
@@ -94,6 +96,7 @@ describe('controllers/appeals/your-appeals', () => {
 
 		it('Does not display appeal in to do list if all documents have been submitted', async () => {
 			mapToAppellantDashboardDisplayData.mockReturnValue(completedData);
+			updateChildAppealDisplayData.mockReturnValue([completedData]);
 
 			await get(req, res);
 
@@ -106,8 +109,10 @@ describe('controllers/appeals/your-appeals', () => {
 
 		it('Does not display appeal in to do list or WFR list if it has been decided', async () => {
 			mapToAppellantDashboardDisplayData.mockReturnValue(decidedData);
+			updateChildAppealDisplayData.mockReturnValue([]);
 
 			await get(req, res);
+			expect(updateChildAppealDisplayData).toHaveBeenCalledWith([]);
 			expect(res.render).toHaveBeenCalledWith(VIEW.APPEALS.YOUR_APPEALS, {
 				toDoAppeals: [],
 				waitingForReviewAppeals: [],
@@ -117,6 +122,8 @@ describe('controllers/appeals/your-appeals', () => {
 
 		it('Does not display appeal in to do list if the next document due is overdue', async () => {
 			mapToAppellantDashboardDisplayData.mockReturnValue(waitingForReviewData);
+			updateChildAppealDisplayData.mockReturnValue([waitingForReviewData]);
+
 			await get(req, res);
 
 			expect(res.render).toHaveBeenCalledWith(VIEW.APPEALS.YOUR_APPEALS, {

--- a/packages/forms-web-app/src/controllers/appeals/your-appeals.js
+++ b/packages/forms-web-app/src/controllers/appeals/your-appeals.js
@@ -1,6 +1,7 @@
 const {
 	mapToAppellantDashboardDisplayData,
-	isToDoAppellantDashboard
+	isToDoAppellantDashboard,
+	updateChildAppealDisplayData
 } = require('../../lib/dashboard-functions');
 const { VIEW } = require('../../lib/views');
 const logger = require('../../lib/logger');
@@ -28,18 +29,23 @@ exports.get = async (req, res) => {
 
 		logger.debug({ undecidedAppeals }, 'undecided appeals');
 
-		const { toDoAppeals, waitingForReviewAppeals } = undecidedAppeals.reduce(
-			(acc, appeal) => {
-				if (isToDoAppellantDashboard(appeal)) {
-					acc.toDoAppeals.push(appeal);
-				} else if (appeal.appealNumber) {
-					// don't add draft appeals to waiting for review
-					acc.waitingForReviewAppeals.push(appeal);
-				}
-				return acc;
-			},
-			{ toDoAppeals: [], waitingForReviewAppeals: [] }
-		);
+		// aligns child's nextJourneyDue information with lead linked case
+		const undecidedWithUpdatedChildAppealDisplayData =
+			updateChildAppealDisplayData(undecidedAppeals);
+
+		const { toDoAppeals, waitingForReviewAppeals } =
+			undecidedWithUpdatedChildAppealDisplayData.reduce(
+				(acc, appeal) => {
+					if (isToDoAppellantDashboard(appeal)) {
+						acc.toDoAppeals.push(appeal);
+					} else if (appeal.appealNumber) {
+						// don't add draft appeals to waiting for review
+						acc.waitingForReviewAppeals.push(appeal);
+					}
+					return acc;
+				},
+				{ toDoAppeals: [], waitingForReviewAppeals: [] }
+			);
 
 		logger.debug({ toDoAppeals }, 'toDoAppeals');
 		logger.debug({ waitingForReviewAppeals }, 'waitingForReviewAppeals');

--- a/packages/forms-web-app/src/controllers/selected-appeal/index.js
+++ b/packages/forms-web-app/src/controllers/selected-appeal/index.js
@@ -34,6 +34,7 @@ const { getDepartmentFromCode } = require('../../services/department.service');
 const logger = require('#lib/logger');
 const config = require('../../config');
 const { formatDateForDisplay } = require('@pins/common/src/lib/format-date');
+const { formatDashboardLinkedCaseDetails } = require('#lib/linked-appeals');
 
 /** @type {Partial<import('@pins/common/src/view-model-maps/sections/def').UserSectionsDict>} */
 const userSectionsDict = {
@@ -77,6 +78,8 @@ exports.get = (layoutTemplate = 'layouts/no-banner-link/main.njk') => {
 
 		const lpa = await getDepartmentFromCode(caseData.LPACode);
 		const headlineData = displayHeadlinesByUser(caseData, lpa.name, userType);
+
+		const linkedCaseDetails = formatDashboardLinkedCaseDetails(caseData);
 
 		const sections = userSectionsDict[userType];
 		if (!isSection(sections)) throw new Error(`No sections configured for user type ${userType}`);
@@ -126,7 +129,8 @@ exports.get = (layoutTemplate = 'layouts/no-banner-link/main.njk') => {
 				rule6StatementDueDate: formatDateForNotification(caseData.statementDueDate),
 				finalCommentDueDate: formatDateForNotification(caseData.finalCommentsDueDate),
 				proofEvidenceDueDate: formatDateForNotification(caseData.proofsOfEvidenceDueDate),
-				rule6ProofEvidenceDueDate: formatDateForNotification(caseData.proofsOfEvidenceDueDate)
+				rule6ProofEvidenceDueDate: formatDateForNotification(caseData.proofsOfEvidenceDueDate),
+				linkedCaseDetails
 			},
 			bannerHtmlOverride
 		};

--- a/packages/forms-web-app/src/lib/linked-appeals.js
+++ b/packages/forms-web-app/src/lib/linked-appeals.js
@@ -1,0 +1,52 @@
+const { APPEAL_LINKED_CASE_STATUS } = require('@planning-inspectorate/data-model');
+
+/**
+ * @typedef {import('appeals-service-api').Api.AppealCaseDetailed} AppealCaseDetailed
+ * @typedef {import('./dashboard-functions').LinkedCaseDetails} LinkedCaseDetails
+ */
+
+/**
+ * @param {AppealCaseDetailed} caseData
+ * @returns {LinkedCaseDetails | null} linkedCaseDetails if appeal is linked, including linked role ie 'lead', 'child'
+ */
+
+const formatDashboardLinkedCaseDetails = (caseData) => {
+	const { linkedCases } = caseData;
+
+	if (!linkedCases || !linkedCases.length) return null;
+
+	const leadCaseReference = linkedCases[0].leadCaseReference;
+
+	const linkedCaseStatus =
+		leadCaseReference === caseData.caseReference
+			? APPEAL_LINKED_CASE_STATUS.LEAD
+			: APPEAL_LINKED_CASE_STATUS.CHILD;
+
+	return {
+		linkedCaseStatus,
+		leadCaseReference,
+		linkedCaseStatusLabel: mapLinkedCaseStatusLabel(linkedCaseStatus)
+	};
+};
+
+/**
+ * Map an linked case status to it's corresponding tag text
+ *
+ * @param {string|undefined} status
+ * @returns {string | null | undefined}
+ */
+const mapLinkedCaseStatusLabel = (status) => {
+	if (!status) return null;
+
+	const labels = {
+		[APPEAL_LINKED_CASE_STATUS.CHILD]: 'Child',
+		[APPEAL_LINKED_CASE_STATUS.LEAD]: 'Lead'
+	};
+
+	return labels[status];
+};
+
+module.exports = {
+	formatDashboardLinkedCaseDetails,
+	mapLinkedCaseStatusLabel
+};

--- a/packages/forms-web-app/src/lib/linked-appeals.test.js
+++ b/packages/forms-web-app/src/lib/linked-appeals.test.js
@@ -1,0 +1,64 @@
+const { APPEAL_LINKED_CASE_STATUS } = require('@planning-inspectorate/data-model');
+const { mapLinkedCaseStatusLabel, formatDashboardLinkedCaseDetails } = require('./linked-appeals');
+
+const testLeadRef = 'testLead1';
+const testChildRef = 'testChild2';
+const testLinkedCases = [
+	{
+		childCaseReference: testChildRef,
+		leadCaseReference: testLeadRef
+	}
+];
+
+describe('lib/linked-appeals', () => {
+	beforeEach(() => {
+		jest.resetAllMocks();
+	});
+
+	describe('mapLinkedCaseStatusLabel', () => {
+		test.each([
+			[APPEAL_LINKED_CASE_STATUS.LEAD, 'Lead'],
+			[APPEAL_LINKED_CASE_STATUS.CHILD, 'Child'],
+			[undefined, null],
+			['InvalidLinkedStatus', undefined]
+		])('correctly maps a %s linked case status to a %s display label', (linkedStatus, label) => {
+			expect(mapLinkedCaseStatusLabel(linkedStatus)).toBe(label);
+		});
+	});
+
+	describe('formatDashboardLinkedCaseDetails', () => {
+		test.each([
+			[
+				{
+					caseReference: testLeadRef,
+					linkedCases: testLinkedCases
+				},
+				{
+					linkedCaseStatus: APPEAL_LINKED_CASE_STATUS.LEAD,
+					leadCaseReference: testLeadRef,
+					linkedCaseStatusLabel: 'Lead'
+				}
+			],
+			[
+				{
+					caseReference: testChildRef,
+					linkedCases: testLinkedCases
+				},
+				{
+					linkedCaseStatus: APPEAL_LINKED_CASE_STATUS.CHILD,
+					leadCaseReference: testLeadRef,
+					linkedCaseStatusLabel: 'Child'
+				}
+			],
+			[
+				{
+					caseReference: 'Not linked case',
+					linkedCases: undefined
+				},
+				null
+			]
+		])('correctly maps a case to dashboard display', (appealCase, displayObject) => {
+			expect(formatDashboardLinkedCaseDetails(appealCase)).toEqual(displayObject);
+		});
+	});
+});

--- a/packages/forms-web-app/src/views/appeals/your-appeals.njk
+++ b/packages/forms-web-app/src/views/appeals/your-appeals.njk
@@ -58,6 +58,9 @@
                               <a href="/appeals/{{item.appealNumber}}" class="govuk-link">
                                 {{item.appealNumber}}
                               </a>
+														{% endif %}
+														{% if item.linkedCaseDetails %}
+															<p><strong class='govuk-tag govuk-tag--grey'>{{item.linkedCaseDetails.linkedCaseStatusLabel}}</strong></p>
                             {% endif %}
                           </td>
                           <td class="govuk-table__cell">
@@ -115,6 +118,9 @@
                             <a href="/appeals/{{item.appealNumber}}" class="govuk-link">
                               {{item.appealNumber}}
                             </a>
+                          {% endif %}
+													{% if item.linkedCaseDetails %}
+														<p><strong class='govuk-tag govuk-tag--grey'>{{item.linkedCaseDetails.linkedCaseStatusLabel}}</strong></p>
                           {% endif %}
                         </td>
                         <td class="govuk-table__cell">

--- a/packages/forms-web-app/src/views/manage-appeals/your-appeals.njk
+++ b/packages/forms-web-app/src/views/manage-appeals/your-appeals.njk
@@ -30,6 +30,9 @@
                     <a href="/manage-appeals/{{item.appealNumber}}" class="govuk-link">
                     {{item.appealNumber}}
                     </a>
+										{% if item.linkedCaseDetails %}
+											<p><strong class='govuk-tag govuk-tag--grey'>{{item.linkedCaseDetails.linkedCaseStatusLabel}}</strong></p>
+                    {% endif %}
                   </td>
                   <td class="govuk-table__cell">{{item.address}}</td>
                   <td class="govuk-table__cell">{{item.appealType}}</td>
@@ -95,6 +98,9 @@
                   <a href="/manage-appeals/{{item.appealNumber}}" class="govuk-link">
                    {{item.appealNumber}}
                   </a>
+									{% if item.linkedCaseDetails %}
+										<p><strong class='govuk-tag govuk-tag--grey'>{{item.linkedCaseDetails.linkedCaseStatusLabel}}</strong></p>
+                  {% endif %}
                 </td>
                 <td class="govuk-table__cell">{{item.address}}</td>
 								<td class="govuk-table__cell">{{item.appealType}}</td>

--- a/packages/forms-web-app/src/views/rule-6/your-appeals.njk
+++ b/packages/forms-web-app/src/views/rule-6/your-appeals.njk
@@ -62,7 +62,7 @@
                           </td>
 													{# To do #}
                           <td class="govuk-table__cell">
-                            <a href="{{item.nextJourneyDue.baseUrl}}" class="govuk-link">
+														<a href="{{item.nextJourneyDue.baseUrl}}" class="govuk-link">
                               {{item.nextJourneyDue.journeyDue}}
                             </a>
                           </td>

--- a/packages/forms-web-app/src/views/selected-appeal/appeal.njk
+++ b/packages/forms-web-app/src/views/selected-appeal/appeal.njk
@@ -196,7 +196,11 @@
 
 			{% endif %}
 
-      		<h1 class="govuk-heading-l">Appeal {{appeal.appealNumber}}</h1>
+      		<h1 class="govuk-heading-l">Appeal {{appeal.appealNumber}}
+						{% if appeal.linkedCaseDetails %}
+							<strong class='govuk-tag govuk-tag--grey'>{{appeal.linkedCaseDetails.linkedCaseStatusLabel}}</strong>
+          	{% endif %}
+					</h1>
 		</div>
 
 		<div class="govuk-grid-column-two-thirds">


### PR DESCRIPTION
### Description of change

Adds linked cases functionality for FO. Includes:
- api - functions to retrieve linked cases for either single or multiple appeals
- web - functions to establish whether an appeal is a linked-lead or linked-child and display accordingly

This PR concerns the Appellant dashboards and Appeal pages, a subsequent PR will implement for the LPA pages (the code is in place)

Seed data cases 0000066 (lead), 0000666 (child)  and 0006666 (child) have been designated as linked cases.

Ticket: https://pins-ds.atlassian.net/browse/A2-3911

### Checklist

- [X] Feature complete and ready for users, or behind feature-flag
- [X] Commit history is linear with no merge commits
- [ ] Requires infrastructure changes

### Important

Please do not merge from `main` (please only [rebase](https://github.com/Planning-Inspectorate/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
