### PR TITLE
fix(A2-3675): show development type on appeal details page for LPA and appellant

### DIFF
--- a/packages/appeals-service-api/src/spec/api-types.d.ts
+++ b/packages/appeals-service-api/src/spec/api-types.d.ts
@@ -153,6 +153,8 @@ export interface AppealCase {
 	advertisedAppeal?: boolean;
 	/** Indicates if the appellant has informed other owners of the site */
 	ownersInformed?: boolean;
+	/** The original description of the type */
+	majorMinorDevelopment?: 'major' | 'minor' | 'other';
 	/** The original description of the development, as provided by the appellant */
 	originalDevelopmentDescription?: string;
 	developmentType?:

--- a/packages/forms-web-app/src/controllers/selected-appeal/appeal-details/appeal-details-rows.js
+++ b/packages/forms-web-app/src/controllers/selected-appeal/appeal-details/appeal-details-rows.js
@@ -157,7 +157,12 @@ exports.detailsRows = (caseData, userType) => {
 			condition: (caseData) => caseData.applicationReference
 		},
 		{
-			keyText: 'What is the development type?',
+			keyText: 'Was your application for a major or minor development?',
+			valueText: caseData.majorMinorDevelopment ?? '',
+			condition: (caseData) => caseData.majorMinorDevelopment
+		},
+		{
+			keyText: 'Was your application about any of the following?',
 			valueText: formatDevelopmentType(caseData.developmentType),
 			condition: () => !hasOrCasPlanningAppeal
 		},

--- a/packages/forms-web-app/src/controllers/selected-appeal/appeal-details/appeal-details-rows.test.js
+++ b/packages/forms-web-app/src/controllers/selected-appeal/appeal-details/appeal-details-rows.test.js
@@ -1,5 +1,7 @@
+const { APPEAL_DEVELOPMENT_TYPE } = require('@planning-inspectorate/data-model');
 const { detailsRows } = require('./appeal-details-rows');
 const { APPEAL_USER_ROLES, LPA_USER_ROLE } = require('@pins/common/src/constants');
+const { CASE_TYPES } = require('@pins/common/src/database/data-static');
 
 describe('appeal-details-rows', () => {
 	const appellant = {
@@ -489,8 +491,56 @@ describe('appeal-details-rows', () => {
 		});
 	});
 
+	describe('Was your application for a major or minor development?', () => {
+		const applicationReferenceIndex = 21;
+
+		it('should display major/minor development type if set', () => {
+			const testCase = structuredClone(caseWithAppellant);
+			testCase.majorMinorDevelopment = 'Major';
+
+			const rows = detailsRows(testCase, APPEAL_USER_ROLES.APPELLANT);
+			expect(rows[applicationReferenceIndex].condition(testCase)).toBeTruthy();
+			expect(rows[applicationReferenceIndex].keyText).toEqual(
+				'Was your application for a major or minor development?'
+			);
+			expect(rows[applicationReferenceIndex].valueText).toEqual('Major');
+		});
+
+		it('should not display the application reference if not set', () => {
+			const testCase = structuredClone(caseWithAppellant);
+
+			const rows = detailsRows(testCase, APPEAL_USER_ROLES.APPELLANT);
+			expect(rows[applicationReferenceIndex].condition(testCase)).toBeFalsy();
+		});
+	});
+
+	describe('Was your application about any of the following?', () => {
+		const developmentTypeIndex = 22;
+
+		it('should display the development type if appeal type code is not HAS', () => {
+			const testCase = structuredClone(caseWithAppellant);
+			testCase.developmentType = APPEAL_DEVELOPMENT_TYPE.HOUSEHOLDER;
+			testCase.appealTypeCode = 'S78';
+
+			const rows = detailsRows(testCase, APPEAL_USER_ROLES.APPELLANT);
+			expect(rows[developmentTypeIndex].condition(testCase)).toEqual(true);
+			expect(rows[developmentTypeIndex].keyText).toEqual(
+				'Was your application about any of the following?'
+			);
+			expect(rows[developmentTypeIndex].valueText).toEqual('Householder development');
+		});
+
+		it('should not display development type if appeal type code is HAS', () => {
+			const testCase = structuredClone(caseWithAppellant);
+			testCase.appealTypeCode = CASE_TYPES.HAS.processCode;
+
+			const rows = detailsRows(testCase, APPEAL_USER_ROLES.APPELLANT);
+			expect(rows[developmentTypeIndex].condition(testCase)).toEqual(false);
+		});
+	});
+
 	describe('Enter the description of development', () => {
-		const descriptionIndex = 22;
+		const descriptionIndex = 23;
 
 		it('should display the development description if set', () => {
 			const testCase = structuredClone(caseWithAppellant);
@@ -511,7 +561,7 @@ describe('appeal-details-rows', () => {
 	});
 
 	describe('Did the local planning authority change the description of development?', () => {
-		const lpaChangedDescriptionIndex = 23;
+		const lpaChangedDescriptionIndex = 24;
 
 		it('should show Green Belt if not null', () => {
 			const testCase = structuredClone(caseWithAppellant);
@@ -541,7 +591,7 @@ describe('appeal-details-rows', () => {
 	});
 
 	describe('Preferred procedure', () => {
-		const procedureIndex = 24;
+		const lpaChangedDescriptionIndex = 25;
 
 		it('should display the appellant preferred procedure if set', () => {
 			const testCase = structuredClone(caseWithAppellant);
@@ -549,21 +599,21 @@ describe('appeal-details-rows', () => {
 			testCase.appellantProcedurePreferenceDetails = 'For reasons';
 
 			const rows = detailsRows(testCase, APPEAL_USER_ROLES.APPELLANT);
-			expect(rows[procedureIndex].condition(testCase)).toBeTruthy();
-			expect(rows[procedureIndex].keyText).toEqual('Preferred procedure');
-			expect(rows[procedureIndex].valueText).toEqual('Inquiry\nFor reasons');
+			expect(rows[lpaChangedDescriptionIndex].condition(testCase)).toBeTruthy();
+			expect(rows[lpaChangedDescriptionIndex].keyText).toEqual('Preferred procedure');
+			expect(rows[lpaChangedDescriptionIndex].valueText).toEqual('Inquiry\nFor reasons');
 		});
 
 		it('should not display the procedure preference if not set', () => {
 			const testCase = structuredClone(caseWithAppellant);
 
 			const rows = detailsRows(testCase, APPEAL_USER_ROLES.APPELLANT);
-			expect(rows[procedureIndex].condition(testCase)).toBeFalsy();
+			expect(rows[lpaChangedDescriptionIndex].condition(testCase)).toBeFalsy();
 		});
 	});
 
 	describe('Cost application', () => {
-		const costsApplicationIndex = 28;
+		const costsApplicationIndex = 29;
 
 		it('should display Yes if applicant applied for costs', () => {
 			const testCase = structuredClone(caseWithAppellant);


### PR DESCRIPTION
### Description of change

Fixes an issue where the development type was not displaying on the Appeal Details page for both LPA and appellant dashboards. 

Ticket: https://pins-ds.atlassian.net/browse/A2-3675

### Checklist

- [X] Feature complete and ready for users, or behind feature-flag
- [X] Commit history is linear with no merge commits
- [ ] Requires infrastructure changes

### Important

Please do not merge from `main` (please only [rebase](https://github.com/Planning-Inspectorate/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
