### PR TITLE
fix(a2-4073): avoid deadlock and duplicate files for multi-file uploads

### DIFF
--- a/packages/appeals-service-api/src/routes/v2/appeal-cases/_caseReference/appellant-final-comment-submission/document-upload/controller.js
+++ b/packages/appeals-service-api/src/routes/v2/appeal-cases/_caseReference/appellant-final-comment-submission/document-upload/controller.js
@@ -29,8 +29,9 @@ async function createSubmissionDocumentUpload(req, res) {
  */
 async function deleteSubmissionDocumentUpload(req, res) {
 	try {
-		const { caseReference, documentId } = req.params;
-		const content = await deleteSubmissionDocument(caseReference, documentId);
+		const { caseReference } = req.params;
+		const documentIds = req.body;
+		const content = await deleteSubmissionDocument(caseReference, documentIds);
 		if (!content) {
 			throw ApiError.unableToDeleteDocumentUpload();
 		}

--- a/packages/appeals-service-api/src/routes/v2/appeal-cases/_caseReference/appellant-final-comment-submission/document-upload/index.js
+++ b/packages/appeals-service-api/src/routes/v2/appeal-cases/_caseReference/appellant-final-comment-submission/document-upload/index.js
@@ -25,6 +25,6 @@ router.use(
 
 // Document upload routes
 router.post('/', asyncHandler(createSubmissionDocumentUpload));
-router.delete('/:documentId', asyncHandler(deleteSubmissionDocumentUpload));
+router.delete('/', asyncHandler(deleteSubmissionDocumentUpload));
 
 module.exports = { router };

--- a/packages/appeals-service-api/src/routes/v2/appeal-cases/_caseReference/appellant-final-comment-submission/document-upload/index.spec.js
+++ b/packages/appeals-service-api/src/routes/v2/appeal-cases/_caseReference/appellant-final-comment-submission/document-upload/index.spec.js
@@ -1,0 +1,137 @@
+const { APPEAL_USER_ROLES } = require('@pins/common/src/constants');
+const { SERVICE_USER_TYPE } = require('@planning-inspectorate/data-model');
+const { CASE_TYPES } = require('@pins/common/src/database/data-static');
+
+const crypto = require('crypto');
+const {
+	createTestAppealCase
+} = require('../../../../../../../__tests__/developer/fixtures/appeals-case-data');
+
+let validUser = '';
+let email = '';
+const validLpa = 'Q9999';
+
+/**
+ * @param {Object} dependencies
+ * @param {function(): import('@prisma/client').PrismaClient} dependencies.getSqlClient
+ * @param {function(string): void} dependencies.setCurrentSub
+ * @param {function(string): void} dependencies.setCurrentLpa
+ * @param {import('supertest').Agent} dependencies.appealsApi
+ */
+module.exports = ({ getSqlClient, setCurrentSub, setCurrentLpa, appealsApi }) => {
+	const sqlClient = getSqlClient();
+
+	beforeAll(async () => {
+		email = crypto.randomUUID() + '@example.com';
+		const user = await sqlClient.appealUser.create({
+			data: {
+				email
+			}
+		});
+		validUser = user.id;
+	});
+
+	/**
+	 * @returns {Promise<import('@prisma/client').AppellantFinalCommentSubmission>}
+	 */
+	const createFinalCommentSubmission = async (caseRef, caseType) => {
+		const appeal = await sqlClient.appeal.create({
+			include: {
+				AppealCase: true
+			},
+			data: {
+				Users: {
+					create: {
+						userId: validUser,
+						role: APPEAL_USER_ROLES.APPELLANT
+					}
+				},
+				AppealCase: {
+					create: createTestAppealCase(caseRef, caseType, validLpa)
+				}
+			}
+		});
+
+		const finalComment = await sqlClient.appellantFinalCommentSubmission.create({
+			data: {
+				AppealCase: {
+					connect: {
+						caseReference: caseRef
+					}
+				}
+			}
+		});
+
+		await sqlClient.serviceUser.create({
+			data: {
+				internalId: crypto.randomUUID(),
+				emailAddress: email,
+				id: crypto.randomUUID(),
+				serviceUserType: SERVICE_USER_TYPE.APPELLANT,
+				caseReference: appeal.AppealCase?.caseReference
+			}
+		});
+
+		return finalComment;
+	};
+
+	const appealTypes = Object.values(CASE_TYPES)
+		.filter((caseType) => !caseType.expedited)
+		.map((caseType) => caseType.processCode);
+
+	describe('/api/v2/appeal-cases/:caseReference/appellant-final-comment-submissions/document-upload', () => {
+		it.each(appealTypes)('Handles document for case type: %s', async (caseType) => {
+			const caseRef = crypto.randomUUID();
+			const finalCommentSubmission = await createFinalCommentSubmission(caseRef, caseType);
+			setCurrentLpa(validLpa);
+			setCurrentSub(validUser);
+
+			const documentUploads = [
+				{
+					name: 'test',
+					fileName: 'fileName',
+					originalFileName: 'orig',
+					location: '/file',
+					type: 'file-type',
+					storageId: 'abcd1234'
+				}
+			];
+
+			const postResponse = await appealsApi
+				.post(`/api/v2/appeal-cases/${caseRef}/appellant-final-comment-submission/document-upload`)
+				.send(documentUploads);
+
+			expect(postResponse.statusCode).toBe(200);
+
+			const uploadedData = await sqlClient.submissionDocumentUpload.findMany({
+				where: {
+					appellantFinalCommentId: finalCommentSubmission.id
+				}
+			});
+
+			expect(uploadedData).toHaveLength(1);
+
+			const deleteResponse = await appealsApi
+				.delete(
+					`/api/v2/appeal-cases/${caseRef}/appellant-final-comment-submission/document-upload`
+				)
+				.send(uploadedData.map((doc) => doc.id));
+
+			expect(deleteResponse.statusCode).toBe(200);
+
+			const deletedData = await sqlClient.submissionDocumentUpload.findMany({
+				where: {
+					appellantFinalCommentId: finalCommentSubmission.id
+				}
+			});
+
+			expect(deletedData).toHaveLength(0);
+		});
+
+		it('404s if the case cannot be found', async () => {
+			await appealsApi
+				.post('/api/v2/appeal-cases/nope/appellant-final-comment-submissions/document-upload')
+				.expect(404);
+		});
+	});
+};

--- a/packages/appeals-service-api/src/routes/v2/appeal-cases/_caseReference/appellant-final-comment-submission/document-upload/repo.js
+++ b/packages/appeals-service-api/src/routes/v2/appeal-cases/_caseReference/appellant-final-comment-submission/document-upload/repo.js
@@ -25,11 +25,18 @@ class SubmissionDocumentUploadRepository {
 	 * Create submission document for given Appellant Final Comment Submission
 	 *
 	 * @param {string} caseReference
-	 * @param {DocumentUploadData} uploadData
+	 * @param {DocumentUploadData[]} uploadData
 	 * @returns {Promise<AppellantFinalCommentSubmission>}
 	 */
 	async createSubmissionDocument(caseReference, uploadData) {
-		const { name, fileName, originalFileName, location, type, id: storageId } = uploadData;
+		const mappedUploadData = uploadData.map((file) => ({
+			name: file.name,
+			fileName: file.fileName,
+			originalFileName: file.originalFileName,
+			location: file.location,
+			type: file.type,
+			storageId: file.id
+		}));
 
 		return await this.dbClient.appellantFinalCommentSubmission.update({
 			where: {
@@ -37,13 +44,8 @@ class SubmissionDocumentUploadRepository {
 			},
 			data: {
 				SubmissionDocumentUpload: {
-					create: {
-						name,
-						fileName,
-						originalFileName,
-						location,
-						type,
-						storageId
+					createMany: {
+						data: mappedUploadData
 					}
 				}
 			},
@@ -62,18 +64,18 @@ class SubmissionDocumentUploadRepository {
 	 * Delete submission document
 	 *
 	 * @param {string} caseReference
-	 * @param {string} documentId
+	 * @param {string[]} documentIds
 	 * @returns {Promise<AppellantFinalCommentSubmission>}
 	 */
-	async deleteSubmissionDocument(caseReference, documentId) {
+	async deleteSubmissionDocument(caseReference, documentIds) {
 		return await this.dbClient.appellantFinalCommentSubmission.update({
 			where: {
 				caseReference: caseReference
 			},
 			data: {
 				SubmissionDocumentUpload: {
-					delete: {
-						id: documentId
+					deleteMany: {
+						id: { in: documentIds }
 					}
 				}
 			},

--- a/packages/appeals-service-api/src/routes/v2/appeal-cases/_caseReference/appellant-final-comment-submission/document-upload/service.js
+++ b/packages/appeals-service-api/src/routes/v2/appeal-cases/_caseReference/appellant-final-comment-submission/document-upload/service.js
@@ -11,7 +11,7 @@ const repo = new SubmissionDocumentUploadRepository();
  * Create a SubmissionDocumentUpload entry
  *
  * @param {string} caseReference
- * @param {DocumentUploadData} uploadData
+ * @param {DocumentUploadData[]} uploadData
  * @return {Promise<AppellantFinalCommentSubmission|null>}
  */
 async function createSubmissionDocument(caseReference, uploadData) {
@@ -28,11 +28,11 @@ async function createSubmissionDocument(caseReference, uploadData) {
  * Delete a SubmissionDocumentUpload entry
  *
  * @param {string} caseReference
- * @param {string} documentId
+ * @param {string[]} documentIds
  * @return {Promise<AppellantFinalCommentSubmission|null>}
  */
-async function deleteSubmissionDocument(caseReference, documentId) {
-	const updatedStatement = repo.deleteSubmissionDocument(caseReference, documentId);
+async function deleteSubmissionDocument(caseReference, documentIds) {
+	const updatedStatement = repo.deleteSubmissionDocument(caseReference, documentIds);
 
 	if (!updatedStatement) {
 		return null;

--- a/packages/appeals-service-api/src/routes/v2/appeal-cases/_caseReference/appellant-proof-evidence-submission/document-upload/controller.js
+++ b/packages/appeals-service-api/src/routes/v2/appeal-cases/_caseReference/appellant-proof-evidence-submission/document-upload/controller.js
@@ -29,8 +29,9 @@ async function createSubmissionDocumentUpload(req, res) {
  */
 async function deleteSubmissionDocumentUpload(req, res) {
 	try {
-		const { caseReference, documentId } = req.params;
-		const content = await deleteSubmissionDocument(caseReference, documentId);
+		const { caseReference } = req.params;
+		const documentIds = req.body;
+		const content = await deleteSubmissionDocument(caseReference, documentIds);
 		if (!content) {
 			throw ApiError.unableToDeleteDocumentUpload();
 		}

--- a/packages/appeals-service-api/src/routes/v2/appeal-cases/_caseReference/appellant-proof-evidence-submission/document-upload/index.js
+++ b/packages/appeals-service-api/src/routes/v2/appeal-cases/_caseReference/appellant-proof-evidence-submission/document-upload/index.js
@@ -25,6 +25,6 @@ router.use(
 
 // Document upload routes
 router.post('/', asyncHandler(createSubmissionDocumentUpload));
-router.delete('/:documentId', asyncHandler(deleteSubmissionDocumentUpload));
+router.delete('/', asyncHandler(deleteSubmissionDocumentUpload));
 
 module.exports = { router };

--- a/packages/appeals-service-api/src/routes/v2/appeal-cases/_caseReference/appellant-proof-evidence-submission/document-upload/index.spec.js
+++ b/packages/appeals-service-api/src/routes/v2/appeal-cases/_caseReference/appellant-proof-evidence-submission/document-upload/index.spec.js
@@ -1,0 +1,131 @@
+const { APPEAL_USER_ROLES } = require('@pins/common/src/constants');
+const { SERVICE_USER_TYPE } = require('@planning-inspectorate/data-model');
+const { CASE_TYPES } = require('@pins/common/src/database/data-static');
+
+const crypto = require('crypto');
+const {
+	createTestAppealCase
+} = require('../../../../../../../__tests__/developer/fixtures/appeals-case-data');
+
+let validUser = '';
+let email = '';
+const validLpa = 'Q9999';
+
+/**
+ * @param {Object} dependencies
+ * @param {function(): import('@prisma/client').PrismaClient} dependencies.getSqlClient
+ * @param {function(string): void} dependencies.setCurrentSub
+ * @param {function(string): void} dependencies.setCurrentLpa
+ * @param {import('supertest').Agent} dependencies.appealsApi
+ */
+module.exports = ({ getSqlClient, setCurrentSub, setCurrentLpa, appealsApi }) => {
+	const sqlClient = getSqlClient();
+
+	beforeAll(async () => {
+		email = crypto.randomUUID() + '@example.com';
+		const user = await sqlClient.appealUser.create({
+			data: {
+				email
+			}
+		});
+		validUser = user.id;
+	});
+
+	/**
+	 * @returns {Promise<import('@prisma/client').AppellantProofOfEvidenceSubmission>}
+	 */
+	const createProofsSubmission = async (caseRef, caseType) => {
+		const appeal = await sqlClient.appeal.create({
+			include: {
+				AppealCase: true
+			},
+			data: {
+				Users: {
+					create: {
+						userId: validUser,
+						role: APPEAL_USER_ROLES.APPELLANT
+					}
+				},
+				AppealCase: {
+					create: createTestAppealCase(caseRef, caseType, validLpa)
+				}
+			}
+		});
+
+		const proofs = await sqlClient.appellantProofOfEvidenceSubmission.create({
+			data: {
+				AppealCase: {
+					connect: {
+						caseReference: caseRef
+					}
+				}
+			}
+		});
+
+		await sqlClient.serviceUser.create({
+			data: {
+				internalId: crypto.randomUUID(),
+				emailAddress: email,
+				id: crypto.randomUUID(),
+				serviceUserType: SERVICE_USER_TYPE.APPELLANT,
+				caseReference: appeal.AppealCase?.caseReference
+			}
+		});
+
+		return proofs;
+	};
+
+	const appealTypes = Object.values(CASE_TYPES)
+		.filter((caseType) => !caseType.expedited)
+		.map((caseType) => caseType.processCode);
+
+	describe('/api/v2/appeal-cases/:caseReference/appellant-proof-evidence-submission/document-upload', () => {
+		it.each(appealTypes)('Handles document for case type: %s', async (caseType) => {
+			const caseRef = crypto.randomUUID();
+			const proofsSubmission = await createProofsSubmission(caseRef, caseType);
+			setCurrentLpa(validLpa);
+			setCurrentSub(validUser);
+
+			const documentUploads = [
+				{
+					name: 'test',
+					fileName: 'fileName',
+					originalFileName: 'orig',
+					location: '/file',
+					type: 'file-type',
+					storageId: 'abcd1234'
+				}
+			];
+
+			const postResponse = await appealsApi
+				.post(`/api/v2/appeal-cases/${caseRef}/appellant-proof-evidence-submission/document-upload`)
+				.send(documentUploads);
+
+			expect(postResponse.statusCode).toBe(200);
+
+			const uploadedData = await sqlClient.submissionDocumentUpload.findMany({
+				where: {
+					appellantProofOfEvidenceId: proofsSubmission.id
+				}
+			});
+
+			expect(uploadedData).toHaveLength(1);
+
+			const deleteResponse = await appealsApi
+				.delete(
+					`/api/v2/appeal-cases/${caseRef}/appellant-proof-evidence-submission/document-upload`
+				)
+				.send(uploadedData.map((doc) => doc.id));
+
+			expect(deleteResponse.statusCode).toBe(200);
+
+			const deletedData = await sqlClient.submissionDocumentUpload.findMany({
+				where: {
+					appellantProofOfEvidenceId: proofsSubmission.id
+				}
+			});
+
+			expect(deletedData).toHaveLength(0);
+		});
+	});
+};

--- a/packages/appeals-service-api/src/routes/v2/appeal-cases/_caseReference/appellant-proof-evidence-submission/document-upload/repo.js
+++ b/packages/appeals-service-api/src/routes/v2/appeal-cases/_caseReference/appellant-proof-evidence-submission/document-upload/repo.js
@@ -25,11 +25,18 @@ class SubmissionDocumentUploadRepository {
 	 * Create submission document for given Appellant Proof Of Evidence Submission
 	 *
 	 * @param {string} caseReference
-	 * @param {DocumentUploadData} uploadData
+	 * @param {DocumentUploadData[]} uploadData
 	 * @returns {Promise<AppellantProofOfEvidenceSubmission>}
 	 */
 	async createSubmissionDocument(caseReference, uploadData) {
-		const { name, fileName, originalFileName, location, type, id: storageId } = uploadData;
+		const mappedUploadData = uploadData.map((file) => ({
+			name: file.name,
+			fileName: file.fileName,
+			originalFileName: file.originalFileName,
+			location: file.location,
+			type: file.type,
+			storageId: file.id
+		}));
 
 		return await this.dbClient.appellantProofOfEvidenceSubmission.update({
 			where: {
@@ -37,13 +44,8 @@ class SubmissionDocumentUploadRepository {
 			},
 			data: {
 				SubmissionDocumentUpload: {
-					create: {
-						name,
-						fileName,
-						originalFileName,
-						location,
-						type,
-						storageId
+					createMany: {
+						data: mappedUploadData
 					}
 				}
 			},
@@ -62,18 +64,18 @@ class SubmissionDocumentUploadRepository {
 	 * Delete submission document
 	 *
 	 * @param {string} caseReference
-	 * @param {string} documentId
+	 * @param {string[]} documentIds
 	 * @returns {Promise<AppellantProofOfEvidenceSubmission>}
 	 */
-	async deleteSubmissionDocument(caseReference, documentId) {
+	async deleteSubmissionDocument(caseReference, documentIds) {
 		return await this.dbClient.appellantProofOfEvidenceSubmission.update({
 			where: {
 				caseReference: caseReference
 			},
 			data: {
 				SubmissionDocumentUpload: {
-					delete: {
-						id: documentId
+					deleteMany: {
+						id: { in: documentIds }
 					}
 				}
 			},

--- a/packages/appeals-service-api/src/routes/v2/appeal-cases/_caseReference/appellant-proof-evidence-submission/document-upload/service.js
+++ b/packages/appeals-service-api/src/routes/v2/appeal-cases/_caseReference/appellant-proof-evidence-submission/document-upload/service.js
@@ -11,7 +11,7 @@ const repo = new SubmissionDocumentUploadRepository();
  * Create a SubmissionDocumentUpload entry
  *
  * @param {string} caseReference
- * @param {DocumentUploadData} uploadData
+ * @param {DocumentUploadData[]} uploadData
  * @return {Promise<AppellantProofOfEvidenceSubmission|null>}
  */
 async function createSubmissionDocument(caseReference, uploadData) {
@@ -28,11 +28,11 @@ async function createSubmissionDocument(caseReference, uploadData) {
  * Delete a SubmissionDocumentUpload entry
  *
  * @param {string} caseReference
- * @param {string} documentId
+ * @param {string[]} documentIds
  * @return {Promise<AppellantProofOfEvidenceSubmission|null>}
  */
-async function deleteSubmissionDocument(caseReference, documentId) {
-	const updatedProofs = repo.deleteSubmissionDocument(caseReference, documentId);
+async function deleteSubmissionDocument(caseReference, documentIds) {
+	const updatedProofs = repo.deleteSubmissionDocument(caseReference, documentIds);
 
 	if (!updatedProofs) {
 		return null;

--- a/packages/appeals-service-api/src/routes/v2/appeal-cases/_caseReference/lpa-final-comment-submission/document-upload/controller.js
+++ b/packages/appeals-service-api/src/routes/v2/appeal-cases/_caseReference/lpa-final-comment-submission/document-upload/controller.js
@@ -29,8 +29,9 @@ async function createSubmissionDocumentUpload(req, res) {
  */
 async function deleteSubmissionDocumentUpload(req, res) {
 	try {
-		const { caseReference, documentId } = req.params;
-		const content = await deleteSubmissionDocument(caseReference, documentId);
+		const { caseReference } = req.params;
+		const documentIds = req.body;
+		const content = await deleteSubmissionDocument(caseReference, documentIds);
 		if (!content) {
 			throw ApiError.unableToDeleteDocumentUpload();
 		}

--- a/packages/appeals-service-api/src/routes/v2/appeal-cases/_caseReference/lpa-final-comment-submission/document-upload/index.js
+++ b/packages/appeals-service-api/src/routes/v2/appeal-cases/_caseReference/lpa-final-comment-submission/document-upload/index.js
@@ -26,6 +26,6 @@ router.use(
 
 // Document upload routes
 router.post('/', lpaCanModifyCase, asyncHandler(createSubmissionDocumentUpload));
-router.delete('/:documentId', lpaCanModifyCase, asyncHandler(deleteSubmissionDocumentUpload));
+router.delete('/', lpaCanModifyCase, asyncHandler(deleteSubmissionDocumentUpload));
 
 module.exports = { router };

--- a/packages/appeals-service-api/src/routes/v2/appeal-cases/_caseReference/lpa-final-comment-submission/document-upload/index.spec.js
+++ b/packages/appeals-service-api/src/routes/v2/appeal-cases/_caseReference/lpa-final-comment-submission/document-upload/index.spec.js
@@ -1,0 +1,129 @@
+const { APPEAL_USER_ROLES } = require('@pins/common/src/constants');
+const { SERVICE_USER_TYPE } = require('@planning-inspectorate/data-model');
+const { CASE_TYPES } = require('@pins/common/src/database/data-static');
+
+const crypto = require('crypto');
+const {
+	createTestAppealCase
+} = require('../../../../../../../__tests__/developer/fixtures/appeals-case-data');
+
+let validUser = '';
+let email = '';
+const validLpa = 'Q9999';
+
+/**
+ * @param {Object} dependencies
+ * @param {function(): import('@prisma/client').PrismaClient} dependencies.getSqlClient
+ * @param {function(string): void} dependencies.setCurrentSub
+ * @param {function(string): void} dependencies.setCurrentLpa
+ * @param {import('supertest').Agent} dependencies.appealsApi
+ */
+module.exports = ({ getSqlClient, setCurrentSub, setCurrentLpa, appealsApi }) => {
+	const sqlClient = getSqlClient();
+
+	beforeAll(async () => {
+		email = crypto.randomUUID() + '@example.com';
+		const user = await sqlClient.appealUser.create({
+			data: {
+				email
+			}
+		});
+		validUser = user.id;
+	});
+
+	/**
+	 * @returns {Promise<import('@prisma/client').LPAFinalCommentSubmission>}
+	 */
+	const createFinalCommentSubmission = async (caseRef, caseType) => {
+		const appeal = await sqlClient.appeal.create({
+			include: {
+				AppealCase: true
+			},
+			data: {
+				Users: {
+					create: {
+						userId: validUser,
+						role: APPEAL_USER_ROLES.APPELLANT
+					}
+				},
+				AppealCase: {
+					create: createTestAppealCase(caseRef, caseType, validLpa)
+				}
+			}
+		});
+
+		const finalComment = await sqlClient.lPAFinalCommentSubmission.create({
+			data: {
+				AppealCase: {
+					connect: {
+						caseReference: caseRef
+					}
+				}
+			}
+		});
+
+		await sqlClient.serviceUser.create({
+			data: {
+				internalId: crypto.randomUUID(),
+				emailAddress: email,
+				id: crypto.randomUUID(),
+				serviceUserType: SERVICE_USER_TYPE.APPELLANT,
+				caseReference: appeal.AppealCase?.caseReference
+			}
+		});
+
+		return finalComment;
+	};
+
+	const appealTypes = Object.values(CASE_TYPES)
+		.filter((caseType) => !caseType.expedited)
+		.map((caseType) => caseType.processCode);
+
+	describe('/api/v2/appeal-cases/:caseReference/lpa-final-comment-submission/document-upload', () => {
+		it.each(appealTypes)('Handles document for case type: %s', async (caseType) => {
+			const caseRef = crypto.randomUUID();
+			const finalCommentSubmission = await createFinalCommentSubmission(caseRef, caseType);
+			setCurrentLpa(validLpa);
+			setCurrentSub(validUser);
+
+			const documentUploads = [
+				{
+					name: 'test',
+					fileName: 'fileName',
+					originalFileName: 'orig',
+					location: '/file',
+					type: 'file-type',
+					storageId: 'abcd1234'
+				}
+			];
+
+			const postResponse = await appealsApi
+				.post(`/api/v2/appeal-cases/${caseRef}/lpa-final-comment-submission/document-upload`)
+				.send(documentUploads);
+
+			expect(postResponse.statusCode).toBe(200);
+
+			const uploadedData = await sqlClient.submissionDocumentUpload.findMany({
+				where: {
+					lpaFinalCommentId: finalCommentSubmission.id
+				}
+			});
+
+			expect(uploadedData).toHaveLength(1);
+
+			const deleteResponse = await appealsApi
+				.delete(`/api/v2/appeal-cases/${caseRef}/lpa-final-comment-submission/document-upload`)
+				.send(uploadedData.map((doc) => doc.id));
+
+			expect(deleteResponse.statusCode).toBe(200);
+
+			const deletedData = await sqlClient.submissionDocumentUpload.findMany({
+				where: {
+					lpaFinalCommentId: finalCommentSubmission.id
+				}
+			});
+
+			expect(deletedData).toHaveLength(0);
+		});
+	});
+};

--- a/packages/appeals-service-api/src/routes/v2/appeal-cases/_caseReference/lpa-final-comment-submission/document-upload/repo.js
+++ b/packages/appeals-service-api/src/routes/v2/appeal-cases/_caseReference/lpa-final-comment-submission/document-upload/repo.js
@@ -25,11 +25,18 @@ class SubmissionDocumentUploadRepository {
 	 * Create submission document for given LPA Final Comment Submission
 	 *
 	 * @param {string} caseReference
-	 * @param {DocumentUploadData} uploadData
+	 * @param {DocumentUploadData[]} uploadData
 	 * @returns {Promise<LPAFinalCommentSubmission>}
 	 */
 	async createSubmissionDocument(caseReference, uploadData) {
-		const { name, fileName, originalFileName, location, type, id: storageId } = uploadData;
+		const mappedUploadData = uploadData.map((file) => ({
+			name: file.name,
+			fileName: file.fileName,
+			originalFileName: file.originalFileName,
+			location: file.location,
+			type: file.type,
+			storageId: file.id
+		}));
 
 		return await this.dbClient.lPAFinalCommentSubmission.update({
 			where: {
@@ -37,13 +44,8 @@ class SubmissionDocumentUploadRepository {
 			},
 			data: {
 				SubmissionDocumentUpload: {
-					create: {
-						name,
-						fileName,
-						originalFileName,
-						location,
-						type,
-						storageId
+					createMany: {
+						data: mappedUploadData
 					}
 				}
 			},
@@ -62,18 +64,18 @@ class SubmissionDocumentUploadRepository {
 	 * Delete submission document
 	 *
 	 * @param {string} caseReference
-	 * @param {string} documentId
+	 * @param {string[]} documentIds
 	 * @returns {Promise<LPAFinalCommentSubmission>}
 	 */
-	async deleteSubmissionDocument(caseReference, documentId) {
+	async deleteSubmissionDocument(caseReference, documentIds) {
 		return await this.dbClient.lPAFinalCommentSubmission.update({
 			where: {
 				caseReference: caseReference
 			},
 			data: {
 				SubmissionDocumentUpload: {
-					delete: {
-						id: documentId
+					deleteMany: {
+						id: { in: documentIds }
 					}
 				}
 			},

--- a/packages/appeals-service-api/src/routes/v2/appeal-cases/_caseReference/lpa-final-comment-submission/document-upload/service.js
+++ b/packages/appeals-service-api/src/routes/v2/appeal-cases/_caseReference/lpa-final-comment-submission/document-upload/service.js
@@ -11,7 +11,7 @@ const repo = new SubmissionDocumentUploadRepository();
  * Create a SubmissionDocumentUpload entry
  *
  * @param {string} caseReference
- * @param {DocumentUploadData} uploadData
+ * @param {DocumentUploadData[]} uploadData
  * @return {Promise<LPAFinalCommentSubmission|null>}
  */
 async function createSubmissionDocument(caseReference, uploadData) {
@@ -28,11 +28,11 @@ async function createSubmissionDocument(caseReference, uploadData) {
  * Delete a SubmissionDocumentUpload entry
  *
  * @param {string} caseReference
- * @param {string} documentId
+ * @param {string[]} documentIds
  * @return {Promise<LPAFinalCommentSubmission|null>}
  */
-async function deleteSubmissionDocument(caseReference, documentId) {
-	const updatedStatement = repo.deleteSubmissionDocument(caseReference, documentId);
+async function deleteSubmissionDocument(caseReference, documentIds) {
+	const updatedStatement = repo.deleteSubmissionDocument(caseReference, documentIds);
 
 	if (!updatedStatement) {
 		return null;

--- a/packages/appeals-service-api/src/routes/v2/appeal-cases/_caseReference/lpa-proof-evidence-submission/document-upload/controller.js
+++ b/packages/appeals-service-api/src/routes/v2/appeal-cases/_caseReference/lpa-proof-evidence-submission/document-upload/controller.js
@@ -29,8 +29,9 @@ async function createSubmissionDocumentUpload(req, res) {
  */
 async function deleteSubmissionDocumentUpload(req, res) {
 	try {
-		const { caseReference, documentId } = req.params;
-		const content = await deleteSubmissionDocument(caseReference, documentId);
+		const { caseReference } = req.params;
+		const documentIds = req.body;
+		const content = await deleteSubmissionDocument(caseReference, documentIds);
 		if (!content) {
 			throw ApiError.unableToDeleteDocumentUpload();
 		}

--- a/packages/appeals-service-api/src/routes/v2/appeal-cases/_caseReference/lpa-proof-evidence-submission/document-upload/index.js
+++ b/packages/appeals-service-api/src/routes/v2/appeal-cases/_caseReference/lpa-proof-evidence-submission/document-upload/index.js
@@ -25,6 +25,6 @@ router.use(
 
 // Document upload routes
 router.post('/', asyncHandler(createSubmissionDocumentUpload));
-router.delete('/:documentId', asyncHandler(deleteSubmissionDocumentUpload));
+router.delete('/', asyncHandler(deleteSubmissionDocumentUpload));
 
 module.exports = { router };

--- a/packages/appeals-service-api/src/routes/v2/appeal-cases/_caseReference/lpa-proof-evidence-submission/document-upload/index.spec.js
+++ b/packages/appeals-service-api/src/routes/v2/appeal-cases/_caseReference/lpa-proof-evidence-submission/document-upload/index.spec.js
@@ -1,0 +1,129 @@
+const { APPEAL_USER_ROLES } = require('@pins/common/src/constants');
+const { SERVICE_USER_TYPE } = require('@planning-inspectorate/data-model');
+const { CASE_TYPES } = require('@pins/common/src/database/data-static');
+
+const crypto = require('crypto');
+const {
+	createTestAppealCase
+} = require('../../../../../../../__tests__/developer/fixtures/appeals-case-data');
+
+let validUser = '';
+let email = '';
+const validLpa = 'Q9999';
+
+/**
+ * @param {Object} dependencies
+ * @param {function(): import('@prisma/client').PrismaClient} dependencies.getSqlClient
+ * @param {function(string): void} dependencies.setCurrentSub
+ * @param {function(string): void} dependencies.setCurrentLpa
+ * @param {import('supertest').Agent} dependencies.appealsApi
+ */
+module.exports = ({ getSqlClient, setCurrentSub, setCurrentLpa, appealsApi }) => {
+	const sqlClient = getSqlClient();
+
+	beforeAll(async () => {
+		email = crypto.randomUUID() + '@example.com';
+		const user = await sqlClient.appealUser.create({
+			data: {
+				email
+			}
+		});
+		validUser = user.id;
+	});
+
+	/**
+	 * @returns {Promise<import('@prisma/client').LPAProofOfEvidenceSubmission>}
+	 */
+	const createProofsSubmission = async (caseRef, caseType) => {
+		const appeal = await sqlClient.appeal.create({
+			include: {
+				AppealCase: true
+			},
+			data: {
+				Users: {
+					create: {
+						userId: validUser,
+						role: APPEAL_USER_ROLES.APPELLANT
+					}
+				},
+				AppealCase: {
+					create: createTestAppealCase(caseRef, caseType, validLpa)
+				}
+			}
+		});
+
+		const proofs = await sqlClient.lPAProofOfEvidenceSubmission.create({
+			data: {
+				AppealCase: {
+					connect: {
+						caseReference: caseRef
+					}
+				}
+			}
+		});
+
+		await sqlClient.serviceUser.create({
+			data: {
+				internalId: crypto.randomUUID(),
+				emailAddress: email,
+				id: crypto.randomUUID(),
+				serviceUserType: SERVICE_USER_TYPE.APPELLANT,
+				caseReference: appeal.AppealCase?.caseReference
+			}
+		});
+
+		return proofs;
+	};
+
+	const appealTypes = Object.values(CASE_TYPES)
+		.filter((caseType) => !caseType.expedited)
+		.map((caseType) => caseType.processCode);
+
+	describe('/api/v2/appeal-cases/:caseReference/lpa-proof-evidence-submission/document-upload', () => {
+		it.each(appealTypes)('Handles document for case type: %s', async (caseType) => {
+			const caseRef = crypto.randomUUID();
+			const proofsSubmission = await createProofsSubmission(caseRef, caseType);
+			setCurrentLpa(validLpa);
+			setCurrentSub(validUser);
+
+			const documentUploads = [
+				{
+					name: 'test',
+					fileName: 'fileName',
+					originalFileName: 'orig',
+					location: '/file',
+					type: 'file-type',
+					storageId: 'abcd1234'
+				}
+			];
+
+			const postResponse = await appealsApi
+				.post(`/api/v2/appeal-cases/${caseRef}/lpa-proof-evidence-submission/document-upload`)
+				.send(documentUploads);
+
+			expect(postResponse.statusCode).toBe(200);
+
+			const uploadedData = await sqlClient.submissionDocumentUpload.findMany({
+				where: {
+					lpaProofOfEvidenceId: proofsSubmission.id
+				}
+			});
+
+			expect(uploadedData).toHaveLength(1);
+
+			const deleteResponse = await appealsApi
+				.delete(`/api/v2/appeal-cases/${caseRef}/lpa-proof-evidence-submission/document-upload`)
+				.send(uploadedData.map((doc) => doc.id));
+
+			expect(deleteResponse.statusCode).toBe(200);
+
+			const deletedData = await sqlClient.submissionDocumentUpload.findMany({
+				where: {
+					lpaProofOfEvidenceId: proofsSubmission.id
+				}
+			});
+
+			expect(deletedData).toHaveLength(0);
+		});
+	});
+};

--- a/packages/appeals-service-api/src/routes/v2/appeal-cases/_caseReference/lpa-proof-evidence-submission/document-upload/repo.js
+++ b/packages/appeals-service-api/src/routes/v2/appeal-cases/_caseReference/lpa-proof-evidence-submission/document-upload/repo.js
@@ -25,11 +25,18 @@ class SubmissionDocumentUploadRepository {
 	 * Create submission document for given lpa Proof Of Evidence Submission
 	 *
 	 * @param {string} caseReference
-	 * @param {DocumentUploadData} uploadData
+	 * @param {DocumentUploadData[]} uploadData
 	 * @returns {Promise<LPAProofOfEvidenceSubmission>}
 	 */
 	async createSubmissionDocument(caseReference, uploadData) {
-		const { name, fileName, originalFileName, location, type, id: storageId } = uploadData;
+		const mappedUploadData = uploadData.map((file) => ({
+			name: file.name,
+			fileName: file.fileName,
+			originalFileName: file.originalFileName,
+			location: file.location,
+			type: file.type,
+			storageId: file.id
+		}));
 
 		return await this.dbClient.lPAProofOfEvidenceSubmission.update({
 			where: {
@@ -37,13 +44,8 @@ class SubmissionDocumentUploadRepository {
 			},
 			data: {
 				SubmissionDocumentUpload: {
-					create: {
-						name,
-						fileName,
-						originalFileName,
-						location,
-						type,
-						storageId
+					createMany: {
+						data: mappedUploadData
 					}
 				}
 			},
@@ -62,18 +64,18 @@ class SubmissionDocumentUploadRepository {
 	 * Delete submission document
 	 *
 	 * @param {string} caseReference
-	 * @param {string} documentId
+	 * @param {string[]} documentIds
 	 * @returns {Promise<LPAProofOfEvidenceSubmission>}
 	 */
-	async deleteSubmissionDocument(caseReference, documentId) {
+	async deleteSubmissionDocument(caseReference, documentIds) {
 		return await this.dbClient.lPAProofOfEvidenceSubmission.update({
 			where: {
 				caseReference: caseReference
 			},
 			data: {
 				SubmissionDocumentUpload: {
-					delete: {
-						id: documentId
+					deleteMany: {
+						id: { in: documentIds }
 					}
 				}
 			},

--- a/packages/appeals-service-api/src/routes/v2/appeal-cases/_caseReference/lpa-proof-evidence-submission/document-upload/service.js
+++ b/packages/appeals-service-api/src/routes/v2/appeal-cases/_caseReference/lpa-proof-evidence-submission/document-upload/service.js
@@ -11,7 +11,7 @@ const repo = new SubmissionDocumentUploadRepository();
  * Create a SubmissionDocumentUpload entry
  *
  * @param {string} caseReference
- * @param {DocumentUploadData} uploadData
+ * @param {DocumentUploadData[]} uploadData
  * @return {Promise<LPAProofOfEvidenceSubmission|null>}
  */
 async function createSubmissionDocument(caseReference, uploadData) {
@@ -28,11 +28,11 @@ async function createSubmissionDocument(caseReference, uploadData) {
  * Delete a SubmissionDocumentUpload entry
  *
  * @param {string} caseReference
- * @param {string} documentId
+ * @param {string[]} documentIds
  * @return {Promise<LPAProofOfEvidenceSubmission|null>}
  */
-async function deleteSubmissionDocument(caseReference, documentId) {
-	const updatedProofs = repo.deleteSubmissionDocument(caseReference, documentId);
+async function deleteSubmissionDocument(caseReference, documentIds) {
+	const updatedProofs = repo.deleteSubmissionDocument(caseReference, documentIds);
 
 	if (!updatedProofs) {
 		return null;

--- a/packages/appeals-service-api/src/routes/v2/appeal-cases/_caseReference/lpa-questionnaire-submission/document-upload/controller.js
+++ b/packages/appeals-service-api/src/routes/v2/appeal-cases/_caseReference/lpa-questionnaire-submission/document-upload/controller.js
@@ -29,8 +29,13 @@ async function createSubmissionDocumentUpload(req, res) {
  */
 async function deleteSubmissionDocumentUpload(req, res) {
 	try {
-		const { caseReference, documentId } = req.params;
-		const content = await deleteSubmissionDocument(caseReference, documentId);
+		const { caseReference } = req.params;
+		const documentIds = req.body;
+
+		if (!documentIds || !Array.isArray(documentIds)) {
+			throw ApiError.unableToDeleteDocumentUpload();
+		}
+		const content = await deleteSubmissionDocument(caseReference, documentIds);
 		if (!content) {
 			throw ApiError.unableToDeleteDocumentUpload();
 		}

--- a/packages/appeals-service-api/src/routes/v2/appeal-cases/_caseReference/lpa-questionnaire-submission/document-upload/index.js
+++ b/packages/appeals-service-api/src/routes/v2/appeal-cases/_caseReference/lpa-questionnaire-submission/document-upload/index.js
@@ -5,6 +5,6 @@ const router = express.Router({ mergeParams: true });
 
 // Document upload routes
 router.post('/', asyncHandler(createSubmissionDocumentUpload));
-router.delete('/:documentId', asyncHandler(deleteSubmissionDocumentUpload));
+router.delete('/', asyncHandler(deleteSubmissionDocumentUpload));
 
 module.exports = { router };

--- a/packages/appeals-service-api/src/routes/v2/appeal-cases/_caseReference/lpa-questionnaire-submission/document-upload/index.spec.js
+++ b/packages/appeals-service-api/src/routes/v2/appeal-cases/_caseReference/lpa-questionnaire-submission/document-upload/index.spec.js
@@ -1,0 +1,130 @@
+const { APPEAL_USER_ROLES } = require('@pins/common/src/constants');
+const { SERVICE_USER_TYPE } = require('@planning-inspectorate/data-model');
+const { CASE_TYPES } = require('@pins/common/src/database/data-static');
+
+const crypto = require('crypto');
+const {
+	createTestAppealCase
+} = require('../../../../../../../__tests__/developer/fixtures/appeals-case-data');
+
+let validUser = '';
+let email = '';
+const validLpa = 'Q9999';
+
+/**
+ * @param {Object} dependencies
+ * @param {function(): import('@prisma/client').PrismaClient} dependencies.getSqlClient
+ * @param {function(string): void} dependencies.setCurrentSub
+ * @param {function(string): void} dependencies.setCurrentLpa
+ * @param {import('supertest').Agent} dependencies.appealsApi
+ */
+module.exports = ({ getSqlClient, setCurrentSub, setCurrentLpa, appealsApi }) => {
+	const sqlClient = getSqlClient();
+
+	beforeAll(async () => {
+		email = crypto.randomUUID() + '@example.com';
+		const user = await sqlClient.appealUser.create({
+			data: {
+				email
+			}
+		});
+		validUser = user.id;
+	});
+
+	/**
+	 * @returns {Promise<import('@prisma/client').LPAQuestionnaireSubmission>}
+	 */
+	const createLPAQSubmission = async (caseRef, caseType) => {
+		const appeal = await sqlClient.appeal.create({
+			include: {
+				AppealCase: true
+			},
+			data: {
+				Users: {
+					create: {
+						userId: validUser,
+						role: APPEAL_USER_ROLES.APPELLANT
+					}
+				},
+				AppealCase: {
+					create: createTestAppealCase(caseRef, caseType, validLpa)
+				}
+			}
+		});
+
+		const lpaq = await sqlClient.lPAQuestionnaireSubmission.create({
+			data: {
+				AppealCase: {
+					connect: {
+						caseReference: caseRef
+					}
+				}
+			}
+		});
+
+		await sqlClient.serviceUser.create({
+			data: {
+				internalId: crypto.randomUUID(),
+				emailAddress: email,
+				id: crypto.randomUUID(),
+				serviceUserType: SERVICE_USER_TYPE.APPELLANT,
+				caseReference: appeal.AppealCase?.caseReference
+			}
+		});
+
+		return lpaq;
+	};
+
+	const appealTypes = Object.values(CASE_TYPES).map((caseType) => caseType.processCode);
+
+	describe('/api/v2/appeal-cases/:caseReference/lpa-questionnaire-submission/document-upload', () => {
+		it.each(appealTypes)(
+			'Formats appellant final comment submission with documents for case %s',
+			async (caseType) => {
+				const caseRef = crypto.randomUUID();
+				const lpaqSubmission = await createLPAQSubmission(caseRef, caseType);
+				setCurrentLpa(validLpa);
+				setCurrentSub(validUser);
+
+				const documentUploads = [
+					{
+						name: 'test',
+						fileName: 'fileName',
+						originalFileName: 'orig',
+						location: '/file',
+						type: 'file-type',
+						storageId: 'abcd1234'
+					}
+				];
+
+				const postResponse = await appealsApi
+					.post(`/api/v2/appeal-cases/${caseRef}/lpa-questionnaire-submission/document-upload`)
+					.send(documentUploads);
+
+				expect(postResponse.statusCode).toBe(200);
+
+				const uploadedData = await sqlClient.submissionDocumentUpload.findMany({
+					where: {
+						questionnaireId: lpaqSubmission.id
+					}
+				});
+
+				expect(uploadedData).toHaveLength(1);
+
+				const deleteResponse = await appealsApi
+					.delete(`/api/v2/appeal-cases/${caseRef}/lpa-questionnaire-submission/document-upload`)
+					.send(uploadedData.map((doc) => doc.id));
+
+				expect(deleteResponse.statusCode).toBe(200);
+
+				const deletedData = await sqlClient.submissionDocumentUpload.findMany({
+					where: {
+						questionnaireId: lpaqSubmission.id
+					}
+				});
+
+				expect(deletedData).toHaveLength(0);
+			}
+		);
+	});
+};

--- a/packages/appeals-service-api/src/routes/v2/appeal-cases/_caseReference/lpa-questionnaire-submission/document-upload/repo.js
+++ b/packages/appeals-service-api/src/routes/v2/appeal-cases/_caseReference/lpa-questionnaire-submission/document-upload/repo.js
@@ -24,11 +24,18 @@ class SubmissionDocumentUploadRepository {
 	 * Create submission document for given questionnaire
 	 *
 	 * @param {string} caseReference
-	 * @param {DocumentUploadData} uploadData
+	 * @param {DocumentUploadData[]} uploadData
 	 * @returns {Promise<LPAQuestionnaireSubmission>}
 	 */
 	async createSubmissionDocument(caseReference, uploadData) {
-		const { name, fileName, originalFileName, location, type, id } = uploadData;
+		const mappedUploadData = uploadData.map((file) => ({
+			name: file.name,
+			fileName: file.fileName,
+			originalFileName: file.originalFileName,
+			location: file.location,
+			type: file.type,
+			storageId: file.id
+		}));
 
 		return await this.dbClient.lPAQuestionnaireSubmission.update({
 			where: {
@@ -36,13 +43,8 @@ class SubmissionDocumentUploadRepository {
 			},
 			data: {
 				SubmissionDocumentUpload: {
-					create: {
-						name,
-						fileName,
-						originalFileName,
-						location,
-						type,
-						storageId: id
+					createMany: {
+						data: mappedUploadData
 					}
 				}
 			},
@@ -64,18 +66,18 @@ class SubmissionDocumentUploadRepository {
 	 * Delete submission document
 	 *
 	 * @param {string} caseReference
-	 * @param {string} documentId
+	 * @param {string[]} documentIds
 	 * @returns {Promise<LPAQuestionnaireSubmission>}
 	 */
-	async deleteSubmissionDocument(caseReference, documentId) {
+	async deleteSubmissionDocument(caseReference, documentIds) {
 		return await this.dbClient.lPAQuestionnaireSubmission.update({
 			where: {
 				appealCaseReference: caseReference
 			},
 			data: {
 				SubmissionDocumentUpload: {
-					delete: {
-						id: documentId
+					deleteMany: {
+						id: { in: documentIds }
 					}
 				}
 			},

--- a/packages/appeals-service-api/src/routes/v2/appeal-cases/_caseReference/lpa-questionnaire-submission/document-upload/service.js
+++ b/packages/appeals-service-api/src/routes/v2/appeal-cases/_caseReference/lpa-questionnaire-submission/document-upload/service.js
@@ -11,7 +11,7 @@ const repo = new SubmissionDocumentUploadRepository();
  * Create a SubmissionDocumentUpload entry
  *
  * @param {string} caseReference
- * @param {DocumentUploadData} uploadData
+ * @param {DocumentUploadData[]} uploadData
  * @return {Promise<LPAQuestionnaireSubmission|null>}
  */
 async function createSubmissionDocument(caseReference, uploadData) {
@@ -28,11 +28,11 @@ async function createSubmissionDocument(caseReference, uploadData) {
  * Delete a SubmissionDocumentUpload entry
  *
  * @param {string} caseReference
- * @param {string} documentId
+ * @param {string[]} documentIds
  * @return {Promise<LPAQuestionnaireSubmission|null>}
  */
-async function deleteSubmissionDocument(caseReference, documentId) {
-	const updatedQuestionnaire = repo.deleteSubmissionDocument(caseReference, documentId);
+async function deleteSubmissionDocument(caseReference, documentIds) {
+	const updatedQuestionnaire = repo.deleteSubmissionDocument(caseReference, documentIds);
 
 	if (!updatedQuestionnaire) {
 		return null;

--- a/packages/appeals-service-api/src/routes/v2/appeal-cases/_caseReference/lpa-statement-submission/document-upload/controller.js
+++ b/packages/appeals-service-api/src/routes/v2/appeal-cases/_caseReference/lpa-statement-submission/document-upload/controller.js
@@ -29,8 +29,9 @@ async function createSubmissionDocumentUpload(req, res) {
  */
 async function deleteSubmissionDocumentUpload(req, res) {
 	try {
-		const { caseReference, documentId } = req.params;
-		const content = await deleteSubmissionDocument(caseReference, documentId);
+		const { caseReference } = req.params;
+		const documentIds = req.body;
+		const content = await deleteSubmissionDocument(caseReference, documentIds);
 		if (!content) {
 			throw ApiError.unableToDeleteDocumentUpload();
 		}

--- a/packages/appeals-service-api/src/routes/v2/appeal-cases/_caseReference/lpa-statement-submission/document-upload/index.js
+++ b/packages/appeals-service-api/src/routes/v2/appeal-cases/_caseReference/lpa-statement-submission/document-upload/index.js
@@ -26,6 +26,6 @@ router.use(
 
 // Document upload routes
 router.post('/', lpaCanModifyCase, asyncHandler(createSubmissionDocumentUpload));
-router.delete('/:documentId', lpaCanModifyCase, asyncHandler(deleteSubmissionDocumentUpload));
+router.delete('/', lpaCanModifyCase, asyncHandler(deleteSubmissionDocumentUpload));
 
 module.exports = { router };

--- a/packages/appeals-service-api/src/routes/v2/appeal-cases/_caseReference/lpa-statement-submission/document-upload/index.spec.js
+++ b/packages/appeals-service-api/src/routes/v2/appeal-cases/_caseReference/lpa-statement-submission/document-upload/index.spec.js
@@ -1,0 +1,129 @@
+const { APPEAL_USER_ROLES } = require('@pins/common/src/constants');
+const { SERVICE_USER_TYPE } = require('@planning-inspectorate/data-model');
+const { CASE_TYPES } = require('@pins/common/src/database/data-static');
+
+const crypto = require('crypto');
+const {
+	createTestAppealCase
+} = require('../../../../../../../__tests__/developer/fixtures/appeals-case-data');
+
+let validUser = '';
+let email = '';
+const validLpa = 'Q9999';
+
+/**
+ * @param {Object} dependencies
+ * @param {function(): import('@prisma/client').PrismaClient} dependencies.getSqlClient
+ * @param {function(string): void} dependencies.setCurrentSub
+ * @param {function(string): void} dependencies.setCurrentLpa
+ * @param {import('supertest').Agent} dependencies.appealsApi
+ */
+module.exports = ({ getSqlClient, setCurrentSub, setCurrentLpa, appealsApi }) => {
+	const sqlClient = getSqlClient();
+
+	beforeAll(async () => {
+		email = crypto.randomUUID() + '@example.com';
+		const user = await sqlClient.appealUser.create({
+			data: {
+				email
+			}
+		});
+		validUser = user.id;
+	});
+
+	/**
+	 * @returns {Promise<import('@prisma/client').LPAStatementSubmission>}
+	 */
+	const createStatementSubmission = async (caseRef, caseType) => {
+		const appeal = await sqlClient.appeal.create({
+			include: {
+				AppealCase: true
+			},
+			data: {
+				Users: {
+					create: {
+						userId: validUser,
+						role: APPEAL_USER_ROLES.APPELLANT
+					}
+				},
+				AppealCase: {
+					create: createTestAppealCase(caseRef, caseType, validLpa)
+				}
+			}
+		});
+
+		const statement = await sqlClient.lPAStatementSubmission.create({
+			data: {
+				AppealCase: {
+					connect: {
+						caseReference: caseRef
+					}
+				}
+			}
+		});
+
+		await sqlClient.serviceUser.create({
+			data: {
+				internalId: crypto.randomUUID(),
+				emailAddress: email,
+				id: crypto.randomUUID(),
+				serviceUserType: SERVICE_USER_TYPE.APPELLANT,
+				caseReference: appeal.AppealCase?.caseReference
+			}
+		});
+
+		return statement;
+	};
+
+	const appealTypes = Object.values(CASE_TYPES)
+		.filter((caseType) => !caseType.expedited)
+		.map((caseType) => caseType.processCode);
+
+	describe('/api/v2/appeal-cases/:caseReference/lpa-statement-submission/document-upload', () => {
+		it.each(appealTypes)('Handles document for case type: %s', async (caseType) => {
+			const caseRef = crypto.randomUUID();
+			const statementSubmission = await createStatementSubmission(caseRef, caseType);
+			setCurrentLpa(validLpa);
+			setCurrentSub(validUser);
+
+			const documentUploads = [
+				{
+					name: 'test',
+					fileName: 'fileName',
+					originalFileName: 'orig',
+					location: '/file',
+					type: 'file-type',
+					storageId: 'abcd1234'
+				}
+			];
+
+			const postResponse = await appealsApi
+				.post(`/api/v2/appeal-cases/${caseRef}/lpa-statement-submission/document-upload`)
+				.send(documentUploads);
+
+			expect(postResponse.statusCode).toBe(200);
+
+			const uploadedData = await sqlClient.submissionDocumentUpload.findMany({
+				where: {
+					lpaStatementId: statementSubmission.id
+				}
+			});
+
+			expect(uploadedData).toHaveLength(1);
+
+			const deleteResponse = await appealsApi
+				.delete(`/api/v2/appeal-cases/${caseRef}/lpa-statement-submission/document-upload`)
+				.send(uploadedData.map((doc) => doc.id));
+
+			expect(deleteResponse.statusCode).toBe(200);
+
+			const deletedData = await sqlClient.submissionDocumentUpload.findMany({
+				where: {
+					lpaStatementId: statementSubmission.id
+				}
+			});
+
+			expect(deletedData).toHaveLength(0);
+		});
+	});
+};

--- a/packages/appeals-service-api/src/routes/v2/appeal-cases/_caseReference/lpa-statement-submission/document-upload/repo.js
+++ b/packages/appeals-service-api/src/routes/v2/appeal-cases/_caseReference/lpa-statement-submission/document-upload/repo.js
@@ -25,11 +25,18 @@ class SubmissionDocumentUploadRepository {
 	 * Create submission document for given LPA statement
 	 *
 	 * @param {string} caseReference
-	 * @param {DocumentUploadData} uploadData
+	 * @param {DocumentUploadData[]} uploadData
 	 * @returns {Promise<LPAStatementSubmission>}
 	 */
 	async createSubmissionDocument(caseReference, uploadData) {
-		const { name, fileName, originalFileName, location, type, id: storageId } = uploadData;
+		const mappedUploadData = uploadData.map((file) => ({
+			name: file.name,
+			fileName: file.fileName,
+			originalFileName: file.originalFileName,
+			location: file.location,
+			type: file.type,
+			storageId: file.id
+		}));
 
 		return await this.dbClient.lPAStatementSubmission.update({
 			where: {
@@ -37,13 +44,8 @@ class SubmissionDocumentUploadRepository {
 			},
 			data: {
 				SubmissionDocumentUpload: {
-					create: {
-						name,
-						fileName,
-						originalFileName,
-						location,
-						type,
-						storageId
+					createMany: {
+						data: mappedUploadData
 					}
 				}
 			},
@@ -62,18 +64,18 @@ class SubmissionDocumentUploadRepository {
 	 * Delete submission document
 	 *
 	 * @param {string} caseReference
-	 * @param {string} documentId
+	 * @param {string[]} documentIds
 	 * @returns {Promise<LPAStatementSubmission>}
 	 */
-	async deleteSubmissionDocument(caseReference, documentId) {
+	async deleteSubmissionDocument(caseReference, documentIds) {
 		return await this.dbClient.lPAStatementSubmission.update({
 			where: {
 				appealCaseReference: caseReference
 			},
 			data: {
 				SubmissionDocumentUpload: {
-					delete: {
-						id: documentId
+					deleteMany: {
+						id: { in: documentIds }
 					}
 				}
 			},

--- a/packages/appeals-service-api/src/routes/v2/appeal-cases/_caseReference/lpa-statement-submission/document-upload/service.js
+++ b/packages/appeals-service-api/src/routes/v2/appeal-cases/_caseReference/lpa-statement-submission/document-upload/service.js
@@ -11,7 +11,7 @@ const repo = new SubmissionDocumentUploadRepository();
  * Create a SubmissionDocumentUpload entry
  *
  * @param {string} caseReference
- * @param {DocumentUploadData} uploadData
+ * @param {DocumentUploadData[]} uploadData
  * @return {Promise<LPAStatementSubmission|null>}
  */
 async function createSubmissionDocument(caseReference, uploadData) {
@@ -28,11 +28,11 @@ async function createSubmissionDocument(caseReference, uploadData) {
  * Delete a SubmissionDocumentUpload entry
  *
  * @param {string} caseReference
- * @param {string} documentId
+ * @param {string[]} documentIds
  * @return {Promise<LPAStatementSubmission|null>}
  */
-async function deleteSubmissionDocument(caseReference, documentId) {
-	const updatedStatement = repo.deleteSubmissionDocument(caseReference, documentId);
+async function deleteSubmissionDocument(caseReference, documentIds) {
+	const updatedStatement = repo.deleteSubmissionDocument(caseReference, documentIds);
 
 	if (!updatedStatement) {
 		return null;

--- a/packages/appeals-service-api/src/routes/v2/appeal-cases/_caseReference/rule-6-proof-evidence-submission/document-upload/controller.js
+++ b/packages/appeals-service-api/src/routes/v2/appeal-cases/_caseReference/rule-6-proof-evidence-submission/document-upload/controller.js
@@ -31,8 +31,9 @@ async function createSubmissionDocumentUpload(req, res) {
 async function deleteSubmissionDocumentUpload(req, res) {
 	try {
 		const userId = req.auth?.payload.sub;
-		const { caseReference, documentId } = req.params;
-		const content = await deleteSubmissionDocument(userId, caseReference, documentId);
+		const { caseReference } = req.params;
+		const documentIds = req.body;
+		const content = await deleteSubmissionDocument(userId, caseReference, documentIds);
 		if (!content) {
 			throw ApiError.unableToDeleteDocumentUpload();
 		}

--- a/packages/appeals-service-api/src/routes/v2/appeal-cases/_caseReference/rule-6-proof-evidence-submission/document-upload/index.js
+++ b/packages/appeals-service-api/src/routes/v2/appeal-cases/_caseReference/rule-6-proof-evidence-submission/document-upload/index.js
@@ -25,6 +25,6 @@ router.use(
 
 // Document upload routes
 router.post('/', asyncHandler(createSubmissionDocumentUpload));
-router.delete('/:documentId', asyncHandler(deleteSubmissionDocumentUpload));
+router.delete('/', asyncHandler(deleteSubmissionDocumentUpload));
 
 module.exports = { router };

--- a/packages/appeals-service-api/src/routes/v2/appeal-cases/_caseReference/rule-6-proof-evidence-submission/document-upload/index.spec.js
+++ b/packages/appeals-service-api/src/routes/v2/appeal-cases/_caseReference/rule-6-proof-evidence-submission/document-upload/index.spec.js
@@ -1,0 +1,134 @@
+const { APPEAL_USER_ROLES } = require('@pins/common/src/constants');
+const { SERVICE_USER_TYPE } = require('@planning-inspectorate/data-model');
+const { CASE_TYPES } = require('@pins/common/src/database/data-static');
+
+const crypto = require('crypto');
+const {
+	createTestAppealCase
+} = require('../../../../../../../__tests__/developer/fixtures/appeals-case-data');
+
+let validUser = '';
+let email = '';
+const validLpa = 'Q9999';
+
+/**
+ * @param {Object} dependencies
+ * @param {function(): import('@prisma/client').PrismaClient} dependencies.getSqlClient
+ * @param {function(string): void} dependencies.setCurrentSub
+ * @param {function(string): void} dependencies.setCurrentLpa
+ * @param {import('supertest').Agent} dependencies.appealsApi
+ */
+module.exports = ({ getSqlClient, setCurrentSub, setCurrentLpa, appealsApi }) => {
+	const sqlClient = getSqlClient();
+
+	beforeAll(async () => {
+		email = crypto.randomUUID() + '@example.com';
+		const user = await sqlClient.appealUser.create({
+			data: {
+				email
+			}
+		});
+		validUser = user.id;
+	});
+
+	/**
+	 * @returns {Promise<import('@prisma/client').Rule6ProofOfEvidenceSubmission>}
+	 */
+	const createProofsSubmission = async (caseRef, caseType) => {
+		const appeal = await sqlClient.appeal.create({
+			include: {
+				AppealCase: true
+			},
+			data: {
+				Users: {
+					create: {
+						userId: validUser,
+						role: APPEAL_USER_ROLES.RULE_6_PARTY
+					}
+				},
+				AppealCase: {
+					create: createTestAppealCase(caseRef, caseType, validLpa)
+				}
+			}
+		});
+
+		const proof = await sqlClient.rule6ProofOfEvidenceSubmission.create({
+			data: {
+				AppealCase: {
+					connect: {
+						caseReference: caseRef
+					}
+				},
+				AppealUser: {
+					connect: {
+						id: validUser
+					}
+				}
+			}
+		});
+
+		await sqlClient.serviceUser.create({
+			data: {
+				internalId: crypto.randomUUID(),
+				emailAddress: email,
+				id: crypto.randomUUID(),
+				serviceUserType: SERVICE_USER_TYPE.APPELLANT,
+				caseReference: appeal.AppealCase?.caseReference
+			}
+		});
+
+		return proof;
+	};
+
+	const appealTypes = Object.values(CASE_TYPES)
+		.filter((caseType) => !caseType.expedited)
+		.map((caseType) => caseType.processCode);
+
+	describe('/api/v2/appeal-cases/:caseReference/rule-6-proof-evidence-submission/document-upload', () => {
+		it.each(appealTypes)('Handles document for case type: %s', async (caseType) => {
+			const caseRef = crypto.randomUUID();
+			const proofsSubmission = await createProofsSubmission(caseRef, caseType);
+			setCurrentLpa(validLpa);
+			setCurrentSub(validUser);
+
+			const documentUploads = [
+				{
+					name: 'test',
+					fileName: 'fileName',
+					originalFileName: 'orig',
+					location: '/file',
+					type: 'file-type',
+					storageId: 'abcd1234'
+				}
+			];
+
+			const postResponse = await appealsApi
+				.post(`/api/v2/appeal-cases/${caseRef}/rule-6-proof-evidence-submission/document-upload`)
+				.send(documentUploads);
+
+			expect(postResponse.statusCode).toBe(200);
+
+			const uploadedData = await sqlClient.submissionDocumentUpload.findMany({
+				where: {
+					rule6ProofOfEvidenceSubmissionId: proofsSubmission.id
+				}
+			});
+
+			expect(uploadedData).toHaveLength(1);
+
+			const deleteResponse = await appealsApi
+				.delete(`/api/v2/appeal-cases/${caseRef}/rule-6-proof-evidence-submission/document-upload`)
+				.send(uploadedData.map((doc) => doc.id));
+
+			expect(deleteResponse.statusCode).toBe(200);
+
+			const deletedData = await sqlClient.submissionDocumentUpload.findMany({
+				where: {
+					rule6ProofOfEvidenceSubmissionId: proofsSubmission.id
+				}
+			});
+
+			expect(deletedData).toHaveLength(0);
+		});
+	});
+};

--- a/packages/appeals-service-api/src/routes/v2/appeal-cases/_caseReference/rule-6-proof-evidence-submission/document-upload/repo.js
+++ b/packages/appeals-service-api/src/routes/v2/appeal-cases/_caseReference/rule-6-proof-evidence-submission/document-upload/repo.js
@@ -26,11 +26,18 @@ class SubmissionDocumentUploadRepository {
 	 *
 	 * @param {string} userId
 	 * @param {string} caseReference
-	 * @param {DocumentUploadData} uploadData
+	 * @param {DocumentUploadData[]} uploadData
 	 * @returns {Promise<Rule6ProofOfEvidenceSubmission>}
 	 */
 	async createSubmissionDocument(userId, caseReference, uploadData) {
-		const { name, fileName, originalFileName, location, type, id: storageId } = uploadData;
+		const mappedUploadData = uploadData.map((file) => ({
+			name: file.name,
+			fileName: file.fileName,
+			originalFileName: file.originalFileName,
+			location: file.location,
+			type: file.type,
+			storageId: file.id
+		}));
 
 		return await this.dbClient.rule6ProofOfEvidenceSubmission.update({
 			where: {
@@ -39,13 +46,8 @@ class SubmissionDocumentUploadRepository {
 			},
 			data: {
 				SubmissionDocumentUpload: {
-					create: {
-						name,
-						fileName,
-						originalFileName,
-						location,
-						type,
-						storageId
+					createMany: {
+						data: mappedUploadData
 					}
 				}
 			},
@@ -65,10 +67,10 @@ class SubmissionDocumentUploadRepository {
 	 *
 	 * @param {string} userId
 	 * @param {string} caseReference
-	 * @param {string} documentId
+	 * @param {string[]} documentIds
 	 * @returns {Promise<Rule6ProofOfEvidenceSubmission>}
 	 */
-	async deleteSubmissionDocument(userId, caseReference, documentId) {
+	async deleteSubmissionDocument(userId, caseReference, documentIds) {
 		return await this.dbClient.rule6ProofOfEvidenceSubmission.update({
 			where: {
 				userId,
@@ -76,8 +78,8 @@ class SubmissionDocumentUploadRepository {
 			},
 			data: {
 				SubmissionDocumentUpload: {
-					delete: {
-						id: documentId
+					deleteMany: {
+						id: { in: documentIds }
 					}
 				}
 			},

--- a/packages/appeals-service-api/src/routes/v2/appeal-cases/_caseReference/rule-6-proof-evidence-submission/document-upload/service.js
+++ b/packages/appeals-service-api/src/routes/v2/appeal-cases/_caseReference/rule-6-proof-evidence-submission/document-upload/service.js
@@ -12,7 +12,7 @@ const repo = new SubmissionDocumentUploadRepository();
  *
  * @param {string | undefined} userId
  * @param {string} caseReference
- * @param {DocumentUploadData} uploadData
+ * @param {DocumentUploadData[]} uploadData
  * @return {Promise<Rule6ProofOfEvidenceSubmission|null>}
  */
 async function createSubmissionDocument(userId, caseReference, uploadData) {
@@ -34,15 +34,15 @@ async function createSubmissionDocument(userId, caseReference, uploadData) {
  *
  * @param {string|undefined} userId
  * @param {string} caseReference
- * @param {string} documentId
+ * @param {string[]} documentIds
  * @return {Promise<Rule6ProofOfEvidenceSubmission|null>}
  */
-async function deleteSubmissionDocument(userId, caseReference, documentId) {
+async function deleteSubmissionDocument(userId, caseReference, documentIds) {
 	if (!userId) {
 		return null;
 	}
 
-	const updatedProofs = repo.deleteSubmissionDocument(userId, caseReference, documentId);
+	const updatedProofs = repo.deleteSubmissionDocument(userId, caseReference, documentIds);
 
 	if (!updatedProofs) {
 		return null;

--- a/packages/appeals-service-api/src/routes/v2/appeal-cases/_caseReference/rule-6-statement-submission/document-upload/controller.js
+++ b/packages/appeals-service-api/src/routes/v2/appeal-cases/_caseReference/rule-6-statement-submission/document-upload/controller.js
@@ -31,8 +31,9 @@ async function createSubmissionDocumentUpload(req, res) {
 async function deleteSubmissionDocumentUpload(req, res) {
 	try {
 		const userId = req.auth?.payload.sub;
-		const { caseReference, documentId } = req.params;
-		const content = await deleteSubmissionDocument(userId, caseReference, documentId);
+		const { caseReference } = req.params;
+		const documentIds = req.body;
+		const content = await deleteSubmissionDocument(userId, caseReference, documentIds);
 		if (!content) {
 			throw ApiError.unableToDeleteDocumentUpload();
 		}

--- a/packages/appeals-service-api/src/routes/v2/appeal-cases/_caseReference/rule-6-statement-submission/document-upload/index.js
+++ b/packages/appeals-service-api/src/routes/v2/appeal-cases/_caseReference/rule-6-statement-submission/document-upload/index.js
@@ -25,6 +25,6 @@ router.use(
 
 // Document upload routes
 router.post('/', asyncHandler(createSubmissionDocumentUpload));
-router.delete('/:documentId', asyncHandler(deleteSubmissionDocumentUpload));
+router.delete('/', asyncHandler(deleteSubmissionDocumentUpload));
 
 module.exports = { router };

--- a/packages/appeals-service-api/src/routes/v2/appeal-cases/_caseReference/rule-6-statement-submission/document-upload/index.spec.js
+++ b/packages/appeals-service-api/src/routes/v2/appeal-cases/_caseReference/rule-6-statement-submission/document-upload/index.spec.js
@@ -1,0 +1,134 @@
+const { APPEAL_USER_ROLES } = require('@pins/common/src/constants');
+const { SERVICE_USER_TYPE } = require('@planning-inspectorate/data-model');
+const { CASE_TYPES } = require('@pins/common/src/database/data-static');
+
+const crypto = require('crypto');
+const {
+	createTestAppealCase
+} = require('../../../../../../../__tests__/developer/fixtures/appeals-case-data');
+
+let validUser = '';
+let email = '';
+const validLpa = 'Q9999';
+
+/**
+ * @param {Object} dependencies
+ * @param {function(): import('@prisma/client').PrismaClient} dependencies.getSqlClient
+ * @param {function(string): void} dependencies.setCurrentSub
+ * @param {function(string): void} dependencies.setCurrentLpa
+ * @param {import('supertest').Agent} dependencies.appealsApi
+ */
+module.exports = ({ getSqlClient, setCurrentSub, setCurrentLpa, appealsApi }) => {
+	const sqlClient = getSqlClient();
+
+	beforeAll(async () => {
+		email = crypto.randomUUID() + '@example.com';
+		const user = await sqlClient.appealUser.create({
+			data: {
+				email
+			}
+		});
+		validUser = user.id;
+	});
+
+	/**
+	 * @returns {Promise<import('@prisma/client').Rule6StatementSubmission>}
+	 */
+	const createStatementSubmission = async (caseRef, caseType) => {
+		const appeal = await sqlClient.appeal.create({
+			include: {
+				AppealCase: true
+			},
+			data: {
+				Users: {
+					create: {
+						userId: validUser,
+						role: APPEAL_USER_ROLES.RULE_6_PARTY
+					}
+				},
+				AppealCase: {
+					create: createTestAppealCase(caseRef, caseType, validLpa)
+				}
+			}
+		});
+
+		const statement = await sqlClient.rule6StatementSubmission.create({
+			data: {
+				AppealCase: {
+					connect: {
+						caseReference: caseRef
+					}
+				},
+				AppealUser: {
+					connect: {
+						id: validUser
+					}
+				}
+			}
+		});
+
+		await sqlClient.serviceUser.create({
+			data: {
+				internalId: crypto.randomUUID(),
+				emailAddress: email,
+				id: crypto.randomUUID(),
+				serviceUserType: SERVICE_USER_TYPE.APPELLANT,
+				caseReference: appeal.AppealCase?.caseReference
+			}
+		});
+
+		return statement;
+	};
+
+	const appealTypes = Object.values(CASE_TYPES)
+		.filter((caseType) => !caseType.expedited)
+		.map((caseType) => caseType.processCode);
+
+	describe('/api/v2/appeal-cases/:caseReference/rule-6-statement-submission/document-upload', () => {
+		it.each(appealTypes)('Handles document for case type: %s', async (caseType) => {
+			const caseRef = crypto.randomUUID();
+			const statementSubmission = await createStatementSubmission(caseRef, caseType);
+			setCurrentLpa(validLpa);
+			setCurrentSub(validUser);
+
+			const documentUploads = [
+				{
+					name: 'test',
+					fileName: 'fileName',
+					originalFileName: 'orig',
+					location: '/file',
+					type: 'file-type',
+					storageId: 'abcd1234'
+				}
+			];
+
+			const postResponse = await appealsApi
+				.post(`/api/v2/appeal-cases/${caseRef}/rule-6-statement-submission/document-upload`)
+				.send(documentUploads);
+
+			expect(postResponse.statusCode).toBe(200);
+
+			const uploadedData = await sqlClient.submissionDocumentUpload.findMany({
+				where: {
+					rule6StatementSubmissionId: statementSubmission.id
+				}
+			});
+
+			expect(uploadedData).toHaveLength(1);
+
+			const deleteResponse = await appealsApi
+				.delete(`/api/v2/appeal-cases/${caseRef}/rule-6-statement-submission/document-upload`)
+				.send(uploadedData.map((doc) => doc.id));
+
+			expect(deleteResponse.statusCode).toBe(200);
+
+			const deletedData = await sqlClient.submissionDocumentUpload.findMany({
+				where: {
+					rule6StatementSubmissionId: statementSubmission.id
+				}
+			});
+
+			expect(deletedData).toHaveLength(0);
+		});
+	});
+};

--- a/packages/appeals-service-api/src/routes/v2/appeal-cases/_caseReference/rule-6-statement-submission/document-upload/repo.js
+++ b/packages/appeals-service-api/src/routes/v2/appeal-cases/_caseReference/rule-6-statement-submission/document-upload/repo.js
@@ -26,11 +26,18 @@ class SubmissionDocumentUploadRepository {
 	 *
 	 * @param {string} userId
 	 * @param {string} caseReference
-	 * @param {DocumentUploadData} uploadData
+	 * @param {DocumentUploadData[]} uploadData
 	 * @returns {Promise<Rule6StatementSubmission>}
 	 */
 	async createSubmissionDocument(userId, caseReference, uploadData) {
-		const { name, fileName, originalFileName, location, type, id: storageId } = uploadData;
+		const mappedUploadData = uploadData.map((file) => ({
+			name: file.name,
+			fileName: file.fileName,
+			originalFileName: file.originalFileName,
+			location: file.location,
+			type: file.type,
+			storageId: file.id
+		}));
 
 		return await this.dbClient.rule6StatementSubmission.update({
 			where: {
@@ -39,13 +46,8 @@ class SubmissionDocumentUploadRepository {
 			},
 			data: {
 				SubmissionDocumentUpload: {
-					create: {
-						name,
-						fileName,
-						originalFileName,
-						location,
-						type,
-						storageId
+					createMany: {
+						data: mappedUploadData
 					}
 				}
 			},
@@ -65,10 +67,10 @@ class SubmissionDocumentUploadRepository {
 	 *
 	 * @param {string} userId
 	 * @param {string} caseReference
-	 * @param {string} documentId
+	 * @param {string[]} documentIds
 	 * @returns {Promise<Rule6StatementSubmission>}
 	 */
-	async deleteSubmissionDocument(userId, caseReference, documentId) {
+	async deleteSubmissionDocument(userId, caseReference, documentIds) {
 		return await this.dbClient.rule6StatementSubmission.update({
 			where: {
 				userId,
@@ -76,8 +78,8 @@ class SubmissionDocumentUploadRepository {
 			},
 			data: {
 				SubmissionDocumentUpload: {
-					delete: {
-						id: documentId
+					deleteMany: {
+						id: { in: documentIds }
 					}
 				}
 			},

--- a/packages/appeals-service-api/src/routes/v2/appeal-cases/_caseReference/rule-6-statement-submission/document-upload/service.js
+++ b/packages/appeals-service-api/src/routes/v2/appeal-cases/_caseReference/rule-6-statement-submission/document-upload/service.js
@@ -12,7 +12,7 @@ const repo = new SubmissionDocumentUploadRepository();
  *
  * @param {string | undefined} userId
  * @param {string} caseReference
- * @param {DocumentUploadData} uploadData
+ * @param {DocumentUploadData[]} uploadData
  * @return {Promise<Rule6StatementSubmission|null>}
  */
 async function createSubmissionDocument(userId, caseReference, uploadData) {
@@ -34,15 +34,15 @@ async function createSubmissionDocument(userId, caseReference, uploadData) {
  *
  * @param {string|undefined} userId
  * @param {string} caseReference
- * @param {string} documentId
+ * @param {string[]} documentIds
  * @return {Promise<Rule6StatementSubmission|null>}
  */
-async function deleteSubmissionDocument(userId, caseReference, documentId) {
+async function deleteSubmissionDocument(userId, caseReference, documentIds) {
 	if (!userId) {
 		return null;
 	}
 
-	const updatedStatement = repo.deleteSubmissionDocument(userId, caseReference, documentId);
+	const updatedStatement = repo.deleteSubmissionDocument(userId, caseReference, documentIds);
 
 	if (!updatedStatement) {
 		return null;

--- a/packages/appeals-service-api/src/routes/v2/appellant-submissions/_id/document-upload/controller.js
+++ b/packages/appeals-service-api/src/routes/v2/appellant-submissions/_id/document-upload/controller.js
@@ -29,8 +29,9 @@ async function createSubmissionDocumentUpload(req, res) {
  */
 async function deleteSubmissionDocumentUpload(req, res) {
 	try {
-		const { id, documentId } = req.params;
-		const content = await deleteSubmissionDocument(id, documentId);
+		const { id } = req.params;
+		const documentIds = req.body;
+		const content = await deleteSubmissionDocument(id, documentIds);
 		if (!content) {
 			throw ApiError.unableToDeleteDocumentUpload();
 		}

--- a/packages/appeals-service-api/src/routes/v2/appellant-submissions/_id/document-upload/index.js
+++ b/packages/appeals-service-api/src/routes/v2/appellant-submissions/_id/document-upload/index.js
@@ -5,6 +5,6 @@ const router = express.Router({ mergeParams: true });
 
 // Document upload routes
 router.post('/', asyncHandler(createSubmissionDocumentUpload));
-router.delete('/:documentId', asyncHandler(deleteSubmissionDocumentUpload));
+router.delete('/', asyncHandler(deleteSubmissionDocumentUpload));
 
 module.exports = { router };

--- a/packages/appeals-service-api/src/routes/v2/appellant-submissions/_id/document-upload/index.spec.js
+++ b/packages/appeals-service-api/src/routes/v2/appellant-submissions/_id/document-upload/index.spec.js
@@ -1,0 +1,108 @@
+const { APPEAL_USER_ROLES } = require('@pins/common/src/constants');
+const { CASE_TYPES } = require('@pins/common/src/database/data-static');
+
+const crypto = require('crypto');
+
+let validUser = '';
+let email = '';
+
+/**
+ * @param {Object} dependencies
+ * @param {function(): import('@prisma/client').PrismaClient} dependencies.getSqlClient
+ * @param {function(string): void} dependencies.setCurrentSub
+ * @param {import('supertest').Agent} dependencies.appealsApi
+ */
+module.exports = ({
+	getSqlClient,
+	setCurrentSub,
+
+	appealsApi
+}) => {
+	const sqlClient = getSqlClient();
+
+	beforeAll(async () => {
+		email = crypto.randomUUID() + '@example.com';
+		const user = await sqlClient.appealUser.create({
+			data: {
+				email
+			}
+		});
+		validUser = user.id;
+	});
+
+	/**
+	 * @param {string} caseType
+	 * @returns {Promise<import('@prisma/client').AppellantSubmission & { AppellantSubmission: import('@prisma/client').AppellantSubmission })}>}
+	 */
+	const createAppellantSubmission = async (caseType) => {
+		const appeal = await sqlClient.appeal.create({
+			select: {
+				AppellantSubmission: true
+			},
+			data: {
+				Users: {
+					create: {
+						userId: validUser,
+						role: APPEAL_USER_ROLES.APPELLANT
+					}
+				},
+				AppellantSubmission: {
+					create: {
+						LPACode: 'Q9999',
+						appealTypeCode: caseType
+					}
+				}
+			}
+		});
+
+		return appeal;
+	};
+
+	const appealTypes = Object.values(CASE_TYPES).map((caseType) => caseType.processCode);
+
+	describe('/api/v2/appellant-submissions/_id/document-upload', () => {
+		it.each(appealTypes)('Handles document for case type: %s', async (caseType) => {
+			const appeal = await createAppellantSubmission(caseType);
+			setCurrentSub(validUser);
+
+			const documentUploads = [
+				{
+					name: 'test',
+					fileName: 'fileName',
+					originalFileName: 'orig',
+					location: '/file',
+					type: 'file-type',
+					storageId: 'abcd1234'
+				}
+			];
+
+			const postResponse = await appealsApi
+				.post(`/api/v2/appellant-submissions/${appeal.AppellantSubmission.id}/document-upload`)
+				.send(documentUploads);
+
+			expect(postResponse.statusCode).toBe(200);
+
+			const uploadedData = await sqlClient.submissionDocumentUpload.findMany({
+				where: {
+					appellantSubmissionId: appeal.AppellantSubmission.id
+				}
+			});
+
+			expect(uploadedData).toHaveLength(1);
+
+			const deleteResponse = await appealsApi
+				.delete(`/api/v2/appellant-submissions/${appeal.AppellantSubmission.id}/document-upload`)
+				.send(uploadedData.map((doc) => doc.id));
+
+			expect(deleteResponse.statusCode).toBe(200);
+
+			const deletedData = await sqlClient.submissionDocumentUpload.findMany({
+				where: {
+					appellantSubmissionId: appeal.AppellantSubmission.id
+				}
+			});
+
+			expect(deletedData).toHaveLength(0);
+		});
+	});
+};

--- a/packages/appeals-service-api/src/routes/v2/appellant-submissions/_id/document-upload/repo.js
+++ b/packages/appeals-service-api/src/routes/v2/appellant-submissions/_id/document-upload/repo.js
@@ -25,11 +25,18 @@ class SubmissionDocumentUploadRepository {
 	 * Create submission document for given questionnaire
 	 *
 	 * @param {string} id
-	 * @param {DocumentUploadData} uploadData
+	 * @param {DocumentUploadData[]} uploadData
 	 * @returns {Promise<AppellantSubmission>}
 	 */
 	async createSubmissionDocument(id, uploadData) {
-		const { name, fileName, originalFileName, location, type, id: storageId } = uploadData;
+		const mappedUploadData = uploadData.map((file) => ({
+			name: file.name,
+			fileName: file.fileName,
+			originalFileName: file.originalFileName,
+			location: file.location,
+			type: file.type,
+			storageId: file.id
+		}));
 
 		return await this.dbClient.appellantSubmission.update({
 			where: {
@@ -37,13 +44,8 @@ class SubmissionDocumentUploadRepository {
 			},
 			data: {
 				SubmissionDocumentUpload: {
-					create: {
-						name,
-						fileName,
-						originalFileName,
-						location,
-						type,
-						storageId
+					createMany: {
+						data: mappedUploadData
 					}
 				}
 			},
@@ -59,18 +61,18 @@ class SubmissionDocumentUploadRepository {
 	 * Delete submission document
 	 *
 	 * @param {string} id
-	 * @param {string} documentId
+	 * @param {string[]} documentIds
 	 * @returns {Promise<AppellantSubmission>}
 	 */
-	async deleteSubmissionDocument(id, documentId) {
+	async deleteSubmissionDocument(id, documentIds) {
 		return await this.dbClient.appellantSubmission.update({
 			where: {
 				id
 			},
 			data: {
 				SubmissionDocumentUpload: {
-					delete: {
-						id: documentId
+					deleteMany: {
+						id: { in: documentIds }
 					}
 				}
 			},

--- a/packages/appeals-service-api/src/routes/v2/appellant-submissions/_id/document-upload/service.js
+++ b/packages/appeals-service-api/src/routes/v2/appellant-submissions/_id/document-upload/service.js
@@ -11,7 +11,7 @@ const repo = new SubmissionDocumentUploadRepository();
  * Create a SubmissionDocumentUpload entry
  *
  * @param {string} id
- * @param {DocumentUploadData} uploadData
+ * @param {DocumentUploadData[]} uploadData
  * @return {Promise<AppellantSubmission|null>}
  */
 async function createSubmissionDocument(id, uploadData) {
@@ -28,11 +28,11 @@ async function createSubmissionDocument(id, uploadData) {
  * Delete a SubmissionDocumentUpload entry
  *
  * @param {string} id
- * @param {string} documentId
+ * @param {string[]} documentIds
  * @return {Promise<AppellantSubmission|null>}
  */
-async function deleteSubmissionDocument(id, documentId) {
-	const updatedQuestionnaire = repo.deleteSubmissionDocument(id, documentId);
+async function deleteSubmissionDocument(id, documentIds) {
+	const updatedQuestionnaire = repo.deleteSubmissionDocument(id, documentIds);
 
 	if (!updatedQuestionnaire) {
 		return null;

--- a/packages/common/src/client/appeals-api-client.js
+++ b/packages/common/src/client/appeals-api-client.js
@@ -436,7 +436,7 @@ class AppealsApiClient {
 
 	/**
 	 * @param {string} caseReference
-	 * @param {object} data
+	 * @param {Array<object>} data
 	 * @returns {Promise<(LPAQuestionnaireSubmission)>}
 	 */
 	async postLPASubmissionDocumentUpload(caseReference, data) {
@@ -486,7 +486,7 @@ class AppealsApiClient {
 
 	/**
 	 * @param {string} caseReference
-	 * @param {object} data
+	 * @param {Array<Object>} data
 	 * @returns {Promise<(LPAStatementSubmission)>}
 	 */
 	async postLPAStatementDocumentUpload(caseReference, data) {
@@ -497,12 +497,12 @@ class AppealsApiClient {
 
 	/**
 	 * @param {string} caseReference
-	 * @param {string} documentId
+	 * @param {string[]} documentIds
 	 * @returns {Promise<(LPAStatementSubmission)>}
 	 */
-	async deleteLPAStatementDocumentUpload(caseReference, documentId) {
-		const endpoint = `${v2}/appeal-cases/${caseReference}/lpa-statement-submission/document-upload/${documentId}`;
-		const response = await this.#makeDeleteRequest(endpoint);
+	async deleteLPAStatementDocumentUpload(caseReference, documentIds) {
+		const endpoint = `${v2}/appeal-cases/${caseReference}/lpa-statement-submission/document-upload`;
+		const response = await this.#makeDeleteRequest(endpoint, documentIds);
 		return response.json();
 	}
 
@@ -562,7 +562,7 @@ class AppealsApiClient {
 
 	/**
 	 * @param {string} caseReference
-	 * @param {object} data
+	 * @param {Array<Object>} data
 	 * @returns {Promise<(AppellantFinalCommentSubmission)>}
 	 */
 	async postAppellantFinalCommentDocumentUpload(caseReference, data) {
@@ -573,12 +573,12 @@ class AppealsApiClient {
 
 	/**
 	 * @param {string} caseReference
-	 * @param {string} documentId
+	 * @param {string[]} documentIds
 	 * @returns {Promise<(AppellantFinalCommentSubmission)>}
 	 */
-	async deleteAppellantFinalCommentDocumentUpload(caseReference, documentId) {
-		const endpoint = `${v2}/appeal-cases/${caseReference}/appellant-final-comment-submission/document-upload/${documentId}`;
-		const response = await this.#makeDeleteRequest(endpoint);
+	async deleteAppellantFinalCommentDocumentUpload(caseReference, documentIds) {
+		const endpoint = `${v2}/appeal-cases/${caseReference}/appellant-final-comment-submission/document-upload`;
+		const response = await this.#makeDeleteRequest(endpoint, documentIds);
 		return response.json();
 	}
 
@@ -624,7 +624,7 @@ class AppealsApiClient {
 
 	/**
 	 * @param {string} caseReference
-	 * @param {object} data
+	 * @param {Array<Object>} data
 	 * @returns {Promise<(AppellantProofOfEvidenceSubmission)>}
 	 */
 	async postAppellantProofOfEvidenceDocumentUpload(caseReference, data) {
@@ -635,12 +635,12 @@ class AppealsApiClient {
 
 	/**
 	 * @param {string} caseReference
-	 * @param {string} documentId
+	 * @param {string[]} documentIds
 	 * @returns {Promise<(AppellantProofOfEvidenceSubmission)>}
 	 */
-	async deleteAppellantProofOfEvidenceDocumentUpload(caseReference, documentId) {
-		const endpoint = `${v2}/appeal-cases/${caseReference}/appellant-proof-evidence-submission/document-upload/${documentId}`;
-		const response = await this.#makeDeleteRequest(endpoint);
+	async deleteAppellantProofOfEvidenceDocumentUpload(caseReference, documentIds) {
+		const endpoint = `${v2}/appeal-cases/${caseReference}/appellant-proof-evidence-submission/document-upload/`;
+		const response = await this.#makeDeleteRequest(endpoint, documentIds);
 		return response.json();
 	}
 
@@ -686,7 +686,7 @@ class AppealsApiClient {
 
 	/**
 	 * @param {string} caseReference
-	 * @param {object} data
+	 * @param {Array<Object>} data
 	 * @returns {Promise<(Rule6ProofOfEvidenceSubmission)>}
 	 */
 	async postRule6ProofOfEvidenceDocumentUpload(caseReference, data) {
@@ -697,12 +697,12 @@ class AppealsApiClient {
 
 	/**
 	 * @param {string} caseReference
-	 * @param {string} documentId
+	 * @param {string[]} documentIds
 	 * @returns {Promise<(Rule6ProofOfEvidenceSubmission)>}
 	 */
-	async deleteRule6ProofOfEvidenceDocumentUpload(caseReference, documentId) {
-		const endpoint = `${v2}/appeal-cases/${caseReference}/rule-6-proof-evidence-submission/document-upload/${documentId}`;
-		const response = await this.#makeDeleteRequest(endpoint);
+	async deleteRule6ProofOfEvidenceDocumentUpload(caseReference, documentIds) {
+		const endpoint = `${v2}/appeal-cases/${caseReference}/rule-6-proof-evidence-submission/document-upload`;
+		const response = await this.#makeDeleteRequest(endpoint, documentIds);
 		return response.json();
 	}
 
@@ -748,7 +748,7 @@ class AppealsApiClient {
 
 	/**
 	 * @param {string} caseReference
-	 * @param {object} data
+	 * @param {Array<Object>} data
 	 * @returns {Promise<(Rule6StatementSubmission)>}
 	 */
 	async postRule6StatementDocumentUpload(caseReference, data) {
@@ -759,12 +759,12 @@ class AppealsApiClient {
 
 	/**
 	 * @param {string} caseReference
-	 * @param {string} documentId
+	 * @param {string[]} documentIds
 	 * @returns {Promise<(Rule6StatementSubmission)>}
 	 */
-	async deleteRule6StatementDocumentUpload(caseReference, documentId) {
-		const endpoint = `${v2}/appeal-cases/${caseReference}/rule-6-statement-submission/document-upload/${documentId}`;
-		const response = await this.#makeDeleteRequest(endpoint);
+	async deleteRule6StatementDocumentUpload(caseReference, documentIds) {
+		const endpoint = `${v2}/appeal-cases/${caseReference}/rule-6-statement-submission/document-upload`;
+		const response = await this.#makeDeleteRequest(endpoint, documentIds);
 		return response.json();
 	}
 
@@ -810,7 +810,7 @@ class AppealsApiClient {
 
 	/**
 	 * @param {string} caseReference
-	 * @param {object} data
+	 * @param {Array<Object>} data
 	 * @returns {Promise<(LPAFinalCommentSubmission)>}
 	 */
 	async postLPAFinalCommentDocumentUpload(caseReference, data) {
@@ -821,12 +821,12 @@ class AppealsApiClient {
 
 	/**
 	 * @param {string} caseReference
-	 * @param {string} documentId
+	 * @param {string[]} documentIds
 	 * @returns {Promise<(LPAFinalCommentSubmission)>}
 	 */
-	async deleteLPAFinalCommentDocumentUpload(caseReference, documentId) {
-		const endpoint = `${v2}/appeal-cases/${caseReference}/lpa-final-comment-submission/document-upload/${documentId}`;
-		const response = await this.#makeDeleteRequest(endpoint);
+	async deleteLPAFinalCommentDocumentUpload(caseReference, documentIds) {
+		const endpoint = `${v2}/appeal-cases/${caseReference}/lpa-final-comment-submission/document-upload`;
+		const response = await this.#makeDeleteRequest(endpoint, documentIds);
 		return response.json();
 	}
 
@@ -872,7 +872,7 @@ class AppealsApiClient {
 
 	/**
 	 * @param {string} caseReference
-	 * @param {object} data
+	 * @param {Array<Object>} data
 	 * @returns {Promise<(LPAProofOfEvidenceSubmission)>}
 	 */
 	async postLpaProofOfEvidenceDocumentUpload(caseReference, data) {
@@ -883,12 +883,12 @@ class AppealsApiClient {
 
 	/**
 	 * @param {string} caseReference
-	 * @param {string} documentId
+	 * @param {string[]} documentIds
 	 * @returns {Promise<(LPAProofOfEvidenceSubmission)>}
 	 */
-	async deleteLpaProofOfEvidenceDocumentUpload(caseReference, documentId) {
-		const endpoint = `${v2}/appeal-cases/${caseReference}/lpa-proof-evidence-submission/document-upload/${documentId}`;
-		const response = await this.#makeDeleteRequest(endpoint);
+	async deleteLpaProofOfEvidenceDocumentUpload(caseReference, documentIds) {
+		const endpoint = `${v2}/appeal-cases/${caseReference}/lpa-proof-evidence-submission/document-upload`;
+		const response = await this.#makeDeleteRequest(endpoint, documentIds);
 		return response.json();
 	}
 
@@ -903,7 +903,7 @@ class AppealsApiClient {
 
 	/**
 	 * @param {string} id
-	 * @param {object} data
+	 * @param {Array<Object>} data
 	 * @returns {Promise<(AppellantSubmission)>}
 	 */
 	async postAppellantSubmissionDocumentUpload(id, data) {
@@ -914,23 +914,23 @@ class AppealsApiClient {
 
 	/**
 	 * @param {string} caseReference
-	 * @param {string} documentId
+	 * @param {string[]} documentIds
 	 * @returns {Promise<(LPAQuestionnaireSubmission)>}
 	 */
-	async deleteLPASubmissionDocumentUpload(caseReference, documentId) {
-		const endpoint = `${v2}/appeal-cases/${caseReference}/lpa-questionnaire-submission/document-upload/${documentId}`;
-		const response = await this.#makeDeleteRequest(endpoint);
+	async deleteLPASubmissionDocumentUpload(caseReference, documentIds) {
+		const endpoint = `${v2}/appeal-cases/${caseReference}/lpa-questionnaire-submission/document-upload/`;
+		const response = await this.#makeDeleteRequest(endpoint, documentIds);
 		return response.json();
 	}
 
 	/**
 	 * @param {string} id
-	 * @param {string} documentId
+	 * @param {string[]} documentIds
 	 * @returns {Promise<(AppellantSubmission)>}
 	 */
-	async deleteAppellantSubmissionDocumentUpload(id, documentId) {
-		const endpoint = `${v2}/appellant-submissions/${id}/document-upload/${documentId}`;
-		const response = await this.#makeDeleteRequest(endpoint);
+	async deleteAppellantSubmissionDocumentUpload(id, documentIds) {
+		const endpoint = `${v2}/appellant-submissions/${id}/document-upload`;
+		const response = await this.#makeDeleteRequest(endpoint, documentIds);
 		return response.json();
 	}
 
@@ -1319,11 +1319,14 @@ class AppealsApiClient {
 
 	/**
 	 * @param {string} endpoint
+	 * @param {Object|Array<Object>} [data]
 	 * @returns {Promise<import('node-fetch').Response>}
 	 * @throws {AppealsApiError|Error}
 	 */
-	#makeDeleteRequest(endpoint) {
-		return this.handler(endpoint, 'DELETE');
+	#makeDeleteRequest(endpoint, data) {
+		return this.handler(endpoint, 'DELETE', {
+			body: data ? JSON.stringify(data) : undefined
+		});
 	}
 }
 

--- a/packages/forms-web-app/__tests__/unit/lib/multi-file-upload-helpers.test.js
+++ b/packages/forms-web-app/__tests__/unit/lib/multi-file-upload-helpers.test.js
@@ -1,4 +1,8 @@
-const { getValidFiles, removeFiles } = require('../../../src/lib/multi-file-upload-helpers');
+const {
+	getValidFiles,
+	removeFiles,
+	removeFilesV2
+} = require('../../../src/lib/multi-file-upload-helpers');
 const { removeDocument } = require('../../../src/lib/documents-api-wrapper');
 const logger = require('../../../src/lib/logger');
 
@@ -8,117 +12,200 @@ jest.mock('../../../src/lib/logger');
 let testFiles;
 const testBaseLocation = 'base-path';
 
-describe('lib/multi-file-upload-helpers/getValidFiles', () => {
-	it('returns array of files with invalid files removed', () => {
-		const validFile = { name: 'scorpio.jpeg', tempFilePath: '/tmp/tmp-1-1679999844879' };
-		const invalidFile = { name: 'globex.gif', tempFilePath: '/tmp/tmp-2-1679999844882' };
+describe('lib/multi-file-upload-helpers', () => {
+	describe('getValidFiles', () => {
+		it('returns array of files with invalid files removed', () => {
+			const validFile = { name: 'scorpio.jpeg', tempFilePath: '/tmp/tmp-1-1679999844879' };
+			const invalidFile = { name: 'globex.gif', tempFilePath: '/tmp/tmp-2-1679999844882' };
 
-		const files = [validFile, invalidFile];
+			const files = [validFile, invalidFile];
 
-		const errors = {
-			'files.upload-documents[1]': {
-				value: {
-					name: 'globex.gif',
-					tempFilePath: '/tmp/tmp-2-1679999844882'
+			const errors = {
+				'files.upload-documents[1]': {
+					value: {
+						name: 'globex.gif',
+						tempFilePath: '/tmp/tmp-2-1679999844882'
+					}
 				}
-			}
-		};
+			};
 
-		expect(getValidFiles(errors, files)).toEqual([validFile]);
+			expect(getValidFiles(errors, files)).toEqual([validFile]);
+		});
 	});
-});
 
-describe('lib/multi-file-upload-helpers/removeFiles', () => {
-	beforeEach(() => {
-		jest.clearAllMocks();
-		testFiles = [
-			{ id: '1', name: 'fileName1.txt', originalFileName: 'file1.txt' },
-			{ id: '2', name: 'fileName2.txt', originalFileName: 'file2.txt' },
-			{ id: '3', name: 'fileName3.txt', originalFileName: 'file3.txt' }
+	describe('removeFiles', () => {
+		beforeEach(() => {
+			jest.clearAllMocks();
+			testFiles = [
+				{ id: '1', name: 'fileName1.txt', originalFileName: 'file1.txt' },
+				{ id: '2', name: 'fileName2.txt', originalFileName: 'file2.txt' },
+				{ id: '3', name: 'fileName3.txt', originalFileName: 'file3.txt' }
+			];
+		});
+
+		it('should remove files from the input array', async () => {
+			const removedFiles = [
+				{ name: testFiles[0].originalFileName },
+				{ name: testFiles[2].originalFileName }
+			];
+
+			removeDocument.mockResolvedValue();
+
+			const result = await removeFiles(testFiles, removedFiles, testBaseLocation);
+
+			expect(removeDocument).toHaveBeenCalledTimes(2);
+			expect(removeDocument).toHaveBeenCalledWith(testBaseLocation, testFiles[0].id);
+			expect(removeDocument).toHaveBeenCalledWith(testBaseLocation, testFiles[2].id);
+			expect(result).toEqual([testFiles[1]]);
+		});
+
+		it('should not modify the input array if no files are removed', async () => {
+			const removedFiles = [];
+
+			const result = await removeFiles(testFiles, removedFiles);
+
+			expect(removeDocument).not.toHaveBeenCalled();
+			expect(result).toEqual(testFiles);
+		});
+
+		it('should return an empty array if all files are removed', async () => {
+			const removedFiles = [
+				{ name: testFiles[0].originalFileName },
+				{ name: testFiles[1].originalFileName },
+				{ name: testFiles[2].originalFileName }
+			];
+
+			removeDocument.mockResolvedValue();
+
+			const result = await removeFiles(testFiles, removedFiles, testBaseLocation);
+
+			expect(removeDocument).toHaveBeenCalledTimes(3);
+			expect(removeDocument).toHaveBeenCalledWith(testBaseLocation, testFiles[0].id);
+			expect(removeDocument).toHaveBeenCalledWith(testBaseLocation, testFiles[1].id);
+			expect(removeDocument).toHaveBeenCalledWith(testBaseLocation, testFiles[2].id);
+			expect(result).toEqual([]);
+		});
+
+		it('should not remove from blob storage if baseLocation is not passed through', async () => {
+			const removedFiles = [
+				{ name: testFiles[0].originalFileName },
+				{ name: testFiles[1].originalFileName },
+				{ name: testFiles[2].originalFileName }
+			];
+
+			const result = await removeFiles(testFiles, removedFiles);
+
+			expect(removeDocument).not.toHaveBeenCalled();
+			expect(result).toEqual([]);
+		});
+
+		it('should indicate if a file failed to be removed but continue to process other files, array will be reorderd', async () => {
+			const removedFiles = [
+				{ name: testFiles[0].originalFileName },
+				{ name: testFiles[2].originalFileName }
+			];
+
+			removeDocument.mockRejectedValueOnce(new Error('Removal failed'));
+			removeDocument.mockResolvedValueOnce();
+
+			const result = await removeFiles(testFiles, removedFiles, testBaseLocation);
+
+			expect(logger.error).toHaveBeenCalledTimes(1);
+			expect(removeDocument).toHaveBeenCalledTimes(2);
+			expect(removeDocument).toHaveBeenCalledWith(testBaseLocation, testFiles[0].id);
+			expect(removeDocument).toHaveBeenCalledWith(testBaseLocation, testFiles[2].id);
+			expect(result).toEqual([
+				testFiles[1],
+				{
+					...testFiles[0],
+					failedToRemove: true
+				}
+			]);
+		});
+
+		it('should error with bad inputs', async () => {
+			await expect(removeFiles()).rejects.toThrow();
+		});
+	});
+
+	describe('removeFilesV2', () => {
+		const mockDeleteDocumentUploadFunction = jest.fn();
+		const testBaseLocation = 'base-path';
+		const testReferenceId = 'ref-123';
+		const testFiles = [
+			{ id: '1', storageId: 's1', originalFileName: 'file1.txt' },
+			{ id: '2', storageId: 's2', originalFileName: 'file2.txt' },
+			{ id: '3', storageId: 's3', originalFileName: 'file3.txt' }
 		];
-	});
 
-	it('should remove files from the input array', async () => {
-		const removedFiles = [
-			{ name: testFiles[0].originalFileName },
-			{ name: testFiles[2].originalFileName }
-		];
+		beforeEach(() => {
+			jest.clearAllMocks();
+		});
 
-		removeDocument.mockResolvedValue();
+		it('removes files from blob and db', async () => {
+			removeDocument.mockResolvedValue();
+			mockDeleteDocumentUploadFunction.mockResolvedValue();
+			const removedFiles = [{ name: 'file1.txt' }, { name: 'file3.txt' }];
+			const result = await removeFilesV2(
+				testFiles,
+				removedFiles,
+				testReferenceId,
+				testBaseLocation,
+				mockDeleteDocumentUploadFunction
+			);
+			expect(removeDocument).toHaveBeenCalledTimes(2);
+			expect(removeDocument).toHaveBeenCalledWith(testBaseLocation, 's1');
+			expect(removeDocument).toHaveBeenCalledWith(testBaseLocation, 's3');
+			expect(mockDeleteDocumentUploadFunction).toHaveBeenCalledWith(testReferenceId, ['1', '3']);
+			expect(result).toEqual([]);
+		});
 
-		const result = await removeFiles(testFiles, removedFiles, testBaseLocation);
+		it('returns failedRemovals if blob removal fails', async () => {
+			removeDocument.mockRejectedValueOnce(new Error('fail'));
+			removeDocument.mockResolvedValueOnce();
+			mockDeleteDocumentUploadFunction.mockResolvedValue();
+			const removedFiles = [{ name: 'file1.txt' }, { name: 'file3.txt' }];
+			const result = await removeFilesV2(
+				testFiles,
+				removedFiles,
+				testReferenceId,
+				testBaseLocation,
+				mockDeleteDocumentUploadFunction
+			);
+			expect(result).toEqual([{ storageId: 's1', originalFileName: 'file1.txt' }]);
+		});
 
-		expect(removeDocument).toHaveBeenCalledTimes(2);
-		expect(removeDocument).toHaveBeenCalledWith(testBaseLocation, testFiles[0].id);
-		expect(removeDocument).toHaveBeenCalledWith(testBaseLocation, testFiles[2].id);
-		expect(result).toEqual([testFiles[1]]);
-	});
+		it('returns failedRemovals if db removal fails', async () => {
+			removeDocument.mockResolvedValue();
+			mockDeleteDocumentUploadFunction.mockRejectedValue(new Error('fail'));
+			const removedFiles = [{ name: 'file1.txt' }, { name: 'file3.txt' }];
+			const result = await removeFilesV2(
+				testFiles,
+				removedFiles,
+				testReferenceId,
+				testBaseLocation,
+				mockDeleteDocumentUploadFunction
+			);
+			expect(result).toEqual([
+				{ storageId: 's1', originalFileName: 'file1.txt' },
+				{ storageId: 's3', originalFileName: 'file3.txt' }
+			]);
+		});
 
-	it('should not modify the input array if no files are removed', async () => {
-		const removedFiles = [];
-
-		const result = await removeFiles(testFiles, removedFiles);
-
-		expect(removeDocument).not.toHaveBeenCalled();
-		expect(result).toEqual(testFiles);
-	});
-
-	it('should return an empty array if all files are removed', async () => {
-		const removedFiles = [
-			{ name: testFiles[0].originalFileName },
-			{ name: testFiles[1].originalFileName },
-			{ name: testFiles[2].originalFileName }
-		];
-
-		removeDocument.mockResolvedValue();
-
-		const result = await removeFiles(testFiles, removedFiles, testBaseLocation);
-
-		expect(removeDocument).toHaveBeenCalledTimes(3);
-		expect(removeDocument).toHaveBeenCalledWith(testBaseLocation, testFiles[0].id);
-		expect(removeDocument).toHaveBeenCalledWith(testBaseLocation, testFiles[1].id);
-		expect(removeDocument).toHaveBeenCalledWith(testBaseLocation, testFiles[2].id);
-		expect(result).toEqual([]);
-	});
-
-	it('should not remove from blob storage if baseLocation is not passed through', async () => {
-		const removedFiles = [
-			{ name: testFiles[0].originalFileName },
-			{ name: testFiles[1].originalFileName },
-			{ name: testFiles[2].originalFileName }
-		];
-
-		const result = await removeFiles(testFiles, removedFiles);
-
-		expect(removeDocument).not.toHaveBeenCalled();
-		expect(result).toEqual([]);
-	});
-
-	it('should indicate if a file failed to be removed but continue to process other files, array will be reorderd', async () => {
-		const removedFiles = [
-			{ name: testFiles[0].originalFileName },
-			{ name: testFiles[2].originalFileName }
-		];
-
-		removeDocument.mockRejectedValueOnce(new Error('Removal failed'));
-		removeDocument.mockResolvedValueOnce();
-
-		const result = await removeFiles(testFiles, removedFiles, testBaseLocation);
-
-		expect(logger.error).toHaveBeenCalledTimes(1);
-		expect(removeDocument).toHaveBeenCalledTimes(2);
-		expect(removeDocument).toHaveBeenCalledWith(testBaseLocation, testFiles[0].id);
-		expect(removeDocument).toHaveBeenCalledWith(testBaseLocation, testFiles[2].id);
-		expect(result).toEqual([
-			testFiles[1],
-			{
-				...testFiles[0],
-				failedToRemove: true
-			}
-		]);
-	});
-
-	it('should error with bad inputs', async () => {
-		await expect(removeFiles()).rejects.toThrow();
+		it('does nothing if no files match removedFiles', async () => {
+			removeDocument.mockResolvedValue();
+			mockDeleteDocumentUploadFunction.mockResolvedValue();
+			const removedFiles = [{ name: 'notfound.txt' }];
+			const result = await removeFilesV2(
+				testFiles,
+				removedFiles,
+				testReferenceId,
+				testBaseLocation,
+				mockDeleteDocumentUploadFunction
+			);
+			expect(removeDocument).not.toHaveBeenCalled();
+			expect(mockDeleteDocumentUploadFunction).toHaveBeenCalledWith(testReferenceId, []);
+			expect(result).toEqual([]);
+		});
 	});
 });

--- a/packages/forms-web-app/src/journeys/get-journey-save.js
+++ b/packages/forms-web-app/src/journeys/get-journey-save.js
@@ -33,7 +33,7 @@ exports.getSaveFunction = (journeyType, api) => {
 /**
  * @param {import('@pins/common/src/dynamic-forms/journey-types').JourneyTypesDefinition} journeyType
  * @param {import('@pins/common/src/client/appeals-api-client').AppealsApiClient} api
- * @returns {function(string, Object): Promise<any>}
+ * @returns {function(string, Array<Object>): Promise<any>}
  */
 exports.getUploadDoumentFunction = (journeyType, api) => {
 	const key = `${journeyType.type}_${journeyType.userType}`;
@@ -58,7 +58,7 @@ exports.getUploadDoumentFunction = (journeyType, api) => {
 /**
  * @param {import('@pins/common/src/dynamic-forms/journey-types').JourneyTypesDefinition} journeyType
  * @param {import('@pins/common/src/client/appeals-api-client').AppealsApiClient} api
- * @returns {function(string, string): Promise<any>}
+ * @returns {function(string, string[]): Promise<any>}
  */
 exports.getRemoveDocumentFunction = (journeyType, api) => {
 	const key = `${journeyType.type}_${journeyType.userType}`;


### PR DESCRIPTION
### Description of change

Duplicate documents being created 
This PR:
- ensures any files uploaded with the same name are deleted
- avoids deadlocks stemming from parallel requests to create/delete documents
- adds missing tests for document upload api endpoints

Ticket: https://pins-ds.atlassian.net/browse/A2-4073

### Checklist

- [x] Feature complete and ready for users, or behind feature-flag
- [x] Commit history is linear with no merge commits
- [ ] Requires infrastructure changes

### Important

Please do not merge from `main` (please only [rebase](https://github.com/Planning-Inspectorate/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
