### PR TITLE
fix: remove wycombe

### DIFF
--- a/packages/appeals-service-api/data/lpa-list.csv
+++ b/packages/appeals-service-api/data/lpa-list.csv
@@ -323,7 +323,7 @@
 320;E60000331;P0430;Buckinghamshire Council Minerals and Waste Applications;mineralsandwaste@buckinghamshire.gov.uk;buckinghamshire.gov.uk;TRUE\n
 ;J0405;J0405;Buckinghamshire Council North and Central Area (formerly Aylesbury);devcontrol.av@buckinghamshire.gov.uk;buckinghamshire.gov.uk;TRUE\n
 ;X0415;X0415;Buckinghamshire Council South and East Area (formerly Chiltern/South Bucks);planning.appeals.csb@buckinghamshire.gov.uk;buckinghamshire.gov.uk;TRUE\n
-;K0425;K0425;Buckinghamshire Council West Area (formerly Wycombe);planning.wyc@buckinghamshire.gov.uk;wycombe.gov.uk;TRUE\n
+;K0425;K0425;Buckinghamshire Council West Area (formerly Wycombe);planning.wyc@buckinghamshire.gov.uk;wycombe.gov.uk;FALSE\n
 321;E60000332;M2840;North Northamptonshire;planningappeals@northnorthants.gov.uk;northnorthants.gov.uk;TRUE\n
 ;U2805;U2805;North Northamptonshire Council - Corby Area;planningservices.cbc@northnorthants.gov.uk;northnorthants.gov.uk;TRUE\n
 ;H2835;H2835;North Northamptonshire County Wellingborough;planningappeals.bcw@northnorthants.gov.uk;northnorthants.gov.uk;TRUE\n


### PR DESCRIPTION
### Description of change

Removes Wycombe from the lpa picker for users

Ticket: https://pins-ds.atlassian.net/browse/A2-4228

### Checklist

- [x] Feature complete and ready for users, or behind feature-flag
- [x] Commit history is linear with no merge commits
- [ ] Requires infrastructure changes

### Important

Please do not merge from `main` (please only [rebase](https://github.com/Planning-Inspectorate/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
