### PR TITLE
fix(a2-3462): correct appeal name on dashboards

### DIFF
--- a/packages/forms-web-app/src/lib/dashboard-functions.js
+++ b/packages/forms-web-app/src/lib/dashboard-functions.js
@@ -449,14 +449,10 @@ const getAppealType = (appealCaseData) => {
 		return getAppealTypeName(appealCaseData.appeal?.appealType);
 	}
 	if (isV2Submission(appealCaseData)) {
-		const submissionType = caseTypeNameWithDefault(
-			appealCaseData?.AppellantSubmission?.appealTypeCode
-		);
-		return `${submissionType} appeal`;
+		return caseTypeNameWithDefault(appealCaseData?.AppellantSubmission?.appealTypeCode);
 	}
 
-	const caseType = caseTypeNameWithDefault(appealCaseData?.appealTypeCode);
-	return `${caseType} appeal`;
+	return caseTypeNameWithDefault(appealCaseData?.appealTypeCode);
 };
 
 module.exports = {

--- a/packages/forms-web-app/src/lib/dashboard-functions.test.js
+++ b/packages/forms-web-app/src/lib/dashboard-functions.test.js
@@ -1,4 +1,7 @@
 const {
+	mapToLPADashboardDisplayData,
+	mapToAppellantDashboardDisplayData,
+	mapToRule6DashboardDisplayData,
 	formatAddress,
 	determineJourneyToDisplayLPADashboard,
 	determineJourneyToDisplayRule6Dashboard,
@@ -10,6 +13,8 @@ const {
 	APPEAL_CASE_STATUS,
 	APPEAL_LINKED_CASE_STATUS
 } = require('@planning-inspectorate/data-model');
+const { CASE_TYPES } = require('@pins/common/src/database/data-static');
+const { APPEAL_ID, APPLICATION_DECISION } = require('@pins/business-rules/src/constants');
 
 jest.mock('@pins/common/src/lib/calculate-due-in-days');
 jest.mock('./calculate-days-since-invalidated');
@@ -308,6 +313,106 @@ describe('lib/dashboard-functions', () => {
 			];
 
 			expect(updateChildAppealDisplayData(testInputArray)).toEqual(expectedOutputArray);
+		});
+	});
+
+	const caseTypes = Object.values(CASE_TYPES);
+
+	describe('mapToLPADashboardDisplayData', () => {
+		caseTypes.forEach((caseType) => {
+			it(`Appeal case returns the case type name for ${caseType.type}`, () => {
+				expect(
+					mapToLPADashboardDisplayData({
+						...testLeadDashboardData,
+						appealTypeCode: caseType.processCode
+					})
+				).toEqual(
+					expect.objectContaining({
+						appealType: caseType.type
+					})
+				);
+			});
+		});
+	});
+
+	describe('mapToAppellantDashboardDisplayData', () => {
+		caseTypes.forEach((caseType) => {
+			it(`Appeal case returns the case type name for ${caseType.type}`, () => {
+				expect(
+					mapToAppellantDashboardDisplayData({
+						...testLeadDashboardData,
+						appealTypeCode: caseType.processCode
+					})
+				).toEqual(
+					expect.objectContaining({
+						appealType: caseType.type
+					})
+				);
+			});
+
+			it(`V2 appeal drafts display on dashboard for ${caseType.type}`, () => {
+				expect(
+					mapToAppellantDashboardDisplayData({
+						AppellantSubmission: {
+							submitted: false,
+							appealTypeCode: caseType.processCode,
+							applicationDecisionDate: new Date().toISOString(),
+							SubmissionAddress: [{}]
+						}
+					})
+				).toEqual(
+					expect.objectContaining({
+						appealType: caseType.type
+					})
+				);
+			});
+		});
+
+		it(`V1 appeal drafts displays on dashboard`, () => {
+			expect(
+				mapToAppellantDashboardDisplayData({
+					appeal: {
+						decisionDate: new Date().toISOString(),
+						appealType: APPEAL_ID.PLANNING_SECTION_78,
+						applicationDecision: APPLICATION_DECISION.REFUSED
+					}
+				})
+			).toEqual(
+				expect.objectContaining({
+					appealType: 'Full appeal'
+				})
+			);
+
+			expect(
+				mapToAppellantDashboardDisplayData({
+					appeal: {
+						decisionDate: new Date().toISOString(),
+						appealType: APPEAL_ID.HOUSEHOLDER,
+						applicationDecision: APPLICATION_DECISION.REFUSED
+					}
+				})
+			).toEqual(
+				expect.objectContaining({
+					appealType: 'Householder appeal'
+				})
+			);
+		});
+	});
+
+	describe('mapToRule6DashboardDisplayData', () => {
+		caseTypes.forEach((caseType) => {
+			it(`Appeal case returns the case type name for ${caseType.type}`, () => {
+				expect(
+					mapToRule6DashboardDisplayData({
+						...testLeadDashboardData,
+						appealTypeCode: caseType.processCode
+					})
+				).toEqual(
+					expect.objectContaining({
+						appealType: caseType.type
+					})
+				);
+			});
 		});
 	});
 });


### PR DESCRIPTION
### Description of change

Removes the word appeal from appeal type in dashboards
Leaving v1 as is as per ticket

Ticket: https://pins-ds.atlassian.net/browse/A2-3462

### Checklist

- [x] Feature complete and ready for users, or behind feature-flag
- [x] Commit history is linear with no merge commits
- [ ] Requires infrastructure changes

### Important

Please do not merge from `main` (please only [rebase](https://github.com/Planning-Inspectorate/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
