### PR TITLE
feat: a2-3746_cas_planning_questionnaire_dashboard

### DIFF
--- a/packages/forms-web-app/src/controllers/selected-appeal/questionnaire-details/appeal-process-details.test.js
+++ b/packages/forms-web-app/src/controllers/selected-appeal/questionnaire-details/appeal-process-details.test.js
@@ -1,41 +1,43 @@
-const { APPEAL_CASE_PROCEDURE } = require('@planning-inspectorate/data-model');
 const { appealProcessRows } = require('./appeal-process-details-rows');
-const { fieldNames } = require('@pins/common/src/dynamic-forms/field-names');
+const { CASE_TYPES } = require('@pins/common/src/database/data-static');
+const { caseTypeLPAQFactory } = require('./test-factory');
+
+const hasLPAQData = caseTypeLPAQFactory(CASE_TYPES.HAS.processCode, 'appealProcess');
+const casPlanningLPAQData = caseTypeLPAQFactory(
+	CASE_TYPES.CAS_PLANNING.processCode,
+	'appealProcess'
+);
+const s78LPAQData = caseTypeLPAQFactory(CASE_TYPES.S78.processCode, 'appealProcess');
+const s20LPAQData = caseTypeLPAQFactory(CASE_TYPES.S20.processCode, 'appealProcess');
+
+const expectedRowsHas = [
+	{ title: 'Appeals near the site', value: 'Yes' },
+	{ title: 'Appeal references', value: '00000001' },
+	{ title: 'Extra conditions', value: 'Yes\nexample new conditions' }
+];
+const expectedRowsS78 = [
+	{ title: 'Appeal procedure', value: 'Inquiry\ninquiry preference\nExpected duration: 6 days' },
+	{ title: 'Appeals near the site', value: 'Yes' },
+	{ title: 'Appeal references', value: '00000001' },
+	{ title: 'Extra conditions', value: 'Yes\nexample new conditions' }
+];
 
 describe('appealProcessRows', () => {
-	it('should create rows with correct data if relevant case data fields exist & field values populated', () => {
-		const caseData = {
-			lpaProcedurePreference: APPEAL_CASE_PROCEDURE.INQUIRY,
-			lpaProcedurePreferenceDetails: 'inquiry preference',
-			lpaProcedurePreferenceDuration: 6,
-			newConditionDetails: 'new condition details',
-			submissionLinkedCases: [
-				{
-					fieldName: fieldNames.nearbyAppealReference,
-					caseReference: '0000002'
-				}
-			]
-		};
+	it.each([
+		['HAS', hasLPAQData, expectedRowsHas],
+		['CAS Planning', casPlanningLPAQData, expectedRowsHas],
+		['S78', s78LPAQData, expectedRowsS78],
+		['S20', s20LPAQData, expectedRowsS78]
+	])(`should create correct rows for appeal type %s`, (_, caseData, expectedRows) => {
+		const visibleRows = appealProcessRows(caseData)
+			.filter((row) => row.condition(caseData))
+			.map((visibleRow) => {
+				return { title: visibleRow.keyText, value: visibleRow.valueText };
+			});
 
-		const rows = appealProcessRows(caseData);
-
-		expect(rows.length).toEqual(4);
-		expect(rows[0].keyText).toEqual('Appeal procedure');
-		expect(rows[0].valueText).toEqual('Inquiry\ninquiry preference\nExpected duration: 6 days');
-		expect(rows[0].condition()).toEqual(true);
-
-		expect(rows[1].keyText).toEqual('Appeals near the site');
-		expect(rows[1].valueText).toEqual('Yes');
-		expect(rows[1].condition()).toEqual(true);
-
-		expect(rows[2].keyText).toEqual('Appeal references');
-		expect(rows[2].valueText).toEqual('0000002');
-		expect(rows[2].condition()).toEqual(true);
-
-		expect(rows[3].keyText).toEqual('Extra conditions');
-		expect(rows[3].valueText).toEqual('Yes\nnew condition details');
-		expect(rows[3].condition()).toEqual(true);
+		expect(visibleRows).toEqual(expectedRows);
 	});
+
 	it('should handle null values correctly', () => {
 		const caseData = {
 			newConditionDetails: null,

--- a/packages/forms-web-app/src/controllers/selected-appeal/questionnaire-details/constraints-details-rows.js
+++ b/packages/forms-web-app/src/controllers/selected-appeal/questionnaire-details/constraints-details-rows.js
@@ -19,7 +19,9 @@ const { isNotUndefinedOrNull } = require('#lib/is-not-undefined-or-null');
 exports.constraintsRows = (caseData) => {
 	const documents = caseData.Documents || [];
 
-	const isHASAppeal = caseData.appealTypeCode === CASE_TYPES.HAS.processCode;
+	const hasOrCasPlanningAppeal =
+		caseData.appealTypeCode === CASE_TYPES.HAS.processCode ||
+		caseData.appealTypeCode === CASE_TYPES.CAS_PLANNING.processCode;
 
 	const affectedListedBuildings = caseData.ListedBuildings?.filter(
 		(x) => x.type === LISTED_RELATION_TYPES.affected
@@ -46,7 +48,7 @@ exports.constraintsRows = (caseData) => {
 		{
 			keyText: 'Changes a listed building',
 			valueText: changedListedBuildingText,
-			condition: () => !isHASAppeal
+			condition: () => !hasOrCasPlanningAppeal
 		},
 		{
 			keyText: 'Listed building details',
@@ -86,7 +88,7 @@ exports.constraintsRows = (caseData) => {
 		{
 			keyText: 'Affects a scheduled monument',
 			valueText: formatYesOrNo(caseData, 'scheduledMonument'),
-			condition: () => !isHASAppeal && isNotUndefinedOrNull(caseData.scheduledMonument)
+			condition: () => !hasOrCasPlanningAppeal && isNotUndefinedOrNull(caseData.scheduledMonument)
 		},
 		{
 			keyText: 'Conservation area',
@@ -117,20 +119,21 @@ exports.constraintsRows = (caseData) => {
 		{
 			keyText: 'Designated sites',
 			valueText: formatDesignations(caseData),
-			condition: () => !isHASAppeal
+			condition: () => !hasOrCasPlanningAppeal
 		},
 		{
 			keyText: 'Tree Preservation Order',
 			valueText: boolToYesNo(
 				documentExists(documents, APPEAL_DOCUMENT_TYPE.TREE_PRESERVATION_PLAN)
 			),
-			condition: () => !isHASAppeal
+			condition: () => !hasOrCasPlanningAppeal
 		},
 		{
 			keyText: 'Uploaded Tree Preservation Order extent',
 			valueText: formatDocumentDetails(documents, APPEAL_DOCUMENT_TYPE.TREE_PRESERVATION_PLAN),
 			condition: () =>
-				!isHASAppeal && documentExists(documents, APPEAL_DOCUMENT_TYPE.TREE_PRESERVATION_PLAN),
+				!hasOrCasPlanningAppeal &&
+				documentExists(documents, APPEAL_DOCUMENT_TYPE.TREE_PRESERVATION_PLAN),
 			isEscaped: true
 		},
 		{

--- a/packages/forms-web-app/src/controllers/selected-appeal/questionnaire-details/constraints-details-rows.test.js
+++ b/packages/forms-web-app/src/controllers/selected-appeal/questionnaire-details/constraints-details-rows.test.js
@@ -1,10 +1,104 @@
 const { CASE_TYPES } = require('@pins/common/src/database/data-static');
-
-const { LISTED_RELATION_TYPES } = require('@pins/common/src/database/data-static');
 const { constraintsRows } = require('./constraints-details-rows');
-const { APPEAL_DOCUMENT_TYPE } = require('@planning-inspectorate/data-model');
+const { caseTypeLPAQFactory } = require('./test-factory');
 
 describe('constraintsRows', () => {
+	const hasLPAQData = caseTypeLPAQFactory(CASE_TYPES.HAS.processCode, 'constraints');
+	const casPlanningLPAQData = caseTypeLPAQFactory(
+		CASE_TYPES.CAS_PLANNING.processCode,
+		'constraints'
+	);
+	const s78LPAQData = caseTypeLPAQFactory(CASE_TYPES.S78.processCode, 'constraints');
+	const s20LPAQData = caseTypeLPAQFactory(CASE_TYPES.S20.processCode, 'constraints');
+
+	const sharedHasCasRows = [
+		{ title: 'Affects a listed building', value: 'Yes' },
+		{ title: 'Listed building details', value: 'LB1' },
+		{ title: 'Conservation area', value: 'Yes' },
+		{
+			title: 'Uploaded conservation area map and guidance',
+			value: 'name.pdf - awaiting review'
+		},
+		{ title: 'Green belt', value: 'Yes' }
+	];
+	const expectedRowsHas = [
+		{
+			title: 'Is a householder appeal the correct type of appeal?',
+			value: 'Yes'
+		},
+		...sharedHasCasRows
+	];
+	const expectedRowsCasPlanning = [
+		{
+			title: 'Is a commercial planning (cas) appeal the correct type of appeal?',
+			value: 'Yes'
+		},
+		...sharedHasCasRows
+	];
+	const expectedRowsS78 = [
+		{
+			title: 'Is a planning appeal the correct type of appeal?',
+			value: 'Yes'
+		},
+		{ title: 'Changes a listed building', value: 'Yes' },
+		{ title: 'Listed building details', value: 'LB2' },
+		{ title: 'Affects a listed building', value: 'Yes' },
+		{ title: 'Listed building details', value: 'LB1' },
+		{ title: 'Conservation area', value: 'Yes' },
+		{
+			title: 'Uploaded conservation area map and guidance',
+			value: 'name.pdf - awaiting review'
+		},
+		{ title: 'Protected species', value: 'Yes' },
+		{ title: 'Green belt', value: 'Yes' },
+		{ title: 'Area of outstanding natural beauty', value: 'Yes' },
+		{ title: 'Designated sites', value: 'Site A\nSite B' },
+		{ title: 'Tree Preservation Order', value: 'Yes' },
+		{
+			title: 'Uploaded Tree Preservation Order extent',
+			value: 'name.pdf - awaiting review'
+		},
+		{ title: 'Gypsy or Traveller', value: 'Yes' },
+		{ title: 'Public right of way', value: 'Yes' },
+		{
+			title: 'Uploaded definitive map and statement extract',
+			value: 'name.pdf - awaiting review'
+		}
+	];
+
+	const expectedRowsS20 = [
+		{
+			title:
+				'Is a planning listed building and conservation area appeal the correct type of appeal?',
+			value: 'Yes'
+		},
+		...expectedRowsS78.slice(1, 5),
+		{
+			title: 'Was a grant or loan made to preserve the listed building at the appeal site?',
+			value: 'Yes'
+		},
+		{ title: 'Was Historic England consulted?', value: 'Yes' },
+		{
+			title: 'Uploaded consultation with Historic England',
+			value: 'name.pdf - awaiting review'
+		},
+		...expectedRowsS78.slice(5, expectedRowsS78.length - 1)
+	];
+
+	it.each([
+		['HAS', hasLPAQData, expectedRowsHas],
+		['CAS Planning', casPlanningLPAQData, expectedRowsCasPlanning],
+		['S78', s78LPAQData, expectedRowsS78],
+		['S20', s20LPAQData, expectedRowsS20]
+	])(`should create correct rows for appeal type %s`, (_, caseData, expectedRows) => {
+		const visibleRows = constraintsRows(caseData)
+			.filter((row) => row.condition(caseData))
+			.map((visibleRow) => {
+				return { title: visibleRow.keyText, value: visibleRow.valueText };
+			});
+		expect(visibleRows).toEqual(expectedRows);
+	});
+
 	const ROW_COUNT = 20;
 	const CORRECT_APPEAL_TYPE_ROW = 0;
 	const CHANGES_LISTED_BUILDING_ROW = 1;
@@ -26,163 +120,6 @@ describe('constraintsRows', () => {
 	const GYPSY_TRAVELLER_ROW = 17;
 	const PUBLIC_RIGHT_OF_WAY_ROW = 18;
 	const DEFINITIVE_MAP_STATEMENT_DOC_ROW = 19;
-
-	it('should create rows with correct data if relevant case data fields exist and field values true/files uploaded/otherwise populated', () => {
-		const caseData = {
-			appealTypeCode: CASE_TYPES.S78.processCode,
-			ListedBuildings: [
-				{
-					listedBuildingReference: 'Building 1',
-					type: LISTED_RELATION_TYPES.affected
-				},
-				{
-					listedBuildingReference: 'Building 2',
-					type: LISTED_RELATION_TYPES.affected
-				},
-				{
-					listedBuildingReference: 'Building 3',
-					type: LISTED_RELATION_TYPES.changed
-				},
-				{
-					listedBuildingReference: 'Building 4',
-					type: LISTED_RELATION_TYPES.changed
-				}
-			],
-			preserveGrantLoan: true,
-			consultHistoricEngland: true,
-			scheduledMonument: true,
-			isCorrectAppealType: true,
-			protectedSpecies: true,
-			isGreenBelt: true,
-			areaOutstandingBeauty: true,
-			designatedSitesNames: ['Yes'],
-			gypsyTraveller: true,
-			publicRightOfWay: true,
-			Documents: [
-				{
-					documentType: APPEAL_DOCUMENT_TYPE.TREE_PRESERVATION_PLAN,
-					id: '12347',
-					filename: 'tree.pdf',
-					redacted: true
-				},
-				{
-					documentType: APPEAL_DOCUMENT_TYPE.DEFINITIVE_MAP_STATEMENT,
-					id: '12348',
-					filename: 'definitive-statement.pdf',
-					redacted: true
-				},
-				{
-					documentType: APPEAL_DOCUMENT_TYPE.HISTORIC_ENGLAND_CONSULTATION,
-					id: '12349',
-					filename: 'consultation.pdf',
-					redacted: true
-				}
-			]
-		};
-		const rows = constraintsRows(caseData);
-		expect(rows.length).toEqual(ROW_COUNT);
-		expect(rows[CORRECT_APPEAL_TYPE_ROW].condition()).toEqual(true);
-		expect(rows[CORRECT_APPEAL_TYPE_ROW].keyText).toEqual(
-			'Is a planning appeal the correct type of appeal?'
-		);
-		expect(rows[CORRECT_APPEAL_TYPE_ROW].valueText).toEqual('Yes');
-
-		expect(rows[CHANGES_LISTED_BUILDING_ROW].condition()).toEqual(true);
-		expect(rows[CHANGES_LISTED_BUILDING_ROW].keyText).toEqual('Changes a listed building');
-		expect(rows[CHANGES_LISTED_BUILDING_ROW].valueText).toEqual('Yes');
-
-		expect(rows[CHANGED_LISTED_BUILDING_DETAILS_ROW].condition()).toEqual(true);
-		expect(rows[CHANGED_LISTED_BUILDING_DETAILS_ROW].keyText).toEqual('Listed building details');
-		expect(rows[CHANGED_LISTED_BUILDING_DETAILS_ROW].valueText).toEqual('Building 3\nBuilding 4');
-
-		expect(rows[AFFECTS_LISTED_BUILDING_ROW].condition()).toEqual(true);
-		expect(rows[AFFECTS_LISTED_BUILDING_ROW].keyText).toEqual('Affects a listed building');
-		expect(rows[AFFECTS_LISTED_BUILDING_ROW].valueText).toEqual('Yes');
-
-		expect(rows[AFFECTED_LISTED_BUILDING_DETAILS_ROW].condition()).toEqual(true);
-		expect(rows[AFFECTED_LISTED_BUILDING_DETAILS_ROW].keyText).toEqual('Listed building details');
-		expect(rows[AFFECTED_LISTED_BUILDING_DETAILS_ROW].valueText).toEqual('Building 1\nBuilding 2');
-
-		expect(rows[PRESERVE_GRANT_LOAN_ROW].condition()).toEqual(true);
-		expect(rows[PRESERVE_GRANT_LOAN_ROW].keyText).toEqual(
-			'Was a grant or loan made to preserve the listed building at the appeal site?'
-		);
-		expect(rows[PRESERVE_GRANT_LOAN_ROW].valueText).toEqual('Yes');
-
-		expect(rows[CONSULT_HISTORIC_ENGLAND_ROW].condition()).toEqual(true);
-		expect(rows[CONSULT_HISTORIC_ENGLAND_ROW].keyText).toEqual('Was Historic England consulted?');
-		expect(rows[CONSULT_HISTORIC_ENGLAND_ROW].valueText).toEqual('Yes');
-
-		expect(rows[HISTORIC_ENGLAND_CONSULTATION_DOC_ROW].condition()).toEqual(true);
-		expect(rows[HISTORIC_ENGLAND_CONSULTATION_DOC_ROW].keyText).toEqual(
-			'Uploaded consultation with Historic England'
-		);
-		expect(rows[HISTORIC_ENGLAND_CONSULTATION_DOC_ROW].valueText).toEqual(
-			'<a href="/published-document/12349" class="govuk-link">consultation.pdf</a>'
-		);
-		expect(rows[HISTORIC_ENGLAND_CONSULTATION_DOC_ROW].isEscaped).toEqual(true);
-
-		expect(rows[AFFECTS_SCHEDULED_MONUMENT_ROW].condition()).toEqual(true);
-		expect(rows[AFFECTS_SCHEDULED_MONUMENT_ROW].keyText).toEqual('Affects a scheduled monument');
-		expect(rows[AFFECTS_SCHEDULED_MONUMENT_ROW].valueText).toEqual('Yes');
-
-		expect(rows[CONSERVATION_AREA_ROW].condition()).toEqual(true);
-		expect(rows[CONSERVATION_AREA_ROW].keyText).toEqual('Conservation area');
-		expect(rows[CONSERVATION_AREA_ROW].valueText).toEqual('No');
-
-		expect(rows[CONSERVATION_MAP_DOC_ROW].condition()).toEqual(false);
-		expect(rows[CONSERVATION_MAP_DOC_ROW].keyText).toEqual(
-			'Uploaded conservation area map and guidance'
-		);
-		expect(rows[CONSERVATION_MAP_DOC_ROW].valueText).toEqual('No');
-		expect(rows[CONSERVATION_MAP_DOC_ROW].isEscaped).toEqual(true);
-
-		expect(rows[PROTECTED_SPECIES_ROW].condition()).toEqual(true);
-		expect(rows[PROTECTED_SPECIES_ROW].keyText).toEqual('Protected species');
-		expect(rows[PROTECTED_SPECIES_ROW].valueText).toEqual('Yes');
-
-		expect(rows[GREEN_BELT_ROW].condition()).toEqual(true);
-		expect(rows[GREEN_BELT_ROW].keyText).toEqual('Green belt');
-		expect(rows[GREEN_BELT_ROW].valueText).toEqual('Yes');
-
-		expect(rows[AREA_OUTSTANDING_BEAUTY_ROW].condition()).toEqual(true);
-		expect(rows[AREA_OUTSTANDING_BEAUTY_ROW].keyText).toEqual('Area of outstanding natural beauty');
-		expect(rows[AREA_OUTSTANDING_BEAUTY_ROW].valueText).toEqual('Yes');
-
-		expect(rows[DESIGNATED_SITES_ROW].condition()).toEqual(true);
-		expect(rows[DESIGNATED_SITES_ROW].keyText).toEqual('Designated sites');
-		expect(rows[DESIGNATED_SITES_ROW].valueText).toEqual('Yes');
-
-		expect(rows[TREE_PRESERVATION_ORDER_ROW].condition()).toEqual(true);
-		expect(rows[TREE_PRESERVATION_ORDER_ROW].keyText).toEqual('Tree Preservation Order');
-		expect(rows[TREE_PRESERVATION_ORDER_ROW].valueText).toEqual('Yes');
-
-		expect(rows[TREE_PRESERVATION_PLAN_DOC_ROW].condition()).toEqual(true);
-		expect(rows[TREE_PRESERVATION_PLAN_DOC_ROW].keyText).toEqual(
-			'Uploaded Tree Preservation Order extent'
-		);
-		expect(rows[TREE_PRESERVATION_PLAN_DOC_ROW].valueText).toEqual(
-			'<a href="/published-document/12347" class="govuk-link">tree.pdf</a>'
-		);
-		expect(rows[TREE_PRESERVATION_PLAN_DOC_ROW].isEscaped).toEqual(true);
-
-		expect(rows[GYPSY_TRAVELLER_ROW].condition()).toEqual(true);
-		expect(rows[GYPSY_TRAVELLER_ROW].keyText).toEqual('Gypsy or Traveller');
-		expect(rows[GYPSY_TRAVELLER_ROW].valueText).toEqual('Yes');
-
-		expect(rows[PUBLIC_RIGHT_OF_WAY_ROW].condition()).toEqual(true);
-		expect(rows[PUBLIC_RIGHT_OF_WAY_ROW].keyText).toEqual('Public right of way');
-		expect(rows[PUBLIC_RIGHT_OF_WAY_ROW].valueText).toEqual('Yes');
-
-		expect(rows[DEFINITIVE_MAP_STATEMENT_DOC_ROW].condition()).toEqual(true);
-		expect(rows[DEFINITIVE_MAP_STATEMENT_DOC_ROW].keyText).toEqual(
-			'Uploaded definitive map and statement extract'
-		);
-		expect(rows[DEFINITIVE_MAP_STATEMENT_DOC_ROW].valueText).toEqual(
-			'<a href="/published-document/12348" class="govuk-link">definitive-statement.pdf</a>'
-		);
-		expect(rows[DEFINITIVE_MAP_STATEMENT_DOC_ROW].isEscaped).toEqual(true);
-	});
 
 	it('should create rows with correct data if relevant case data fields and field values false/no files uploaded/otherwise not populated', () => {
 		const caseData = {
@@ -318,100 +255,6 @@ describe('constraintsRows', () => {
 		expect(rows[AREA_OUTSTANDING_BEAUTY_ROW].condition()).toEqual(false);
 		expect(rows[DESIGNATED_SITES_ROW].condition()).toEqual(true);
 		expect(rows[TREE_PRESERVATION_ORDER_ROW].condition()).toEqual(true);
-		expect(rows[TREE_PRESERVATION_PLAN_DOC_ROW].condition()).toEqual(false);
-		expect(rows[GYPSY_TRAVELLER_ROW].condition()).toEqual(false);
-		expect(rows[PUBLIC_RIGHT_OF_WAY_ROW].condition()).toEqual(false);
-		expect(rows[DEFINITIVE_MAP_STATEMENT_DOC_ROW].condition()).toEqual(false);
-	});
-
-	it('should create rows with correct data for HAS appeal', () => {
-		const caseData = {
-			appealTypeCode: CASE_TYPES.HAS.processCode,
-			isCorrectAppealType: true,
-			ListedBuildings: [
-				{
-					listedBuildingReference: 'Building 1',
-					type: LISTED_RELATION_TYPES.affected
-				},
-				{
-					listedBuildingReference: 'Building 2',
-					type: LISTED_RELATION_TYPES.affected
-				},
-				{
-					listedBuildingReference: 'Building 3',
-					type: LISTED_RELATION_TYPES.changed
-				},
-				{
-					listedBuildingReference: 'Building 4',
-					type: LISTED_RELATION_TYPES.changed
-				}
-			],
-			scheduledMonument: false,
-			isGreenBelt: true,
-			Documents: [
-				{
-					documentType: APPEAL_DOCUMENT_TYPE.CONSERVATION_MAP,
-					id: '12345',
-					filename: 'conservationmap1.pdf',
-					redacted: true
-				},
-				{
-					documentType: APPEAL_DOCUMENT_TYPE.CONSERVATION_MAP,
-					id: '12346',
-					filename: 'conservationmap2.pdf',
-					redacted: true
-				}
-			]
-		};
-		const rows = constraintsRows(caseData);
-
-		expect(rows.length).toEqual(ROW_COUNT);
-		expect(rows[CORRECT_APPEAL_TYPE_ROW].condition()).toEqual(true);
-		expect(rows[CORRECT_APPEAL_TYPE_ROW].keyText).toEqual(
-			'Is a householder appeal the correct type of appeal?'
-		);
-		expect(rows[CORRECT_APPEAL_TYPE_ROW].valueText).toEqual('Yes');
-
-		expect(rows[CHANGES_LISTED_BUILDING_ROW].condition()).toEqual(false);
-		expect(rows[CHANGES_LISTED_BUILDING_ROW].keyText).toEqual('Changes a listed building');
-		expect(rows[CHANGES_LISTED_BUILDING_ROW].valueText).toEqual('Yes');
-
-		expect(rows[CHANGED_LISTED_BUILDING_DETAILS_ROW].condition()).toEqual(true);
-		expect(rows[CHANGED_LISTED_BUILDING_DETAILS_ROW].keyText).toEqual('Listed building details');
-		expect(rows[CHANGED_LISTED_BUILDING_DETAILS_ROW].valueText).toEqual('Building 3\nBuilding 4');
-
-		expect(rows[AFFECTS_LISTED_BUILDING_ROW].condition()).toEqual(true);
-		expect(rows[AFFECTS_LISTED_BUILDING_ROW].keyText).toEqual('Affects a listed building');
-		expect(rows[AFFECTS_LISTED_BUILDING_ROW].valueText).toEqual('Yes');
-
-		expect(rows[AFFECTED_LISTED_BUILDING_DETAILS_ROW].condition()).toEqual(true);
-		expect(rows[AFFECTED_LISTED_BUILDING_DETAILS_ROW].keyText).toEqual('Listed building details');
-		expect(rows[AFFECTED_LISTED_BUILDING_DETAILS_ROW].valueText).toEqual('Building 1\nBuilding 2');
-
-		expect(rows[AFFECTS_SCHEDULED_MONUMENT_ROW].condition()).toEqual(false);
-
-		expect(rows[CONSERVATION_AREA_ROW].condition()).toEqual(true);
-		expect(rows[CONSERVATION_AREA_ROW].keyText).toEqual('Conservation area');
-		expect(rows[CONSERVATION_AREA_ROW].valueText).toEqual('Yes');
-
-		expect(rows[CONSERVATION_MAP_DOC_ROW].condition()).toEqual(true);
-		expect(rows[CONSERVATION_MAP_DOC_ROW].keyText).toEqual(
-			'Uploaded conservation area map and guidance'
-		);
-		expect(rows[CONSERVATION_MAP_DOC_ROW].valueText).toEqual(
-			'<a href="/published-document/12345" class="govuk-link">conservationmap1.pdf</a>\n<a href="/published-document/12346" class="govuk-link">conservationmap2.pdf</a>'
-		);
-		expect(rows[CONSERVATION_MAP_DOC_ROW].isEscaped).toEqual(true);
-
-		expect(rows[PROTECTED_SPECIES_ROW].condition()).toEqual(false);
-
-		expect(rows[GREEN_BELT_ROW].condition()).toEqual(true);
-		expect(rows[GREEN_BELT_ROW].keyText).toEqual('Green belt');
-		expect(rows[GREEN_BELT_ROW].valueText).toEqual('Yes');
-
-		expect(rows[AREA_OUTSTANDING_BEAUTY_ROW].condition()).toEqual(false);
-		expect(rows[DESIGNATED_SITES_ROW].condition()).toEqual(false);
-		expect(rows[TREE_PRESERVATION_ORDER_ROW].condition()).toEqual(false);
 		expect(rows[TREE_PRESERVATION_PLAN_DOC_ROW].condition()).toEqual(false);
 		expect(rows[GYPSY_TRAVELLER_ROW].condition()).toEqual(false);
 		expect(rows[PUBLIC_RIGHT_OF_WAY_ROW].condition()).toEqual(false);

--- a/packages/forms-web-app/src/controllers/selected-appeal/questionnaire-details/consultation-details-rows.js
+++ b/packages/forms-web-app/src/controllers/selected-appeal/questionnaire-details/consultation-details-rows.js
@@ -14,7 +14,9 @@ exports.consultationRows = (caseData) => {
 	);
 	const otherPartyRepresentationsText = boolToYesNo(hasOtherPartyRepresentations);
 
-	const isHASAppeal = caseData.appealTypeCode === CASE_TYPES.HAS.processCode;
+	const hasOrCasPlanningAppeal =
+		caseData.appealTypeCode === CASE_TYPES.HAS.processCode ||
+		caseData.appealTypeCode === CASE_TYPES.CAS_PLANNING.processCode;
 
 	return [
 		{
@@ -27,7 +29,7 @@ exports.consultationRows = (caseData) => {
 			valueText: boolToYesNo(
 				documentExists(documents, APPEAL_DOCUMENT_TYPE.CONSULTATION_RESPONSES)
 			),
-			condition: () => !isHASAppeal
+			condition: () => !hasOrCasPlanningAppeal
 		},
 		{
 			keyText: 'Uploaded consultation responses and standing advice',

--- a/packages/forms-web-app/src/controllers/selected-appeal/questionnaire-details/environmental-details-rows.js
+++ b/packages/forms-web-app/src/controllers/selected-appeal/questionnaire-details/environmental-details-rows.js
@@ -20,8 +20,11 @@ const {
 exports.environmentalRows = (caseData) => {
 	const documents = caseData.Documents || [];
 
-	const isHASAppeal = caseData.appealTypeCode === CASE_TYPES.HAS.processCode;
-	if (isHASAppeal) return [];
+	const hasOrCasPlanningAppeal =
+		caseData.appealTypeCode === CASE_TYPES.HAS.processCode ||
+		caseData.appealTypeCode === CASE_TYPES.CAS_PLANNING.processCode;
+
+	if (hasOrCasPlanningAppeal) return [];
 
 	const isSchedule1 =
 		caseData.environmentalImpactSchedule === APPEAL_EIA_ENVIRONMENTAL_IMPACT_SCHEDULE.SCHEDULE_1;

--- a/packages/forms-web-app/src/controllers/selected-appeal/questionnaire-details/environmental-details-rows.test.js
+++ b/packages/forms-web-app/src/controllers/selected-appeal/questionnaire-details/environmental-details-rows.test.js
@@ -1,23 +1,89 @@
 const { environmentalRows } = require('./environmental-details-rows');
 const { APPEAL_DOCUMENT_TYPE } = require('@planning-inspectorate/data-model');
+const { caseTypeLPAQFactory } = require('./test-factory');
+const { CASE_TYPES } = require('@pins/common/src/database/data-static');
 
 describe('environmentalRows', () => {
-	it('should create rows', () => {
-		const rows = environmentalRows({});
-		expect(rows.length).toEqual(12);
+	const eiaSchedule1Data = caseTypeLPAQFactory(CASE_TYPES.S78.processCode, 'eia', 'schedule-1');
+	const eiaSchedule2Data = caseTypeLPAQFactory(CASE_TYPES.S20.processCode, 'eia', 'schedule-2');
+	const eiaNullData = caseTypeLPAQFactory(CASE_TYPES.S20.processCode, 'eia', null);
 
-		expect(rows[0].keyText).toEqual('Schedule type');
-		expect(rows[1].keyText).toEqual('Development description');
-		expect(rows[2].keyText).toEqual('In, partly in, or likely to affect sensitive area');
-		expect(rows[3].keyText).toEqual('Meets or exceeds threshold or criteria in column 2');
-		expect(rows[4].keyText).toEqual('Issued screening opinion');
-		expect(rows[5].keyText).toEqual('Uploaded screening opinion');
-		expect(rows[6].keyText).toEqual('Received scoping opinion');
-		expect(rows[7].keyText).toEqual('Uploaded scoping opinion');
-		expect(rows[8].keyText).toEqual('Screening opinion indicated environmental statement needed');
-		expect(rows[9].keyText).toEqual('Did Environmental statement');
-		expect(rows[10].keyText).toEqual('Uploaded environmental statement');
-		expect(rows[11].keyText).toEqual('Uploaded screening direction');
+	const expectedSchedule1Rows = [
+		{ title: 'Schedule type', value: 'Schedule 1' },
+		{ title: 'Did Environmental statement', value: 'No' },
+		{
+			title: 'Uploaded environmental statement',
+			value: 'name.pdf - awaiting review'
+		}
+	];
+	const expectedSchedule2Rows = [
+		{ title: 'Schedule type', value: 'Schedule 2' },
+		{
+			title: 'Development description',
+			value: 'Agriculture and aquaculture'
+		},
+		{
+			title: 'In, partly in, or likely to affect sensitive area',
+			value: 'Yes\nSensitive area details here'
+		},
+		{
+			title: 'Meets or exceeds threshold or criteria in column 2',
+			value: 'Yes'
+		},
+		{ title: 'Issued screening opinion', value: 'Yes' },
+		{
+			title: 'Uploaded screening opinion',
+			value: 'name.pdf - awaiting review'
+		},
+		{ title: 'Received scoping opinion', value: 'Yes' },
+		{
+			title: 'Uploaded scoping opinion',
+			value: 'name.pdf - awaiting review'
+		},
+		{
+			title: 'Screening opinion indicated environmental statement needed',
+			value: 'Yes'
+		},
+		{ title: 'Did Environmental statement', value: 'Yes' },
+		{
+			title: 'Uploaded environmental statement',
+			value: 'name.pdf - awaiting review'
+		}
+	];
+	const expectedNullRows = [
+		{ title: 'Schedule type', value: 'Other' },
+		{ title: 'Issued screening opinion', value: 'Yes' },
+		{
+			title: 'Uploaded screening opinion',
+			value: 'name.pdf - awaiting review'
+		},
+		{ title: 'Received scoping opinion', value: 'Yes' },
+		{
+			title: 'Uploaded scoping opinion',
+			value: 'name.pdf - awaiting review'
+		},
+		{
+			title: 'Screening opinion indicated environmental statement needed',
+			value: ''
+		},
+		{ title: 'Did Environmental statement', value: '' },
+		{
+			title: 'Uploaded environmental statement',
+			value: 'name.pdf - awaiting review'
+		}
+	];
+
+	it.each([
+		['schedule-1', eiaSchedule1Data, expectedSchedule1Rows],
+		['schedule-2', eiaSchedule2Data, expectedSchedule2Rows],
+		['null', eiaNullData, expectedNullRows]
+	])(`should create correct rows for appeal type %s`, (_, caseData, expectedRows) => {
+		const visibleRows = environmentalRows(caseData)
+			.filter((row) => row.condition(caseData))
+			.map((visibleRow) => {
+				return { title: visibleRow.keyText, value: visibleRow.valueText };
+			});
+		expect(visibleRows).toEqual(expectedRows);
 	});
 
 	it('should show a document', () => {

--- a/packages/forms-web-app/src/controllers/selected-appeal/questionnaire-details/notified-details-rows.test.js
+++ b/packages/forms-web-app/src/controllers/selected-appeal/questionnaire-details/notified-details-rows.test.js
@@ -1,114 +1,50 @@
-const { APPEAL_DOCUMENT_TYPE } = require('@planning-inspectorate/data-model');
-const { LPA_NOTIFICATION_METHODS } = require('@pins/common/src/database/data-static');
+const { CASE_TYPES } = require('@pins/common/src/database/data-static');
 const { notifiedRows } = require('./notified-details-rows');
+const { caseTypeLPAQFactory } = require('./test-factory');
 
 describe('notifiedDetailsRows', () => {
-	const whoNotifiedRow = 0;
-	const typeRow = 1;
-	const noticeRow = 2;
-	const letterRow = 3;
-	const advertRow = 4;
-	const appealNotificatonRow = 5;
-
 	it('should create rows with correct data if relevant case data fields exist and files uploaded/field values otherwise populated', () => {
-		const caseData = {
-			AppealCaseLpaNotificationMethod: [
-				{ lPANotificationMethodsKey: LPA_NOTIFICATION_METHODS.notice.key },
-				{ lPANotificationMethodsKey: LPA_NOTIFICATION_METHODS.letter.key },
-				{ lPANotificationMethodsKey: LPA_NOTIFICATION_METHODS.pressAdvert.key }
-			],
-			Documents: [
-				{
-					documentType: APPEAL_DOCUMENT_TYPE.WHO_NOTIFIED,
-					id: '12345',
-					filename: 'whonotified1.pdf',
-					redacted: true
-				},
-				{
-					documentType: APPEAL_DOCUMENT_TYPE.WHO_NOTIFIED_SITE_NOTICE,
-					id: '12346',
-					filename: 'sitenotice1.pdf',
-					redacted: true
-				},
-				{
-					documentType: APPEAL_DOCUMENT_TYPE.WHO_NOTIFIED_LETTER_TO_NEIGHBOURS,
-					id: '12347',
-					filename: 'neighbours.pdf',
-					redacted: true
-				},
-				{
-					documentType: APPEAL_DOCUMENT_TYPE.WHO_NOTIFIED_PRESS_ADVERT,
-					id: '12348',
-					filename: 'press.pdf',
-					redacted: true
-				},
-				{
-					documentType: APPEAL_DOCUMENT_TYPE.APPEAL_NOTIFICATION,
-					id: '12349',
-					filename: 'appeal-notifcation.pdf',
-					redacted: true
-				}
-			]
-		};
+		const caseData = caseTypeLPAQFactory(CASE_TYPES.S20.processCode, 'notifiedParties');
 
-		const rows = notifiedRows(caseData);
+		const expectedRows = [
+			{ title: 'Who was notified', value: 'name.pdf - awaiting review' },
+			{ title: 'Type of Notification', value: '' },
+			{ title: 'Site notice', value: 'name.pdf - awaiting review' },
+			{
+				title: 'Letter sent to neighbours',
+				value: 'name.pdf - awaiting review'
+			},
+			{ title: 'Press advert', value: 'name.pdf - awaiting review' },
+			{
+				title: 'Appeal notification letter',
+				value: 'name.pdf - awaiting review'
+			}
+		];
 
-		expect(rows.length).toEqual(6);
-
-		expect(rows[whoNotifiedRow].condition()).toEqual(true);
-		expect(rows[whoNotifiedRow].keyText).toEqual('Who was notified');
-		expect(rows[whoNotifiedRow].valueText).toEqual(
-			'<a href="/published-document/12345" class="govuk-link">whonotified1.pdf</a>'
-		);
-		expect(rows[whoNotifiedRow].isEscaped).toEqual(true);
-
-		expect(rows[typeRow].condition()).toEqual(true);
-		expect(rows[typeRow].keyText).toEqual('Type of Notification');
-		expect(rows[typeRow].valueText).toEqual(
-			'A site notice\nLetter/email to interested parties\nA press advert'
-		);
-
-		expect(rows[noticeRow].condition()).toEqual(true);
-		expect(rows[noticeRow].keyText).toEqual('Site notice');
-		expect(rows[noticeRow].valueText).toEqual(
-			'<a href="/published-document/12346" class="govuk-link">sitenotice1.pdf</a>'
-		);
-		expect(rows[noticeRow].isEscaped).toEqual(true);
-
-		expect(rows[letterRow].condition()).toEqual(true);
-		expect(rows[letterRow].keyText).toEqual('Letter sent to neighbours');
-		expect(rows[letterRow].valueText).toEqual(
-			'<a href="/published-document/12347" class="govuk-link">neighbours.pdf</a>'
-		);
-		expect(rows[letterRow].isEscaped).toEqual(true);
-
-		expect(rows[advertRow].condition()).toEqual(true);
-		expect(rows[advertRow].keyText).toEqual('Press advert');
-		expect(rows[advertRow].valueText).toEqual(
-			'<a href="/published-document/12348" class="govuk-link">press.pdf</a>'
-		);
-		expect(rows[advertRow].isEscaped).toEqual(true);
-
-		expect(rows[appealNotificatonRow].condition()).toEqual(true);
-		expect(rows[appealNotificatonRow].keyText).toEqual('Appeal notification letter');
-		expect(rows[appealNotificatonRow].valueText).toEqual(
-			'<a href="/published-document/12349" class="govuk-link">appeal-notifcation.pdf</a>'
-		);
-		expect(rows[appealNotificatonRow].isEscaped).toEqual(true);
+		const visibleRows = notifiedRows(caseData)
+			.filter((row) => row.condition(caseData))
+			.map((visibleRow) => {
+				return { title: visibleRow.keyText, value: visibleRow.valueText };
+			});
+		expect(visibleRows).toEqual(expectedRows);
 	});
 
 	it('should not display if no fields/files exist', () => {
-		const rows = notifiedRows({
+		const expectedRows = [
+			{ title: 'Who was notified', value: 'No' },
+			{ title: 'Type of Notification', value: '' },
+			{ title: 'Site notice', value: 'No' },
+			{ title: 'Letter sent to neighbours', value: 'No' },
+			{ title: 'Press advert', value: 'No' },
+			{ title: 'Appeal notification letter', value: 'No' }
+		];
+
+		const visibleRows = notifiedRows({
 			AppealCaseLpaNotificationMethod: [],
 			Documents: []
+		}).map((visibleRow) => {
+			return { title: visibleRow.keyText, value: visibleRow.valueText };
 		});
-
-		expect(rows.length).toEqual(6);
-		expect(rows[whoNotifiedRow].condition()).toEqual(false);
-		expect(rows[typeRow].condition()).toEqual(false);
-		expect(rows[noticeRow].condition()).toEqual(false);
-		expect(rows[letterRow].condition()).toEqual(false);
-		expect(rows[advertRow].condition()).toEqual(false);
-		expect(rows[appealNotificatonRow].condition()).toEqual(false);
+		expect(visibleRows).toEqual(expectedRows);
 	});
 });

--- a/packages/forms-web-app/src/controllers/selected-appeal/questionnaire-details/planning-officer-details-rows.js
+++ b/packages/forms-web-app/src/controllers/selected-appeal/questionnaire-details/planning-officer-details-rows.js
@@ -18,14 +18,6 @@ const { isNotUndefinedOrNull } = require('#lib/is-not-undefined-or-null');
 exports.planningOfficerReportRows = (caseData) => {
 	const documents = caseData.Documents || [];
 
-	const hasEmergingPlan = documentExists(documents, APPEAL_DOCUMENT_TYPE.EMERGING_PLAN);
-	const emergingPlanText = boolToYesNo(hasEmergingPlan);
-
-	const hasSupplementaryPlanning = documentExists(
-		documents,
-		APPEAL_DOCUMENT_TYPE.SUPPLEMENTARY_PLANNING
-	);
-	const supplementaryPlanningText = boolToYesNo(hasSupplementaryPlanning);
 	return [
 		{
 			keyText: "Planning officer's report",
@@ -49,13 +41,13 @@ exports.planningOfficerReportRows = (caseData) => {
 		},
 		{
 			keyText: 'Emerging plan',
-			valueText: emergingPlanText,
+			valueText: boolToYesNo(documentExists(documents, APPEAL_DOCUMENT_TYPE.EMERGING_PLAN)),
 			condition: () => true
 		},
 		{
 			keyText: 'Uploaded emerging plan and supporting information',
 			valueText: formatDocumentDetails(documents, APPEAL_DOCUMENT_TYPE.EMERGING_PLAN),
-			condition: () => hasEmergingPlan,
+			condition: () => documentExists(documents, APPEAL_DOCUMENT_TYPE.EMERGING_PLAN),
 			isEscaped: true
 		},
 		{
@@ -66,13 +58,15 @@ exports.planningOfficerReportRows = (caseData) => {
 		},
 		{
 			keyText: 'Supplementary planning documents',
-			valueText: supplementaryPlanningText,
+			valueText: boolToYesNo(
+				documentExists(documents, APPEAL_DOCUMENT_TYPE.SUPPLEMENTARY_PLANNING)
+			),
 			condition: () => true
 		},
 		{
 			keyText: 'Uploaded supplementary planning documents',
 			valueText: formatDocumentDetails(documents, APPEAL_DOCUMENT_TYPE.SUPPLEMENTARY_PLANNING),
-			condition: () => hasSupplementaryPlanning,
+			condition: () => documentExists(documents, APPEAL_DOCUMENT_TYPE.SUPPLEMENTARY_PLANNING),
 			isEscaped: true
 		},
 		{

--- a/packages/forms-web-app/src/controllers/selected-appeal/questionnaire-details/planning-officer-details-rows.test.js
+++ b/packages/forms-web-app/src/controllers/selected-appeal/questionnaire-details/planning-officer-details-rows.test.js
@@ -1,11 +1,117 @@
 const { planningOfficerReportRows } = require('./planning-officer-details-rows');
 const { APPEAL_DOCUMENT_TYPE } = require('@planning-inspectorate/data-model');
 const { CASE_TYPES } = require('@pins/common/src/database/data-static');
+const { caseTypeLPAQFactory } = require('./test-factory');
 
 const date = new Date('2020-12-17T03:24:00');
 const formattedDate = '17 Dec 2020';
 
 describe('planningOfficerReportRows', () => {
+	const hasLPAQData = caseTypeLPAQFactory(CASE_TYPES.HAS.processCode, 'planningOfficersReport');
+	const casPlanningLPAQData = caseTypeLPAQFactory(
+		CASE_TYPES.CAS_PLANNING.processCode,
+		'planningOfficersReport'
+	);
+	const s78LPAQData = caseTypeLPAQFactory(CASE_TYPES.S78.processCode, 'planningOfficersReport');
+	const s20LPAQData = caseTypeLPAQFactory(CASE_TYPES.S20.processCode, 'planningOfficersReport');
+
+	const expectedRowsHas = [
+		{
+			title: "Planning officer's report",
+			value: 'name.pdf - awaiting review'
+		},
+		{
+			title: 'Plans, drawings and list of plans',
+			value: 'name.pdf - awaiting review'
+		},
+		{
+			title: 'Policies from statutory development plan',
+			value: 'name.pdf - awaiting review'
+		},
+		{ title: 'Emerging plan', value: 'Yes' },
+		{
+			title: 'Uploaded emerging plan and supporting information',
+			value: 'name.pdf - awaiting review'
+		},
+		{
+			title: 'Uploaded other relevant policies',
+			value: 'name.pdf - awaiting review'
+		},
+		{ title: 'Supplementary planning documents', value: 'Yes' },
+		{
+			title: 'Uploaded supplementary planning documents',
+			value: 'name.pdf - awaiting review'
+		}
+	];
+	const expectedCasPlanningRows = [
+		{
+			title: "Planning officer's report",
+			value: 'name.pdf - awaiting review'
+		},
+		{
+			title: 'Policies from statutory development plan',
+			value: 'name.pdf - awaiting review'
+		},
+		{ title: 'Emerging plan', value: 'No' },
+		{ title: 'Supplementary planning documents', value: 'Yes' },
+		{
+			title: 'Uploaded supplementary planning documents',
+			value: 'name.pdf - awaiting review'
+		}
+	];
+
+	const expectedRowsS78 = [
+		{
+			title: "Planning officer's report",
+			value: 'name.pdf - awaiting review'
+		},
+		{
+			title: 'Policies from statutory development plan',
+			value: 'name.pdf - awaiting review'
+		},
+		{ title: 'Emerging plan', value: 'Yes' },
+		{
+			title: 'Uploaded emerging plan and supporting information',
+			value: 'name.pdf - awaiting review'
+		},
+		{
+			title: 'Uploaded other relevant policies',
+			value: 'name.pdf - awaiting review'
+		},
+		{ title: 'Supplementary planning documents', value: 'Yes' },
+		{
+			title: 'Uploaded supplementary planning documents',
+			value: 'name.pdf - awaiting review'
+		},
+		{ title: 'Community infrastructure levy', value: 'Yes' },
+		{
+			title: 'Uploaded community infrastructure levy',
+			value: 'name.pdf - awaiting review'
+		},
+		{
+			title: 'Community infrastructure levy formally adopted',
+			value: 'Yes'
+		},
+		{
+			title: 'Date community infrastructure levy adopted',
+			value: '1 Jan 2023'
+		}
+	];
+
+	it.each([
+		['HAS', hasLPAQData, expectedRowsHas],
+		['CAS Planning', casPlanningLPAQData, expectedCasPlanningRows],
+		['S78', s78LPAQData, expectedRowsS78],
+		['S20', s20LPAQData, expectedRowsS78]
+	])(`should create correct rows for appeal type %s`, (_, caseData, expectedRows) => {
+		const visibleRows = planningOfficerReportRows(caseData)
+			.filter((row) => row.condition(caseData))
+			.map((visibleRow) => {
+				return { title: visibleRow.keyText, value: visibleRow.valueText };
+			});
+		expect(visibleRows).toEqual(expectedRows);
+	});
+
 	it('should create row with correct data if relevant case fields exist and files uploaded/field values otherwise populated', () => {
 		const caseData = {
 			appealTypeCode: CASE_TYPES.HAS.processCode,

--- a/packages/forms-web-app/src/controllers/selected-appeal/questionnaire-details/site-access-details-rows.js
+++ b/packages/forms-web-app/src/controllers/selected-appeal/questionnaire-details/site-access-details-rows.js
@@ -36,6 +36,11 @@ exports.siteAccessRows = (caseData) => {
 			keyText: 'Reason for Inspector visit',
 			valueText: caseData.reasonForNeighbourVisits || '',
 			condition: () => hasNeighbourAddressesField && !!caseData.reasonForNeighbourVisits
+		},
+		{
+			keyText: 'Potential safety risks',
+			valueText: formatSiteSafetyRisks(caseData),
+			condition: () => true
 		}
 	];
 
@@ -49,12 +54,6 @@ exports.siteAccessRows = (caseData) => {
 			});
 		});
 	}
-
-	rows.push({
-		keyText: 'Potential safety risks',
-		valueText: formatSiteSafetyRisks(caseData),
-		condition: () => true
-	});
 
 	return rows;
 };

--- a/packages/forms-web-app/src/controllers/selected-appeal/questionnaire-details/site-access-details-rows.test.js
+++ b/packages/forms-web-app/src/controllers/selected-appeal/questionnaire-details/site-access-details-rows.test.js
@@ -1,83 +1,47 @@
+const { CASE_TYPES } = require('@pins/common/src/database/data-static');
+const { caseTypeLPAQFactory } = require('./test-factory');
 const { siteAccessRows } = require('./site-access-details-rows');
 
 describe('siteAccessRows', () => {
-	it('should create rows with correct data if relevant case data fields exist & field values populated', () => {
-		const caseData = {
-			siteAccessDetails: ['appellant access details do not show', 'lpa access details for show'],
-			siteSafetyDetails: ['appellant safety details do not show', 'lpa safety details for show'],
-			reasonForNeighbourVisits: 'some neighbouring site access details',
-			NeighbouringAddresses: [
-				{
-					addressLine1: 'address 1 l1',
-					addressLine2: 'address 1 l2',
-					townCity: 'town',
-					postcode: 'ab1 2cd'
-				},
-				{
-					addressLine1: 'address 2 l1',
-					addressLine2: 'address 2 l2',
-					townCity: 'another town',
-					postcode: 'ef3 4gh'
-				}
-			]
-		};
+	const caseData = caseTypeLPAQFactory(CASE_TYPES.HAS.processCode, 'siteAccess');
 
-		const rows = siteAccessRows(caseData);
-
-		expect(rows.length).toEqual(7);
-
-		expect(rows[0].condition()).toEqual(true);
-		expect(rows[0].keyText).toEqual(
-			'Might the inspector need access to the appellant’s land or property?'
-		);
-		expect(rows[0].valueText).toEqual('Yes');
-
-		expect(rows[1].condition()).toEqual(true);
-		expect(rows[1].keyText).toEqual('Reason for Inspector access');
-		expect(rows[1].valueText).toEqual('lpa access details for show');
-
-		expect(rows[2].condition()).toEqual(true);
-		expect(rows[2].keyText).toEqual(
-			'Might the inspector need to enter a neighbour’s land or property?'
-		);
-		expect(rows[2].valueText).toEqual('Yes');
-
-		expect(rows[3].condition()).toEqual(true);
-		expect(rows[3].keyText).toEqual('Reason for Inspector visit');
-		expect(rows[3].valueText).toEqual('some neighbouring site access details');
-
-		expect(rows[4].condition()).toEqual(true);
-		expect(rows[4].keyText).toEqual('Neighbouring site 1');
-		expect(rows[4].valueText).toEqual('address 1 l1\naddress 1 l2\ntown\nab1 2cd');
-
-		expect(rows[5].condition()).toEqual(true);
-		expect(rows[5].keyText).toEqual('Neighbouring site 2');
-		expect(rows[5].valueText).toEqual('address 2 l1\naddress 2 l2\nanother town\nef3 4gh');
-
-		expect(rows[6].condition()).toEqual(true);
-		expect(rows[6].keyText).toEqual('Potential safety risks');
-		expect(rows[6].valueText).toEqual('Yes\nlpa safety details for show');
-	});
-
-	it('should handle site access and site safety rows correctly', () => {
-		const caseData = {
-			siteAccessDetails: ['', 'lpa access details'],
-			siteSafetyDetails: ['', 'lpa safety details']
-		};
-		const rows = siteAccessRows(caseData);
-		expect(rows[0].condition()).toEqual(true);
-		expect(rows[0].keyText).toEqual(
-			'Might the inspector need access to the appellant’s land or property?'
-		);
-		expect(rows[0].valueText).toEqual('Yes');
-
-		expect(rows[1].condition()).toEqual(true);
-		expect(rows[1].keyText).toEqual('Reason for Inspector access');
-		expect(rows[1].valueText).toEqual('lpa access details');
-
-		expect(rows[4].condition()).toEqual(true);
-		expect(rows[4].keyText).toEqual('Potential safety risks');
-		expect(rows[4].valueText).toEqual('Yes\nlpa safety details');
+	const expectedRows = [
+		{
+			title: 'Might the inspector need access to the appellant’s land or property?',
+			value: 'Yes'
+		},
+		{
+			title: 'Reason for Inspector access',
+			value: 'access details from LPA'
+		},
+		{
+			title: 'Might the inspector need to enter a neighbour’s land or property?',
+			value: 'Yes'
+		},
+		{
+			title: 'Reason for Inspector visit',
+			value: 'Reason for neighbour visits here'
+		},
+		{
+			title: 'Potential safety risks',
+			value: 'Yes\nlpa safety details for show'
+		},
+		{
+			title: 'Neighbouring site 1',
+			value: 'address 1 l1\naddress 1 l2\ntown\nab1 2cd'
+		},
+		{
+			title: 'Neighbouring site 2',
+			value: 'address 2 l1\naddress 2 l2\nanother town\nef3 4gh'
+		}
+	];
+	it(`should create correct rows for appeal type %s`, () => {
+		const visibleRows = siteAccessRows(caseData)
+			.filter((row) => row.condition(caseData))
+			.map((visibleRow) => {
+				return { title: visibleRow.keyText, value: visibleRow.valueText };
+			});
+		expect(visibleRows).toEqual(expectedRows);
 	});
 
 	it('should handle false values correctly', () => {

--- a/packages/forms-web-app/src/controllers/selected-appeal/questionnaire-details/test-factory.js
+++ b/packages/forms-web-app/src/controllers/selected-appeal/questionnaire-details/test-factory.js
@@ -1,0 +1,341 @@
+const { CASE_TYPES, LISTED_RELATION_TYPES } = require('@pins/common/src/database/data-static');
+const {
+	APPEAL_DOCUMENT_TYPE,
+	APPEAL_EIA_ENVIRONMENTAL_IMPACT_SCHEDULE
+} = require('@planning-inspectorate/data-model');
+
+/** @param {string} type */
+const makeDocument = (type) => ({
+	id: '',
+	filename: 'name.pdf',
+	originalFilename: 'nameOg.pdf',
+	size: 100000,
+	documentURI: '',
+	sourceSystem: '',
+	caseReference: '0000001',
+	origin: '',
+	stage: '',
+	dateCreated: '2023-01-01',
+	documentType: type
+});
+
+/**
+ * @param {"S78" | "HAS" | "S20" | "ADVERTS" | "CAS_ADVERTS" | "CAS_PLANNING"} appealTypeCode
+ */
+const makeConstraintsSectionData = (appealTypeCode) => {
+	const s78S20Shared = {
+		ListedBuildings: [
+			{ type: LISTED_RELATION_TYPES.affected, listedBuildingReference: 'LB1' },
+			{ type: LISTED_RELATION_TYPES.changed, listedBuildingReference: 'LB2' }
+		],
+		affectsScheduledMonument: true,
+		protectedSpecies: true,
+		areaOutstandingBeauty: true,
+		designatedSitesNames: ['Site A', 'Site B'],
+		gypsyTraveller: true,
+		publicRightOfWay: true,
+		Documents: [
+			makeDocument(APPEAL_DOCUMENT_TYPE.CONSERVATION_MAP),
+			makeDocument(APPEAL_DOCUMENT_TYPE.TREE_PRESERVATION_PLAN)
+		]
+	};
+	switch (appealTypeCode) {
+		case CASE_TYPES.HAS.processCode:
+		case CASE_TYPES.CAS_PLANNING.processCode:
+			return {
+				ListedBuildings: [{ type: LISTED_RELATION_TYPES.affected, listedBuildingReference: 'LB1' }],
+				conservationArea: true,
+				Documents: [makeDocument(APPEAL_DOCUMENT_TYPE.CONSERVATION_MAP)]
+			};
+		case CASE_TYPES.S78.processCode:
+			return {
+				...s78S20Shared,
+				Documents: [
+					...s78S20Shared.Documents,
+					makeDocument(APPEAL_DOCUMENT_TYPE.DEFINITIVE_MAP_STATEMENT)
+				]
+			};
+		case CASE_TYPES.S20.processCode:
+			return {
+				...s78S20Shared,
+				preserveGrantLoan: true,
+				consultHistoricEngland: true,
+				Documents: [
+					...s78S20Shared.Documents,
+					makeDocument(APPEAL_DOCUMENT_TYPE.HISTORIC_ENGLAND_CONSULTATION)
+				]
+			};
+	}
+};
+
+/**
+ * @param {"schedule-1" | "schedule-2" | null} scheduleType
+ */
+const makeEiaSectionData = (scheduleType) => {
+	switch (scheduleType) {
+		case APPEAL_EIA_ENVIRONMENTAL_IMPACT_SCHEDULE.SCHEDULE_1:
+			return {
+				environmentalImpactSchedule: APPEAL_EIA_ENVIRONMENTAL_IMPACT_SCHEDULE.SCHEDULE_1,
+				completedEnvironmentalStatement: false,
+				requiresEnvironmentalStatement: true,
+				Documents: [makeDocument(APPEAL_DOCUMENT_TYPE.EIA_ENVIRONMENTAL_STATEMENT)]
+			};
+		case APPEAL_EIA_ENVIRONMENTAL_IMPACT_SCHEDULE.SCHEDULE_2:
+			return {
+				environmentalImpactSchedule: APPEAL_EIA_ENVIRONMENTAL_IMPACT_SCHEDULE.SCHEDULE_2,
+				developmentDescription: 'agriculture-aquaculture',
+				sensitiveAreaDetails: 'Sensitive area details here',
+				columnTwoThreshold: true,
+				screeningOpinion: true,
+				scopingOpinion: true,
+				requiresEnvironmentalStatement: true,
+				completedEnvironmentalStatement: true,
+				Documents: [
+					makeDocument(APPEAL_DOCUMENT_TYPE.EIA_SCREENING_OPINION),
+					makeDocument(APPEAL_DOCUMENT_TYPE.EIA_SCOPING_OPINION),
+					makeDocument(APPEAL_DOCUMENT_TYPE.EIA_ENVIRONMENTAL_STATEMENT)
+				]
+			};
+		default:
+			return {
+				environmentalImpactSchedule: 'No',
+				screeningOpinion: true,
+				Documents: [
+					makeDocument(APPEAL_DOCUMENT_TYPE.EIA_SCREENING_OPINION),
+					makeDocument(APPEAL_DOCUMENT_TYPE.EIA_SCOPING_OPINION),
+					makeDocument(APPEAL_DOCUMENT_TYPE.EIA_ENVIRONMENTAL_STATEMENT)
+				]
+			};
+	}
+};
+
+const makeNotifiedPartiesSectionData = () => {
+	return {
+		AppealCaseLpaNotificationMethod: [
+			{ id: 1, key: 'advert', name: 'A press advert' },
+			{ id: 2, key: 'siteNotice', name: 'A site notice' },
+			{ id: 1, key: 'letter', name: 'A letter' }
+		],
+		Documents: [
+			makeDocument(APPEAL_DOCUMENT_TYPE.WHO_NOTIFIED),
+			makeDocument(APPEAL_DOCUMENT_TYPE.WHO_NOTIFIED_SITE_NOTICE),
+			makeDocument(APPEAL_DOCUMENT_TYPE.WHO_NOTIFIED_LETTER_TO_NEIGHBOURS),
+			makeDocument(APPEAL_DOCUMENT_TYPE.WHO_NOTIFIED_PRESS_ADVERT),
+			makeDocument(APPEAL_DOCUMENT_TYPE.APPEAL_NOTIFICATION)
+		]
+	};
+};
+
+/**
+ * @param {"S78" | "HAS" | "S20" | "ADVERTS" | "CAS_ADVERTS" | "CAS_PLANNING"} appealTypeCode
+ */
+const makeConsultationResponsesSectionData = (appealTypeCode) => {
+	switch (appealTypeCode) {
+		case CASE_TYPES.S78.processCode:
+		case CASE_TYPES.S20.processCode:
+			return {
+				statutoryConsultees: true,
+				consultedBodiesDetails: 'Consulted bodies details here',
+				Documents: [
+					makeDocument(APPEAL_DOCUMENT_TYPE.OTHER_PARTY_REPRESENTATIONS),
+					makeDocument(APPEAL_DOCUMENT_TYPE.CONSULTATION_RESPONSES)
+				]
+			};
+		case CASE_TYPES.HAS.processCode:
+		case CASE_TYPES.CAS_PLANNING.processCode:
+			return {
+				Documents: [makeDocument(APPEAL_DOCUMENT_TYPE.OTHER_PARTY_REPRESENTATIONS)]
+			};
+	}
+};
+
+/**
+ * @param {"S78" | "HAS" | "S20" | "ADVERTS" | "CAS_ADVERTS" | "CAS_PLANNING"} appealTypeCode
+ */
+const makePlanningOfficerReportSectionData = (appealTypeCode) => {
+	const sharedDocs = [
+		makeDocument(APPEAL_DOCUMENT_TYPE.PLANNING_OFFICER_REPORT),
+		makeDocument(APPEAL_DOCUMENT_TYPE.DEVELOPMENT_PLAN_POLICIES),
+		makeDocument(APPEAL_DOCUMENT_TYPE.SUPPLEMENTARY_PLANNING)
+	];
+	switch (appealTypeCode) {
+		case CASE_TYPES.S78.processCode:
+		case CASE_TYPES.S20.processCode:
+			return {
+				infrastructureLevy: true,
+				infrastructureLevyAdopted: true,
+				infrastructureLevyAdoptedDate: '2023-01-01',
+				Documents: [
+					...sharedDocs,
+					makeDocument(APPEAL_DOCUMENT_TYPE.COMMUNITY_INFRASTRUCTURE_LEVY),
+					makeDocument(APPEAL_DOCUMENT_TYPE.EMERGING_PLAN),
+					makeDocument(APPEAL_DOCUMENT_TYPE.OTHER_RELEVANT_POLICIES)
+				]
+			};
+		case CASE_TYPES.HAS.processCode:
+			return {
+				Documents: [
+					...sharedDocs,
+					makeDocument(APPEAL_DOCUMENT_TYPE.PLANS_DRAWINGS),
+					makeDocument(APPEAL_DOCUMENT_TYPE.EMERGING_PLAN),
+					makeDocument(APPEAL_DOCUMENT_TYPE.OTHER_RELEVANT_POLICIES)
+				]
+			};
+		case CASE_TYPES.CAS_PLANNING.processCode:
+			return {
+				Documents: [...sharedDocs]
+			};
+		default:
+			return {};
+	}
+};
+
+const makeSiteAccessSectionData = () => {
+	return {
+		siteAccessDetails: ['access details from appellant', 'access details from LPA'],
+		siteSafetyDetails: ['appellant safety details do not show', 'lpa safety details for show'],
+		NeighbouringAddresses: [
+			{
+				addressLine1: 'address 1 l1',
+				addressLine2: 'address 1 l2',
+				townCity: 'town',
+				postcode: 'ab1 2cd'
+			},
+			{
+				addressLine1: 'address 2 l1',
+				addressLine2: 'address 2 l2',
+				townCity: 'another town',
+				postcode: 'ef3 4gh'
+			}
+		],
+		reasonForNeighbourVisits: 'Reason for neighbour visits here'
+	};
+};
+
+/**
+ * @param {"S78" | "HAS" | "S20" | "ADVERTS" | "CAS_ADVERTS" | "CAS_PLANNING"} appealTypeCode
+ */
+const makeAppealProcessSectionData = (appealTypeCode) => {
+	switch (appealTypeCode) {
+		case CASE_TYPES.HAS.processCode:
+		case CASE_TYPES.CAS_PLANNING.processCode:
+			return {
+				submissionLinkedCases: [
+					{
+						id: '1',
+						fieldName: 'nearbyAppealReference',
+						caseReference: '00000001'
+					}
+				],
+				newConditionDetails: 'example new conditions'
+			};
+		case CASE_TYPES.S78.processCode:
+		case CASE_TYPES.S20.processCode:
+			return {
+				lpaProcedurePreference: 'inquiry',
+				submissionLinkedCases: [
+					{
+						id: '1',
+						fieldName: 'nearbyAppealReference',
+						caseReference: '00000001'
+					}
+				],
+				newConditionDetails: 'example new conditions'
+			};
+	}
+};
+
+/**
+ * @param {"S78" | "HAS" | "S20" | "ADVERTS" | "CAS_ADVERTS" | "CAS_PLANNING"} appealTypeCode
+ * @param {"constraints"| "eia" | "consultation" | "notifiedParties" | "planningOfficersReport" | "siteAccess" | "appealProcess"} section
+ * @param {"schedule-1" | "schedule-2" | null} scheduleType
+ * @returns
+ */
+const makeCaseTypeRows = (appealTypeCode, section, scheduleType) => {
+	switch (section) {
+		case 'constraints':
+			return makeConstraintsSectionData(appealTypeCode);
+		case 'eia':
+			if (
+				appealTypeCode === CASE_TYPES.S78.processCode ||
+				appealTypeCode === CASE_TYPES.S20.processCode
+			) {
+				return makeEiaSectionData(scheduleType);
+			} else break;
+		case 'consultation':
+			return makeConsultationResponsesSectionData(appealTypeCode);
+		case 'notifiedParties':
+			return makeNotifiedPartiesSectionData();
+		case 'planningOfficersReport':
+			return makePlanningOfficerReportSectionData(appealTypeCode);
+		case 'siteAccess':
+			return makeSiteAccessSectionData();
+		case 'appealProcess':
+			return makeAppealProcessSectionData(appealTypeCode);
+		default: {
+			if (
+				appealTypeCode === CASE_TYPES.S78.processCode ||
+				appealTypeCode === CASE_TYPES.S20.processCode
+			) {
+				return [
+					makeConstraintsSectionData(appealTypeCode),
+					makeEiaSectionData(scheduleType),
+					makeConsultationResponsesSectionData(appealTypeCode),
+					makeNotifiedPartiesSectionData(),
+					makePlanningOfficerReportSectionData(appealTypeCode),
+					makeSiteAccessSectionData(),
+					makeAppealProcessSectionData(appealTypeCode)
+				];
+			} else
+				return [
+					makeConstraintsSectionData(appealTypeCode),
+					makeConsultationResponsesSectionData(appealTypeCode),
+					makeNotifiedPartiesSectionData(),
+					makePlanningOfficerReportSectionData(appealTypeCode),
+					makeSiteAccessSectionData(),
+					makeAppealProcessSectionData(appealTypeCode)
+				];
+		}
+	}
+};
+
+/**
+ * @param {"S78" | "HAS" | "S20" | "ADVERTS" | "CAS_ADVERTS" | "CAS_PLANNING"} appealTypeCode
+ * @param {"constraints"| "eia" | "consultation" | "notifiedParties" | "planningOfficersReport" | "siteAccess" | "appealProcess" | null} section
+ * @param {"schedule-1" | "schedule-2" | null} [scheduleType]
+ * @returns {import('appeals-service-api').Api.AppealCaseDetailed } caseData
+ */
+const caseTypeLPAQFactory = (appealTypeCode, section, scheduleType) => {
+	// Factory function to create case data with specific appeal type and expected procedure
+	// This is used to test the rows generation for different appeal types
+
+	return {
+		caseReference: '0000001',
+		LPACode: 'LPACODE',
+		applicationDecision: 'refused',
+		applicationDecisionDate: '2023-01-01',
+		applicationReference: 'APP-0001',
+		siteAddressLine1: '123 Main St',
+		siteAddressPostcode: 'AB12 3CD',
+		appealTypeCode: appealTypeCode,
+		lpaProcedurePreferenceDetails: 'inquiry preference',
+		lpaProcedurePreferenceDuration: 6,
+		isCorrectAppealType: true,
+		isGreenBelt: true,
+
+		...makeCaseTypeRows(appealTypeCode, section, scheduleType)
+	};
+};
+
+module.exports = {
+	makeDocument,
+	makeConstraintsSectionData,
+	makeEiaSectionData,
+	makeNotifiedPartiesSectionData,
+	makeConsultationResponsesSectionData,
+	makePlanningOfficerReportSectionData,
+	makeSiteAccessSectionData,
+	makeAppealProcessSectionData,
+	makeCaseTypeRows,
+	caseTypeLPAQFactory
+};

--- a/packages/forms-web-app/src/controllers/selected-appeal/questionnaire-details/test-factory.test.js
+++ b/packages/forms-web-app/src/controllers/selected-appeal/questionnaire-details/test-factory.test.js
@@ -1,0 +1,684 @@
+const { CASE_TYPES, LISTED_RELATION_TYPES } = require('@pins/common/src/database/data-static');
+const {
+	makeConstraintsSectionData,
+	makeEiaSectionData,
+	makeNotifiedPartiesSectionData,
+	makeConsultationResponsesSectionData,
+	makePlanningOfficerReportSectionData,
+	makeSiteAccessSectionData,
+	makeAppealProcessSectionData
+} = require('./test-factory');
+const { APPEAL_EIA_ENVIRONMENTAL_IMPACT_SCHEDULE } = require('@planning-inspectorate/data-model');
+
+describe('makeConstraintsSectionData', () => {
+	const expectedHasConstraints = {
+		ListedBuildings: [{ type: LISTED_RELATION_TYPES.affected, listedBuildingReference: 'LB1' }],
+		conservationArea: true,
+		Documents: [
+			{
+				id: '',
+				filename: 'name.pdf',
+				originalFilename: 'nameOg.pdf',
+				size: 100000,
+				documentURI: '',
+				sourceSystem: '',
+				caseReference: '0000001',
+				origin: '',
+				stage: '',
+				dateCreated: '2023-01-01',
+				documentType: 'conservationMap'
+			}
+		]
+	};
+
+	const expectedS78S20Constraints = {
+		ListedBuildings: [
+			{ type: LISTED_RELATION_TYPES.affected, listedBuildingReference: 'LB1' },
+			{ type: LISTED_RELATION_TYPES.changed, listedBuildingReference: 'LB2' }
+		],
+		affectsScheduledMonument: true,
+		protectedSpecies: true,
+		areaOutstandingBeauty: true,
+		designatedSitesNames: ['Site A', 'Site B'],
+		gypsyTraveller: true,
+		publicRightOfWay: true,
+		Documents: [
+			{
+				id: '',
+				filename: 'name.pdf',
+				originalFilename: 'nameOg.pdf',
+				size: 100000,
+				documentURI: '',
+				sourceSystem: '',
+				caseReference: '0000001',
+				origin: '',
+				stage: '',
+				dateCreated: '2023-01-01',
+				documentType: 'conservationMap'
+			},
+			{
+				id: '',
+				filename: 'name.pdf',
+				originalFilename: 'nameOg.pdf',
+				size: 100000,
+				documentURI: '',
+				sourceSystem: '',
+				caseReference: '0000001',
+				origin: '',
+				stage: '',
+				dateCreated: '2023-01-01',
+				documentType: 'treePreservationPlan'
+			}
+		]
+	};
+
+	test.each([
+		['HAS', CASE_TYPES.HAS.processCode, expectedHasConstraints],
+		['CAS_PLANNING', CASE_TYPES.CAS_PLANNING.processCode, expectedHasConstraints],
+		[
+			'S78',
+			CASE_TYPES.S78.processCode,
+			{
+				...expectedS78S20Constraints,
+				Documents: [
+					...expectedS78S20Constraints.Documents,
+					{
+						id: '',
+						filename: 'name.pdf',
+						originalFilename: 'nameOg.pdf',
+						size: 100000,
+						documentURI: '',
+						sourceSystem: '',
+						caseReference: '0000001',
+						origin: '',
+						stage: '',
+						dateCreated: '2023-01-01',
+						documentType: 'definitiveMapStatement'
+					}
+				]
+			}
+		],
+		[
+			'S20',
+			CASE_TYPES.S20.processCode,
+			{
+				...expectedS78S20Constraints,
+				preserveGrantLoan: true,
+				consultHistoricEngland: true,
+				Documents: [
+					...expectedS78S20Constraints.Documents,
+					{
+						id: '',
+						filename: 'name.pdf',
+						originalFilename: 'nameOg.pdf',
+						size: 100000,
+						documentURI: '',
+						sourceSystem: '',
+						caseReference: '0000001',
+						origin: '',
+						stage: '',
+						dateCreated: '2023-01-01',
+						documentType: 'historicEnglandConsultation'
+					}
+				]
+			}
+		]
+	])('returns expected constraints for %s', (_label, input, expected) => {
+		expect(makeConstraintsSectionData(input)).toEqual(expected);
+	});
+});
+
+describe('makeEiaSectionData', () => {
+	const expectedSchedule1 = {
+		environmentalImpactSchedule: 'schedule-1',
+		completedEnvironmentalStatement: false,
+		requiresEnvironmentalStatement: true,
+		Documents: [
+			{
+				id: '',
+				filename: 'name.pdf',
+				originalFilename: 'nameOg.pdf',
+				size: 100000,
+				documentURI: '',
+				sourceSystem: '',
+				caseReference: '0000001',
+				origin: '',
+				stage: '',
+				dateCreated: '2023-01-01',
+				documentType: 'eiaEnvironmentalStatement'
+			}
+		]
+	};
+
+	const expectedSchedule2 = {
+		environmentalImpactSchedule: 'schedule-2',
+		developmentDescription: 'agriculture-aquaculture',
+		sensitiveAreaDetails: 'Sensitive area details here',
+		columnTwoThreshold: true,
+		screeningOpinion: true,
+		scopingOpinion: true,
+		requiresEnvironmentalStatement: true,
+		completedEnvironmentalStatement: true,
+		Documents: [
+			{
+				id: '',
+				filename: 'name.pdf',
+				originalFilename: 'nameOg.pdf',
+				size: 100000,
+				documentURI: '',
+				sourceSystem: '',
+				caseReference: '0000001',
+				origin: '',
+				stage: '',
+				dateCreated: '2023-01-01',
+				documentType: 'eiaScreeningOpinion'
+			},
+			{
+				id: '',
+				filename: 'name.pdf',
+				originalFilename: 'nameOg.pdf',
+				size: 100000,
+				documentURI: '',
+				sourceSystem: '',
+				caseReference: '0000001',
+				origin: '',
+				stage: '',
+				dateCreated: '2023-01-01',
+				documentType: 'eiaScopingOpinion'
+			},
+			{
+				id: '',
+				filename: 'name.pdf',
+				originalFilename: 'nameOg.pdf',
+				size: 100000,
+				documentURI: '',
+				sourceSystem: '',
+				caseReference: '0000001',
+				origin: '',
+				stage: '',
+				dateCreated: '2023-01-01',
+				documentType: 'eiaEnvironmentalStatement'
+			}
+		]
+	};
+
+	const expectedNo = {
+		environmentalImpactSchedule: 'No',
+		screeningOpinion: true,
+		Documents: [
+			{
+				id: '',
+				filename: 'name.pdf',
+				originalFilename: 'nameOg.pdf',
+				size: 100000,
+				documentURI: '',
+				sourceSystem: '',
+				caseReference: '0000001',
+				origin: '',
+				stage: '',
+				dateCreated: '2023-01-01',
+				documentType: 'eiaScreeningOpinion'
+			},
+			{
+				id: '',
+				filename: 'name.pdf',
+				originalFilename: 'nameOg.pdf',
+				size: 100000,
+				documentURI: '',
+				sourceSystem: '',
+				caseReference: '0000001',
+				origin: '',
+				stage: '',
+				dateCreated: '2023-01-01',
+				documentType: 'eiaScopingOpinion'
+			},
+			{
+				id: '',
+				filename: 'name.pdf',
+				originalFilename: 'nameOg.pdf',
+				size: 100000,
+				documentURI: '',
+				sourceSystem: '',
+				caseReference: '0000001',
+				origin: '',
+				stage: '',
+				dateCreated: '2023-01-01',
+				documentType: 'eiaEnvironmentalStatement'
+			}
+		]
+	};
+
+	test.each([
+		['Schedule 1', APPEAL_EIA_ENVIRONMENTAL_IMPACT_SCHEDULE.SCHEDULE_1, expectedSchedule1],
+		['Schedule 2', APPEAL_EIA_ENVIRONMENTAL_IMPACT_SCHEDULE.SCHEDULE_2, expectedSchedule2],
+		['No', 'No', expectedNo]
+	])('returns expected output for %s', (_label, input, expected) => {
+		expect(makeEiaSectionData(input)).toEqual(expected);
+	});
+});
+
+describe('makeNotifiedPartiesSectionData', () => {
+	const expectedData = {
+		AppealCaseLpaNotificationMethod: [
+			{ id: 1, key: 'advert', name: 'A press advert' },
+			{ id: 2, key: 'siteNotice', name: 'A site notice' },
+			{ id: 1, key: 'letter', name: 'A letter' }
+		],
+		Documents: [
+			{
+				caseReference: '0000001',
+				dateCreated: '2023-01-01',
+				documentType: 'whoNotified',
+				documentURI: '',
+				filename: 'name.pdf',
+				id: '',
+				origin: '',
+				originalFilename: 'nameOg.pdf',
+				size: 100000,
+				sourceSystem: '',
+				stage: ''
+			},
+			{
+				caseReference: '0000001',
+				dateCreated: '2023-01-01',
+				documentType: 'whoNotifiedSiteNotice',
+				documentURI: '',
+				filename: 'name.pdf',
+				id: '',
+				origin: '',
+				originalFilename: 'nameOg.pdf',
+				size: 100000,
+				sourceSystem: '',
+				stage: ''
+			},
+			{
+				caseReference: '0000001',
+				dateCreated: '2023-01-01',
+				documentType: 'whoNotifiedLetterToNeighbours',
+				documentURI: '',
+				filename: 'name.pdf',
+				id: '',
+				origin: '',
+				originalFilename: 'nameOg.pdf',
+				size: 100000,
+				sourceSystem: '',
+				stage: ''
+			},
+			{
+				caseReference: '0000001',
+				dateCreated: '2023-01-01',
+				documentType: 'whoNotifiedPressAdvert',
+				documentURI: '',
+				filename: 'name.pdf',
+				id: '',
+				origin: '',
+				originalFilename: 'nameOg.pdf',
+				size: 100000,
+				sourceSystem: '',
+				stage: ''
+			},
+			{
+				caseReference: '0000001',
+				dateCreated: '2023-01-01',
+				documentType: 'appealNotification',
+				documentURI: '',
+				filename: 'name.pdf',
+				id: '',
+				origin: '',
+				originalFilename: 'nameOg.pdf',
+				size: 100000,
+				sourceSystem: '',
+				stage: ''
+			}
+		]
+	};
+
+	test('returns expected output for %s', () => {
+		expect(makeNotifiedPartiesSectionData()).toEqual(expectedData);
+	});
+});
+
+describe('makeConsultationResponsesSectionData', () => {
+	const expectedS78 = {
+		statutoryConsultees: true,
+		consultedBodiesDetails: 'Consulted bodies details here',
+		Documents: [
+			{
+				id: '',
+				filename: 'name.pdf',
+				originalFilename: 'nameOg.pdf',
+				size: 100000,
+				documentURI: '',
+				sourceSystem: '',
+				caseReference: '0000001',
+				origin: '',
+				stage: '',
+				dateCreated: '2023-01-01',
+				documentType: 'otherPartyRepresentations'
+			},
+			{
+				id: '',
+				filename: 'name.pdf',
+				originalFilename: 'nameOg.pdf',
+				size: 100000,
+				documentURI: '',
+				sourceSystem: '',
+				caseReference: '0000001',
+				origin: '',
+				stage: '',
+				dateCreated: '2023-01-01',
+				documentType: 'consultationResponses'
+			}
+		]
+	};
+
+	const expectedHas = {
+		Documents: [
+			{
+				id: '',
+				filename: 'name.pdf',
+				originalFilename: 'nameOg.pdf',
+				size: 100000,
+				documentURI: '',
+				sourceSystem: '',
+				caseReference: '0000001',
+				origin: '',
+				stage: '',
+				dateCreated: '2023-01-01',
+				documentType: 'otherPartyRepresentations'
+			}
+		]
+	};
+	test.each([
+		['S78', CASE_TYPES.S78.processCode, expectedS78],
+		['HAS', CASE_TYPES.HAS.processCode, expectedHas],
+		['S20', CASE_TYPES.S20.processCode, expectedS78],
+		['CAS_PLANNING', CASE_TYPES.CAS_PLANNING.processCode, expectedHas]
+	])('returns expected output for %s', (_label, input, expected) => {
+		expect(makeConsultationResponsesSectionData(input)).toEqual(expected);
+	});
+});
+
+describe('makePlanningOfficerReportSectionData', () => {
+	const expectedS78 = {
+		infrastructureLevy: true,
+		infrastructureLevyAdopted: true,
+		infrastructureLevyAdoptedDate: '2023-01-01',
+		Documents: [
+			{
+				id: '',
+				filename: 'name.pdf',
+				originalFilename: 'nameOg.pdf',
+				size: 100000,
+				documentURI: '',
+				sourceSystem: '',
+				caseReference: '0000001',
+				origin: '',
+				stage: '',
+				dateCreated: '2023-01-01',
+				documentType: 'planningOfficerReport'
+			},
+			{
+				id: '',
+				filename: 'name.pdf',
+				originalFilename: 'nameOg.pdf',
+				size: 100000,
+				documentURI: '',
+				sourceSystem: '',
+				caseReference: '0000001',
+				origin: '',
+				stage: '',
+				dateCreated: '2023-01-01',
+				documentType: 'developmentPlanPolicies'
+			},
+			{
+				id: '',
+				filename: 'name.pdf',
+				originalFilename: 'nameOg.pdf',
+				size: 100000,
+				documentURI: '',
+				sourceSystem: '',
+				caseReference: '0000001',
+				origin: '',
+				stage: '',
+				dateCreated: '2023-01-01',
+				documentType: 'supplementaryPlanning'
+			},
+			{
+				id: '',
+				filename: 'name.pdf',
+				originalFilename: 'nameOg.pdf',
+				size: 100000,
+				documentURI: '',
+				sourceSystem: '',
+				caseReference: '0000001',
+				origin: '',
+				stage: '',
+				dateCreated: '2023-01-01',
+				documentType: 'communityInfrastructureLevy'
+			},
+			{
+				id: '',
+				filename: 'name.pdf',
+				originalFilename: 'nameOg.pdf',
+				size: 100000,
+				documentURI: '',
+				sourceSystem: '',
+				caseReference: '0000001',
+				origin: '',
+				stage: '',
+				dateCreated: '2023-01-01',
+				documentType: 'emergingPlan'
+			},
+			{
+				id: '',
+				filename: 'name.pdf',
+				originalFilename: 'nameOg.pdf',
+				size: 100000,
+				documentURI: '',
+				sourceSystem: '',
+				caseReference: '0000001',
+				origin: '',
+				stage: '',
+				dateCreated: '2023-01-01',
+				documentType: 'otherRelevantPolicies'
+			}
+		]
+	};
+
+	const expectedHas = {
+		Documents: [
+			{
+				id: '',
+				filename: 'name.pdf',
+				originalFilename: 'nameOg.pdf',
+				size: 100000,
+				documentURI: '',
+				sourceSystem: '',
+				caseReference: '0000001',
+				origin: '',
+				stage: '',
+				dateCreated: '2023-01-01',
+				documentType: 'planningOfficerReport'
+			},
+			{
+				id: '',
+				filename: 'name.pdf',
+				originalFilename: 'nameOg.pdf',
+				size: 100000,
+				documentURI: '',
+				sourceSystem: '',
+				caseReference: '0000001',
+				origin: '',
+				stage: '',
+				dateCreated: '2023-01-01',
+				documentType: 'developmentPlanPolicies'
+			},
+			{
+				id: '',
+				filename: 'name.pdf',
+				originalFilename: 'nameOg.pdf',
+				size: 100000,
+				documentURI: '',
+				sourceSystem: '',
+				caseReference: '0000001',
+				origin: '',
+				stage: '',
+				dateCreated: '2023-01-01',
+				documentType: 'supplementaryPlanning'
+			},
+			{
+				id: '',
+				filename: 'name.pdf',
+				originalFilename: 'nameOg.pdf',
+				size: 100000,
+				documentURI: '',
+				sourceSystem: '',
+				caseReference: '0000001',
+				origin: '',
+				stage: '',
+				dateCreated: '2023-01-01',
+				documentType: 'plansDrawings'
+			},
+			{
+				id: '',
+				filename: 'name.pdf',
+				originalFilename: 'nameOg.pdf',
+				size: 100000,
+				documentURI: '',
+				sourceSystem: '',
+				caseReference: '0000001',
+				origin: '',
+				stage: '',
+				dateCreated: '2023-01-01',
+				documentType: 'emergingPlan'
+			},
+			{
+				id: '',
+				filename: 'name.pdf',
+				originalFilename: 'nameOg.pdf',
+				size: 100000,
+				documentURI: '',
+				sourceSystem: '',
+				caseReference: '0000001',
+				origin: '',
+				stage: '',
+				dateCreated: '2023-01-01',
+				documentType: 'otherRelevantPolicies'
+			}
+		]
+	};
+
+	const expectedCasPlanning = {
+		Documents: [
+			{
+				id: '',
+				filename: 'name.pdf',
+				originalFilename: 'nameOg.pdf',
+				size: 100000,
+				documentURI: '',
+				sourceSystem: '',
+				caseReference: '0000001',
+				origin: '',
+				stage: '',
+				dateCreated: '2023-01-01',
+				documentType: 'planningOfficerReport'
+			},
+			{
+				id: '',
+				filename: 'name.pdf',
+				originalFilename: 'nameOg.pdf',
+				size: 100000,
+				documentURI: '',
+				sourceSystem: '',
+				caseReference: '0000001',
+				origin: '',
+				stage: '',
+				dateCreated: '2023-01-01',
+				documentType: 'developmentPlanPolicies'
+			},
+			{
+				id: '',
+				filename: 'name.pdf',
+				originalFilename: 'nameOg.pdf',
+				size: 100000,
+				documentURI: '',
+				sourceSystem: '',
+				caseReference: '0000001',
+				origin: '',
+				stage: '',
+				dateCreated: '2023-01-01',
+				documentType: 'supplementaryPlanning'
+			}
+		]
+	};
+
+	test.each([
+		['S78', CASE_TYPES.S78.processCode, expectedS78],
+		['HAS', CASE_TYPES.HAS.processCode, expectedHas],
+		['S20', CASE_TYPES.S20.processCode, expectedS78],
+		['CAS_PLANNING', CASE_TYPES.CAS_PLANNING.processCode, expectedCasPlanning]
+	])('returns expected output for %s', (_label, input, expected) => {
+		expect(makePlanningOfficerReportSectionData(input)).toEqual(expected);
+	});
+});
+
+describe('makeSiteAccessSectionData', () => {
+	const expectedData = {
+		siteAccessDetails: ['access details from appellant', 'access details from LPA'],
+		siteSafetyDetails: ['appellant safety details do not show', 'lpa safety details for show'],
+		NeighbouringAddresses: [
+			{
+				addressLine1: 'address 1 l1',
+				addressLine2: 'address 1 l2',
+				postcode: 'ab1 2cd',
+				townCity: 'town'
+			},
+			{
+				addressLine1: 'address 2 l1',
+				addressLine2: 'address 2 l2',
+				postcode: 'ef3 4gh',
+				townCity: 'another town'
+			}
+		],
+		reasonForNeighbourVisits: 'Reason for neighbour visits here'
+	};
+
+	test('returns expected output for %s', () => {
+		expect(makeSiteAccessSectionData()).toEqual(expectedData);
+	});
+});
+
+describe('makeAppealProcessSectionData', () => {
+	const expectedHasAndCasPlanning = {
+		submissionLinkedCases: [
+			{
+				id: '1',
+				fieldName: 'nearbyAppealReference',
+				caseReference: '00000001'
+			}
+		],
+		newConditionDetails: 'example new conditions'
+	};
+
+	const expectedS78AndS20 = {
+		lpaProcedurePreference: 'inquiry',
+		submissionLinkedCases: [
+			{
+				id: '1',
+				fieldName: 'nearbyAppealReference',
+				caseReference: '00000001'
+			}
+		],
+		newConditionDetails: 'example new conditions'
+	};
+
+	test.each([
+		['HAS', CASE_TYPES.HAS.processCode, expectedHasAndCasPlanning],
+		['CAS_PLANNING', CASE_TYPES.CAS_PLANNING.processCode, expectedHasAndCasPlanning],
+		['S78', CASE_TYPES.S78.processCode, expectedS78AndS20],
+		['S20', CASE_TYPES.S20.processCode, expectedS78AndS20]
+	])('returns expected output for %s', (_label, input, expected) => {
+		expect(makeAppealProcessSectionData(input)).toEqual(expected);
+	});
+});


### PR DESCRIPTION
### Description of change

Adds relevant cas planning questionnaire rows to the dashboards. Refactors generation of lpaq test data into factory function

Ticket: https://pins-ds.atlassian.net/browse/A2-3746

### Checklist

- [x] Feature complete and ready for users, or behind feature-flag
- [x] Commit history is linear with no merge commits
- [ ] Requires infrastructure changes

### Important

Please do not merge from `main` (please only [rebase](https://github.com/Planning-Inspectorate/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
