### PR TITLE
feat: adding description of advertisement to the advert appeal form

### DIFF
--- a/packages/forms-web-app/src/dynamic-forms/adverts-appeal-form/journey.js
+++ b/packages/forms-web-app/src/dynamic-forms/adverts-appeal-form/journey.js
@@ -76,7 +76,7 @@ const makeSections = (response) => [
 		.addQuestion(questions.healthAndSafety)
 		.addQuestion(questions.enterApplicationReference)
 		.addQuestion(questions.planningApplicationDate)
-		.addQuestion(questions.enterDevelopmentDescription)
+		.addQuestion(questions.enterAdvertisementDescription)
 		.addQuestion(questions.updateAdvertisementDescription)
 		.addQuestion(questions.anyOtherAppeals)
 		.addQuestion(questions.linkAppeals)

--- a/packages/forms-web-app/src/dynamic-forms/docs/adverts-appeal-form-journey.md
+++ b/packages/forms-web-app/src/dynamic-forms/docs/adverts-appeal-form-journey.md
@@ -76,7 +76,7 @@ condition: () => shouldDisplayTellingLandowners(response, questions);
 - radio `/health-safety-issues/` Health and safety issues
 - single-line-input `/reference-number/` What is the application reference number?
 - date `/application-date/` What date did you submit your application?
-- text-entry `/enter-description-of-development/` Enter the description of development that you submitted in your application
+- text-entry `/description-advertisement/` Enter the description of the advertisement that you submitted in your application
 - boolean `/description-advertisement-correct/` Did the local planning authority change the description of the advertisement?
 - boolean `/other-appeals/` Are there other appeals linked to your development?
 - list-add-more `/enter-appeal-reference/` Add another appeal?

--- a/packages/forms-web-app/src/dynamic-forms/questions.js
+++ b/packages/forms-web-app/src/dynamic-forms/questions.js
@@ -2673,6 +2673,22 @@ exports.questionProps = {
 				attributes: { 'data-cy': 'answer-no' }
 			}
 		]
+	},
+	enterAdvertisementDescription: {
+		type: 'text-entry',
+		title: 'Enter the description of the advertisement',
+		question: 'Enter the description of the advertisement that you submitted in your application',
+		fieldName: 'developmentDescriptionOriginal',
+		url: 'description-advertisement',
+		validators: [
+			new RequiredValidator('Enter a description'),
+			new StringValidator({
+				maxLength: {
+					maxLength: appealFormV2.textInputMaxLength,
+					maxLengthMessage: `Your description must be ${appealFormV2.textInputMaxLength} characters or less`
+				}
+			})
+		]
 	}
 };
 

--- a/packages/forms-web-app/src/journeys/__snapshots__/index.test.js.snap
+++ b/packages/forms-web-app/src/journeys/__snapshots__/index.test.js.snap
@@ -403,6 +403,38 @@ exports[`Dynamic forms journey tests appellant Advertisement Advertisement shoul
 </main>"
 `;
 
+exports[`Dynamic forms journey tests appellant Advertisement Advertisement should render the description-advertisement question 1`] = `
+"<main id="main-content" role="main" class="govuk-main-wrapper govuk-main-wrapper--auto-spacing">
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds"></div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds"><span class="govuk-caption-l"> Prepare appeal</span>
+        </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+            <form action="" method="post" novalidate=null>
+                <h1 class="govuk-label-wrapper"><label class="govuk-label govuk-label--l" for="developmentDescriptionOriginal"> Enter the description of the advertisement that you submitted in your application</label></h1>
+                <div class="govuk-form-group">
+                    <div id="developmentDescriptionOriginal-hint" class="govuk-hint"></div>
+                    <textarea class="govuk-textarea" id="developmentDescriptionOriginal"
+                    name="developmentDescriptionOriginal" rows="5" aria-describedby="developmentDescriptionOriginal-hint"></textarea>
+                </div>
+                <button type="submit" class="govuk-button" data-module="govuk-button"
+                data-cy="button-save-and-continue">Continue</button>
+            </form>
+        </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+            <p class="govuk-body"><a href="/appeals/adverts/appeal-form/your-appeal?id=appeal-ref" class="govuk-link">Return to your appeal</a>
+            </p>
+        </div>
+    </div>
+</main>"
+`;
+
 exports[`Dynamic forms journey tests appellant Advertisement Advertisement should render the description-advertisement-correct question 1`] = `
 "<main id="main-content" role="main" class="govuk-main-wrapper govuk-main-wrapper--auto-spacing">
     <div class="govuk-grid-row">
@@ -476,40 +508,6 @@ exports[`Dynamic forms journey tests appellant Advertisement Advertisement shoul
         data-cy="button-save-and-continue">Continue</button>
         </form>
     </div>
-    </div>
-    <div class="govuk-grid-row">
-        <div class="govuk-grid-column-two-thirds">
-            <p class="govuk-body"><a href="/appeals/adverts/appeal-form/your-appeal?id=appeal-ref" class="govuk-link">Return to your appeal</a>
-            </p>
-        </div>
-    </div>
-</main>"
-`;
-
-exports[`Dynamic forms journey tests appellant Advertisement Advertisement should render the enter-description-of-development question 1`] = `
-"<main id="main-content" role="main" class="govuk-main-wrapper govuk-main-wrapper--auto-spacing">
-    <div class="govuk-grid-row">
-        <div class="govuk-grid-column-two-thirds"></div>
-    </div>
-    <div class="govuk-grid-row">
-        <div class="govuk-grid-column-two-thirds"><span class="govuk-caption-l"> Prepare appeal</span>
-        </div>
-    </div>
-    <div class="govuk-grid-row">
-        <div class="govuk-grid-column-two-thirds">
-            <form action="" method="post" novalidate=null>
-                <h1 class="govuk-label-wrapper"><label class="govuk-label govuk-label--l" for="developmentDescriptionOriginal"> Enter the description of development that you submitted in your application</label></h1>
-                <div class="govuk-form-group">
-                    <div id="developmentDescriptionOriginal-hint" class="govuk-hint">If the local planning authority changed the description of development,
-                        you can upload evidence of your agreement to change the description later.</div>
-                    <textarea
-                    class="govuk-textarea" id="developmentDescriptionOriginal" name="developmentDescriptionOriginal"
-                    rows="5" aria-describedby="developmentDescriptionOriginal-hint"></textarea>
-                </div>
-                <button type="submit" class="govuk-button" data-module="govuk-button"
-                data-cy="button-save-and-continue">Continue</button>
-            </form>
-        </div>
     </div>
     <div class="govuk-grid-row">
         <div class="govuk-grid-column-two-thirds">
@@ -1703,10 +1701,10 @@ exports[`Dynamic forms journey tests appellant Advertisement renders listing pag
                                 <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals/adverts/prepare-appeal/application-date?id=appeal-ref">Answer<span class="govuk-visually-hidden"> What date did you submit your application?</span></a>
                                 </dd>
                         </div>
-                        <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Enter the description of development that you submitted in your application</dt>
+                        <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Enter the description of the advertisement</dt>
                             <dd
                             class="govuk-summary-list__value">Not started</dd>
-                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals/adverts/prepare-appeal/enter-description-of-development?id=appeal-ref">Answer<span class="govuk-visually-hidden"> Enter the description of development that you submitted in your application</span></a>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals/adverts/prepare-appeal/description-advertisement?id=appeal-ref">Answer<span class="govuk-visually-hidden"> Enter the description of the advertisement that you submitted in your application</span></a>
                                 </dd>
                         </div>
                         <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Did the local planning authority change the description of the advertisement?</dt>


### PR DESCRIPTION
### Description of change

Adding 'Enter the description of the advertisement' to the advert appeal form, it reuses the developmentDescriptionOriginal data field.

Ticket: https://pins-ds.atlassian.net/browse/A2-

### Testing

Manual testing for copy (all screenshots taken from locally running version):

- for copy 
<img width="790" height="462" alt="image" src="https://github.com/user-attachments/assets/29e86e54-be93-48f5-b68e-9941abeed414" />

- for empty error message
<img width="805" height="646" alt="image" src="https://github.com/user-attachments/assets/a6a49630-b356-4c79-941a-91d29ebd6fc2" />

- for too long error message (test text was 1010 characters)
<img width="892" height="723" alt="image" src="https://github.com/user-attachments/assets/9bd48875-97aa-4360-b0cc-6c163a042abc" />

- for continuing and returning back retaining the entered text

### Checklist

- [x] Feature complete and ready for users, or behind feature-flag
- [x] Commit history is linear with no merge commits
- [ ] Requires infrastructure changes

### Important

Please do not merge from `main` (please only [rebase](https://github.com/Planning-Inspectorate/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
