### PR TITLE
fix(a2-4029): amend format of decision date on public appeal details page

### DIFF
--- a/packages/forms-web-app/src/utils/format-comment-decided-data.js
+++ b/packages/forms-web-app/src/utils/format-comment-decided-data.js
@@ -14,7 +14,9 @@ exports.formatCommentDecidedData = (appeal) => {
 	if (!appeal.caseDecisionOutcomeDate) return {};
 
 	return {
-		formattedCaseDecisionDate: formatDateForDisplay(appeal.caseDecisionOutcomeDate),
+		formattedCaseDecisionDate: formatDateForDisplay(appeal.caseDecisionOutcomeDate, {
+			format: 'd MMMM yyyy'
+		}),
 		formattedDecisionColour: mapDecisionColour(appeal.caseDecisionOutcome),
 		caseDecisionOutcome: mapDecisionLabel(appeal.caseDecisionOutcome) ?? appeal.caseDecisionOutcome,
 		decisionDocuments: filterDecisionDocuments(appeal.Documents)

--- a/packages/forms-web-app/src/utils/format-comment-decided-data.test.js
+++ b/packages/forms-web-app/src/utils/format-comment-decided-data.test.js
@@ -19,7 +19,7 @@ describe('formatCommentDecidedData', () => {
 	it('should return formatted data when caseDecisionOutcomeDate is provided', () => {
 		const result = formatCommentDecidedData(appeal);
 		expect(result).toEqual({
-			formattedCaseDecisionDate: '31 Dec 2024',
+			formattedCaseDecisionDate: '31 December 2024',
 			formattedDecisionColour: 'green',
 			caseDecisionOutcome: 'Allowed',
 			decisionDocuments: [{ documentType: APPEAL_DOCUMENT_TYPE.CASE_DECISION_LETTER, id: 'doc1' }]


### PR DESCRIPTION
### Description of change

Ticket: https://pins-ds.atlassian.net/browse/A2-4029

Use fullm onth format for public site decided appeals details

### Checklist

- [X] Feature complete and ready for users, or behind feature-flag
- [X] Commit history is linear with no merge commits
- [ ] Requires infrastructure changes

### Important

Please do not merge from `main` (please only [rebase](https://github.com/Planning-Inspectorate/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
