### PR TITLE
feat: adding the upload change of advertisement evidence question(A2-3…

### DIFF
--- a/packages/forms-web-app/src/dynamic-forms/adverts-appeal-form/journey.js
+++ b/packages/forms-web-app/src/dynamic-forms/adverts-appeal-form/journey.js
@@ -80,7 +80,10 @@ const makeSections = (response) => [
 		.addQuestion(questions.planningApplicationDate)
 		.addQuestion(questions.enterAdvertisementDescription)
 		.addQuestion(questions.updateAdvertisementDescription)
-		// upload description advertisement question placeholder with condition on whether LPA changed advertisement description
+		.addQuestion(questions.uploadChangeOfAdvertisementEvidence)
+		.withCondition(() =>
+			questionHasAnswer(response, questions.updateAdvertisementDescription, 'yes')
+		)
 		.addQuestion(questions.anyOtherAppeals)
 		.addQuestion(questions.linkAppeals)
 		.withCondition(() => questionHasAnswer(response, questions.anyOtherAppeals, 'yes')),

--- a/packages/forms-web-app/src/dynamic-forms/docs/adverts-appeal-form-journey.md
+++ b/packages/forms-web-app/src/dynamic-forms/docs/adverts-appeal-form-journey.md
@@ -82,6 +82,12 @@ condition: () => shouldDisplayTellingLandowners(response, questions);
 - date `/application-date/` What date did you submit your application?
 - text-entry `/description-advertisement/` Enter the description of the advertisement that you submitted in your application
 - boolean `/description-advertisement-correct/` Did the local planning authority change the description of the advertisement?
+- multi-file-upload `/upload-description-evidence/` Upload evidence of your agreement to change the description of the advertisement
+
+```js
+condition: () => questionHasAnswer(response, questions.updateAdvertisementDescription, 'yes');
+```
+
 - boolean `/other-appeals/` Are there other appeals linked to your development?
 - list-add-more `/enter-appeal-reference/` Add another appeal?
 

--- a/packages/forms-web-app/src/dynamic-forms/questions.js
+++ b/packages/forms-web-app/src/dynamic-forms/questions.js
@@ -2690,6 +2690,23 @@ exports.questionProps = {
 				}
 			})
 		]
+	},
+	uploadChangeOfAdvertisementEvidence: {
+		type: 'multi-file-upload',
+		title: 'Upload evidence of your agreement to change the description of the advertisement',
+		question: 'Upload evidence of your agreement to change the description of the advertisement',
+		description:
+			'For example, an email or letter from the local planning authority that confirms they have changed the description of the advertisement.',
+		fieldName: 'uploadChangeOfDescriptionEvidence',
+		url: 'upload-description-evidence',
+		validators: [
+			new RequiredFileUploadValidator(
+				'Select the evidence of your agreement to change the description of the advertisement'
+			),
+			new MultifileUploadValidator()
+		],
+		documentType: documentTypes.uploadChangeOfDescriptionEvidence,
+		actionHiddenText: 'evidence of your agreement to change the description of the advertisement'
 	}
 };
 

--- a/packages/forms-web-app/src/journeys/__snapshots__/index.test.js.snap
+++ b/packages/forms-web-app/src/journeys/__snapshots__/index.test.js.snap
@@ -1418,6 +1418,52 @@ exports[`Dynamic forms journey tests appellant Advertisement Advertisement shoul
 </main>"
 `;
 
+exports[`Dynamic forms journey tests appellant Advertisement Advertisement should render the upload-description-evidence question 1`] = `
+"<main id="main-content" role="main" class="govuk-main-wrapper govuk-main-wrapper--auto-spacing">
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds"><span class="govuk-caption-l">Prepare appeal</span>
+            <h1 class="govuk-heading-l">Upload evidence of your agreement to change the description of the advertisement</h1>
+            <p class="govuk-body">For example, an email or letter from the local planning authority that
+                confirms they have changed the description of the advertisement.</p>
+            <form
+            action="" method="post" novalidate=null enctype="multipart/form-data">
+                <div class="moj-multi-file-upload">
+                    <div class="moj-multi-file__uploaded-files" aria-live="polite">
+                        <div class="moj-multi-file__uploaded-files-container moj-hidden">
+                            <h2 class="govuk-heading-m" id="-uploaded-files-heading">Files added</h2>
+                            <ul class="govuk-summary-list moj-multi-file-upload__list"></ul>
+                        </div>
+                    </div>
+                    <div class="moj-multi-file-upload__upload">
+                        <div class="govuk-form-group">
+                            <label class="govuk-label govuk-label--m" for="uploadChangeOfDescriptionEvidence">Upload files</label>
+                            <div id="uploadChangeOfDescriptionEvidence-hint" class="govuk-hint">The files must be a DOC, DOCX, PDF, TIF, JPG or PNG and be smaller than
+                                1GB</div>
+                            <input class="govuk-file-upload moj-multi-file-upload__input"
+                            id="uploadChangeOfDescriptionEvidence" name="uploadChangeOfDescriptionEvidence"
+                            type="file" aria-describedby="uploadChangeOfDescriptionEvidence-hint" multiple="">
+                        </div>
+                        <button value="upload-and-remain-on-page" type="submit" name="upload-and-remain-on-page"
+                        class="govuk-button govuk-button--secondary moj-multi-file-upload__button"
+                        data-module="govuk-button" data-cy="button-upload-file">Upload file</button>
+                    </div>
+                </div>
+                <div class="govuk-button-group">
+                    <button type="submit" class="govuk-button" data-module="govuk-button"
+                    data-cy="button-save-and-continue">Continue</button>
+                </div>
+                </form>
+        </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+            <p class="govuk-body"><a href="/appeals/adverts/appeal-form/your-appeal?id=appeal-ref" class="govuk-link">Return to your appeal</a>
+            </p>
+        </div>
+    </div>
+</main>"
+`;
+
 exports[`Dynamic forms journey tests appellant Advertisement Advertisement should render the upload-plans-drawings-documents question 1`] = `
 "<main id="main-content" role="main" class="govuk-main-wrapper govuk-main-wrapper--auto-spacing">
     <div class="govuk-grid-row">
@@ -3090,6 +3136,52 @@ exports[`Dynamic forms journey tests appellant Commercial advertisement (CAS) Co
                     data-cy="button-save-and-continue">Continue</button>
                 </div>
             </form>
+        </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+            <p class="govuk-body"><a href="/appeals/adverts/appeal-form/your-appeal?id=appeal-ref" class="govuk-link">Return to your appeal</a>
+            </p>
+        </div>
+    </div>
+</main>"
+`;
+
+exports[`Dynamic forms journey tests appellant Commercial advertisement (CAS) Commercial advertisement (CAS) should render the upload-description-evidence question 1`] = `
+"<main id="main-content" role="main" class="govuk-main-wrapper govuk-main-wrapper--auto-spacing">
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds"><span class="govuk-caption-l">Prepare appeal</span>
+            <h1 class="govuk-heading-l">Upload evidence of your agreement to change the description of the advertisement</h1>
+            <p class="govuk-body">For example, an email or letter from the local planning authority that
+                confirms they have changed the description of the advertisement.</p>
+            <form
+            action="" method="post" novalidate=null enctype="multipart/form-data">
+                <div class="moj-multi-file-upload">
+                    <div class="moj-multi-file__uploaded-files" aria-live="polite">
+                        <div class="moj-multi-file__uploaded-files-container moj-hidden">
+                            <h2 class="govuk-heading-m" id="-uploaded-files-heading">Files added</h2>
+                            <ul class="govuk-summary-list moj-multi-file-upload__list"></ul>
+                        </div>
+                    </div>
+                    <div class="moj-multi-file-upload__upload">
+                        <div class="govuk-form-group">
+                            <label class="govuk-label govuk-label--m" for="uploadChangeOfDescriptionEvidence">Upload files</label>
+                            <div id="uploadChangeOfDescriptionEvidence-hint" class="govuk-hint">The files must be a DOC, DOCX, PDF, TIF, JPG or PNG and be smaller than
+                                1GB</div>
+                            <input class="govuk-file-upload moj-multi-file-upload__input"
+                            id="uploadChangeOfDescriptionEvidence" name="uploadChangeOfDescriptionEvidence"
+                            type="file" aria-describedby="uploadChangeOfDescriptionEvidence-hint" multiple="">
+                        </div>
+                        <button value="upload-and-remain-on-page" type="submit" name="upload-and-remain-on-page"
+                        class="govuk-button govuk-button--secondary moj-multi-file-upload__button"
+                        data-module="govuk-button" data-cy="button-upload-file">Upload file</button>
+                    </div>
+                </div>
+                <div class="govuk-button-group">
+                    <button type="submit" class="govuk-button" data-module="govuk-button"
+                    data-cy="button-save-and-continue">Continue</button>
+                </div>
+                </form>
         </div>
     </div>
     <div class="govuk-grid-row">


### PR DESCRIPTION
…897)

### Description of change

- Adding the new question
- Adding to the question flow
- Updating the snaps and docs

Ticket: https://pins-ds.atlassian.net/browse/A2-3897

### Testing

Manually checked (all screenshot from locally running version):

- Matches the copy deck
<img width="687" height="826" alt="image" src="https://github.com/user-attachments/assets/5b7b4b3d-1b9b-43f8-b4c4-96aabc830795" />

- Errors when the file is the incorrect type
<img width="690" height="997" alt="image" src="https://github.com/user-attachments/assets/12f0d86c-d337-4357-99f0-d1d6b1369632" />

- Errors when the file is too large
<img width="682" height="937" alt="image" src="https://github.com/user-attachments/assets/12eff07a-788e-4657-8d78-65b7c429de02" />

### Checklist

- [x] Feature complete and ready for users, or behind feature-flag
- [x] Commit history is linear with no merge commits
- [ ] Requires infrastructure changes

### Important

Please do not merge from `main` (please only [rebase](https://github.com/Planning-Inspectorate/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
