### PR TITLE
Feat(4148): Adding bys section to selected appeal details

### DIFF
--- a/packages/appeals-service-api/src/spec/api-types.d.ts
+++ b/packages/appeals-service-api/src/spec/api-types.d.ts
@@ -171,6 +171,19 @@ export interface AppealCase {
 		| 'minor-traveller-caravan'
 		| 'other-major'
 		| 'other-minor';
+	typeOfPlanningApplication?:
+		| 'full-appeal'
+		| 'householder-planning'
+		| 'listed-building'
+		| 'outline-planning'
+		| 'prior-approval'
+		| 'reserved-matters'
+		| 'removal-or-variation-of-conditions'
+		| 'minor-commercial-development'
+		| 'minor-commercial-advertisement'
+		| 'advertisement'
+		| 'something-else'
+		| 'i-have-not-made-a-planning-application';
 	/** Indicates if the LPA considers the appeal type appropriate */
 	isCorrectAppealType?: boolean;
 	/** Indicates if the appellant has applied for costs */

--- a/packages/appeals-service-api/src/spec/appeal-case.yaml
+++ b/packages/appeals-service-api/src/spec/appeal-case.yaml
@@ -215,7 +215,23 @@ components:
               'other-minor',
               null
             ]
-
+        typeOfPlanningApplication:
+          type: string
+          enum: 
+            [
+              'full-appeal',
+              'householder-planning',
+              'listed-building',
+              'outline-planning',
+              'prior-approval',
+              'reserved-matters',
+              'removal-or-variation-of-conditions',
+              'minor-commercial-development',
+              'minor-commercial-advertisement',
+              'advertisement',
+              'something-else',
+              'i-have-not-made-a-planning-application'
+            ]
         # LPA fields
         isCorrectAppealType:
           type: boolean

--- a/packages/common/src/view-model-maps/appeal-headline.js
+++ b/packages/common/src/view-model-maps/appeal-headline.js
@@ -12,11 +12,16 @@ const { caseTypeNameWithDefault } = require('../lib/format-case-type');
  */
 
 /**
- * @param {AppealCaseDetailed} caseData
- * @param {string} lpaName
- * @param {AppealToUserRoles|LpaUserRole|null} role
+ * @param {object} options
+ * @param {AppealCaseDetailed} options.caseData
+ * @param {string} [options.lpaName='']
+ * @param {AppealToUserRoles|LpaUserRole|null} [options.role=APPEAL_USER_ROLES.INTERESTED_PARTY]
  */
-const formatHeadlineData = (caseData, lpaName, role = APPEAL_USER_ROLES.INTERESTED_PARTY) => {
+const formatHeadlineData = ({
+	caseData,
+	lpaName = '',
+	role = APPEAL_USER_ROLES.INTERESTED_PARTY
+}) => {
 	const { caseReference, appealTypeCode, caseProcedure, users, applicationReference, linkedCases } =
 		caseData;
 
@@ -45,10 +50,12 @@ const formatHeadlineData = (caseData, lpaName, role = APPEAL_USER_ROLES.INTEREST
 			key: applicant.key,
 			value: applicant.value
 		},
-		{
-			key: { text: 'Local planning authority' },
-			value: { text: lpaName }
-		},
+		lpaName
+			? {
+					key: { text: 'Local planning authority' },
+					value: { text: lpaName }
+				}
+			: {},
 		{
 			key: { text: 'Application number' },
 			value: { text: applicationReference }
@@ -87,7 +94,7 @@ const shouldFormatHeadlines = (_caseData, userType) =>
  */
 const displayHeadlinesByUser = (caseData, lpaName, userType) => {
 	if (shouldFormatHeadlines(caseData, userType)) {
-		return formatHeadlineData(caseData, lpaName, userType);
+		return formatHeadlineData({ caseData, lpaName, role: userType });
 	}
 	return null;
 };

--- a/packages/forms-web-app/src/controllers/selected-appeal/appeal-details/appeal-before-you-start-rows.js
+++ b/packages/forms-web-app/src/controllers/selected-appeal/appeal-details/appeal-before-you-start-rows.js
@@ -1,0 +1,67 @@
+const { boolToYesNo } = require('@pins/common');
+const { formatDateForDisplay } = require('@pins/common/src/lib/format-date');
+
+/**
+ * @typedef {import('appeals-service-api').Api.AppealCaseDetailed} AppealCaseDetailed
+ * @typedef {import("@pins/common/src/view-model-maps/rows/def").Rows} Rows
+ */
+
+/**
+ * @param {AppealCaseDetailed} caseData
+ * @param {string} lpaName
+ * @returns {Rows}
+ */
+exports.bysRows = (caseData, lpaName) => [
+	{
+		keyText: 'Which local planning authority (LPA) do you want to appeal against?',
+		valueText: lpaName,
+		condition: () => true
+	},
+	{
+		keyText: 'Have you received an enforcement notice?',
+		valueText: boolToYesNo(false), // is always false for appeals that have been submitted
+		condition: () => true
+	},
+	{
+		keyText: 'What type of application is your appeal about?',
+		valueText: caseData.typeOfPlanningApplication
+			? applicationTypeMappings[caseData.typeOfPlanningApplication]
+			: '',
+		condition: () => true
+	},
+	{
+		keyText: 'What date did you submit your application?',
+		valueText: formatDateForDisplay(caseData.applicationDate),
+		condition: (caseData) => caseData.applicationDate != null
+	},
+	{
+		keyText: 'Was your application granted or refused?',
+		valueText: mapApplicationDecision(caseData.applicationDecision),
+		condition: () => true
+	},
+	{
+		keyText: 'What is the date on the decision letter from the local planning authority?',
+		valueText: formatDateForDisplay(caseData.applicationDecisionDate),
+		condition: () => true
+	}
+];
+
+const applicationTypeMappings = {
+	'full-appeal': 'Full planning',
+	'householder-planning': 'Householder planning',
+	'listed-building': 'Listed building consent',
+	advertisement: 'Displaying an advertisement',
+	'minor-commercial-development': 'Minor commercial development',
+	'minor-commercial-advertisement': 'Minor commercial advertisement',
+	'outline-planning': 'Outline planning',
+	'prior-approval': 'Prior approval',
+	'reserved-matters': 'Reserved matters',
+	'removal-or-variation-of-conditions': 'Removal or variation of conditions',
+	'something-else': 'Something else',
+	'i-have-not-made-a-planning-application': 'I have not made a planning application'
+};
+
+const mapApplicationDecision = (/** @type {string} */ decison) => {
+	if (decison === 'not_received') return 'I have not received a decision';
+	return decison.replace(/^\w/, (c) => c.toUpperCase());
+};

--- a/packages/forms-web-app/src/controllers/selected-appeal/appeal-details/appeal-before-you-start-rows.test.js
+++ b/packages/forms-web-app/src/controllers/selected-appeal/appeal-details/appeal-before-you-start-rows.test.js
@@ -1,0 +1,60 @@
+const { CASE_TYPES } = require('@pins/common/src/database/data-static');
+const { bysRows } = require('./appeal-before-you-start-rows');
+const { APPLICATION_DECISION } = require('@pins/business-rules/src/constants');
+
+describe('bys-rows', () => {
+	const caseData = {
+		caseReference: 'test-ref',
+		LPACode: '111111',
+		appealTypeCode: CASE_TYPES.S78.processCode,
+		applicationReference: 'app-ref',
+		enforcementNotice: false,
+		typeOfPlanningApplication: 'full-appeal',
+		applicationDate: '2025-01-01T08:00:00.000Z',
+		applicationDecision: APPLICATION_DECISION.REFUSED,
+		applicationDecisionDate: '2025-02-01T08:00:00.000Z',
+		siteAddressLine1: '1 test street',
+		siteAddressPostcode: '1TT 2AA'
+	};
+	/**
+	 * @type {import("@pins/common/src/view-model-maps/rows/def").Rows} Rows
+	 */
+	let rows;
+
+	// @ts-ignore
+	beforeEach(() => (rows = bysRows(caseData, 'Test LPA')));
+
+	it('should display the lpa name row', () => {
+		expect(rows[0].keyText).toEqual(
+			'Which local planning authority (LPA) do you want to appeal against?'
+		);
+		expect(rows[0].valueText).toEqual('Test LPA');
+	});
+
+	it('should display the enforcement notice row', () => {
+		expect(rows[1].keyText).toEqual('Have you received an enforcement notice?');
+		expect(rows[1].valueText).toEqual('No');
+	});
+
+	it('should display type of application the appeal is about row', () => {
+		expect(rows[2].keyText).toEqual('What type of application is your appeal about?');
+		expect(rows[2].valueText).toEqual('Full planning');
+	});
+
+	it('should display the date the application was submitted row', () => {
+		expect(rows[3].keyText).toEqual('What date did you submit your application?');
+		expect(rows[3].valueText).toEqual('1 Jan 2025');
+	});
+
+	it('should display whether the application was granted or refused row', () => {
+		expect(rows[4].keyText).toEqual('Was your application granted or refused?');
+		expect(rows[4].valueText).toEqual('Refused');
+	});
+
+	it('should display date on the decision letter from lpa row', () => {
+		expect(rows[5].keyText).toEqual(
+			'What is the date on the decision letter from the local planning authority?'
+		);
+		expect(rows[5].valueText).toEqual('1 Feb 2025');
+	});
+});

--- a/packages/forms-web-app/src/controllers/selected-appeal/appeal-details/appeal-details-rows.js
+++ b/packages/forms-web-app/src/controllers/selected-appeal/appeal-details/appeal-details-rows.js
@@ -11,7 +11,6 @@ const {
 } = require('@pins/common');
 const { CASE_TYPES } = require('@pins/common/src/database/data-static');
 const { APPEAL_USER_ROLES } = require('@pins/common/src/constants');
-const { formatDateForDisplay } = require('@pins/common/src/lib/format-date');
 const { fieldNames } = require('@pins/common/src/dynamic-forms/field-names');
 
 /**
@@ -156,11 +155,6 @@ exports.detailsRows = (caseData, userType) => {
 			keyText: 'Application reference',
 			valueText: caseData.applicationReference,
 			condition: (caseData) => caseData.applicationReference
-		},
-		{
-			keyText: 'What date did you submit your planning application?',
-			valueText: formatDateForDisplay(caseData.applicationDate),
-			condition: (caseData) => caseData.applicationDate != null
 		},
 		{
 			keyText: 'What is the development type?',

--- a/packages/forms-web-app/src/controllers/selected-appeal/appeal-details/appeal-details-rows.test.js
+++ b/packages/forms-web-app/src/controllers/selected-appeal/appeal-details/appeal-details-rows.test.js
@@ -490,7 +490,7 @@ describe('appeal-details-rows', () => {
 	});
 
 	describe('Enter the description of development', () => {
-		const descriptionIndex = 23;
+		const descriptionIndex = 22;
 
 		it('should display the development description if set', () => {
 			const testCase = structuredClone(caseWithAppellant);
@@ -511,7 +511,7 @@ describe('appeal-details-rows', () => {
 	});
 
 	describe('Did the local planning authority change the description of development?', () => {
-		const lpaChangedDescriptionIndex = 24;
+		const lpaChangedDescriptionIndex = 23;
 
 		it('should show Green Belt if not null', () => {
 			const testCase = structuredClone(caseWithAppellant);
@@ -541,7 +541,7 @@ describe('appeal-details-rows', () => {
 	});
 
 	describe('Preferred procedure', () => {
-		const procedureIndex = 25;
+		const procedureIndex = 24;
 
 		it('should display the appellant preferred procedure if set', () => {
 			const testCase = structuredClone(caseWithAppellant);
@@ -563,7 +563,7 @@ describe('appeal-details-rows', () => {
 	});
 
 	describe('Cost application', () => {
-		const costsApplicationIndex = 29;
+		const costsApplicationIndex = 28;
 
 		it('should display Yes if applicant applied for costs', () => {
 			const testCase = structuredClone(caseWithAppellant);

--- a/packages/forms-web-app/src/controllers/selected-appeal/appeal-details/index.js
+++ b/packages/forms-web-app/src/controllers/selected-appeal/appeal-details/index.js
@@ -13,6 +13,7 @@ const { addCSStoHtml } = require('#lib/add-css-to-html');
 
 const logger = require('#lib/logger');
 const config = require('../..//../config');
+const { bysRows } = require('./appeal-before-you-start-rows');
 
 /**
  * Shared controller for /appeals/:caseRef/appeal-details, manage-appeals/:caseRef/appeal-details rule-6-appeals/:caseRef/appeal-details
@@ -63,7 +64,10 @@ exports.get = (layoutTemplate = 'layouts/no-banner-link/main.njk') => {
 		logger.debug({ caseData }, 'caseData');
 
 		const lpa = await getDepartmentFromCode(caseData.LPACode);
-		const headlineData = formatHeadlineData(caseData, lpa.name, userType);
+		const headlineData = formatHeadlineData({ caseData, role: userType });
+
+		const beforeYouStartRows = bysRows(caseData, lpa.name);
+		const beforeYouStart = formatRows(beforeYouStartRows, caseData);
 
 		const appealDetailsRows = detailsRows(caseData, userType);
 		const appealDetails = formatRows(appealDetailsRows, caseData);
@@ -88,6 +92,7 @@ exports.get = (layoutTemplate = 'layouts/no-banner-link/main.njk') => {
 			appeal: {
 				appealNumber,
 				headlineData,
+				beforeYouStart,
 				appealDetails,
 				appealDocuments
 			},

--- a/packages/forms-web-app/src/controllers/selected-appeal/appeal-details/index.test.js
+++ b/packages/forms-web-app/src/controllers/selected-appeal/appeal-details/index.test.js
@@ -11,12 +11,14 @@ const { formatRows, formatHeadlineData } = require('@pins/common');
 const { VIEW } = require('#lib/views');
 const { generatePDF } = require('#lib/pdf-api-wrapper');
 const { addCSStoHtml } = require('#lib/add-css-to-html');
+const { bysRows } = require('./appeal-before-you-start-rows');
 
 jest.mock('#lib/determine-user');
 jest.mock('../../../services/user.service');
 jest.mock('../../../services/department.service');
 jest.mock('./appeal-details-rows');
 jest.mock('./appeal-documents-rows');
+jest.mock('./appeal-before-you-start-rows');
 jest.mock('@pins/common');
 jest.mock('#lib/pdf-api-wrapper');
 jest.mock('#lib/add-css-to-html');
@@ -51,7 +53,8 @@ const expectedViewContext = {
 		appealNumber: 123456,
 		headlineData: 'formatted headline data',
 		appealDetails: 'some formatted row data',
-		appealDocuments: 'some formatted row data'
+		appealDocuments: 'some formatted row data',
+		beforeYouStart: 'some formatted row data'
 	},
 	pdfDownloadUrl: 'a/fake/url?pdf=true',
 	backToAppealOverviewLink: 'a/fake'
@@ -64,6 +67,7 @@ describe('controllers/selected-appeal/appeal-details/index', () => {
 		getUserFromSession.mockReturnValue({ email: 'test@example.com' });
 		getDepartmentFromCode.mockReturnValue({ name: 'Test LPA' });
 		documentsRows.mockReturnValue('returned document rows');
+		bysRows.mockReturnValue('returned bys rows');
 		detailsRows.mockReturnValue('returned details rows');
 		formatRows.mockReturnValue('some formatted row data');
 		formatHeadlineData.mockReturnValue('formatted headline data');
@@ -97,9 +101,11 @@ describe('controllers/selected-appeal/appeal-details/index', () => {
 			});
 			expect(getDepartmentFromCode).toHaveBeenCalledWith('Q9999');
 			expect(detailsRows).toHaveBeenCalledWith(caseData, LPA_USER_ROLE);
+			expect(bysRows).toHaveBeenCalledWith(caseData, 'Test LPA');
 			expect(documentsRows).toHaveBeenCalledWith(caseData);
+			expect(formatRows).toHaveBeenCalledWith('returned bys rows', caseData);
 			expect(formatRows).toHaveBeenCalledWith('returned details rows', caseData);
-			expect(formatHeadlineData).toHaveBeenCalledWith(caseData, 'Test LPA', LPA_USER_ROLE);
+			expect(formatHeadlineData).toHaveBeenCalledWith({ caseData, role: LPA_USER_ROLE });
 
 			expect(generatePDF).not.toHaveBeenCalled();
 			expect(addCSStoHtml).not.toHaveBeenCalled();
@@ -138,9 +144,10 @@ describe('controllers/selected-appeal/appeal-details/index', () => {
 			expect(getDepartmentFromCode).toHaveBeenCalledWith('Q9999');
 			expect(detailsRows).toHaveBeenCalledWith(caseData, LPA_USER_ROLE);
 			expect(documentsRows).toHaveBeenCalledWith(caseData);
+			expect(bysRows).toHaveBeenCalledWith(caseData, 'Test LPA');
+			expect(formatRows).toHaveBeenCalledWith('returned bys rows', caseData);
 			expect(formatRows).toHaveBeenCalledWith('returned details rows', caseData);
-			expect(formatHeadlineData).toHaveBeenCalledWith(caseData, 'Test LPA', LPA_USER_ROLE);
-
+			expect(formatHeadlineData).toHaveBeenCalledWith({ caseData, role: LPA_USER_ROLE });
 			expect(res.render).toHaveBeenCalledWith(
 				VIEW.SELECTED_APPEAL.APPEAL_DETAILS,
 				pdfExpectedViewContext,

--- a/packages/forms-web-app/src/controllers/selected-appeal/planning-obligation-details/index.js
+++ b/packages/forms-web-app/src/controllers/selected-appeal/planning-obligation-details/index.js
@@ -51,7 +51,7 @@ exports.get = (layoutTemplate = 'layouts/no-banner-link/main.njk') => {
 		const planningObligationDetails = formatRows(appealPlanningObligationRows, caseData);
 
 		const lpa = await getDepartmentFromCode(caseData.LPACode);
-		const headlineData = formatHeadlineData(caseData, lpa.name, userType);
+		const headlineData = formatHeadlineData({ caseData, lpaName: lpa.name, role: userType });
 
 		let bannerHtmlOverride;
 		if (userType !== LPA_USER_ROLE) {

--- a/packages/forms-web-app/src/controllers/selected-appeal/questionnaire-details/index.js
+++ b/packages/forms-web-app/src/controllers/selected-appeal/questionnaire-details/index.js
@@ -72,7 +72,7 @@ exports.get = (layoutTemplate = 'layouts/no-banner-link/main.njk') => {
 		}
 
 		// headline data
-		const headlineData = formatHeadlineData(caseData, lpa.name, userType);
+		const headlineData = formatHeadlineData({ caseData, lpaName: lpa.name, role: userType });
 		// constraints details
 		const constraintsDetailsRows = constraintsRows(caseData);
 		const constraintsDetails = formatQuestionnaireRows(constraintsDetailsRows, caseData);

--- a/packages/forms-web-app/src/controllers/selected-appeal/questionnaire-details/index.test.js
+++ b/packages/forms-web-app/src/controllers/selected-appeal/questionnaire-details/index.test.js
@@ -119,7 +119,11 @@ describe('controllers/selected-appeal/questionnaire-details/index', () => {
 				userId: '123'
 			});
 			expect(getDepartmentFromCode).toHaveBeenCalledWith('Q9999');
-			expect(formatHeadlineData).toHaveBeenCalledWith(caseData, 'Test LPA', LPA_USER_ROLE);
+			expect(formatHeadlineData).toHaveBeenCalledWith({
+				caseData,
+				lpaName: 'Test LPA',
+				role: LPA_USER_ROLE
+			});
 			expect(constraintsRows).toHaveBeenCalledWith(caseData);
 			expect(environmentalRows).toHaveBeenCalledWith(caseData);
 			expect(notifiedRows).toHaveBeenCalledWith(caseData);
@@ -163,7 +167,11 @@ describe('controllers/selected-appeal/questionnaire-details/index', () => {
 				userId: '123'
 			});
 			expect(getDepartmentFromCode).toHaveBeenCalledWith('Q9999');
-			expect(formatHeadlineData).toHaveBeenCalledWith(caseData, 'Test LPA', LPA_USER_ROLE);
+			expect(formatHeadlineData).toHaveBeenCalledWith({
+				caseData,
+				lpaName: 'Test LPA',
+				role: LPA_USER_ROLE
+			});
 			expect(constraintsRows).toHaveBeenCalledWith(caseData);
 			expect(environmentalRows).toHaveBeenCalledWith(caseData);
 			expect(notifiedRows).toHaveBeenCalledWith(caseData);

--- a/packages/forms-web-app/src/controllers/selected-appeal/representations/index.js
+++ b/packages/forms-web-app/src/controllers/selected-appeal/representations/index.js
@@ -91,7 +91,7 @@ exports.get = (representationParams, layoutTemplate = 'layouts/no-banner-link/ma
 		const backToAppealOverviewLink = getParentPathLink(req.originalUrl);
 
 		const lpa = await getDepartmentFromCode(caseData.LPACode);
-		const headlineData = formatHeadlineData(caseData, lpa.name, userType);
+		const headlineData = formatHeadlineData({ caseData, lpaName: lpa.name, role: userType });
 		const formattedRepresentations = formatRepresentations(caseData, representationsForDisplay);
 
 		const representationView =

--- a/packages/forms-web-app/src/routes/file-based-router/comment-planning-appeal/appeals/_appealNumber/controller.js
+++ b/packages/forms-web-app/src/routes/file-based-router/comment-planning-appeal/appeals/_appealNumber/controller.js
@@ -19,7 +19,7 @@ const selectedAppeal = async (req, res) => {
 	createInterestedPartySession(req, appealNumber, appeal.siteAddressPostcode);
 
 	const lpa = await getDepartmentFromCode(appeal.LPACode);
-	const headlineData = formatHeadlineData(appeal, lpa.name);
+	const headlineData = formatHeadlineData({ caseData: appeal, lpaName: lpa.name });
 
 	const status = getAppealStatus(appeal);
 

--- a/packages/forms-web-app/src/routes/file-based-router/comment-planning-appeal/appeals/_appealNumber/controller.test.js
+++ b/packages/forms-web-app/src/routes/file-based-router/comment-planning-appeal/appeals/_appealNumber/controller.test.js
@@ -71,7 +71,7 @@ describe('selectedAppeal Controller Tests', () => {
 		expect(formatCommentDecidedData).toHaveBeenCalledWith(appeal);
 		expect(formatCommentInquiryText).toHaveBeenCalledWith(appeal.Events);
 		expect(formatCommentHearingText).toHaveBeenCalledWith(appeal.Events);
-		expect(formatHeadlineData).toHaveBeenCalledWith(appeal, lpa.name);
+		expect(formatHeadlineData).toHaveBeenCalledWith({ caseData: appeal, lpaName: lpa.name });
 		expect(res.render).toHaveBeenCalledWith('comment-planning-appeal/appeals/_appealNumber/index', {
 			appeal: {
 				...appeal,

--- a/packages/forms-web-app/src/views/selected-appeal/appeal-details.njk
+++ b/packages/forms-web-app/src/views/selected-appeal/appeal-details.njk
@@ -48,6 +48,13 @@
 
 			<hr class="govuk-section-break govuk-section-break--visible govuk-section-break--m">
 
+			<h2 class="govuk-heading-l">Before you start</h2>
+
+			{{ govukSummaryList({
+				classes: "govuk-summary-list long-answers",
+				rows: appeal.beforeYouStart
+			}) }}
+
 			<h2 class="govuk-heading-l">{{ appealDetailsSuffix }} appeal</h2>
 
 			{{ govukSummaryList({


### PR DESCRIPTION
### Description of change
- Added new BYSD section to the appeal details page
- Adding new field to AppealCase Model to map the typeOfApplication (we already collect this) 
- Making lpa name optional since this is not needed in selected-appeals appeal-details but used in other sections
<!-- Please describe the change -->

Ticket: https://pins-ds.atlassian.net/browse/A2-4148

### Checklist

- [x] Feature complete and ready for users, or behind feature-flag
- [x] Commit history is linear with no merge commits
- [ ] Requires infrastructure changes

### Important

Please do not merge from `main` (please only [rebase](https://github.com/Planning-Inspectorate/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
