### PR TITLE
fix(a2-4142): avoid html line break in truncated text

### DIFF
--- a/packages/forms-web-app/src/lib/representation-functions.js
+++ b/packages/forms-web-app/src/lib/representation-functions.js
@@ -203,10 +203,9 @@ const formatRepresentations = (caseData, representations) => {
 		const fullText = representation.redacted
 			? representation.redactedRepresentation
 			: representation.originalRepresentation;
-		const escaped = fullText ? escape(fullText) : undefined;
-		const newLined = escaped ? nl2br(escaped) : undefined;
-		const truncated = (newLined && newLined.length > 150) || false;
-		const truncatedText = truncated ? newLined.substring(0, 150) + '...' : newLined;
+
+		const isTruncated = (fullText && fullText.length > 150) || false;
+		const truncatedText = isTruncated ? fullText.substring(0, 150) + '...' : fullText;
 
 		const rowLabel = formatRowLabelAndKey(representation.representationType);
 
@@ -228,9 +227,9 @@ const formatRepresentations = (caseData, representations) => {
 			key: { text: `${rowLabel} ${index + 1}` },
 			rowLabel,
 			value: {
-				text: newLined,
-				truncatedText: truncatedText,
-				truncated: truncated,
+				text: fullText ? nl2br(escape(fullText)) : undefined,
+				truncatedText: fullText ? nl2br(escape(truncatedText)) : undefined,
+				truncated: isTruncated,
 				documents: formattedDocuments
 			}
 		};

--- a/packages/forms-web-app/src/lib/representation-functions.test.js
+++ b/packages/forms-web-app/src/lib/representation-functions.test.js
@@ -599,6 +599,44 @@ describe('lib/representation-functions', () => {
 	});
 
 	describe('formatRepresentations', () => {
+		it('truncates before adding html line breaks', async () => {
+			const truncateLimit = 'a'.repeat(149);
+
+			const formattedRepresentations = formatRepresentations({}, [
+				{ originalRepresentation: truncateLimit },
+				{ originalRepresentation: truncateLimit + '\nTest' }
+			]);
+
+			const expectedResult = [
+				{
+					key: {
+						text: `Representation 1`
+					},
+					rowLabel: 'Representation',
+					value: {
+						text: truncateLimit,
+						truncatedText: truncateLimit,
+						truncated: false,
+						documents: expect.any(Array)
+					}
+				},
+				{
+					key: {
+						text: `Representation 2`
+					},
+					rowLabel: 'Representation',
+					value: {
+						text: truncateLimit + '<br>Test',
+						truncatedText: truncateLimit + '<br>...',
+						truncated: true,
+						documents: expect.any(Array)
+					}
+				}
+			];
+
+			expect(formattedRepresentations).toEqual(expectedResult);
+		});
+
 		it('formats an array of statements', async () => {
 			const formattedRepresentations = formatRepresentations({}, testStatements);
 			const expectedResult = [


### PR DESCRIPTION
### Description of change

Truncation could happen in middle of `<br>` tag leading to broken html/read more button

Ticket: https://pins-ds.atlassian.net/browse/A2-4142

### Checklist

- [x] Feature complete and ready for users, or behind feature-flag
- [x] Commit history is linear with no merge commits
- [ ] Requires infrastructure changes

### Important

Please do not merge from `main` (please only [rebase](https://github.com/Planning-Inspectorate/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
