### PR TITLE
fix(A2-4225): sort display order of decision documents

### DIFF
--- a/packages/forms-web-app/src/controllers/selected-appeal/index.js
+++ b/packages/forms-web-app/src/controllers/selected-appeal/index.js
@@ -154,8 +154,14 @@ const formatTitleSuffix = (userType) => {
  * @param {import('appeals-service-api').Api.Document[]} documents
  * @return {import('appeals-service-api').Api.Document[]}
  */
-const filterDecisionDocuments = (documents) =>
-	documents.filter((document) => {
+const filterDecisionDocuments = (documents) => {
+	const decisionDocumentDisplayOrder = {
+		[APPEAL_DOCUMENT_TYPE.CASE_DECISION_LETTER]: 0,
+		[APPEAL_DOCUMENT_TYPE.APPELLANT_COSTS_DECISION_LETTER]: 1,
+		[APPEAL_DOCUMENT_TYPE.LPA_COSTS_DECISION_LETTER]: 2
+	};
+
+	const decisionDocuments = documents.filter((document) => {
 		if (
 			document.documentType === APPEAL_DOCUMENT_TYPE.CASE_DECISION_LETTER ||
 			document.documentType === APPEAL_DOCUMENT_TYPE.LPA_COSTS_DECISION_LETTER ||
@@ -165,6 +171,12 @@ const filterDecisionDocuments = (documents) =>
 		}
 		return false;
 	});
+
+	return decisionDocuments.sort(
+		(a, b) =>
+			decisionDocumentDisplayOrder[a.documentType] - decisionDocumentDisplayOrder[b.documentType]
+	);
+};
 
 /**
  *


### PR DESCRIPTION
### Description of change

Sorts order of decision documents for display on appeal pages

Ticket: https://pins-ds.atlassian.net/browse/A2-4225

### Checklist

- [X] Feature complete and ready for users, or behind feature-flag
- [X] Commit history is linear with no merge commits
- [ ] Requires infrastructure changes

### Important

Please do not merge from `main` (please only [rebase](https://github.com/Planning-Inspectorate/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
