### PR TITLE
Feat/a2 4023 linked appeals final comments appellant

### DIFF
--- a/packages/appeals-service-api/src/configuration/config.js
+++ b/packages/appeals-service-api/src/configuration/config.js
@@ -37,7 +37,8 @@ let config = {
 		sql: {
 			// don't use the admin connection string for general use
 			connectionString: process.env.SQL_CONNECTION_STRING
-		}
+		},
+		queryBatchSize: 200
 	},
 	documents: {
 		timeout: parseInt(process.env.DOCUMENTS_SERVICE_API_TIMEOUT, 10) || 10000,

--- a/packages/appeals-service-api/src/routes/v2/appeal-cases/service.js
+++ b/packages/appeals-service-api/src/routes/v2/appeal-cases/service.js
@@ -70,6 +70,7 @@ async function getCaseAndAppellant(opts) {
 
 	appeal = await appendAppellantAndAgent(appeal);
 	appeal = await appendAppealRelations(appeal);
+	appeal = await appendLinkedCases(appeal);
 
 	return parseJSONFields(appeal);
 }

--- a/packages/appeals-service-api/src/routes/v2/users/_id/appeal-cases/_caseReference/service.js
+++ b/packages/appeals-service-api/src/routes/v2/users/_id/appeal-cases/_caseReference/service.js
@@ -14,6 +14,7 @@ exports.get = async ({ caseReference, userId, role }) => {
 		if (data) {
 			data = await caseService.appendAppellantAndAgent(data);
 			data = await caseService.appendAppealRelations(data);
+			data = await caseService.appendLinkedCases(data);
 
 			return caseService.parseJSONFields(data);
 		}
@@ -23,6 +24,7 @@ exports.get = async ({ caseReference, userId, role }) => {
 		if (data) {
 			data = await caseService.appendAppellantAndAgent(data);
 			data = await caseService.appendAppealRelations(data);
+			data = await caseService.appendLinkedCases(data);
 
 			return caseService.parseJSONFields(data);
 		}

--- a/packages/business-rules/src/rules/appeal-case/case-due-dates.js
+++ b/packages/business-rules/src/rules/appeal-case/case-due-dates.js
@@ -3,6 +3,7 @@ const {
 	APPEAL_REPRESENTATION_TYPE
 } = require('@planning-inspectorate/data-model');
 const { deadlineHasPassed } = require('@pins/common/src/lib/deadline-has-passed');
+const { isChildLinkedAppeal } = require('@pins/common/src/lib/linked-appeals');
 const { representationExists } = require('@pins/common/src/lib/representations');
 const { APPEAL_USER_ROLES } = require('@pins/common/src/constants');
 
@@ -142,11 +143,3 @@ exports.isLPAFinalCommentOpen = (appealCaseData) =>
 	!isChildLinkedAppeal(appealCaseData) &&
 	finalCommentsAreOpen(appealCaseData) &&
 	!appealCaseData.LPACommentsSubmittedDate;
-
-/**
- * check whether case is a child linked case
- * @param {AppealCaseDetailed} appealCaseData
- * @returns {boolean}
- */
-const isChildLinkedAppeal = (appealCaseData) =>
-	appealCaseData.linkedCases?.[0].childCaseReference === appealCaseData.caseReference;

--- a/packages/business-rules/src/rules/appeal-case/case-due-dates.js
+++ b/packages/business-rules/src/rules/appeal-case/case-due-dates.js
@@ -56,7 +56,9 @@ const statementsAreOpen = (appealCaseData) =>
  * @returns {boolean}
  */
 exports.isLPAStatementOpen = (appealCaseData) =>
-	statementsAreOpen(appealCaseData) && !appealCaseData.LPAStatementSubmittedDate;
+	!isChildLinkedAppeal(appealCaseData) &&
+	statementsAreOpen(appealCaseData) &&
+	!appealCaseData.LPAStatementSubmittedDate;
 
 /**
  * Checks if statements are open for all rule 6 parties
@@ -127,7 +129,9 @@ const finalCommentsAreOpen = (appealCaseData) =>
  * @returns {boolean}
  */
 exports.isAppellantFinalCommentOpen = (appealCaseData) =>
-	finalCommentsAreOpen(appealCaseData) && !appealCaseData.appellantCommentsSubmittedDate;
+	!isChildLinkedAppeal(appealCaseData) &&
+	finalCommentsAreOpen(appealCaseData) &&
+	!appealCaseData.appellantCommentsSubmittedDate;
 
 /**
  * final comment is open for LPA
@@ -135,4 +139,14 @@ exports.isAppellantFinalCommentOpen = (appealCaseData) =>
  * @returns {boolean}
  */
 exports.isLPAFinalCommentOpen = (appealCaseData) =>
-	finalCommentsAreOpen(appealCaseData) && !appealCaseData.LPACommentsSubmittedDate;
+	!isChildLinkedAppeal(appealCaseData) &&
+	finalCommentsAreOpen(appealCaseData) &&
+	!appealCaseData.LPACommentsSubmittedDate;
+
+/**
+ * check whether case is a child linked case
+ * @param {AppealCaseDetailed} appealCaseData
+ * @returns {boolean}
+ */
+const isChildLinkedAppeal = (appealCaseData) =>
+	appealCaseData.linkedCases?.[0].childCaseReference === appealCaseData.caseReference;

--- a/packages/business-rules/src/rules/appeal-case/case-due-dates.test.js
+++ b/packages/business-rules/src/rules/appeal-case/case-due-dates.test.js
@@ -23,6 +23,7 @@ describe('case-due-dates', () => {
 
 	beforeEach(() => {
 		appealCaseData = {
+			caseReference: 'testCaseReference',
 			lpaQuestionnaireDueDate: null,
 			lpaQuestionnaireSubmittedDate: null,
 			caseStatus: null,
@@ -109,6 +110,19 @@ describe('case-due-dates', () => {
 				expect(isLPAStatementOpen(appealCaseData)).toBe(true);
 			});
 
+			it('should return true if case is a lead linked case and other conditions are satisfied', () => {
+				appealCaseData.statementDueDate = '2025-03-01';
+				deadlineHasPassed.mockReturnValueOnce(false);
+				appealCaseData.lpaQuestionnaireValidationOutcomeDate = '2025-03-01';
+				appealCaseData.linkedCases = [
+					{
+						childCaseReference: 'aDifferentCase',
+						leadCaseReference: appealCaseData.caseReference
+					}
+				];
+				expect(isLPAStatementOpen(appealCaseData)).toBe(true);
+			});
+
 			it('should return false if statements are not open', () => {
 				expect(isLPAStatementOpen(appealCaseData)).toBe(false);
 			});
@@ -118,6 +132,19 @@ describe('case-due-dates', () => {
 				deadlineHasPassed.mockReturnValue(false);
 				appealCaseData.caseStatus = APPEAL_CASE_STATUS.STATEMENTS;
 				appealCaseData.LPAStatementSubmittedDate = '2025-03-02';
+				expect(isLPAStatementOpen(appealCaseData)).toBe(false);
+			});
+
+			it('should return false if case is a child linked case', () => {
+				appealCaseData.statementDueDate = '2025-03-01';
+				deadlineHasPassed.mockReturnValueOnce(false);
+				appealCaseData.lpaQuestionnaireValidationOutcomeDate = '2025-03-01';
+				appealCaseData.linkedCases = [
+					{
+						childCaseReference: appealCaseData.caseReference,
+						leadCaseReference: 'testLeadReference'
+					}
+				];
 				expect(isLPAStatementOpen(appealCaseData)).toBe(false);
 			});
 		});
@@ -220,6 +247,19 @@ describe('case-due-dates', () => {
 				expect(isAppellantFinalCommentOpen(appealCaseData)).toBe(true);
 			});
 
+			it('should return true if case is a lead linked case and other conditions satisfied', () => {
+				appealCaseData.finalCommentsDueDate = '2025-03-01';
+				deadlineHasPassed.mockReturnValue(false);
+				appealCaseData.caseStatus = APPEAL_CASE_STATUS.FINAL_COMMENTS;
+				appealCaseData.linkedCases = [
+					{
+						childCaseReference: 'aDifferentCaseReference',
+						leadCaseReference: appealCaseData.caseReference
+					}
+				];
+				expect(isAppellantFinalCommentOpen(appealCaseData)).toBe(true);
+			});
+
 			it('should return false if final comments are not open', () => {
 				expect(isAppellantFinalCommentOpen(appealCaseData)).toBe(false);
 			});
@@ -229,6 +269,19 @@ describe('case-due-dates', () => {
 				deadlineHasPassed.mockReturnValue(false);
 				appealCaseData.caseStatus = APPEAL_CASE_STATUS.FINAL_COMMENTS;
 				appealCaseData.appellantCommentsSubmittedDate = '2025-03-02';
+				expect(isAppellantFinalCommentOpen(appealCaseData)).toBe(false);
+			});
+
+			it('should return false if case is a child linked case', () => {
+				appealCaseData.finalCommentsDueDate = '2025-03-01';
+				deadlineHasPassed.mockReturnValue(false);
+				appealCaseData.caseStatus = APPEAL_CASE_STATUS.FINAL_COMMENTS;
+				appealCaseData.linkedCases = [
+					{
+						childCaseReference: appealCaseData.caseReference,
+						leadCaseReference: 'testLeadReference'
+					}
+				];
 				expect(isAppellantFinalCommentOpen(appealCaseData)).toBe(false);
 			});
 		});
@@ -241,6 +294,19 @@ describe('case-due-dates', () => {
 				expect(isLPAFinalCommentOpen(appealCaseData)).toBe(true);
 			});
 
+			it('should return true if case is a lead linked case and other conditions are satisfied', () => {
+				appealCaseData.finalCommentsDueDate = '2025-03-01';
+				deadlineHasPassed.mockReturnValue(false);
+				appealCaseData.caseStatus = APPEAL_CASE_STATUS.FINAL_COMMENTS;
+				appealCaseData.linkedCases = [
+					{
+						childCaseReference: 'aDifferentCaseReference',
+						leadCaseReference: appealCaseData.caseReference
+					}
+				];
+				expect(isLPAFinalCommentOpen(appealCaseData)).toBe(true);
+			});
+
 			it('should return false if final comments are not open', () => {
 				expect(isLPAFinalCommentOpen(appealCaseData)).toBe(false);
 			});
@@ -250,6 +316,19 @@ describe('case-due-dates', () => {
 				deadlineHasPassed.mockReturnValue(false);
 				appealCaseData.caseStatus = APPEAL_CASE_STATUS.FINAL_COMMENTS;
 				appealCaseData.LPACommentsSubmittedDate = '2025-03-02';
+				expect(isLPAFinalCommentOpen(appealCaseData)).toBe(false);
+			});
+
+			it('should return false if case is a child linked case', () => {
+				appealCaseData.finalCommentsDueDate = '2025-03-01';
+				deadlineHasPassed.mockReturnValue(false);
+				appealCaseData.caseStatus = APPEAL_CASE_STATUS.FINAL_COMMENTS;
+				appealCaseData.linkedCases = [
+					{
+						childCaseReference: appealCaseData.caseReference,
+						leadCaseReference: 'testLeadReference'
+					}
+				];
 				expect(isLPAFinalCommentOpen(appealCaseData)).toBe(false);
 			});
 		});

--- a/packages/common/src/lib/linked-appeals.js
+++ b/packages/common/src/lib/linked-appeals.js
@@ -2,7 +2,7 @@ const { APPEAL_LINKED_CASE_STATUS } = require('@planning-inspectorate/data-model
 
 /**
  * @typedef {import('appeals-service-api').Api.AppealCaseDetailed} AppealCaseDetailed
- * @typedef {import('./dashboard-functions').LinkedCaseDetails} LinkedCaseDetails
+ * @typedef {import('../../../forms-web-app/src/lib/dashboard-functions').LinkedCaseDetails} LinkedCaseDetails
  */
 
 /**
@@ -46,7 +46,16 @@ const mapLinkedCaseStatusLabel = (status) => {
 	return labels[status];
 };
 
+/**
+ * check whether case is a child linked case
+ * @param {AppealCaseDetailed} appealCaseData
+ * @returns {boolean}
+ */
+const isChildLinkedAppeal = (appealCaseData) =>
+	appealCaseData.linkedCases?.[0].childCaseReference === appealCaseData.caseReference;
+
 module.exports = {
 	formatDashboardLinkedCaseDetails,
-	mapLinkedCaseStatusLabel
+	mapLinkedCaseStatusLabel,
+	isChildLinkedAppeal
 };

--- a/packages/common/src/lib/linked-appeals.test.js
+++ b/packages/common/src/lib/linked-appeals.test.js
@@ -1,5 +1,8 @@
 const { APPEAL_LINKED_CASE_STATUS } = require('@planning-inspectorate/data-model');
-const { mapLinkedCaseStatusLabel, formatDashboardLinkedCaseDetails } = require('./linked-appeals');
+const {
+	mapLinkedCaseStatusLabel,
+	formatDashboardLinkedCaseDetails
+} = require('@pins/common/src/lib/linked-appeals');
 
 const testLeadRef = 'testLead1';
 const testChildRef = 'testChild2';

--- a/packages/forms-web-app/__tests__/unit/controllers/lpa-dashboard/your-appeals.test.js
+++ b/packages/forms-web-app/__tests__/unit/controllers/lpa-dashboard/your-appeals.test.js
@@ -7,7 +7,8 @@ const { baseHASUrl } = require('../../../../src/dynamic-forms/has-questionnaire/
 const { mockReq, mockRes } = require('../../mocks');
 const {
 	mapToLPADashboardDisplayData,
-	isToDoLPADashboard
+	isToDoLPADashboard,
+	updateChildAppealDisplayData
 } = require('../../../../src/lib/dashboard-functions');
 const { isFeatureActive } = require('../../../../src/featureFlag');
 
@@ -60,6 +61,7 @@ describe('controllers/lpa-dashboard/your-appeals', () => {
 			req.appealsApiClient.getAppealsCasesByLpaAndStatus.mockResolvedValue([]);
 			req.appealsApiClient.getDecidedAppealsCountV2.mockResolvedValue(mockDecidedCount);
 			mapToLPADashboardDisplayData.mockReturnValue(mockAppealData);
+			updateChildAppealDisplayData.mockReturnValue([mockAppealData]);
 			isToDoLPADashboard.mockReturnValue(true);
 			isFeatureActive.mockResolvedValueOnce(false);
 
@@ -86,6 +88,7 @@ describe('controllers/lpa-dashboard/your-appeals', () => {
 			req.appealsApiClient.getAppealsCasesByLpaAndStatus.mockResolvedValue([]);
 			req.appealsApiClient.getDecidedAppealsCountV2.mockResolvedValue(mockDecidedCount);
 			mapToLPADashboardDisplayData.mockReturnValue(mockAppealData);
+			updateChildAppealDisplayData.mockReturnValue([mockAppealData]);
 			isToDoLPADashboard.mockReturnValue(true);
 			isFeatureActive.mockResolvedValueOnce(true);
 
@@ -112,6 +115,7 @@ describe('controllers/lpa-dashboard/your-appeals', () => {
 			req.appealsApiClient.getAppealsCasesByLpaAndStatus.mockResolvedValue([]);
 			req.appealsApiClient.getDecidedAppealsCountV2.mockResolvedValue(mockDecidedCount);
 			mapToLPADashboardDisplayData.mockReturnValue(mockAppealData);
+			updateChildAppealDisplayData.mockReturnValue([mockAppealData]);
 			isToDoLPADashboard.mockReturnValue(true);
 
 			await getYourAppeals(req, res);

--- a/packages/forms-web-app/jsconfig.json
+++ b/packages/forms-web-app/jsconfig.json
@@ -1,6 +1,10 @@
 {
 	"extends": "../../jsconfig.json",
-	"include": ["**/*.js"],
+	"include": [
+		"**/*.js",
+		"../common/src/lib/linked-appeals.js",
+		"../common/src/lib/linked-appeals.test.js"
+	],
 	"compilerOptions": {
 		"baseUrl": ".",
 		"paths": {

--- a/packages/forms-web-app/src/controllers/selected-appeal/index.js
+++ b/packages/forms-web-app/src/controllers/selected-appeal/index.js
@@ -34,7 +34,7 @@ const { getDepartmentFromCode } = require('../../services/department.service');
 const logger = require('#lib/logger');
 const config = require('../../config');
 const { formatDateForDisplay } = require('@pins/common/src/lib/format-date');
-const { formatDashboardLinkedCaseDetails } = require('#lib/linked-appeals');
+const { formatDashboardLinkedCaseDetails } = require('@pins/common/src/lib/linked-appeals');
 
 /** @type {Partial<import('@pins/common/src/view-model-maps/sections/def').UserSectionsDict>} */
 const userSectionsDict = {

--- a/packages/forms-web-app/src/views/appeals/your-appeals.njk
+++ b/packages/forms-web-app/src/views/appeals/your-appeals.njk
@@ -81,7 +81,7 @@
                               </a>
 														{% elif item.displayInvalid %}
 															<strong class='govuk-tag govuk-tag--grey'>Invalid</strong>
-                            {% else %}
+                            {% elif item.displayNextJourneyLink %}
                               <a href="{{item.nextJourneyDue.baseUrl}}" class="govuk-link">
                                 {{item.nextJourneyDue.journeyDue}}
                               </a>

--- a/packages/forms-web-app/src/views/manage-appeals/your-appeals.njk
+++ b/packages/forms-web-app/src/views/manage-appeals/your-appeals.njk
@@ -63,7 +63,7 @@
                   <td class="govuk-table__cell govuk-table__cell--numeric">
 										{% if item.displayInvalid %}
 											<strong class='govuk-tag govuk-tag--grey'>Invalid</strong>
-                    {% else %}
+                    {% elif item.displayNextJourneyLink  %}
                       <a href="{{item.nextJourneyDue.baseUrl}}" class="govuk-link">
                           {{item.nextJourneyDue.journeyDue}}
                           <span class="govuk-visually-hidden"> for {{item.appealNumber}}</span>


### PR DESCRIPTION
### Description of change

Adds logic to determine whether to display various calls to action for child appeals.

Includes batching logic for linked cases calls

Ticket: https://pins-ds.atlassian.net/browse/A2-4023
 https://pins-ds.atlassian.net/browse/A2-3975
 https://pins-ds.atlassian.net/browse/A2-4006

### Checklist

- [X] Feature complete and ready for users, or behind feature-flag
- [X] Commit history is linear with no merge commits
- [ ] Requires infrastructure changes

### Important

Please do not merge from `main` (please only [rebase](https://github.com/Planning-Inspectorate/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
