### PR TITLE
feat: add landowner permission to advert appeal journey (A2-3772)

### DIFF
--- a/packages/appeals-service-api/src/spec/api-types.d.ts
+++ b/packages/appeals-service-api/src/spec/api-types.d.ts
@@ -658,6 +658,7 @@ export interface AppellantSubmission {
 	siteAddress?: boolean;
 	highwayLand?: boolean;
 	advertInPosition?: boolean;
+	landownerPermission?: boolean;
 	SubmissionAddress?: SubmissionAddress[];
 	SubmissionListedBuilding?: object[];
 }

--- a/packages/appeals-service-api/src/spec/appellant-submission.yaml
+++ b/packages/appeals-service-api/src/spec/appellant-submission.yaml
@@ -202,6 +202,9 @@ components:
         advertInPosition:
           type: boolean
 
+        landownerPermission:
+          type: boolean
+
         SubmissionAddress:
           type: array
           items:

--- a/packages/database/src/migrations/20250819092028_add_landowner_permission_to_appellant_submission/migration.sql
+++ b/packages/database/src/migrations/20250819092028_add_landowner_permission_to_appellant_submission/migration.sql
@@ -1,0 +1,19 @@
+BEGIN TRY
+
+BEGIN TRAN;
+
+-- AlterTable
+ALTER TABLE [dbo].[AppellantSubmission] ADD [landownerPermission] BIT;
+
+COMMIT TRAN;
+
+END TRY
+BEGIN CATCH
+
+IF @@TRANCOUNT > 0
+BEGIN
+    ROLLBACK TRAN;
+END;
+THROW
+
+END CATCH

--- a/packages/database/src/schema.prisma
+++ b/packages/database/src/schema.prisma
@@ -712,7 +712,7 @@ model AppellantSubmission {
   // dates
   onApplicationDate DateTime?
 
-  //appellant / agent details
+  // appellant / agent details
   isAppellant          Boolean?
   appellantFirstName   String?
   appellantLastName    String?
@@ -745,6 +745,7 @@ model AppellantSubmission {
   section3aGrant                     Boolean?
   highwayLand                        Boolean?
   advertInPosition                   Boolean?
+  landownerPermission                Boolean?
 
   // boolean text
   appellantSiteSafety                            String?

--- a/packages/forms-web-app/src/dynamic-forms/cas-adverts-appeal-form/journey.js
+++ b/packages/forms-web-app/src/dynamic-forms/cas-adverts-appeal-form/journey.js
@@ -63,6 +63,7 @@ const sections = [
 		)
 		.addQuestion(questions.identifyingLandowners)
 		.withCondition((response) => shouldDisplayIdentifyingLandowners(response, questions))
+		.addQuestion(questions.landownerPermission)
 		.addQuestion(questions.advertisingAppeal)
 		.withCondition(
 			(response) =>

--- a/packages/forms-web-app/src/dynamic-forms/docs/cas-adverts-appeal-form-journey.md
+++ b/packages/forms-web-app/src/dynamic-forms/docs/cas-adverts-appeal-form-journey.md
@@ -57,6 +57,7 @@ condition: (response) =>
 condition: (response) => shouldDisplayIdentifyingLandowners(response, questions);
 ```
 
+- boolean `/landowner-permission/` Do you have the landowner’s permission?
 - boolean `/advertising-appeal/` Advertising your appeal
 
 ```js

--- a/packages/forms-web-app/src/dynamic-forms/questions.js
+++ b/packages/forms-web-app/src/dynamic-forms/questions.js
@@ -2649,6 +2649,14 @@ exports.questionProps = {
 		fieldName: 'advertInPosition',
 		url: 'advertisement-position',
 		validators: [new RequiredValidator('Select yes if the advertisement is in position')]
+	},
+	landownerPermission: {
+		type: 'boolean',
+		title: 'Do you have the landowner’s permission?',
+		question: 'Do you have the landowner’s permission?',
+		fieldName: 'landownerPermission',
+		url: 'landowner-permission',
+		validators: [new RequiredValidator('Select yes if you have the landowner’s permission')]
 	}
 };
 

--- a/packages/forms-web-app/src/journeys/__snapshots__/index.test.js.snap
+++ b/packages/forms-web-app/src/journeys/__snapshots__/index.test.js.snap
@@ -798,6 +798,52 @@ exports[`Dynamic forms journey tests appellant Commercial advertisement (CAS) Co
 </main>"
 `;
 
+exports[`Dynamic forms journey tests appellant Commercial advertisement (CAS) Commercial advertisement (CAS) should render the landowner-permission question 1`] = `
+"<main id="main-content" role="main" class="govuk-main-wrapper govuk-main-wrapper--auto-spacing">
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds"></div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds"><span class="govuk-caption-l"> Prepare appeal</span>
+        </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+            <form action="" method="post" novalidate=null>
+                <div class="govuk-form-group">
+                    <fieldset class="govuk-fieldset" aria-describedby="landownerPermission-hint">
+                        <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+                            <h1 class="govuk-fieldset__heading"> Do you have the landowner’s permission?</h1>
+                        </legend>
+                        <div id="landownerPermission-hint" class="govuk-hint"></div>
+                        <div class="govuk-radios govuk-radios" data-module="govuk-radios">
+                            <div class="govuk-radios__item">
+                                <input class="govuk-radios__input" id="landownerPermission" name="landownerPermission"
+                                type="radio" value="yes" data-cy="answer-yes">
+                                <label class="govuk-label govuk-radios__label" for="landownerPermission">Yes</label>
+                            </div>
+                            <div class="govuk-radios__item">
+                                <input class="govuk-radios__input" id="landownerPermission-2" name="landownerPermission"
+                                type="radio" value="no" data-cy="answer-no">
+                                <label class="govuk-label govuk-radios__label" for="landownerPermission-2">No</label>
+                            </div>
+                        </div>
+                    </fieldset>
+                </div>
+                <button type="submit" class="govuk-button" data-module="govuk-button"
+                data-cy="button-save-and-continue">Continue</button>
+            </form>
+        </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+            <p class="govuk-body"><a href="/appeals/adverts/appeal-form/your-appeal?id=appeal-ref" class="govuk-link">Return to your appeal</a>
+            </p>
+        </div>
+    </div>
+</main>"
+`;
+
 exports[`Dynamic forms journey tests appellant Commercial advertisement (CAS) Commercial advertisement (CAS) should render the other-appeals question 1`] = `
 "<main id="main-content" role="main" class="govuk-main-wrapper govuk-main-wrapper--auto-spacing">
     <div class="govuk-grid-row">
@@ -1617,6 +1663,12 @@ exports[`Dynamic forms journey tests appellant Commercial advertisement (CAS) re
                             <dd
                             class="govuk-summary-list__value">Not started</dd>
                                 <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals/adverts/prepare-appeal/identifying-landowners?id=appeal-ref">Answer<span class="govuk-visually-hidden"> Identifying the landowners</span></a>
+                                </dd>
+                        </div>
+                        <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Do you have the landowner’s permission?</dt>
+                            <dd
+                            class="govuk-summary-list__value">Not started</dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals/adverts/prepare-appeal/landowner-permission?id=appeal-ref">Answer<span class="govuk-visually-hidden"> Do you have the landowner’s permission?</span></a>
                                 </dd>
                         </div>
                         <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Have the landowners been told about the appeal?</dt>


### PR DESCRIPTION
### Description of change

Adding the landowner permission question for CAS advert (and advert) appeal types

Ticket: https://pins-ds.atlassian.net/browse/A2-3772

### Checklist

- [x] Feature complete and ready for users, or behind feature-flag
- [x] Commit history is linear with no merge commits
- [ ] Requires infrastructure changes

### Important

Please do not merge from `main` (please only [rebase](https://github.com/Planning-Inspectorate/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
