### PR TITLE
fix(a2-4205): amend update child next journey function for dashboards

### DIFF
--- a/packages/common/src/constants.js
+++ b/packages/common/src/constants.js
@@ -52,6 +52,8 @@ module.exports = {
 		RULE_6: 'rule6'
 	},
 	SUBMISSIONS: {
+		CONTINUE: 'Continue',
+		INVALID: 'Invalid',
 		QUESTIONNAIRE: 'Questionnaire',
 		STATEMENT: 'Statement',
 		FINAL_COMMENT: 'Final comments',

--- a/packages/forms-web-app/src/lib/dashboard-functions.js
+++ b/packages/forms-web-app/src/lib/dashboard-functions.js
@@ -17,7 +17,7 @@ const {
 	isAppellantFinalCommentOpen,
 	isLPAFinalCommentOpen
 } = require('@pins/business-rules/src/rules/appeal-case/case-due-dates');
-
+const { SUBMISSIONS } = require('@pins/common/src/constants');
 const {
 	formatAddress,
 	isAppealSubmission,
@@ -201,7 +201,7 @@ const overdueJourneyNotToBeDisplayed = (dueJourney) => {
 	return !!(
 		dueJourney.dueInDays &&
 		dueJourney.dueInDays < 0 &&
-		dueJourney.journeyDue !== 'Questionnaire'
+		dueJourney.journeyDue !== SUBMISSIONS.QUESTIONNAIRE
 	);
 };
 
@@ -259,28 +259,28 @@ const determineJourneyToDisplayLPADashboard = (appealCaseData) => {
 		return {
 			deadline: appealCaseData.lpaQuestionnaireDueDate,
 			dueInDays: calculateDueInDays(appealCaseData.lpaQuestionnaireDueDate),
-			journeyDue: 'Questionnaire',
+			journeyDue: SUBMISSIONS.QUESTIONNAIRE,
 			baseUrl: `${questionnaireBaseUrl}/${appealCaseData.caseReference}`
 		};
 	} else if (isLPAStatementOpen(appealCaseData)) {
 		return {
 			deadline: appealCaseData.statementDueDate,
 			dueInDays: calculateDueInDays(appealCaseData.statementDueDate),
-			journeyDue: 'Statement',
+			journeyDue: SUBMISSIONS.STATEMENT,
 			baseUrl: `${statementBaseUrl}/${appealCaseData.caseReference}/entry`
 		};
 	} else if (isLPAFinalCommentOpen(appealCaseData)) {
 		return {
 			deadline: appealCaseData.finalCommentsDueDate,
 			dueInDays: calculateDueInDays(appealCaseData.finalCommentsDueDate),
-			journeyDue: 'Final comment',
+			journeyDue: SUBMISSIONS.FINAL_COMMENT,
 			baseUrl: `${finalCommentBaseUrl}/${appealCaseData.caseReference}/entry`
 		};
 	} else if (isLPAProofsOfEvidenceOpen(appealCaseData)) {
 		return {
 			deadline: appealCaseData.proofsOfEvidenceDueDate,
 			dueInDays: calculateDueInDays(appealCaseData.proofsOfEvidenceDueDate),
-			journeyDue: 'Proofs of Evidence',
+			journeyDue: SUBMISSIONS.PROOFS_EVIDENCE,
 			baseUrl: `${proofsBaseUrl}/${appealCaseData.caseReference}/entry`
 		};
 	}
@@ -303,34 +303,34 @@ const determineJourneyToDisplayAppellantDashboard = (caseOrSubmission) => {
 		return {
 			deadline,
 			dueInDays: calculateDueInDays(deadline),
-			journeyDue: 'Continue'
+			journeyDue: SUBMISSIONS.CONTINUE
 		};
 	} else if (isV2Submission(caseOrSubmission)) {
 		const deadline = calculateAppealDueDeadline(caseOrSubmission);
 		return {
 			deadline,
 			dueInDays: calculateDueInDays(deadline),
-			journeyDue: 'Continue'
+			journeyDue: SUBMISSIONS.CONTINUE
 		};
 	} else if (displayInvalidAppeal(caseOrSubmission)) {
 		return {
 			deadline: null,
 			/// ensures invalid appeals appear at the top of the of the display
 			dueInDays: -100000,
-			journeyDue: 'Invalid'
+			journeyDue: SUBMISSIONS.INVALID
 		};
 	} else if (isAppellantFinalCommentOpen(caseOrSubmission)) {
 		return {
 			deadline: caseOrSubmission.finalCommentsDueDate,
 			dueInDays: calculateDueInDays(caseOrSubmission.finalCommentsDueDate),
-			journeyDue: 'Final comments',
+			journeyDue: SUBMISSIONS.FINAL_COMMENT,
 			baseUrl: `${appellantFinalCommentBaseUrl}/${caseOrSubmission.caseReference}/entry`
 		};
 	} else if (isAppellantProofsOfEvidenceOpen(caseOrSubmission)) {
 		return {
 			deadline: caseOrSubmission.proofsOfEvidenceDueDate,
 			dueInDays: calculateDueInDays(caseOrSubmission.proofsOfEvidenceDueDate),
-			journeyDue: 'Proofs of evidence',
+			journeyDue: SUBMISSIONS.PROOFS_EVIDENCE,
 			baseUrl: `${appellantProofsBaseUrl}/${caseOrSubmission.caseReference}/entry`
 		};
 	}
@@ -352,14 +352,14 @@ const determineJourneyToDisplayRule6Dashboard = (appealCaseData) => {
 		return {
 			deadline: appealCaseData.statementDueDate,
 			dueInDays: calculateDueInDays(appealCaseData.statementDueDate),
-			journeyDue: 'Statement',
+			journeyDue: SUBMISSIONS.STATEMENT,
 			baseUrl: `${rule6StatementBaseUrl}/${appealCaseData.caseReference}/entry`
 		};
 	} else if (isRule6ProofsOfEvidenceOpen(appealCaseData)) {
 		return {
 			deadline: appealCaseData.proofsOfEvidenceDueDate,
 			dueInDays: calculateDueInDays(appealCaseData.proofsOfEvidenceDueDate),
-			journeyDue: 'Proof of Evidence',
+			journeyDue: SUBMISSIONS.PROOFS_EVIDENCE,
 			baseUrl: `${rule6ProofsBaseUrl}/${appealCaseData.caseReference}/entry`
 		};
 	}
@@ -384,7 +384,10 @@ const updateChildAppealDisplayData = (displayDataArray) => {
 	if (!leadCases.length) return displayDataArray;
 
 	return displayDataArray.map((caseData) => {
-		if (caseData.linkedCaseDetails?.linkedCaseStatus === APPEAL_LINKED_CASE_STATUS.CHILD) {
+		if (
+			caseData.linkedCaseDetails?.linkedCaseStatus === APPEAL_LINKED_CASE_STATUS.CHILD &&
+			caseData.nextJourneyDue.journeyDue !== SUBMISSIONS.QUESTIONNAIRE
+		) {
 			return {
 				...caseData,
 				nextJourneyDue:

--- a/packages/forms-web-app/src/lib/dashboard-functions.test.js
+++ b/packages/forms-web-app/src/lib/dashboard-functions.test.js
@@ -15,6 +15,7 @@ const {
 } = require('@planning-inspectorate/data-model');
 const { CASE_TYPES } = require('@pins/common/src/database/data-static');
 const { APPEAL_ID, APPLICATION_DECISION } = require('@pins/business-rules/src/constants');
+const { SUBMISSIONS } = require('@pins/common/src/constants');
 
 jest.mock('@pins/common/src/lib/calculate-due-in-days');
 jest.mock('./calculate-days-since-invalidated');
@@ -40,9 +41,37 @@ const proofsBaseUrl = `/manage-appeals/proof-evidence/${testCaseRef}/entry`;
 const rule6StatementBaseUrl = `/rule-6/appeal-statement/${testCaseRef}/entry`;
 const rule6ProofsBaseUrl = `/rule-6/proof-evidence/${testCaseRef}/entry`;
 
+const testQuestionnaireJourney = {
+	deadline: 'Tomorrow',
+	dueInDays: 1,
+	journeyDue: SUBMISSIONS.QUESTIONNAIRE,
+	baseUrl: 'testQuestionnaireUrl'
+};
+
+const testLead1StatementJourney = {
+	deadline: 'Tomorrow',
+	dueInDays: 1,
+	journeyDue: SUBMISSIONS.STATEMENT,
+	baseUrl: 'testLead1StatementUrl'
+};
+
+const testLead2StatementJourney = {
+	deadline: 'Tomorrow',
+	dueInDays: 1,
+	journeyDue: SUBMISSIONS.STATEMENT,
+	baseUrl: 'testLead2StatementUrl'
+};
+
+const testChildStatementJourney = {
+	deadline: 'Tomorrow and a day',
+	dueInDays: 2,
+	journeyDue: SUBMISSIONS.STATEMENT,
+	baseUrl: 'testChildStatementUrl'
+};
+
 const testLeadDashboardData = {
 	appealNumber: 'TestLeadCase',
-	nextJourneyDue: 'LeadCaseJourney',
+	nextJourneyDue: testLead1StatementJourney,
 	linkedCaseDetails: {
 		linkedCaseStatus: APPEAL_LINKED_CASE_STATUS.LEAD,
 		leadCaseReference: 'TestLeadCase',
@@ -51,7 +80,7 @@ const testLeadDashboardData = {
 };
 const testLeadDashboardData2 = {
 	appealNumber: 'TestLeadCase2',
-	nextJourneyDue: 'LeadCaseJourney2',
+	nextJourneyDue: testLead2StatementJourney,
 	linkedCaseDetails: {
 		linkedCaseStatus: APPEAL_LINKED_CASE_STATUS.LEAD,
 		leadCaseReference: 'TestLeadCase2',
@@ -60,7 +89,7 @@ const testLeadDashboardData2 = {
 };
 const testChildDashboardData = {
 	appealNumber: 'TestChildCase',
-	nextJourneyDue: 'ChildCaseJourney',
+	nextJourneyDue: testChildStatementJourney,
 	linkedCaseDetails: {
 		linkedCaseStatus: APPEAL_LINKED_CASE_STATUS.CHILD,
 		leadCaseReference: testLeadDashboardData.appealNumber,
@@ -139,7 +168,7 @@ describe('lib/dashboard-functions', () => {
 			const expectedQuestionnaireDetails = {
 				deadline: '2023-07-07T13:53:31.6003126+00:00',
 				dueInDays: 3,
-				journeyDue: 'Questionnaire',
+				journeyDue: SUBMISSIONS.QUESTIONNAIRE,
 				baseUrl: questionnaireBaseUrl
 			};
 
@@ -163,7 +192,7 @@ describe('lib/dashboard-functions', () => {
 			const expectedStatementDetails = {
 				deadline: '2023-07-17T13:53:31.6003126+00:00',
 				dueInDays: 13,
-				journeyDue: 'Statement',
+				journeyDue: SUBMISSIONS.STATEMENT,
 				baseUrl: statementBaseUrl
 			};
 
@@ -189,7 +218,7 @@ describe('lib/dashboard-functions', () => {
 			const expectedFinalCommentDetails = {
 				deadline: '2023-07-27T13:53:31.6003126+00:00',
 				dueInDays: 23,
-				journeyDue: 'Final comment',
+				journeyDue: SUBMISSIONS.FINAL_COMMENT,
 				baseUrl: finalCommentBaseUrl
 			};
 
@@ -215,7 +244,7 @@ describe('lib/dashboard-functions', () => {
 			const expectedProofsDetails = {
 				deadline: '2023-07-27T13:53:31.6003126+00:00',
 				dueInDays: 23,
-				journeyDue: 'Proofs of Evidence',
+				journeyDue: SUBMISSIONS.PROOFS_EVIDENCE,
 				baseUrl: proofsBaseUrl
 			};
 
@@ -248,7 +277,7 @@ describe('lib/dashboard-functions', () => {
 			const expectedStatementDetails = {
 				deadline: '2023-07-07T13:53:31.6003126+00:00',
 				dueInDays: 13,
-				journeyDue: 'Statement',
+				journeyDue: SUBMISSIONS.STATEMENT,
 				baseUrl: `${rule6StatementBaseUrl}`
 			};
 
@@ -270,7 +299,7 @@ describe('lib/dashboard-functions', () => {
 			const expectedProofsDetails = {
 				deadline: '2023-07-27T13:53:31.6003126+00:00',
 				dueInDays: 23,
-				journeyDue: 'Proof of Evidence',
+				journeyDue: SUBMISSIONS.PROOFS_EVIDENCE,
 				baseUrl: `${rule6ProofsBaseUrl}`
 			};
 
@@ -287,6 +316,19 @@ describe('lib/dashboard-functions', () => {
 			expect(updateChildAppealDisplayData([testChildDashboardData])).toEqual([
 				testChildDashboardData
 			]);
+		});
+
+		it('does not update child appeal data if the child next journey is questionnaire', () => {
+			const testChildDataAtQuestionnaire = structuredClone(testChildDashboardData);
+			testChildDataAtQuestionnaire.nextJourneyDue = testQuestionnaireJourney;
+
+			const testInputArray = [
+				testLeadDashboardData,
+				testLeadDashboardData2,
+				testChildDataAtQuestionnaire
+			];
+
+			expect(updateChildAppealDisplayData(testInputArray)).toEqual(testInputArray);
 		});
 
 		it('updates a child appeal data with the relevant lead appeal journey', () => {


### PR DESCRIPTION
### Description of change

On dashboards child appeals should move in sync with lead appeals (and submissions are made against the lead), and so on dashboards we replace the child next journey due with the lead next journey due.  The exception is for Questionnaires, where an LPAQ is submitted in respect of each appeal.  This PR prevents child Questionnaire journeys updating.

Ticket: https://pins-ds.atlassian.net/browse/A2-4205

### Checklist

- [X] Feature complete and ready for users, or behind feature-flag
- [X] Commit history is linear with no merge commits
- [ ] Requires infrastructure changes

### Important

Please do not merge from `main` (please only [rebase](https://github.com/Planning-Inspectorate/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
