### PR TITLE
feat: cas advert and advert bys logic (A2-3652)

### DIFF
--- a/packages/appeals-service-api/src/services/appeal.service.js
+++ b/packages/appeals-service-api/src/services/appeal.service.js
@@ -116,7 +116,8 @@ function isValidAppeal(appeal) {
 		appeal.appealType === APPEAL_ID.PLANNING_SECTION_78 ||
 		appeal.appealType === APPEAL_ID.PLANNING_LISTED_BUILDING ||
 		appeal.appealType === APPEAL_ID.MINOR_COMMERCIAL ||
-		appeal.appealType === APPEAL_ID.ADVERTISEMENT
+		appeal.appealType === APPEAL_ID.ADVERTISEMENT ||
+		appeal.appealType === APPEAL_ID.MINOR_COMMERCIAL_ADVERTISEMENT
 	) {
 		errors = validateFullAppeal(appeal);
 	} else {

--- a/packages/business-rules/src/constants.js
+++ b/packages/business-rules/src/constants.js
@@ -39,7 +39,6 @@ const TYPE_OF_PLANNING_APPLICATION = {
 	RESERVED_MATTERS: 'reserved-matters',
 	REMOVAL_OR_VARIATION_OF_CONDITIONS: 'removal-or-variation-of-conditions',
 	MINOR_COMMERCIAL_DEVELOPMENT: 'minor-commercial-development',
-	MINOR_COMMERCIAL_ADVERTISEMENT: 'minor-commercial-advertisement',
 	ADVERTISEMENT: 'advertisement',
 	SOMETHING_ELSE: 'something-else',
 	I_HAVE_NOT_MADE_A_PLANNING_APPLICATION: 'i-have-not-made-a-planning-application'

--- a/packages/business-rules/src/schemas/validate.js
+++ b/packages/business-rules/src/schemas/validate.js
@@ -18,7 +18,8 @@ const validate = (action, data, config = { abortEarly: false }) => {
 		case APPEAL_ID.PLANNING_LISTED_BUILDING:
 		case APPEAL_ID.MINOR_COMMERCIAL:
 		case APPEAL_ID.ADVERTISEMENT:
-			// listed building and MINOR_COMMERCIAL appeal is v2 only - we use
+		case APPEAL_ID.MINOR_COMMERCIAL_ADVERTISEMENT:
+			// listed building, MINOR_COMMERCIAL, ADVERTISEMENT and MINOR_COMMERCIAL ADVERTISEMENT appeal is v2 only - we use
 			// full appeal validator here for BYS validation
 			return fullAppeal[action].validate(data, config);
 		default:

--- a/packages/common/src/dynamic-forms/journey-types.js
+++ b/packages/common/src/dynamic-forms/journey-types.js
@@ -88,6 +88,12 @@ exports.JOURNEY_TYPES = Object.freeze({
 		userType: APPEAL_USER_ROLES.APPELLANT,
 		caseType: CASE_TYPES.ADVERTS.processCode
 	},
+	CAS_ADVERTS_APPEAL_FORM: {
+		id: 'adverts-appeal-form',
+		type: exports.JOURNEY_TYPE.appealForm,
+		userType: APPEAL_USER_ROLES.APPELLANT,
+		caseType: CASE_TYPES.CAS_ADVERTS.processCode
+	},
 	ADVERTS_QUESTIONNAIRE: {
 		id: 'adverts-questionnaire',
 		type: exports.JOURNEY_TYPE.questionnaire,

--- a/packages/forms-web-app/__tests__/unit/controllers/before-you-start/can-use-service.test.js
+++ b/packages/forms-web-app/__tests__/unit/controllers/before-you-start/can-use-service.test.js
@@ -6,13 +6,7 @@ const priorApprovalHASAppeal = require('../../../mockData/prior-approval/prior-a
 const removalOrVariationOfConditionsFPAppeal = require('../../../mockData/removal-or-variation-of-conditions/removal-or-variation-of-conditions-fp-route');
 const removalOrVariationOfConditionsHASAppeal = require('../../../mockData/removal-or-variation-of-conditions/removal-or-variation-of-conditions-has-route');
 const { getDepartmentFromId } = require('../../../../src/services/department.service');
-const {
-	TYPE_OF_PLANNING_APPLICATION: {
-		MINOR_COMMERCIAL_DEVELOPMENT,
-		MINOR_COMMERCIAL_ADVERTISEMENT,
-		ADVERTISEMENT
-	}
-} = require('@pins/business-rules/src/constants');
+const { TYPE_OF_PLANNING_APPLICATION, APPEAL_ID } = require('@pins/business-rules/src/constants');
 const {
 	VIEW: {
 		HOUSEHOLDER_PLANNING: {
@@ -569,7 +563,7 @@ describe('controllers/before-you-start/can-use-service', () => {
 				return flag === FLAG.CAS_PLANNING_APPEAL_FORM_V2;
 			});
 			const casPlanningAppeal = {
-				typeOfPlanningApplication: MINOR_COMMERCIAL_DEVELOPMENT,
+				typeOfPlanningApplication: TYPE_OF_PLANNING_APPLICATION.MINOR_COMMERCIAL_DEVELOPMENT,
 				lpaCode: 'E60000068',
 				decisionDate: fullAppeal.decisionDate,
 				eligibility: {
@@ -609,7 +603,8 @@ describe('controllers/before-you-start/can-use-service', () => {
 				return flag === FLAG.ADVERTS_APPEAL_FORM_V2;
 			});
 			const advertsAppeal = {
-				typeOfPlanningApplication: ADVERTISEMENT,
+				typeOfPlanningApplication: TYPE_OF_PLANNING_APPLICATION.ADVERTISEMENT,
+				appealType: APPEAL_ID.ADVERTISEMENT,
 				lpaCode: 'E60000068',
 				decisionDate: fullAppeal.decisionDate,
 				eligibility: {
@@ -626,7 +621,7 @@ describe('controllers/before-you-start/can-use-service', () => {
 				applicationAbout: null,
 				applicationDecision: 'Granted with conditions',
 				applicationType: 'Advertisement',
-				deadlineDate: { date: 4, day: 'Friday', month: 'November', year: 2022 },
+				deadlineDate: { date: 29, day: 'Wednesday', month: 'June', year: 2022 },
 				decisionDate: '04 May 2022',
 				dateOfDecisionLabel: 'Date of decision',
 				enforcementNotice: 'No',
@@ -648,12 +643,12 @@ describe('controllers/before-you-start/can-use-service', () => {
 					return flag === FLAG.CAS_ADVERTS_APPEAL_FORM_V2;
 				});
 				const advertsAppeal = {
-					typeOfPlanningApplication: MINOR_COMMERCIAL_ADVERTISEMENT,
+					typeOfPlanningApplication: TYPE_OF_PLANNING_APPLICATION.ADVERTISEMENT,
+					appealType: APPEAL_ID.MINOR_COMMERCIAL_ADVERTISEMENT,
 					lpaCode: 'E60000068',
 					decisionDate: fullAppeal.decisionDate,
 					eligibility: {
-						applicationDecision: 'granted',
-						planningApplicationAbout: ['none_of_these']
+						applicationDecision: 'refused'
 					}
 				};
 				req = mockReq(advertsAppeal);
@@ -663,9 +658,9 @@ describe('controllers/before-you-start/can-use-service', () => {
 				expect(res.render).toHaveBeenCalledWith(canUseServiceFullAppealUrl, {
 					appealLPD: 'Bradford',
 					applicationAbout: null,
-					applicationDecision: 'Granted with conditions',
-					applicationType: 'Minor commercial advertisement',
-					deadlineDate: { date: 4, day: 'Friday', month: 'November', year: 2022 },
+					applicationDecision: 'Refused',
+					applicationType: 'Advertisement',
+					deadlineDate: { date: 29, day: 'Wednesday', month: 'June', year: 2022 },
 					decisionDate: '04 May 2022',
 					dateOfDecisionLabel: 'Date of decision',
 					enforcementNotice: 'No',

--- a/packages/forms-web-app/__tests__/unit/controllers/full-appeal/submit-appeal/email-address-confirmed.test.js
+++ b/packages/forms-web-app/__tests__/unit/controllers/full-appeal/submit-appeal/email-address-confirmed.test.js
@@ -90,8 +90,7 @@ describe('controllers/full-appeal/submit-appeal/email-address-confirmed', () => 
 		});
 		it('calls correct template: cas adverts', async () => {
 			req.session.appeal.appealType = APPEAL_ID.MINOR_COMMERCIAL_ADVERTISEMENT;
-			req.session.appeal.typeOfPlanningApplication =
-				TYPE_OF_PLANNING_APPLICATION.MINOR_COMMERCIAL_ADVERTISEMENT;
+			req.session.appeal.typeOfPlanningApplication = TYPE_OF_PLANNING_APPLICATION.ADVERTISEMENT;
 			isLpaInFeatureFlag.mockImplementation((_, flag) => {
 				return flag === FLAG.CAS_ADVERTS_APPEAL_FORM_V2;
 			});

--- a/packages/forms-web-app/__tests__/unit/controllers/full-appeal/type-of-planning-application.test.js
+++ b/packages/forms-web-app/__tests__/unit/controllers/full-appeal/type-of-planning-application.test.js
@@ -60,6 +60,7 @@ describe('controllers/full-appeal/type-of-planning-application', () => {
 				false,
 				false,
 				false,
+				false,
 				'full-appeal'
 			);
 			expect(res.render).toHaveBeenCalledWith(TYPE_OF_PLANNING_APPLICATION, {
@@ -74,6 +75,7 @@ describe('controllers/full-appeal/type-of-planning-application', () => {
 			await getTypeOfPlanningApplication(req, res);
 
 			expect(typeOfPlanningApplicationRadioItems).toHaveBeenCalledWith(
+				true,
 				true,
 				true,
 				true,
@@ -385,6 +387,31 @@ describe('controllers/full-appeal/type-of-planning-application', () => {
 			});
 
 			expect(res.redirect).toHaveBeenCalledWith('/before-you-start/planning-application-about');
+		});
+
+		it('should redirect to the granted-or-refused page - cas adverts', async () => {
+			isLpaInFeatureFlag.mockImplementation((_, flag) => {
+				return flag === FLAG.CAS_ADVERTS_APPEAL_FORM_V2;
+			});
+
+			const planningApplication = ADVERTISEMENT;
+
+			const mockRequest = {
+				...req,
+				body: { 'type-of-planning-application': planningApplication }
+			};
+
+			await postTypeOfPlanningApplication(mockRequest, res);
+
+			const updatedAppeal = appeal;
+			updatedAppeal.appealType = mapPlanningApplication(planningApplication);
+			updatedAppeal.typeOfPlanningApplication = planningApplication;
+
+			expect(createOrUpdateAppeal).toHaveBeenCalledWith({
+				...updatedAppeal
+			});
+
+			expect(res.redirect).toHaveBeenCalledWith('/before-you-start/granted-or-refused');
 		});
 
 		it('should redirect to the granted-or-refused page - adverts', async () => {

--- a/packages/forms-web-app/src/controllers/before-you-start/can-use-service.js
+++ b/packages/forms-web-app/src/controllers/before-you-start/can-use-service.js
@@ -31,7 +31,6 @@ const {
 		PRIOR_APPROVAL,
 		LISTED_BUILDING,
 		MINOR_COMMERCIAL_DEVELOPMENT,
-		MINOR_COMMERCIAL_ADVERTISEMENT,
 		ADVERTISEMENT
 	}
 } = require('@pins/business-rules/src/constants');
@@ -298,7 +297,6 @@ exports.getCanUseService = async (req, res) => {
 		case RESERVED_MATTERS:
 		case LISTED_BUILDING:
 		case MINOR_COMMERCIAL_DEVELOPMENT:
-		case MINOR_COMMERCIAL_ADVERTISEMENT:
 		case ADVERTISEMENT:
 			await canUseServiceFullAppeal(req, res);
 			break;

--- a/packages/forms-web-app/src/controllers/full-appeal/type-of-planning-application.js
+++ b/packages/forms-web-app/src/controllers/full-appeal/type-of-planning-application.js
@@ -29,9 +29,10 @@ const {
 const getTypeOfPlanningApplication = async (req, res) => {
 	const { appeal } = req.session;
 
-	const [isV2forS20, isV2forCASPlanning, isV2forAdverts] = await Promise.all([
+	const [isV2forS20, isV2forCASPlanning, isV2forCASAdverts, isV2forAdverts] = await Promise.all([
 		isLpaInFeatureFlag(appeal.lpaCode, FLAG.S20_APPEAL_FORM_V2),
 		isLpaInFeatureFlag(appeal.lpaCode, FLAG.CAS_PLANNING_APPEAL_FORM_V2),
+		isLpaInFeatureFlag(appeal.lpaCode, FLAG.CAS_ADVERTS_APPEAL_FORM_V2),
 		isLpaInFeatureFlag(appeal.lpaCode, FLAG.ADVERTS_APPEAL_FORM_V2)
 	]);
 
@@ -40,6 +41,7 @@ const getTypeOfPlanningApplication = async (req, res) => {
 		radioItems: typeOfPlanningApplicationRadioItems(
 			isV2forS20,
 			isV2forCASPlanning,
+			isV2forCASAdverts,
 			isV2forAdverts,
 			appeal.typeOfPlanningApplication
 		)
@@ -53,12 +55,14 @@ const postTypeOfPlanningApplication = async (req, res) => {
 
 	const typeOfPlanningApplication = body['type-of-planning-application'];
 
-	const [isV2forS20, isV2forCASPlanning, isV2forS78, isV2forAdverts] = await Promise.all([
-		isLpaInFeatureFlag(appeal.lpaCode, FLAG.S20_APPEAL_FORM_V2),
-		isLpaInFeatureFlag(appeal.lpaCode, FLAG.CAS_PLANNING_APPEAL_FORM_V2),
-		isLpaInFeatureFlag(appeal.lpaCode, FLAG.S78_APPEAL_FORM_V2),
-		isLpaInFeatureFlag(appeal.lpaCode, FLAG.ADVERTS_APPEAL_FORM_V2)
-	]);
+	const [isV2forS20, isV2forCASPlanning, isV2forS78, isV2forCASAdverts, isV2forAdverts] =
+		await Promise.all([
+			isLpaInFeatureFlag(appeal.lpaCode, FLAG.S20_APPEAL_FORM_V2),
+			isLpaInFeatureFlag(appeal.lpaCode, FLAG.CAS_PLANNING_APPEAL_FORM_V2),
+			isLpaInFeatureFlag(appeal.lpaCode, FLAG.S78_APPEAL_FORM_V2),
+			isLpaInFeatureFlag(appeal.lpaCode, FLAG.CAS_ADVERTS_APPEAL_FORM_V2),
+			isLpaInFeatureFlag(appeal.lpaCode, FLAG.ADVERTS_APPEAL_FORM_V2)
+		]);
 
 	let isListedBuilding = null;
 	if (isV2forS20 && typeOfPlanningApplication !== REMOVAL_OR_VARIATION_OF_CONDITIONS) {
@@ -71,6 +75,7 @@ const postTypeOfPlanningApplication = async (req, res) => {
 			radioItems: typeOfPlanningApplicationRadioItems(
 				isV2forS20,
 				isV2forCASPlanning,
+				isV2forCASAdverts,
 				isV2forAdverts,
 				appeal.typeOfPlanningApplication
 			),
@@ -93,6 +98,7 @@ const postTypeOfPlanningApplication = async (req, res) => {
 			radioItems: typeOfPlanningApplicationRadioItems(
 				isV2forS20,
 				isV2forCASPlanning,
+				isV2forCASAdverts,
 				isV2forAdverts,
 				appeal.typeOfPlanningApplication
 			),
@@ -117,7 +123,7 @@ const postTypeOfPlanningApplication = async (req, res) => {
 				? res.redirect('/before-you-start/planning-application-about')
 				: res.redirect('/before-you-start/use-existing-service-application-type');
 		case ADVERTISEMENT:
-			return isV2forAdverts
+			return isV2forCASAdverts || isV2forAdverts
 				? res.redirect('/before-you-start/granted-or-refused')
 				: res.redirect('/before-you-start/use-existing-service-application-type');
 		case PRIOR_APPROVAL:

--- a/packages/forms-web-app/src/journeys/__snapshots__/index.test.js.snap
+++ b/packages/forms-web-app/src/journeys/__snapshots__/index.test.js.snap
@@ -1772,6 +1772,1778 @@ exports[`Dynamic forms journey tests appellant Advertisement renders listing pag
 </main>"
 `;
 
+exports[`Dynamic forms journey tests appellant Commercial advertisement (CAS) Commercial advertisement (CAS) should render the advertisement-position question 1`] = `
+"<main id="main-content" role="main" class="govuk-main-wrapper govuk-main-wrapper--auto-spacing">
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds"></div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds"><span class="govuk-caption-l"> Prepare appeal</span>
+        </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+            <form action="" method="post" novalidate=null>
+                <div class="govuk-form-group">
+                    <fieldset class="govuk-fieldset" aria-describedby="advertInPosition-hint">
+                        <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+                            <h1 class="govuk-fieldset__heading"> Is the advertisement in position?</h1>
+                        </legend>
+                        <div id="advertInPosition-hint" class="govuk-hint"></div>
+                        <div class="govuk-radios govuk-radios" data-module="govuk-radios">
+                            <div class="govuk-radios__item">
+                                <input class="govuk-radios__input" id="advertInPosition" name="advertInPosition"
+                                type="radio" value="yes" data-cy="answer-yes">
+                                <label class="govuk-label govuk-radios__label" for="advertInPosition">Yes</label>
+                            </div>
+                            <div class="govuk-radios__item">
+                                <input class="govuk-radios__input" id="advertInPosition-2" name="advertInPosition"
+                                type="radio" value="no" data-cy="answer-no">
+                                <label class="govuk-label govuk-radios__label" for="advertInPosition-2">No</label>
+                            </div>
+                        </div>
+                    </fieldset>
+                </div>
+                <button type="submit" class="govuk-button" data-module="govuk-button"
+                data-cy="button-save-and-continue">Continue</button>
+            </form>
+        </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+            <p class="govuk-body"><a href="/appeals/adverts/appeal-form/your-appeal?id=appeal-ref" class="govuk-link">Return to your appeal</a>
+            </p>
+        </div>
+    </div>
+</main>"
+`;
+
+exports[`Dynamic forms journey tests appellant Commercial advertisement (CAS) Commercial advertisement (CAS) should render the advertising-appeal question 1`] = `
+"<main id="main-content" role="main" class="govuk-main-wrapper govuk-main-wrapper--auto-spacing">
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds"></div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds"><span class="govuk-caption-l"> Prepare appeal</span>
+        </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+            <form action="" method="post" novalidate=null>
+                <div class="govuk-form-group">
+                    <fieldset class="govuk-fieldset" aria-describedby="advertisedAppeal-hint">
+                        <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+                            <h1 class="govuk-fieldset__heading"> Advertising your appeal</h1>
+                        </legend>
+                        <div id="advertisedAppeal-hint" class="govuk-hint">
+                            <p class="govuk-!-margin-bottom-2">You must have advertised your appeal in the press.</p>
+                            <p class="govuk-!-margin-bottom-2">You must have done this within the last 21 days using a copy of the
+                                <a
+                                href="https://assets.publishing.service.gov.uk/government/uploads/system/uploads/attachment_data/file/1136768/Annexe_2A_2B_3_AND_4_planning.pdf"
+                                target="_blank">form in annexe 2A or 2B of the 'making your appeal' guidance (opens in
+                                    new tab)</a>.</p>
+                            <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">Have you advertised the appeal?</legend>
+                        </div>
+                        <div class="govuk-checkboxes govuk-checkboxes" data-module="govuk-checkboxes">
+                            <div class="govuk-checkboxes__item">
+                                <input class="govuk-checkboxes__input" id="advertisedAppeal" name="advertisedAppeal"
+                                type="checkbox" value="yes" data-cy="answer-yes">
+                                <label class="govuk-label govuk-checkboxes__label" for="advertisedAppeal">I confirm that I’ve advertised my appeal in the press within the last
+                                    21 days using a copy of the form in annexe 2A or 2B</label>
+                            </div>
+                        </div>
+                    </fieldset>
+                </div>
+                <button type="submit" class="govuk-button" data-module="govuk-button"
+                data-cy="button-save-and-continue">Continue</button>
+            </form>
+        </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+            <p class="govuk-body"><a href="/appeals/adverts/appeal-form/your-appeal?id=appeal-ref" class="govuk-link">Return to your appeal</a>
+            </p>
+        </div>
+    </div>
+</main>"
+`;
+
+exports[`Dynamic forms journey tests appellant Commercial advertisement (CAS) Commercial advertisement (CAS) should render the appeal-site-address question 1`] = `
+"<main id="main-content" role="main" class="govuk-main-wrapper govuk-main-wrapper--auto-spacing">
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds"></div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds"><span class="govuk-caption-l"> Prepare appeal</span>
+        </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+            <form action="" method="post" novalidate=null>
+                <fieldset class="govuk-fieldset">
+                    <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+                        <h1 class="govuk-fieldset__heading"> What is the address of the appeal site?</h1>
+                    </legend>
+                    <p class="govuk-hint">The address should match what is on the application to the local planning
+                        authority.</p>
+                    <div class="govuk-form-group">
+                        <label class="govuk-label" for="address-line-1">Address line 1</label>
+                        <input class="govuk-input" id="address-line-1" name="siteAddress_addressLine1"
+                        type="text" autocomplete="address-line1">
+                    </div>
+                    <div class="govuk-form-group">
+                        <label class="govuk-label" for="address-line-2">Address line 2 (optional)</label>
+                        <input class="govuk-input" id="address-line-2"
+                        name="siteAddress_addressLine2" type="text" autocomplete="address-line2">
+                    </div>
+                    <div class="govuk-form-group">
+                        <label class="govuk-label" for="address-town">Town or city</label>
+                        <input class="govuk-input govuk-!-width-two-thirds"
+                        id="address-town" name="siteAddress_townCity" type="text" autocomplete="address-level2">
+                    </div>
+                    <div class="govuk-form-group">
+                        <label class="govuk-label" for="address-county">County (optional)</label>
+                        <input class="govuk-input govuk-!-width-two-thirds"
+                        id="address-county" name="siteAddress_county" type="text" autocomplete="address-level1">
+                    </div>
+                    <div class="govuk-form-group">
+                        <label class="govuk-label" for="address-postcode">Postcode</label>
+                        <input class="govuk-input govuk-input--width-10" id="address-postcode"
+                        name="siteAddress_postcode" type="text" autocomplete="postal-code">
+                    </div>
+                    <button type="submit" class="govuk-button" data-module="govuk-button"
+                    data-cy="button-save-and-continue">Continue</button>
+                </fieldset>
+            </form>
+        </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+            <p class="govuk-body"><a href="/appeals/adverts/appeal-form/your-appeal?id=appeal-ref" class="govuk-link">Return to your appeal</a>
+            </p>
+        </div>
+    </div>
+</main>"
+`;
+
+exports[`Dynamic forms journey tests appellant Commercial advertisement (CAS) Commercial advertisement (CAS) should render the applicant-name question 1`] = `
+"<main id="main-content" role="main" class="govuk-main-wrapper govuk-main-wrapper--auto-spacing">
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds"></div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds"><span class="govuk-caption-l"> Prepare appeal</span>
+        </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+            <form action="" method="post" novalidate=null>
+                <fieldset class="govuk-fieldset">
+                    <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+                        <h1 class="govuk-fieldset__heading"> What is the applicant&#39;s name?</h1>
+                    </legend>
+                    <p class="govuk-hint">Enter the name as it's written on the application form.</p>
+                    <div class="govuk-form-group">
+                        <label class="govuk-label govuk-label" for="appellantFirstName">First name</label>
+                        <input class="govuk-input govuk-input-!-width-three-quarters"
+                        id="appellantFirstName" name="appellantFirstName" type="text" spellcheck="false"
+                        autocomplete="given-name">
+                    </div>
+                    <div class="govuk-form-group">
+                        <label class="govuk-label govuk-label" for="appellantLastName">Last name</label>
+                        <input class="govuk-input govuk-input-!-width-three-quarters"
+                        id="appellantLastName" name="appellantLastName" type="text" spellcheck="false"
+                        autocomplete="family-name">
+                    </div>
+                    <div class="govuk-form-group">
+                        <label class="govuk-label govuk-label" for="appellantCompanyName">Company name (optional)</label>
+                        <input class="govuk-input govuk-input-!-width-three-quarters"
+                        id="appellantCompanyName" name="appellantCompanyName" type="text" spellcheck="false">
+                    </div>
+                </fieldset>
+                <button type="submit" class="govuk-button" data-module="govuk-button"
+                data-cy="button-save-and-continue">Continue</button>
+            </form>
+        </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+            <p class="govuk-body"><a href="/appeals/adverts/appeal-form/your-appeal?id=appeal-ref" class="govuk-link">Return to your appeal</a>
+            </p>
+        </div>
+    </div>
+</main>"
+`;
+
+exports[`Dynamic forms journey tests appellant Commercial advertisement (CAS) Commercial advertisement (CAS) should render the application-date question 1`] = `
+"<main id="main-content" role="main" class="govuk-main-wrapper govuk-main-wrapper--auto-spacing">
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds"></div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds"><span class="govuk-caption-l"> Prepare appeal</span>
+        </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+            <form action="" method="post" novalidate=null>
+                <div class="govuk-form-group">
+                    <fieldset class="govuk-fieldset" role="group" aria-describedby="onApplicationDate-hint">
+                        <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+                            <h1 class="govuk-fieldset__heading"> What date did you submit your application?</h1>
+                        </legend>
+                        <div id="onApplicationDate-hint" class="govuk-hint">For example, 5 6 2025</div>
+                        <div class="govuk-date-input" id="onApplicationDate">
+                            <div class="govuk-date-input__item">
+                                <div class="govuk-form-group">
+                                    <label class="govuk-label govuk-date-input__label" for="onApplicationDate_day">Day</label>
+                                    <input class="govuk-input govuk-date-input__input govuk-input--width-2"
+                                    id="onApplicationDate_day" name="onApplicationDate_day" type="text" inputmode="numeric">
+                                </div>
+                            </div>
+                            <div class="govuk-date-input__item">
+                                <div class="govuk-form-group">
+                                    <label class="govuk-label govuk-date-input__label" for="onApplicationDate_month">Month</label>
+                                    <input class="govuk-input govuk-date-input__input govuk-input--width-2"
+                                    id="onApplicationDate_month" name="onApplicationDate_month" type="text"
+                                    inputmode="numeric">
+                                </div>
+                            </div>
+                            <div class="govuk-date-input__item">
+                                <div class="govuk-form-group">
+                                    <label class="govuk-label govuk-date-input__label" for="onApplicationDate_year">Year</label>
+                                    <input class="govuk-input govuk-date-input__input govuk-input--width-4"
+                                    id="onApplicationDate_year" name="onApplicationDate_year" type="text" inputmode="numeric">
+                                </div>
+                            </div>
+                        </div>
+                    </fieldset>
+                </div>
+                <button type="submit" class="govuk-button" data-module="govuk-button"
+                data-cy="button-save-and-continue">Continue</button>
+            </form>
+        </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+            <p class="govuk-body"><a href="/appeals/adverts/appeal-form/your-appeal?id=appeal-ref" class="govuk-link">Return to your appeal</a>
+            </p>
+        </div>
+    </div>
+</main>"
+`;
+
+exports[`Dynamic forms journey tests appellant Commercial advertisement (CAS) Commercial advertisement (CAS) should render the application-name question 1`] = `
+"<main id="main-content" role="main" class="govuk-main-wrapper govuk-main-wrapper--auto-spacing">
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds"></div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds"><span class="govuk-caption-l"> Prepare appeal</span>
+        </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+            <form action="" method="post" novalidate=null>
+                <div class="govuk-form-group">
+                    <fieldset class="govuk-fieldset" aria-describedby="isAppellant-hint">
+                        <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+                            <h1 class="govuk-fieldset__heading"> Was the application made in your name?</h1>
+                        </legend>
+                        <div id="isAppellant-hint" class="govuk-hint">If you are not the applicant, you must have their permission to submit
+                            an appeal on their behalf.</div>
+                        <div class="govuk-radios govuk-radios"
+                        data-module="govuk-radios">
+                            <div class="govuk-radios__item">
+                                <input class="govuk-radios__input" id="isAppellant" name="isAppellant"
+                                type="radio" value="yes" data-cy="answer-yes">
+                                <label class="govuk-label govuk-radios__label" for="isAppellant">Yes, the application was made in my name</label>
+                            </div>
+                            <div class="govuk-radios__item">
+                                <input class="govuk-radios__input" id="isAppellant-2" name="isAppellant"
+                                type="radio" value="no" data-cy="answer-no">
+                                <label class="govuk-label govuk-radios__label" for="isAppellant-2">No, I&#39;m acting on behalf of the applicant</label>
+                            </div>
+                        </div>
+                    </fieldset>
+                </div>
+                <button type="submit" class="govuk-button" data-module="govuk-button"
+                data-cy="button-save-and-continue">Continue</button>
+            </form>
+        </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+            <p class="govuk-body"><a href="/appeals/adverts/appeal-form/your-appeal?id=appeal-ref" class="govuk-link">Return to your appeal</a>
+            </p>
+        </div>
+    </div>
+</main>"
+`;
+
+exports[`Dynamic forms journey tests appellant Commercial advertisement (CAS) Commercial advertisement (CAS) should render the apply-appeal-costs question 1`] = `
+"<main id="main-content" role="main" class="govuk-main-wrapper govuk-main-wrapper--auto-spacing">
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds"></div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds"><span class="govuk-caption-l"> Upload documents</span>
+        </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+            <form action="" method="post" novalidate=null>
+                <div class="govuk-form-group">
+                    <fieldset class="govuk-fieldset" aria-describedby="costApplication-hint">
+                        <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+                            <h1 class="govuk-fieldset__heading"> Do you need to apply for an award of appeal costs?</h1>
+                        </legend>
+                        <div id="costApplication-hint" class="govuk-hint"></div>
+                        <div class="govuk-radios govuk-radios" data-module="govuk-radios">
+                            <div class="govuk-radios__item">
+                                <input class="govuk-radios__input" id="costApplication" name="costApplication"
+                                type="radio" value="yes" data-cy="answer-yes">
+                                <label class="govuk-label govuk-radios__label" for="costApplication">Yes</label>
+                            </div>
+                            <div class="govuk-radios__item">
+                                <input class="govuk-radios__input" id="costApplication-2" name="costApplication"
+                                type="radio" value="no" data-cy="answer-no">
+                                <label class="govuk-label govuk-radios__label" for="costApplication-2">No</label>
+                            </div>
+                        </div>
+                    </fieldset>
+                </div>
+                <button type="submit" class="govuk-button" data-module="govuk-button"
+                data-cy="button-save-and-continue">Continue</button>
+            </form>
+        </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+            <p class="govuk-body"><a href="/appeals/adverts/appeal-form/your-appeal?id=appeal-ref" class="govuk-link">Return to your appeal</a>
+            </p>
+        </div>
+    </div>
+</main>"
+`;
+
+exports[`Dynamic forms journey tests appellant Commercial advertisement (CAS) Commercial advertisement (CAS) should render the contact-details question 1`] = `
+"<main id="main-content" role="main" class="govuk-main-wrapper govuk-main-wrapper--auto-spacing">
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds"></div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds"><span class="govuk-caption-l"> Prepare appeal</span>
+        </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+            <form action="" method="post" novalidate=null>
+                <fieldset class="govuk-fieldset">
+                    <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+                        <h1 class="govuk-fieldset__heading"> Contact details</h1>
+                    </legend>
+                    <div class="govuk-form-group">
+                        <label class="govuk-label govuk-label" for="contactFirstName">First name</label>
+                        <input class="govuk-input govuk-input-!-width-three-quarters"
+                        id="contactFirstName" name="contactFirstName" type="text" spellcheck="false"
+                        autocomplete="given-name">
+                    </div>
+                    <div class="govuk-form-group">
+                        <label class="govuk-label govuk-label" for="contactLastName">Last name</label>
+                        <input class="govuk-input govuk-input-!-width-three-quarters"
+                        id="contactLastName" name="contactLastName" type="text" spellcheck="false"
+                        autocomplete="family-name">
+                    </div>
+                    <div class="govuk-form-group">
+                        <label class="govuk-label govuk-label" for="contactCompanyName">Organisation name (optional)</label>
+                        <input class="govuk-input govuk-input-!-width-three-quarters"
+                        id="contactCompanyName" name="contactCompanyName" type="text" spellcheck="false">
+                    </div>
+                </fieldset>
+                <button type="submit" class="govuk-button" data-module="govuk-button"
+                data-cy="button-save-and-continue">Continue</button>
+            </form>
+        </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+            <p class="govuk-body"><a href="/appeals/adverts/appeal-form/your-appeal?id=appeal-ref" class="govuk-link">Return to your appeal</a>
+            </p>
+        </div>
+    </div>
+</main>"
+`;
+
+exports[`Dynamic forms journey tests appellant Commercial advertisement (CAS) Commercial advertisement (CAS) should render the description-advertisement question 1`] = `
+"<main id="main-content" role="main" class="govuk-main-wrapper govuk-main-wrapper--auto-spacing">
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds"></div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds"><span class="govuk-caption-l"> Prepare appeal</span>
+        </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+            <form action="" method="post" novalidate=null>
+                <h1 class="govuk-label-wrapper"><label class="govuk-label govuk-label--l" for="developmentDescriptionOriginal"> Enter the description of the advertisement that you submitted in your application</label></h1>
+                <div class="govuk-form-group">
+                    <div id="developmentDescriptionOriginal-hint" class="govuk-hint"></div>
+                    <textarea class="govuk-textarea" id="developmentDescriptionOriginal"
+                    name="developmentDescriptionOriginal" rows="5" aria-describedby="developmentDescriptionOriginal-hint"></textarea>
+                </div>
+                <button type="submit" class="govuk-button" data-module="govuk-button"
+                data-cy="button-save-and-continue">Continue</button>
+            </form>
+        </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+            <p class="govuk-body"><a href="/appeals/adverts/appeal-form/your-appeal?id=appeal-ref" class="govuk-link">Return to your appeal</a>
+            </p>
+        </div>
+    </div>
+</main>"
+`;
+
+exports[`Dynamic forms journey tests appellant Commercial advertisement (CAS) Commercial advertisement (CAS) should render the description-advertisement-correct question 1`] = `
+"<main id="main-content" role="main" class="govuk-main-wrapper govuk-main-wrapper--auto-spacing">
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds"></div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds"><span class="govuk-caption-l"> Prepare appeal</span>
+        </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+            <form action="" method="post" novalidate=null>
+                <div class="govuk-form-group">
+                    <fieldset class="govuk-fieldset" aria-describedby="updateDevelopmentDescription-hint">
+                        <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+                            <h1 class="govuk-fieldset__heading"> Did the local planning authority change the description of the advertisement?</h1>
+                        </legend>
+                        <div id="updateDevelopmentDescription-hint" class="govuk-hint">We need to know if the description of the advertisement is the same as
+                            what is on your application.</div>
+                        <div class="govuk-radios govuk-radios"
+                        data-module="govuk-radios">
+                            <div class="govuk-radios__item">
+                                <input class="govuk-radios__input" id="updateDevelopmentDescription" name="updateDevelopmentDescription"
+                                type="radio" value="yes" data-cy="answer-yes">
+                                <label class="govuk-label govuk-radios__label" for="updateDevelopmentDescription">Yes, I agreed a new description with the local planning authority</label>
+                            </div>
+                            <div class="govuk-radios__item">
+                                <input class="govuk-radios__input" id="updateDevelopmentDescription-2"
+                                name="updateDevelopmentDescription" type="radio" value="no" data-cy="answer-no">
+                                <label class="govuk-label govuk-radios__label" for="updateDevelopmentDescription-2">No</label>
+                            </div>
+                        </div>
+                    </fieldset>
+                </div>
+                <button type="submit" class="govuk-button" data-module="govuk-button"
+                data-cy="button-save-and-continue">Continue</button>
+            </form>
+        </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+            <p class="govuk-body"><a href="/appeals/adverts/appeal-form/your-appeal?id=appeal-ref" class="govuk-link">Return to your appeal</a>
+            </p>
+        </div>
+    </div>
+</main>"
+`;
+
+exports[`Dynamic forms journey tests appellant Commercial advertisement (CAS) Commercial advertisement (CAS) should render the enter-appeal-reference question 1`] = `
+"<main id="main-content" role="main" class="govuk-main-wrapper govuk-main-wrapper--auto-spacing">
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds"></div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds"><span class="govuk-caption-l"> Prepare appeal</span>
+        </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+            <form action="" method="post" novalidate=null>
+                <h1 class="govuk-label-wrapper"><label class="govuk-label govuk-label--l" for="appellantLinkedCaseReference"> Enter the appeal reference number</label></h1>
+                <p class="govuk-body">Enter the appeal reference number from the Planning Inspectorate.</p>
+                <div
+                class="govuk-form-group">
+                    <div id="appellantLinkedCaseReference-hint" class="govuk-hint">For example, 0221532.</div>
+                    <input class="govuk-input govuk-input--width-10"
+                    id="appellantLinkedCaseReference" name="appellantLinkedCaseReference" type="text"
+                    aria-describedby="appellantLinkedCaseReference-hint">
+        </div>
+        <button type="submit" class="govuk-button" data-module="govuk-button"
+        data-cy="button-save-and-continue">Continue</button>
+        </form>
+    </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+            <p class="govuk-body"><a href="/appeals/adverts/appeal-form/your-appeal?id=appeal-ref" class="govuk-link">Return to your appeal</a>
+            </p>
+        </div>
+    </div>
+</main>"
+`;
+
+exports[`Dynamic forms journey tests appellant Commercial advertisement (CAS) Commercial advertisement (CAS) should render the green-belt question 1`] = `
+"<main id="main-content" role="main" class="govuk-main-wrapper govuk-main-wrapper--auto-spacing">
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds"></div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds"><span class="govuk-caption-l"> Prepare appeal</span>
+        </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+            <form action="" method="post" novalidate=null>
+                <div class="govuk-form-group">
+                    <fieldset class="govuk-fieldset" aria-describedby="appellantGreenBelt-hint">
+                        <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+                            <h1 class="govuk-fieldset__heading"> Is the appeal site in a green belt?</h1>
+                        </legend>
+                        <div id="appellantGreenBelt-hint" class="govuk-hint"></div>
+                        <div class="govuk-radios govuk-radios" data-module="govuk-radios">
+                            <div class="govuk-radios__item">
+                                <input class="govuk-radios__input" id="appellantGreenBelt" name="appellantGreenBelt"
+                                type="radio" value="yes" data-cy="answer-yes">
+                                <label class="govuk-label govuk-radios__label" for="appellantGreenBelt">Yes</label>
+                            </div>
+                            <div class="govuk-radios__item">
+                                <input class="govuk-radios__input" id="appellantGreenBelt-2" name="appellantGreenBelt"
+                                type="radio" value="no" data-cy="answer-no">
+                                <label class="govuk-label govuk-radios__label" for="appellantGreenBelt-2">No</label>
+                            </div>
+                        </div>
+                    </fieldset>
+                </div>
+                <button type="submit" class="govuk-button" data-module="govuk-button"
+                data-cy="button-save-and-continue">Continue</button>
+            </form>
+        </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+            <p class="govuk-body"><a href="/appeals/adverts/appeal-form/your-appeal?id=appeal-ref" class="govuk-link">Return to your appeal</a>
+            </p>
+        </div>
+    </div>
+</main>"
+`;
+
+exports[`Dynamic forms journey tests appellant Commercial advertisement (CAS) Commercial advertisement (CAS) should render the health-safety-issues question 1`] = `
+"<main id="main-content" role="main" class="govuk-main-wrapper govuk-main-wrapper--auto-spacing">
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds"></div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds"><span class="govuk-caption-l"> Prepare appeal</span>
+        </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+            <form action="" method="post" novalidate=null>
+                <h1 class="govuk-heading-l">Health and safety issues</h1>
+                <p class="govuk-body"></p>
+                <p class="govuk-!-margin-bottom-2">Understanding any health and safety issues will help an inspector carry
+                    out a site visit.</p>
+                <p class="govuk-!-margin-bottom-2">For example:</p>
+                <ul class="govuk-list govuk-list--bullet">
+                    <li>animals at the site, for example pets or livestock</li>
+                    <li>any vulnerable or potentially violent people who may be at the site</li>
+                    <li>poor mobile signal at the site</li>
+                    <li>access issues for people with limited mobility</li>
+                    <li>overgrown vegetation that could restrict access to the site</li>
+                    <li>building works or other operations taking place on the site</li>
+                    <li>site-specific safety arrangements that are in place</li>
+                    <li>areas of the site that require specialist equipment or training for access,
+                        for example heights or confined spaces</li>
+                    <li>requirements to view the site from a height, for example from a roof or
+                        balcony</li>
+                    <li>risk of exposure to chemicals, asbestos or radiation</li>
+                    <li>unmarked changes in level or missing fittings</li>
+                </ul>
+                <div class="govuk-form-group">
+                    <fieldset class="govuk-fieldset">
+                        <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">Are there any health and safety issues on the appeal site?</legend>
+                        <div
+                        class="govuk-radios govuk-radios" data-module="govuk-radios">
+                            <div class="govuk-radios__item">
+                                <input class="govuk-radios__input" id="appellantSiteSafety" name="appellantSiteSafety"
+                                type="radio" value="yes" data-aria-controls="conditional-appellantSiteSafety"
+                                data-cy="answer-yes">
+                                <label class="govuk-label govuk-radios__label" for="appellantSiteSafety">Yes</label>
+                            </div>
+                            <div class="govuk-radios__conditional govuk-radios__conditional--hidden"
+                            id="conditional-appellantSiteSafety">
+                                <div class="govuk-form-group">
+                                    <label class="govuk-label" for="appellantSiteSafety_appellantSiteSafetyDetails">Tell us about the health and safety issues</label>
+                                    <div id="appellantSiteSafety_appellantSiteSafetyDetails-hint"
+                                    class="govuk-hint"></div>
+                                    <textarea class="govuk-textarea" id="appellantSiteSafety_appellantSiteSafetyDetails"
+                                    name="appellantSiteSafety_appellantSiteSafetyDetails" rows="5" aria-describedby="appellantSiteSafety_appellantSiteSafetyDetails-hint"></textarea>
+                                </div>
+                            </div>
+                            <div class="govuk-radios__item">
+                                <input class="govuk-radios__input" id="appellantSiteSafety-2" name="appellantSiteSafety"
+                                type="radio" value="no" data-cy="answer-no">
+                                <label class="govuk-label govuk-radios__label" for="appellantSiteSafety-2">No</label>
+                            </div>
+                </div>
+                </fieldset>
+        </div>
+        <button type="submit" class="govuk-button" data-module="govuk-button"
+        data-cy="button-save-and-continue">Continue</button>
+        </form>
+    </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+            <p class="govuk-body"><a href="/appeals/adverts/appeal-form/your-appeal?id=appeal-ref" class="govuk-link">Return to your appeal</a>
+            </p>
+        </div>
+    </div>
+</main>"
+`;
+
+exports[`Dynamic forms journey tests appellant Commercial advertisement (CAS) Commercial advertisement (CAS) should render the highway-land question 1`] = `
+"<main id="main-content" role="main" class="govuk-main-wrapper govuk-main-wrapper--auto-spacing">
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds"></div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds"><span class="govuk-caption-l"> Prepare appeal</span>
+        </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+            <form action="" method="post" novalidate=null>
+                <div class="govuk-form-group">
+                    <fieldset class="govuk-fieldset" aria-describedby="highwayLand-hint">
+                        <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+                            <h1 class="govuk-fieldset__heading"> Is the appeal site on highway land?</h1>
+                        </legend>
+                        <div id="highwayLand-hint" class="govuk-hint"></div>
+                        <div class="govuk-radios govuk-radios" data-module="govuk-radios">
+                            <div class="govuk-radios__item">
+                                <input class="govuk-radios__input" id="highwayLand" name="highwayLand"
+                                type="radio" value="yes" data-cy="answer-yes">
+                                <label class="govuk-label govuk-radios__label" for="highwayLand">Yes</label>
+                            </div>
+                            <div class="govuk-radios__item">
+                                <input class="govuk-radios__input" id="highwayLand-2" name="highwayLand"
+                                type="radio" value="no" data-cy="answer-no">
+                                <label class="govuk-label govuk-radios__label" for="highwayLand-2">No</label>
+                            </div>
+                        </div>
+                    </fieldset>
+                </div>
+                <button type="submit" class="govuk-button" data-module="govuk-button"
+                data-cy="button-save-and-continue">Continue</button>
+            </form>
+        </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+            <p class="govuk-body"><a href="/appeals/adverts/appeal-form/your-appeal?id=appeal-ref" class="govuk-link">Return to your appeal</a>
+            </p>
+        </div>
+    </div>
+</main>"
+`;
+
+exports[`Dynamic forms journey tests appellant Commercial advertisement (CAS) Commercial advertisement (CAS) should render the identifying-landowners question 1`] = `
+"<main id="main-content" role="main" class="govuk-main-wrapper govuk-main-wrapper--auto-spacing">
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds"></div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds"><span class="govuk-caption-l"> Prepare appeal</span>
+        </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+            <form action="" method="post" novalidate=null>
+                <div class="govuk-form-group">
+                    <fieldset class="govuk-fieldset" aria-describedby="identifiedOwners-hint">
+                        <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+                            <h1 class="govuk-fieldset__heading"> Identifying the landowners</h1>
+                        </legend>
+                        <div id="identifiedOwners-hint" class="govuk-hint">
+                            <p class="govuk-!-margin-bottom-2">You must have attempted to identify all the landowners.</p>
+                            <p class="govuk-!-margin-bottom-2">This includes:</p>
+                            <ul class="govuk-list govuk-list--bullet">
+                                <li>searching the land registry</li>
+                                <li>putting up a site notice at the appeal site</li>
+                            </ul>
+                            <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">Have you attempted to identify the landowners?</legend>
+                        </div>
+                        <div class="govuk-checkboxes govuk-checkboxes" data-module="govuk-checkboxes">
+                            <div class="govuk-checkboxes__item">
+                                <input class="govuk-checkboxes__input" id="identifiedOwners" name="identifiedOwners"
+                                type="checkbox" value="yes" data-cy="answer-yes">
+                                <label class="govuk-label govuk-checkboxes__label" for="identifiedOwners">I confirm that I’ve attempted to identify all the landowners, but have
+                                    not been successful</label>
+                            </div>
+                        </div>
+                    </fieldset>
+                </div>
+                <button type="submit" class="govuk-button" data-module="govuk-button"
+                data-cy="button-save-and-continue">Continue</button>
+            </form>
+        </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+            <p class="govuk-body"><a href="/appeals/adverts/appeal-form/your-appeal?id=appeal-ref" class="govuk-link">Return to your appeal</a>
+            </p>
+        </div>
+    </div>
+</main>"
+`;
+
+exports[`Dynamic forms journey tests appellant Commercial advertisement (CAS) Commercial advertisement (CAS) should render the inspector-need-access question 1`] = `
+"<main id="main-content" role="main" class="govuk-main-wrapper govuk-main-wrapper--auto-spacing">
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds"></div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds"><span class="govuk-caption-l"> Prepare appeal</span>
+        </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+            <form action="" method="post" novalidate=null>
+                <fieldset class="govuk-fieldset">
+                    <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+                        <h1 class="govuk-fieldset__heading"> Will an inspector need to access your land or property?</h1>
+                    </legend>
+                    <p class="govuk-!-margin-bottom-2">An inspector will visit the appeal site to assess the development’s impact
+                        on its surroundings.</p>
+                    <p class="govuk-!-margin-bottom-2">If the inspector can view the appeal site from a public road or footpath
+                        without entering your land or property, they do not need access.</p>
+                    <div
+                    class="govuk-form-group">
+                        <div class="govuk-radios govuk-radios" data-module="govuk-radios">
+                            <div class="govuk-radios__item">
+                                <input class="govuk-radios__input" id="appellantSiteAccess" name="appellantSiteAccess"
+                                type="radio" value="yes" data-aria-controls="conditional-appellantSiteAccess"
+                                data-cy="answer-yes">
+                                <label class="govuk-label govuk-radios__label" for="appellantSiteAccess">Yes</label>
+                            </div>
+                            <div class="govuk-radios__conditional govuk-radios__conditional--hidden"
+                            id="conditional-appellantSiteAccess">
+                                <div class="govuk-form-group">
+                                    <label class="govuk-label" for="appellantSiteAccess_appellantSiteAccessDetails">Enter a reason why an inspector cannot view the appeal site from a public
+                                        road or footpath.</label>
+                                    <div id="appellantSiteAccess_appellantSiteAccessDetails-hint"
+                                    class="govuk-hint">For example, the appeal site is at the rear of a terraced property.</div>
+                                    <textarea
+                                    class="govuk-textarea" id="appellantSiteAccess_appellantSiteAccessDetails"
+                                    name="appellantSiteAccess_appellantSiteAccessDetails" rows="5" aria-describedby="appellantSiteAccess_appellantSiteAccessDetails-hint"></textarea>
+                                </div>
+                            </div>
+                            <div class="govuk-radios__item">
+                                <input class="govuk-radios__input" id="appellantSiteAccess-2" name="appellantSiteAccess"
+                                type="radio" value="no" data-cy="answer-no">
+                                <label class="govuk-label govuk-radios__label" for="appellantSiteAccess-2">No</label>
+                            </div>
+                        </div>
+        </div>
+        </fieldset>
+        <button type="submit" class="govuk-button" data-module="govuk-button"
+        data-cy="button-save-and-continue">Continue</button>
+        </form>
+    </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+            <p class="govuk-body"><a href="/appeals/adverts/appeal-form/your-appeal?id=appeal-ref" class="govuk-link">Return to your appeal</a>
+            </p>
+        </div>
+    </div>
+</main>"
+`;
+
+exports[`Dynamic forms journey tests appellant Commercial advertisement (CAS) Commercial advertisement (CAS) should render the landowner-permission question 1`] = `
+"<main id="main-content" role="main" class="govuk-main-wrapper govuk-main-wrapper--auto-spacing">
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds"></div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds"><span class="govuk-caption-l"> Prepare appeal</span>
+        </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+            <form action="" method="post" novalidate=null>
+                <div class="govuk-form-group">
+                    <fieldset class="govuk-fieldset" aria-describedby="landownerPermission-hint">
+                        <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+                            <h1 class="govuk-fieldset__heading"> Do you have the landowner’s permission?</h1>
+                        </legend>
+                        <div id="landownerPermission-hint" class="govuk-hint"></div>
+                        <div class="govuk-radios govuk-radios" data-module="govuk-radios">
+                            <div class="govuk-radios__item">
+                                <input class="govuk-radios__input" id="landownerPermission" name="landownerPermission"
+                                type="radio" value="yes" data-cy="answer-yes">
+                                <label class="govuk-label govuk-radios__label" for="landownerPermission">Yes</label>
+                            </div>
+                            <div class="govuk-radios__item">
+                                <input class="govuk-radios__input" id="landownerPermission-2" name="landownerPermission"
+                                type="radio" value="no" data-cy="answer-no">
+                                <label class="govuk-label govuk-radios__label" for="landownerPermission-2">No</label>
+                            </div>
+                        </div>
+                    </fieldset>
+                </div>
+                <button type="submit" class="govuk-button" data-module="govuk-button"
+                data-cy="button-save-and-continue">Continue</button>
+            </form>
+        </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+            <p class="govuk-body"><a href="/appeals/adverts/appeal-form/your-appeal?id=appeal-ref" class="govuk-link">Return to your appeal</a>
+            </p>
+        </div>
+    </div>
+</main>"
+`;
+
+exports[`Dynamic forms journey tests appellant Commercial advertisement (CAS) Commercial advertisement (CAS) should render the other-appeals question 1`] = `
+"<main id="main-content" role="main" class="govuk-main-wrapper govuk-main-wrapper--auto-spacing">
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds"></div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds"><span class="govuk-caption-l"> Prepare appeal</span>
+        </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+            <form action="" method="post" novalidate=null>
+                <div class="govuk-form-group">
+                    <fieldset class="govuk-fieldset" aria-describedby="appellantLinkedCase-hint">
+                        <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+                            <h1 class="govuk-fieldset__heading"> Are there other appeals linked to your development?</h1>
+                        </legend>
+                        <div id="appellantLinkedCase-hint" class="govuk-hint">Only tell us about ongoing appeals that have not already received a decision.</div>
+                        <div
+                        class="govuk-radios govuk-radios" data-module="govuk-radios">
+                            <div class="govuk-radios__item">
+                                <input class="govuk-radios__input" id="appellantLinkedCase" name="appellantLinkedCase"
+                                type="radio" value="yes" data-cy="answer-yes">
+                                <label class="govuk-label govuk-radios__label" for="appellantLinkedCase">Yes</label>
+                            </div>
+                            <div class="govuk-radios__item">
+                                <input class="govuk-radios__input" id="appellantLinkedCase-2" name="appellantLinkedCase"
+                                type="radio" value="no" data-cy="answer-no">
+                                <label class="govuk-label govuk-radios__label" for="appellantLinkedCase-2">No</label>
+                            </div>
+                </div>
+                </fieldset>
+        </div>
+        <button type="submit" class="govuk-button" data-module="govuk-button"
+        data-cy="button-save-and-continue">Continue</button>
+        </form>
+    </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+            <p class="govuk-body"><a href="/appeals/adverts/appeal-form/your-appeal?id=appeal-ref" class="govuk-link">Return to your appeal</a>
+            </p>
+        </div>
+    </div>
+</main>"
+`;
+
+exports[`Dynamic forms journey tests appellant Commercial advertisement (CAS) Commercial advertisement (CAS) should render the own-all-land question 1`] = `
+"<main id="main-content" role="main" class="govuk-main-wrapper govuk-main-wrapper--auto-spacing">
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds"></div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds"><span class="govuk-caption-l"> Prepare appeal</span>
+        </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+            <form action="" method="post" novalidate=null>
+                <div class="govuk-form-group">
+                    <fieldset class="govuk-fieldset" aria-describedby="ownsAllLand-hint">
+                        <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+                            <h1 class="govuk-fieldset__heading"> Do you own all of the land involved in the appeal?</h1>
+                        </legend>
+                        <div id="ownsAllLand-hint" class="govuk-hint"></div>
+                        <div class="govuk-radios govuk-radios" data-module="govuk-radios">
+                            <div class="govuk-radios__item">
+                                <input class="govuk-radios__input" id="ownsAllLand" name="ownsAllLand"
+                                type="radio" value="yes" data-cy="answer-yes">
+                                <label class="govuk-label govuk-radios__label" for="ownsAllLand">Yes</label>
+                            </div>
+                            <div class="govuk-radios__item">
+                                <input class="govuk-radios__input" id="ownsAllLand-2" name="ownsAllLand"
+                                type="radio" value="no" data-cy="answer-no">
+                                <label class="govuk-label govuk-radios__label" for="ownsAllLand-2">No</label>
+                            </div>
+                        </div>
+                    </fieldset>
+                </div>
+                <button type="submit" class="govuk-button" data-module="govuk-button"
+                data-cy="button-save-and-continue">Continue</button>
+            </form>
+        </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+            <p class="govuk-body"><a href="/appeals/adverts/appeal-form/your-appeal?id=appeal-ref" class="govuk-link">Return to your appeal</a>
+            </p>
+        </div>
+    </div>
+</main>"
+`;
+
+exports[`Dynamic forms journey tests appellant Commercial advertisement (CAS) Commercial advertisement (CAS) should render the own-some-land question 1`] = `
+"<main id="main-content" role="main" class="govuk-main-wrapper govuk-main-wrapper--auto-spacing">
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds"></div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds"><span class="govuk-caption-l"> Prepare appeal</span>
+        </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+            <form action="" method="post" novalidate=null>
+                <div class="govuk-form-group">
+                    <fieldset class="govuk-fieldset" aria-describedby="ownsSomeLand-hint">
+                        <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+                            <h1 class="govuk-fieldset__heading"> Do you own some of the land involved in the appeal?</h1>
+                        </legend>
+                        <div id="ownsSomeLand-hint" class="govuk-hint"></div>
+                        <div class="govuk-radios govuk-radios" data-module="govuk-radios">
+                            <div class="govuk-radios__item">
+                                <input class="govuk-radios__input" id="ownsSomeLand" name="ownsSomeLand"
+                                type="radio" value="yes" data-cy="answer-yes">
+                                <label class="govuk-label govuk-radios__label" for="ownsSomeLand">Yes</label>
+                            </div>
+                            <div class="govuk-radios__item">
+                                <input class="govuk-radios__input" id="ownsSomeLand-2" name="ownsSomeLand"
+                                type="radio" value="no" data-cy="answer-no">
+                                <label class="govuk-label govuk-radios__label" for="ownsSomeLand-2">No</label>
+                            </div>
+                        </div>
+                    </fieldset>
+                </div>
+                <button type="submit" class="govuk-button" data-module="govuk-button"
+                data-cy="button-save-and-continue">Continue</button>
+            </form>
+        </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+            <p class="govuk-body"><a href="/appeals/adverts/appeal-form/your-appeal?id=appeal-ref" class="govuk-link">Return to your appeal</a>
+            </p>
+        </div>
+    </div>
+</main>"
+`;
+
+exports[`Dynamic forms journey tests appellant Commercial advertisement (CAS) Commercial advertisement (CAS) should render the owns-land-involved question 1`] = `
+"<main id="main-content" role="main" class="govuk-main-wrapper govuk-main-wrapper--auto-spacing">
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds"></div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds"><span class="govuk-caption-l"> Prepare appeal</span>
+        </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+            <form action="" method="post" novalidate=null>
+                <fieldset class="govuk-fieldset">
+                    <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+                        <h1 class="govuk-fieldset__heading"> Do you know who owns the land involved in the appeal?</h1>
+                    </legend>
+                    <div class="govuk-form-group">
+                        <div class="govuk-radios govuk-radios" data-module="govuk-radios">
+                            <div class="govuk-radios__item">
+                                <input class="govuk-radios__input" id="knowsAllOwners" name="knowsAllOwners"
+                                type="radio" value="yes" data-cy="answer-yes">
+                                <label class="govuk-label govuk-radios__label" for="knowsAllOwners">Yes, I know who owns all the land</label>
+                            </div>
+                            <div class="govuk-radios__item">
+                                <input class="govuk-radios__input" id="knowsAllOwners-2" name="knowsAllOwners"
+                                type="radio" value="some" data-cy="answer-some">
+                                <label class="govuk-label govuk-radios__label" for="knowsAllOwners-2">I know who owns some of the land</label>
+                            </div>
+                            <div class="govuk-radios__item">
+                                <input class="govuk-radios__input" id="knowsAllOwners-3" name="knowsAllOwners"
+                                type="radio" value="no" data-cy="answer-no">
+                                <label class="govuk-label govuk-radios__label" for="knowsAllOwners-3">No, I do not know who owns any of the land</label>
+                            </div>
+                        </div>
+                    </div>
+                </fieldset>
+                <button type="submit" class="govuk-button" data-module="govuk-button"
+                data-cy="button-save-and-continue">Continue</button>
+            </form>
+        </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+            <p class="govuk-body"><a href="/appeals/adverts/appeal-form/your-appeal?id=appeal-ref" class="govuk-link">Return to your appeal</a>
+            </p>
+        </div>
+    </div>
+</main>"
+`;
+
+exports[`Dynamic forms journey tests appellant Commercial advertisement (CAS) Commercial advertisement (CAS) should render the owns-rest-of-land question 1`] = `
+"<main id="main-content" role="main" class="govuk-main-wrapper govuk-main-wrapper--auto-spacing">
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds"></div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds"><span class="govuk-caption-l"> Prepare appeal</span>
+        </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+            <form action="" method="post" novalidate=null>
+                <fieldset class="govuk-fieldset">
+                    <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+                        <h1 class="govuk-fieldset__heading"> Do you know who owns the rest of the land involved in the appeal?</h1>
+                    </legend>
+                    <div class="govuk-form-group">
+                        <div class="govuk-radios govuk-radios" data-module="govuk-radios">
+                            <div class="govuk-radios__item">
+                                <input class="govuk-radios__input" id="knowsOtherOwners" name="knowsOtherOwners"
+                                type="radio" value="yes" data-cy="answer-yes">
+                                <label class="govuk-label govuk-radios__label" for="knowsOtherOwners">Yes, I know who owns all of the land</label>
+                            </div>
+                            <div class="govuk-radios__item">
+                                <input class="govuk-radios__input" id="knowsOtherOwners-2" name="knowsOtherOwners"
+                                type="radio" value="some" data-cy="answer-some">
+                                <label class="govuk-label govuk-radios__label" for="knowsOtherOwners-2">I know who owns some of the land</label>
+                            </div>
+                            <div class="govuk-radios__item">
+                                <input class="govuk-radios__input" id="knowsOtherOwners-3" name="knowsOtherOwners"
+                                type="radio" value="no" data-cy="answer-no">
+                                <label class="govuk-label govuk-radios__label" for="knowsOtherOwners-3">No, I do not know who owns any of the land</label>
+                            </div>
+                        </div>
+                    </div>
+                </fieldset>
+                <button type="submit" class="govuk-button" data-module="govuk-button"
+                data-cy="button-save-and-continue">Continue</button>
+            </form>
+        </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+            <p class="govuk-body"><a href="/appeals/adverts/appeal-form/your-appeal?id=appeal-ref" class="govuk-link">Return to your appeal</a>
+            </p>
+        </div>
+    </div>
+</main>"
+`;
+
+exports[`Dynamic forms journey tests appellant Commercial advertisement (CAS) Commercial advertisement (CAS) should render the phone-number question 1`] = `
+"<main id="main-content" role="main" class="govuk-main-wrapper govuk-main-wrapper--auto-spacing">
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds"></div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds"><span class="govuk-caption-l"> Prepare appeal</span>
+        </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+            <form action="" method="post" novalidate=null>
+                <h1 class="govuk-heading-l"> What is your phone number?</h1>
+                <p class="govuk-body">We may use your phone number to contact you about the appeal.</p>
+                <div
+                class="govuk-form-group">
+                    <label class="govuk-label govuk-label" for="contactPhoneNumber">UK telephone number</label>
+                    <div id="contactPhoneNumber-hint" class="govuk-hint"></div>
+                    <input class="govuk-input govuk-input--width-10" id="contactPhoneNumber"
+                    name="contactPhoneNumber" type="tel" value="" aria-describedby="contactPhoneNumber-hint"
+                    autocomplete="tel">
+        </div>
+        <button type="submit" class="govuk-button" data-module="govuk-button"
+        data-cy="button-save-and-continue">Continue</button>
+        </form>
+    </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+            <p class="govuk-body"><a href="/appeals/adverts/appeal-form/your-appeal?id=appeal-ref" class="govuk-link">Return to your appeal</a>
+            </p>
+        </div>
+    </div>
+</main>"
+`;
+
+exports[`Dynamic forms journey tests appellant Commercial advertisement (CAS) Commercial advertisement (CAS) should render the reference-number question 1`] = `
+"<main id="main-content" role="main" class="govuk-main-wrapper govuk-main-wrapper--auto-spacing">
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds"></div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds"><span class="govuk-caption-l"> Prepare appeal</span>
+        </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+            <form action="" method="post" novalidate=null>
+                <div class="govuk-form-group">
+                    <h1 class="govuk-label-wrapper"><label class="govuk-label govuk-label--l" for="applicationReference"> What is the application reference number?</label></h1>
+                    <div id="applicationReference-hint" class="govuk-hint">You can find this on any correspondence from the local planning authority.
+                        For example, the letter confirming your application.</div>
+                    <input class="govuk-input govuk-input--width-10"
+                    id="applicationReference" name="applicationReference" type="text" value=""
+                    aria-describedby="applicationReference-hint">
+                </div>
+                <button type="submit" class="govuk-button" data-module="govuk-button"
+                data-cy="button-save-and-continue">Continue</button>
+            </form>
+        </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+            <p class="govuk-body"><a href="/appeals/adverts/appeal-form/your-appeal?id=appeal-ref" class="govuk-link">Return to your appeal</a>
+            </p>
+        </div>
+    </div>
+</main>"
+`;
+
+exports[`Dynamic forms journey tests appellant Commercial advertisement (CAS) Commercial advertisement (CAS) should render the site-area question 1`] = `
+"<main id="main-content" role="main" class="govuk-main-wrapper govuk-main-wrapper--auto-spacing">
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds"></div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds"><span class="govuk-caption-l"> Prepare appeal</span>
+        </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+            <h1 class="govuk-heading-l">What is the area of the appeal site?</h1>
+            <p class="govuk-body"></p>
+            <form action="" method="post" novalidate=null>
+                <div class="govuk-form-group">
+                    <div id="siteAreaSquareMetres-hint" class="govuk-hint">Total site area, in square metres.</div>
+                    <div class="govuk-input__wrapper">
+                        <input class="govuk-input govuk-input--width-5" id="siteAreaSquareMetres"
+                        name="siteAreaSquareMetres" type="text" spellcheck="false" value="" aria-describedby="siteAreaSquareMetres-hint"
+                        inputmode="numeric">
+                        <div class="govuk-input__suffix" aria-hidden="true">m²</div>
+                    </div>
+                </div>
+                <button type="submit" class="govuk-button" data-module="govuk-button"
+                data-cy="button-save-and-continue">Continue</button>
+            </form>
+        </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+            <p class="govuk-body"><a href="/appeals/adverts/appeal-form/your-appeal?id=appeal-ref" class="govuk-link">Return to your appeal</a>
+            </p>
+        </div>
+    </div>
+</main>"
+`;
+
+exports[`Dynamic forms journey tests appellant Commercial advertisement (CAS) Commercial advertisement (CAS) should render the telling-landowners question 1`] = `
+"<main id="main-content" role="main" class="govuk-main-wrapper govuk-main-wrapper--auto-spacing">
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds"></div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds"><span class="govuk-caption-l"> Prepare appeal</span>
+        </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+            <form action="" method="post" novalidate=null>
+                <div class="govuk-form-group">
+                    <fieldset class="govuk-fieldset" aria-describedby="informedOwners-hint">
+                        <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+                            <h1 class="govuk-fieldset__heading"> Telling the landowners</h1>
+                        </legend>
+                        <div id="informedOwners-hint" class="govuk-hint">
+                            <p class="govuk-!-margin-bottom-2">You must have told all of the landowners about the appeal.</p>
+                            <p class="govuk-!-margin-bottom-2">You must have done this within the last 21 days using a copy of the
+                                <a
+                                href="https://assets.publishing.service.gov.uk/government/uploads/system/uploads/attachment_data/file/1136768/Annexe_2A_2B_3_AND_4_planning.pdf"
+                                target="_blank">form in annexe 2A or 2B of the 'making your appeal' guidance (opens in
+                                    new tab)</a>.</p>
+                            <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">Have the landowners been told about the appeal?</legend>
+                        </div>
+                        <div class="govuk-checkboxes govuk-checkboxes" data-module="govuk-checkboxes">
+                            <div class="govuk-checkboxes__item">
+                                <input class="govuk-checkboxes__input" id="informedOwners" name="informedOwners"
+                                type="checkbox" value="yes" data-cy="answer-yes">
+                                <label class="govuk-label govuk-checkboxes__label" for="informedOwners">I confirm that I’ve told all the landowners about my appeal within the
+                                    last 21 days using a copy of the form in annexe 2A or 2B</label>
+                            </div>
+                        </div>
+                    </fieldset>
+                </div>
+                <button type="submit" class="govuk-button" data-module="govuk-button"
+                data-cy="button-save-and-continue">Continue</button>
+            </form>
+        </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+            <p class="govuk-body"><a href="/appeals/adverts/appeal-form/your-appeal?id=appeal-ref" class="govuk-link">Return to your appeal</a>
+            </p>
+        </div>
+    </div>
+</main>"
+`;
+
+exports[`Dynamic forms journey tests appellant Commercial advertisement (CAS) Commercial advertisement (CAS) should render the upload-appeal-costs-application question 1`] = `
+"<main id="main-content" role="main" class="govuk-main-wrapper govuk-main-wrapper--auto-spacing">
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds"><span class="govuk-caption-l">Upload documents</span>
+            <h1 class="govuk-heading-l">Upload your application for an award of appeal costs</h1>
+            <form action="" method="post" novalidate=null enctype="multipart/form-data">
+                <div class="moj-multi-file-upload">
+                    <div class="moj-multi-file__uploaded-files" aria-live="polite">
+                        <div class="moj-multi-file__uploaded-files-container moj-hidden">
+                            <h2 class="govuk-heading-m" id="-uploaded-files-heading">Files added</h2>
+                            <ul class="govuk-summary-list moj-multi-file-upload__list"></ul>
+                        </div>
+                    </div>
+                    <div class="moj-multi-file-upload__upload">
+                        <div class="govuk-form-group">
+                            <label class="govuk-label govuk-label--m" for="uploadCostApplication">Upload files</label>
+                            <div id="uploadCostApplication-hint" class="govuk-hint">The files must be a DOC, DOCX, PDF, TIF, JPG or PNG and be smaller than
+                                1GB</div>
+                            <input class="govuk-file-upload moj-multi-file-upload__input"
+                            id="uploadCostApplication" name="uploadCostApplication" type="file" aria-describedby="uploadCostApplication-hint"
+                            multiple="">
+                        </div>
+                        <button value="upload-and-remain-on-page" type="submit" name="upload-and-remain-on-page"
+                        class="govuk-button govuk-button--secondary moj-multi-file-upload__button"
+                        data-module="govuk-button" data-cy="button-upload-file">Upload file</button>
+                    </div>
+                </div>
+                <div class="govuk-button-group">
+                    <button type="submit" class="govuk-button" data-module="govuk-button"
+                    data-cy="button-save-and-continue">Continue</button>
+                </div>
+            </form>
+        </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+            <p class="govuk-body"><a href="/appeals/adverts/appeal-form/your-appeal?id=appeal-ref" class="govuk-link">Return to your appeal</a>
+            </p>
+        </div>
+    </div>
+</main>"
+`;
+
+exports[`Dynamic forms journey tests appellant Commercial advertisement (CAS) Commercial advertisement (CAS) should render the upload-appeal-statement question 1`] = `
+"<main id="main-content" role="main" class="govuk-main-wrapper govuk-main-wrapper--auto-spacing">
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds"><span class="govuk-caption-l">Upload documents</span>
+            <h1 class="govuk-heading-l">Upload your appeal statement</h1>
+            <p class="govuk-body">Your appeal statement explains why you disagree with the local planning
+                authority’s decision.</p>
+            <p class="govuk-body">You can upload any documents that you refer to in your appeal statement
+                later.</p>
+            <div class="govuk-inset-text">Do not include any sensitive information in your statement. It will delay
+                your appeal.</div>
+            <details class="govuk-details">
+                <summary class="govuk-details__summary"><span class="govuk-details__summary-text"> What is sensitive information? </span>
+                </summary>
+                <div class="govuk-details__text">
+                    <p class="govuk-body">Sensitive information refers to:</p>
+                    <ul class="govuk-list govuk-list--bullet">
+                        <li>comments from children</li>
+                        <li>information relating to children</li>
+                        <li>information relating to health</li>
+                        <li>information relating to crime</li>
+                    </ul>
+                    <p class="govuk-body">It also includes any information relating to an individual's:</p>
+                    <ul class="govuk-list govuk-list--bullet">
+                        <li>race</li>
+                        <li>ethnic origin</li>
+                        <li>politics</li>
+                        <li>religion</li>
+                        <li>trade union membership</li>
+                        <li>genetics</li>
+                        <li>physical characteristics</li>
+                        <li>sex life</li>
+                        <li>sexual orientation</li>
+                    </ul>
+                </div>
+            </details>
+            <form action="" method="post" novalidate=null enctype="multipart/form-data">
+                <div class="moj-multi-file-upload">
+                    <div class="moj-multi-file__uploaded-files" aria-live="polite">
+                        <div class="moj-multi-file__uploaded-files-container moj-hidden">
+                            <h2 class="govuk-heading-m" id="-uploaded-files-heading">Files added</h2>
+                            <ul class="govuk-summary-list moj-multi-file-upload__list"></ul>
+                        </div>
+                    </div>
+                    <div class="moj-multi-file-upload__upload">
+                        <div class="govuk-form-group">
+                            <label class="govuk-label govuk-label--m" for="uploadAppellantStatement">Upload files</label>
+                            <div id="uploadAppellantStatement-hint" class="govuk-hint">The files must be a DOC, DOCX, PDF, TIF, JPG or PNG and be smaller than
+                                1GB</div>
+                            <input class="govuk-file-upload moj-multi-file-upload__input"
+                            id="uploadAppellantStatement" name="uploadAppellantStatement" type="file"
+                            aria-describedby="uploadAppellantStatement-hint" multiple="">
+                        </div>
+                        <button value="upload-and-remain-on-page" type="submit" name="upload-and-remain-on-page"
+                        class="govuk-button govuk-button--secondary moj-multi-file-upload__button"
+                        data-module="govuk-button" data-cy="button-upload-file">Upload file</button>
+                    </div>
+                </div>
+                <div class="govuk-button-group">
+                    <button type="submit" class="govuk-button" data-module="govuk-button"
+                    data-cy="button-save-and-continue">Continue</button>
+                </div>
+            </form>
+        </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+            <p class="govuk-body"><a href="/appeals/adverts/appeal-form/your-appeal?id=appeal-ref" class="govuk-link">Return to your appeal</a>
+            </p>
+        </div>
+    </div>
+</main>"
+`;
+
+exports[`Dynamic forms journey tests appellant Commercial advertisement (CAS) Commercial advertisement (CAS) should render the upload-application-form question 1`] = `
+"<main id="main-content" role="main" class="govuk-main-wrapper govuk-main-wrapper--auto-spacing">
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds"><span class="govuk-caption-l">Upload documents</span>
+            <h1 class="govuk-heading-l">Upload your application form</h1>
+            <p class="govuk-body">Upload the application form that you sent to the local planning authority,
+                including the date. Do not upload a draft application.
+                <br>If you do not have your application form, you can search for it on the
+                local planning authority’s website.</p>
+            <form action="" method="post" novalidate=null
+            enctype="multipart/form-data">
+                <div class="moj-multi-file-upload">
+                    <div class="moj-multi-file__uploaded-files" aria-live="polite">
+                        <div class="moj-multi-file__uploaded-files-container moj-hidden">
+                            <h2 class="govuk-heading-m" id="-uploaded-files-heading">Files added</h2>
+                            <ul class="govuk-summary-list moj-multi-file-upload__list"></ul>
+                        </div>
+                    </div>
+                    <div class="moj-multi-file-upload__upload">
+                        <div class="govuk-form-group">
+                            <label class="govuk-label govuk-label--m" for="uploadOriginalApplicationForm">Upload files</label>
+                            <div id="uploadOriginalApplicationForm-hint" class="govuk-hint">The files must be a DOC, DOCX, PDF, TIF, JPG or PNG and be smaller than
+                                1GB</div>
+                            <input class="govuk-file-upload moj-multi-file-upload__input"
+                            id="uploadOriginalApplicationForm" name="uploadOriginalApplicationForm"
+                            type="file" aria-describedby="uploadOriginalApplicationForm-hint" multiple="">
+                        </div>
+                        <button value="upload-and-remain-on-page" type="submit" name="upload-and-remain-on-page"
+                        class="govuk-button govuk-button--secondary moj-multi-file-upload__button"
+                        data-module="govuk-button" data-cy="button-upload-file">Upload file</button>
+                    </div>
+                </div>
+                <div class="govuk-button-group">
+                    <button type="submit" class="govuk-button" data-module="govuk-button"
+                    data-cy="button-save-and-continue">Continue</button>
+                </div>
+            </form>
+        </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+            <p class="govuk-body"><a href="/appeals/adverts/appeal-form/your-appeal?id=appeal-ref" class="govuk-link">Return to your appeal</a>
+            </p>
+        </div>
+    </div>
+</main>"
+`;
+
+exports[`Dynamic forms journey tests appellant Commercial advertisement (CAS) Commercial advertisement (CAS) should render the upload-decision-letter question 1`] = `
+"<main id="main-content" role="main" class="govuk-main-wrapper govuk-main-wrapper--auto-spacing">
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds"><span class="govuk-caption-l">Upload documents</span>
+            <h1 class="govuk-heading-l">Upload the decision letter from the local planning authority</h1>
+            <p class="govuk-body">This letter tells you about the decision on your application.
+                <br>
+                <br>We need the letter from the local planning authority that tells you their
+                decision on your application (also called a ‘decision notice’).
+                <br>
+                <br>Do not upload the planning officer’s report.</p>
+            <form action="" method="post"
+            novalidate=null enctype="multipart/form-data">
+                <div class="moj-multi-file-upload">
+                    <div class="moj-multi-file__uploaded-files" aria-live="polite">
+                        <div class="moj-multi-file__uploaded-files-container moj-hidden">
+                            <h2 class="govuk-heading-m" id="-uploaded-files-heading">Files added</h2>
+                            <ul class="govuk-summary-list moj-multi-file-upload__list"></ul>
+                        </div>
+                    </div>
+                    <div class="moj-multi-file-upload__upload">
+                        <div class="govuk-form-group">
+                            <label class="govuk-label govuk-label--m" for="uploadApplicationDecisionLetter">Upload files</label>
+                            <div id="uploadApplicationDecisionLetter-hint" class="govuk-hint">The files must be a DOC, DOCX, PDF, TIF, JPG or PNG and be smaller than
+                                1GB</div>
+                            <input class="govuk-file-upload moj-multi-file-upload__input"
+                            id="uploadApplicationDecisionLetter" name="uploadApplicationDecisionLetter"
+                            type="file" aria-describedby="uploadApplicationDecisionLetter-hint" multiple="">
+                        </div>
+                        <button value="upload-and-remain-on-page" type="submit" name="upload-and-remain-on-page"
+                        class="govuk-button govuk-button--secondary moj-multi-file-upload__button"
+                        data-module="govuk-button" data-cy="button-upload-file">Upload file</button>
+                    </div>
+                </div>
+                <div class="govuk-button-group">
+                    <button type="submit" class="govuk-button" data-module="govuk-button"
+                    data-cy="button-save-and-continue">Continue</button>
+                </div>
+            </form>
+        </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+            <p class="govuk-body"><a href="/appeals/adverts/appeal-form/your-appeal?id=appeal-ref" class="govuk-link">Return to your appeal</a>
+            </p>
+        </div>
+    </div>
+</main>"
+`;
+
+exports[`Dynamic forms journey tests appellant Commercial advertisement (CAS) Commercial advertisement (CAS) should render the upload-description-evidence question 1`] = `
+"<main id="main-content" role="main" class="govuk-main-wrapper govuk-main-wrapper--auto-spacing">
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds"><span class="govuk-caption-l">Upload documents</span>
+            <h1 class="govuk-heading-l">Upload evidence of your agreement to change the description of development</h1>
+            <p class="govuk-body">For example, an email or letter from the local planning authority that
+                confirms they have changed the description of development.</p>
+            <form action=""
+            method="post" novalidate=null enctype="multipart/form-data">
+                <div class="moj-multi-file-upload">
+                    <div class="moj-multi-file__uploaded-files" aria-live="polite">
+                        <div class="moj-multi-file__uploaded-files-container moj-hidden">
+                            <h2 class="govuk-heading-m" id="-uploaded-files-heading">Files added</h2>
+                            <ul class="govuk-summary-list moj-multi-file-upload__list"></ul>
+                        </div>
+                    </div>
+                    <div class="moj-multi-file-upload__upload">
+                        <div class="govuk-form-group">
+                            <label class="govuk-label govuk-label--m" for="uploadChangeOfDescriptionEvidence">Upload files</label>
+                            <div id="uploadChangeOfDescriptionEvidence-hint" class="govuk-hint">The files must be a DOC, DOCX, PDF, TIF, JPG or PNG and be smaller than
+                                1GB</div>
+                            <input class="govuk-file-upload moj-multi-file-upload__input"
+                            id="uploadChangeOfDescriptionEvidence" name="uploadChangeOfDescriptionEvidence"
+                            type="file" aria-describedby="uploadChangeOfDescriptionEvidence-hint" multiple="">
+                        </div>
+                        <button value="upload-and-remain-on-page" type="submit" name="upload-and-remain-on-page"
+                        class="govuk-button govuk-button--secondary moj-multi-file-upload__button"
+                        data-module="govuk-button" data-cy="button-upload-file">Upload file</button>
+                    </div>
+                </div>
+                <div class="govuk-button-group">
+                    <button type="submit" class="govuk-button" data-module="govuk-button"
+                    data-cy="button-save-and-continue">Continue</button>
+                </div>
+            </form>
+        </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+            <p class="govuk-body"><a href="/appeals/adverts/appeal-form/your-appeal?id=appeal-ref" class="govuk-link">Return to your appeal</a>
+            </p>
+        </div>
+    </div>
+</main>"
+`;
+
+exports[`Dynamic forms journey tests appellant Commercial advertisement (CAS) Commercial advertisement (CAS) should render the upload-plans-drawings-documents question 1`] = `
+"<main id="main-content" role="main" class="govuk-main-wrapper govuk-main-wrapper--auto-spacing">
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds"><span class="govuk-caption-l">Upload documents</span>
+            <h1 class="govuk-heading-l">Upload your plans, drawings and supporting documents you submitted with your application</h1>
+            <p class="govuk-body">You must upload all of the plans, drawings and supporting documents that
+                you submitted to the local planning authority with your planning application.</p>
+            <p
+            class="govuk-body">Do not include any new or updated documents. We’ll ask for these later.</p>
+                <form
+                action="" method="post" novalidate=null enctype="multipart/form-data">
+                    <div class="moj-multi-file-upload">
+                        <div class="moj-multi-file__uploaded-files" aria-live="polite">
+                            <div class="moj-multi-file__uploaded-files-container moj-hidden">
+                                <h2 class="govuk-heading-m" id="-uploaded-files-heading">Files added</h2>
+                                <ul class="govuk-summary-list moj-multi-file-upload__list"></ul>
+                            </div>
+                        </div>
+                        <div class="moj-multi-file-upload__upload">
+                            <div class="govuk-form-group">
+                                <label class="govuk-label govuk-label--m" for="uploadPlansDrawings">Upload files</label>
+                                <div id="uploadPlansDrawings-hint" class="govuk-hint">The files must be a DOC, DOCX, PDF, TIF, JPG or PNG and be smaller than
+                                    1GB</div>
+                                <input class="govuk-file-upload moj-multi-file-upload__input"
+                                id="uploadPlansDrawings" name="uploadPlansDrawings" type="file" aria-describedby="uploadPlansDrawings-hint"
+                                multiple="">
+                            </div>
+                            <button value="upload-and-remain-on-page" type="submit" name="upload-and-remain-on-page"
+                            class="govuk-button govuk-button--secondary moj-multi-file-upload__button"
+                            data-module="govuk-button" data-cy="button-upload-file">Upload file</button>
+                        </div>
+                    </div>
+                    <div class="govuk-button-group">
+                        <button type="submit" class="govuk-button" data-module="govuk-button"
+                        data-cy="button-save-and-continue">Continue</button>
+                    </div>
+                    </form>
+        </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+            <p class="govuk-body"><a href="/appeals/adverts/appeal-form/your-appeal?id=appeal-ref" class="govuk-link">Return to your appeal</a>
+            </p>
+        </div>
+    </div>
+</main>"
+`;
+
+exports[`Dynamic forms journey tests appellant Commercial advertisement (CAS) renders listing page 1`] = `
+"<main id="main-content" role="main" class="govuk-main-wrapper govuk-main-wrapper--auto-spacing">
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds"><span class="govuk-caption-l"> Commercial advertisement (CAS) Appeal</span>
+        </div>
+    </div>
+    <style>
+        .appeal-details .govuk-summary-list__key,
+          .appeal-details .govuk-summary-list__value,
+          .appeal-details .govuk-summary-list__actions {
+              padding-top: 0.2rem;
+              padding-bottom: 0;
+          }
+    </style>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-full govuk-!-margin-bottom-3">
+            <h1 class="govuk-heading-l"> Your appeal</h1>
+        </div>
+        <div class="govuk-grid-column-full">
+            <p class="govuk-body">Your deadline to submit this appeal is 25 Sep 2025.</p>
+            <p class="govuk-body"><a href="/appeals/your-appeals" class="govuk-link--no-visited-state">Save and come back later</a>.</p>
+            <hr
+            class="govuk-section-break govuk-section-break--visible govuk-section-break--l">
+        </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-three-quarters-from-desktop">
+            <p class="govuk-body govuk-!-font-weight-bold">Appeal incomplete</p>
+            <p class="govuk-!-margin-bottom-7">You have completed 0 of 3 sections.</p>
+        </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-full">
+            <style>
+                .app-task-list {
+                          padding-left: 0;
+                        }
+                        .app-task-list>li {
+                          position: relative;
+                          list-style-type: none;
+                
+                        }
+                        .app-task-list__section .govuk-tag {
+                          position: absolute;
+                          top: 3px;
+                          right: 0;
+                        }
+                        .app-task-list .govuk-summary-list {
+                          border-top: 1px solid #b1b4b6;
+                        }
+            </style>
+            <ol class="app-task-list">
+                <li class="govuk-!-margin-bottom-9">
+                    <div class="app-task-list__section">
+                        <h2 class="govuk-heading-m"><span class="app-task-list__section-number">1. </span> Prepare appeal<strong class="govuk-tag govuk-tag--grey moj-task-list__task-completed"> Not started</strong></h2>
+                    </div>
+                    <dl class="govuk-summary-list">
+                        <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Was the application made in your name? </dt>
+                            <dd
+                            class="govuk-summary-list__value">Not started</dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals/adverts/prepare-appeal/application-name?id=appeal-ref">Answer<span class="govuk-visually-hidden"> Was the application made in your name?</span></a>
+                                </dd>
+                        </div>
+                        <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Contact details</dt>
+                            <dd class="govuk-summary-list__value">Not started</dd>
+                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals/adverts/prepare-appeal/contact-details?id=appeal-ref">Answer<span class="govuk-visually-hidden"> Contact details</span></a>
+                            </dd>
+                        </div>
+                        <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> What is your phone number?</dt>
+                            <dd
+                            class="govuk-summary-list__value">Not started</dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals/adverts/prepare-appeal/phone-number?id=appeal-ref">Answer<span class="govuk-visually-hidden"> What is your phone number?</span></a>
+                                </dd>
+                        </div>
+                        <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> What is the address of the appeal site?</dt>
+                            <dd
+                            class="govuk-summary-list__value">Not started</dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals/adverts/prepare-appeal/appeal-site-address?id=appeal-ref">Answer<span class="govuk-visually-hidden"> What is the address of the appeal site?</span></a>
+                                </dd>
+                        </div>
+                        <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Is the appeal site on highway land?</dt>
+                            <dd
+                            class="govuk-summary-list__value">Not started</dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals/adverts/prepare-appeal/highway-land?id=appeal-ref">Answer<span class="govuk-visually-hidden"> Is the appeal site on highway land?</span></a>
+                                </dd>
+                        </div>
+                        <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Is the advertisement in position?</dt>
+                            <dd
+                            class="govuk-summary-list__value">Not started</dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals/adverts/prepare-appeal/advertisement-position?id=appeal-ref">Answer<span class="govuk-visually-hidden"> Is the advertisement in position?</span></a>
+                                </dd>
+                        </div>
+                        <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> What is the area of the appeal site?</dt>
+                            <dd
+                            class="govuk-summary-list__value">Not started</dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals/adverts/prepare-appeal/site-area?id=appeal-ref">Answer<span class="govuk-visually-hidden"> What is the area of the appeal site?</span></a>
+                                </dd>
+                        </div>
+                        <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Is the appeal site in a green belt?</dt>
+                            <dd
+                            class="govuk-summary-list__value">Not started</dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals/adverts/prepare-appeal/green-belt?id=appeal-ref">Answer<span class="govuk-visually-hidden"> Is the appeal site in a green belt?</span></a>
+                                </dd>
+                        </div>
+                        <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Do you own all of the land involved in the appeal?</dt>
+                            <dd
+                            class="govuk-summary-list__value">Not started</dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals/adverts/prepare-appeal/own-all-land?id=appeal-ref">Answer<span class="govuk-visually-hidden"> Do you own all of the land involved in the appeal?</span></a>
+                                </dd>
+                        </div>
+                        <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Have you attempted to identify the landowners?</dt>
+                            <dd
+                            class="govuk-summary-list__value">Not started</dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals/adverts/prepare-appeal/identifying-landowners?id=appeal-ref">Answer<span class="govuk-visually-hidden"> Identifying the landowners</span></a>
+                                </dd>
+                        </div>
+                        <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Do you have the landowner’s permission?</dt>
+                            <dd
+                            class="govuk-summary-list__value">Not started</dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals/adverts/prepare-appeal/landowner-permission?id=appeal-ref">Answer<span class="govuk-visually-hidden"> Do you have the landowner’s permission?</span></a>
+                                </dd>
+                        </div>
+                        <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Have the landowners been told about the appeal?</dt>
+                            <dd
+                            class="govuk-summary-list__value">Not started</dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals/adverts/prepare-appeal/telling-landowners?id=appeal-ref">Answer<span class="govuk-visually-hidden"> Telling the landowners</span></a>
+                                </dd>
+                        </div>
+                        <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Will an inspector need to access your land or property?</dt>
+                            <dd
+                            class="govuk-summary-list__value">Not started</dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals/adverts/prepare-appeal/inspector-need-access?id=appeal-ref">Answer<span class="govuk-visually-hidden"> Will an inspector need to access your land or property?</span></a>
+                                </dd>
+                        </div>
+                        <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Are there any health and safety issues on the appeal site?</dt>
+                            <dd
+                            class="govuk-summary-list__value">Not started</dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals/adverts/prepare-appeal/health-safety-issues?id=appeal-ref">Answer<span class="govuk-visually-hidden"> Health and safety issues</span></a>
+                                </dd>
+                        </div>
+                        <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> What is the application reference number?</dt>
+                            <dd
+                            class="govuk-summary-list__value">Not started</dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals/adverts/prepare-appeal/reference-number?id=appeal-ref">Answer<span class="govuk-visually-hidden"> What is the application reference number?</span></a>
+                                </dd>
+                        </div>
+                        <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> What date did you submit your application?</dt>
+                            <dd
+                            class="govuk-summary-list__value">Not started</dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals/adverts/prepare-appeal/application-date?id=appeal-ref">Answer<span class="govuk-visually-hidden"> What date did you submit your application?</span></a>
+                                </dd>
+                        </div>
+                        <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Enter the description of the advertisement</dt>
+                            <dd
+                            class="govuk-summary-list__value">Not started</dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals/adverts/prepare-appeal/description-advertisement?id=appeal-ref">Answer<span class="govuk-visually-hidden"> Enter the description of the advertisement that you submitted in your application</span></a>
+                                </dd>
+                        </div>
+                        <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Did the local planning authority change the description of the advertisement?</dt>
+                            <dd
+                            class="govuk-summary-list__value">Not started</dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals/adverts/prepare-appeal/description-advertisement-correct?id=appeal-ref">Answer<span class="govuk-visually-hidden"> Did the local planning authority change the description of the advertisement?</span></a>
+                                </dd>
+                        </div>
+                        <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Are there other appeals linked to your development?</dt>
+                            <dd
+                            class="govuk-summary-list__value">Not started</dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals/adverts/prepare-appeal/other-appeals?id=appeal-ref">Answer<span class="govuk-visually-hidden"> Are there other appeals linked to your development?</span></a>
+                                </dd>
+                        </div>
+                    </dl>
+                </li>
+                <li class="govuk-!-margin-bottom-9">
+                    <div class="app-task-list__section">
+                        <h2 class="govuk-heading-m"><span class="app-task-list__section-number">2. </span> Upload documents<strong class="govuk-tag govuk-tag--grey moj-task-list__task-completed"> Not started</strong></h2>
+                    </div>
+                    <dl class="govuk-summary-list">
+                        <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Application form</dt>
+                            <dd class="govuk-summary-list__value">Not started</dd>
+                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals/adverts/upload-documents/upload-application-form?id=appeal-ref">Upload<span class="govuk-visually-hidden"> your application form</span></a>
+                            </dd>
+                        </div>
+                        <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Decision letter</dt>
+                            <dd class="govuk-summary-list__value">Not started</dd>
+                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals/adverts/upload-documents/upload-decision-letter?id=appeal-ref">Upload<span class="govuk-visually-hidden"> the decision letter from the local planning authority</span></a>
+                            </dd>
+                        </div>
+                        <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Appeal statement</dt>
+                            <dd class="govuk-summary-list__value">Not started</dd>
+                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals/adverts/upload-documents/upload-appeal-statement?id=appeal-ref">Upload<span class="govuk-visually-hidden"> your appeal statement</span></a>
+                            </dd>
+                        </div>
+                        <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Do you need to apply for an award of appeal costs?</dt>
+                            <dd
+                            class="govuk-summary-list__value">Not started</dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals/adverts/upload-documents/apply-appeal-costs?id=appeal-ref">Answer<span class="govuk-visually-hidden"> Do you need to apply for an award of appeal costs?</span></a>
+                                </dd>
+                        </div>
+                        <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Plans, drawings and supporting documents</dt>
+                            <dd
+                            class="govuk-summary-list__value">Not started</dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals/adverts/upload-documents/upload-plans-drawings-documents?id=appeal-ref">Upload<span class="govuk-visually-hidden"> your plans, drawings and supporting documents you submitted with your application</span></a>
+                                </dd>
+                        </div>
+                    </dl>
+                </li>
+                <li>
+                    <div class="app-task-list__section">
+                        <h2 class="govuk-heading-m"><span class="app-task-list__section-number">3. </span> Submit<strong class="govuk-tag govuk-tag--grey"> Cannot start yet</strong></h2>
+                        <dl class="govuk-summary-list">
+                            <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Accept declaration and submit</dt>
+                                <dd
+                                class="govuk-summary-list__value"></dd>
+                            </div>
+                        </dl>
+                    </div>
+                </li>
+            </ol>
+        </div>
+    </div>
+</main>"
+`;
+
 exports[`Dynamic forms journey tests appellant Commercial planning (CAS) Commercial planning (CAS) should render the advertising-appeal question 1`] = `
 "<main id="main-content" role="main" class="govuk-main-wrapper govuk-main-wrapper--auto-spacing">
     <div class="govuk-grid-row">

--- a/packages/forms-web-app/src/lib/get-next-page-from-can-use-service-page.js
+++ b/packages/forms-web-app/src/lib/get-next-page-from-can-use-service-page.js
@@ -3,7 +3,6 @@ const {
 		HOUSEHOLDER_PLANNING,
 		LISTED_BUILDING,
 		MINOR_COMMERCIAL_DEVELOPMENT,
-		MINOR_COMMERCIAL_ADVERTISEMENT,
 		ADVERTISEMENT,
 		PRIOR_APPROVAL,
 		REMOVAL_OR_VARIATION_OF_CONDITIONS
@@ -50,11 +49,11 @@ const getNextPageFromCanUseServicePage = async (appeal) => {
 				return nextPage.casAppeal;
 			}
 			return nextPage.fullAppeal;
-		case MINOR_COMMERCIAL_ADVERTISEMENT:
-			return nextPage.advert;
 		case ADVERTISEMENT:
+			if (applicationDecision === REFUSED) {
+				return nextPage.casAdvert;
+			}
 			return nextPage.advert;
-
 		default:
 			return nextPage.fullAppeal;
 	}
@@ -82,9 +81,8 @@ const getNextPage = async (/** @type {string} */ lpaCode) => {
 			isV2forS20 ? 'email-address' : 'planning-application-number'
 		}`,
 		casAppeal: `/cas-planning/${isV2forCAS ? 'email-address' : 'planning-application-number'}`,
-		advert: `/adverts/${
-			isV2forCASAdverts || isV2forAdverts ? 'email-address' : 'planning-application-number'
-		}`
+		casAdvert: `/adverts/${isV2forCASAdverts ? 'email-address' : 'planning-application-number'}`,
+		advert: `/adverts/${isV2forAdverts ? 'email-address' : 'planning-application-number'}`
 	};
 };
 

--- a/packages/forms-web-app/src/lib/get-next-page-from-can-use-service-page.test.js
+++ b/packages/forms-web-app/src/lib/get-next-page-from-can-use-service-page.test.js
@@ -6,7 +6,8 @@ const {
 		HOUSEHOLDER_PLANNING,
 		PRIOR_APPROVAL,
 		REMOVAL_OR_VARIATION_OF_CONDITIONS,
-		LISTED_BUILDING
+		LISTED_BUILDING,
+		ADVERTISEMENT
 	},
 	APPLICATION_DECISION: { REFUSED, GRANTED, NODECISIONRECEIVED },
 	APPEAL_ID
@@ -18,6 +19,7 @@ const { getNextPageFromCanUseServicePage } = require('./get-next-page-from-can-u
 const householderNextPage = '/appeal-householder-decision/email-address';
 const fullAppealNextPage = '/full-appeal/submit-appeal/email-address';
 const listedBuildingNextPage = '/listed-building/email-address';
+const advertNextPage = '/adverts/email-address';
 
 jest.mock('../../src/lib/is-lpa-in-feature-flag.js');
 
@@ -131,6 +133,24 @@ describe('getNextPageFromCanUseServicePage', () => {
 			eligibility: {}
 		};
 		expect(await getNextPageFromCanUseServicePage(appeal)).toEqual(listedBuildingNextPage);
+	});
+
+	it('returns correct page (advert) for cas advert application', async () => {
+		const appeal = {
+			typeOfPlanningApplication: ADVERTISEMENT,
+			appealType: APPEAL_ID.MINOR_COMMERCIAL_ADVERTISEMENT,
+			eligibility: {}
+		};
+		expect(await getNextPageFromCanUseServicePage(appeal)).toEqual(advertNextPage);
+	});
+
+	it('returns correct page (advert) for advert application', async () => {
+		const appeal = {
+			typeOfPlanningApplication: ADVERTISEMENT,
+			appealType: APPEAL_ID.ADVERTISEMENT,
+			eligibility: {}
+		};
+		expect(await getNextPageFromCanUseServicePage(appeal)).toEqual(advertNextPage);
 	});
 
 	it.each([[FULL_APPEAL], [OUTLINE_PLANNING, RESERVED_MATTERS]])(

--- a/packages/forms-web-app/src/lib/type-of-planning-application-radio-items.js
+++ b/packages/forms-web-app/src/lib/type-of-planning-application-radio-items.js
@@ -26,6 +26,7 @@ const {
 exports.typeOfPlanningApplicationRadioItems = (
 	isS20featureFlag,
 	isCASPlanningFeatureFlag,
+	isCASAdvertsFeatureFlag,
 	isAdvertsFeatureFlag,
 	typeOfPlanningApplication
 ) => {
@@ -134,7 +135,7 @@ exports.typeOfPlanningApplicationRadioItems = (
 		? s20Filtered
 		: s20Filtered.filter((item) => item.value !== MINOR_COMMERCIAL_DEVELOPMENT);
 	// only return the minor commercial advertisment option if feature flag turned on
-	return isAdvertsFeatureFlag
+	return isAdvertsFeatureFlag || isCASAdvertsFeatureFlag
 		? casPlanningFiltered
 		: casPlanningFiltered.filter((item) => item.value !== ADVERTISEMENT);
 };

--- a/packages/forms-web-app/src/lib/type-of-planning-application-radio-items.test.js
+++ b/packages/forms-web-app/src/lib/type-of-planning-application-radio-items.test.js
@@ -13,36 +13,43 @@ const {
 
 describe('typeOfPlanningApplicationRadioItems', () => {
 	it('returns items list with listed building if s20 feature flag true', () => {
-		const itemsList = typeOfPlanningApplicationRadioItems(true, false, false);
+		const itemsList = typeOfPlanningApplicationRadioItems(true, false, false, false);
 		expect(itemsList.length).toEqual(10);
 		expect(itemsList[2].value).toEqual(LISTED_BUILDING);
 	});
 
 	it('returns items list without conditionals if feature flags false', () => {
-		const itemsList = typeOfPlanningApplicationRadioItems(false, false, false);
+		const itemsList = typeOfPlanningApplicationRadioItems(false, false, false, false);
 		expect(itemsList.length).toEqual(9);
 		expect(itemsList[2].value).toEqual(OUTLINE_PLANNING);
 	});
 
 	it('returns items list without minor commercial if feature flag false', () => {
-		const itemsList = typeOfPlanningApplicationRadioItems(false, false, false);
+		const itemsList = typeOfPlanningApplicationRadioItems(false, false, false, false);
 		expect(itemsList.length).toEqual(9);
 		expect(itemsList[2].value).toEqual(OUTLINE_PLANNING);
 	});
 
 	it('returns minor commercial if feature flag true', () => {
-		const itemsList = typeOfPlanningApplicationRadioItems(false, true, false);
+		const itemsList = typeOfPlanningApplicationRadioItems(false, true, false, false);
 		expect(itemsList.length).toEqual(10);
 		expect(itemsList[2].value).toEqual(MINOR_COMMERCIAL_DEVELOPMENT);
 	});
-	it('returns advertisement if feature flag true', () => {
-		const itemsList = typeOfPlanningApplicationRadioItems(false, false, true);
+
+	it('returns advertisement if cas advert feature flag true', () => {
+		const itemsList = typeOfPlanningApplicationRadioItems(false, false, true, false);
+		expect(itemsList.length).toEqual(10);
+		expect(itemsList[2].value).toEqual(ADVERTISEMENT);
+	});
+
+	it('returns advertisement if advert feature flag true', () => {
+		const itemsList = typeOfPlanningApplicationRadioItems(false, false, false, true);
 		expect(itemsList.length).toEqual(10);
 		expect(itemsList[2].value).toEqual(ADVERTISEMENT);
 	});
 
 	it('sets checked for type of planning application', () => {
-		const itemsList = typeOfPlanningApplicationRadioItems(true, false, false, FULL_APPEAL);
+		const itemsList = typeOfPlanningApplicationRadioItems(true, false, false, false, FULL_APPEAL);
 		expect(itemsList[0].checked).toEqual(true);
 	});
 });


### PR DESCRIPTION
### Description of change

- Removing MINOR_COMMERCIAL_ADVERTISEMENT as a type of planning application
- Adding logic to set the appeal type depending on the answer to the 'granted or refused' question
- Making sure behaviour was correct when different combinations of cas advert and advert feature flags are enabled
- Making sure that both CAS advert and advert are able to access the appeal form
- Updating/adding relevant tests

Ticket: https://pins-ds.atlassian.net/browse/A2-3652

### Testing
Updated various tests
Manual testing:

- CAS advert: false
- Advert: false
'Displaying an advertisement' does not show up as an option in the 'What type of application is your appeal about?' radio
<img width="742" height="1183" alt="image" src="https://github.com/user-attachments/assets/5c3cd921-4793-4fe5-8635-31b61fda82c0" />


- CAS advert: true
- Advert: false
'Displaying an advertisement' does show up as an option in the 'What type of application is your appeal about?' radio
<img width="739" height="1222" alt="image" src="https://github.com/user-attachments/assets/50b38e6e-9a6c-40e9-b5be-b7cb66d82e8e" />

If you answer 'Refused' for 'Was your application granted or refused?' you continue through the flow as appeal type CAS advert (MINOR_COMMERCIAL_ADVERTISEMENT). If you answer 'Granted with conditions' or 'I have not received a decision' you are redirected to the 'You need to use the existing service page'

- CAS advert: false
- Advert: true
'Displaying an advertisement' does show up as an option in the 'What type of application is your appeal about?' radio (see above image)

If you answer 'Granted with conditions' or 'I have not received a decision' for 'Was your application granted or refused?' you continue through the flow as appeal type advert (ADVERTISEMENT). If you answer 'Refused' you are redirected to the 'You need to use the existing service page'

- CAS advert: true
- Advert: true
'Displaying an advertisement' does show up as an option in the 'What type of application is your appeal about?' radio (see above image)

If you answer 'Granted with conditions' or 'I have not received a decision' for 'Was your application granted or refused?' you continue through the flow as appeal type advert (ADVERTISEMENT). If you answer 'Refused' you continue through the flow as appeal type CAS advert (MINOR_COMMERCIAL_ADVERTISEMENT)

In the appeals list the appeals show up as the correct appeal type, and you are able to access the appeal form for both appeal types.

### Checklist

- [x] Feature complete and ready for users, or behind feature-flag
- [x] Commit history is linear with no merge commits
- [ ] Requires infrastructure changes

### Important

Please do not merge from `main` (please only [rebase](https://github.com/Planning-Inspectorate/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
