### PR TITLE
feat(4149): toggle bys application decision question depending on original decision

### DIFF
--- a/packages/appeals-service-api/src/spec/api-types.d.ts
+++ b/packages/appeals-service-api/src/spec/api-types.d.ts
@@ -93,7 +93,7 @@ export interface AppealCase {
 	/** The unique identifier of the LPA application */
 	applicationReference: string;
 	/** The outcome of the original LPA decision */
-	applicationDecision: 'granted' | 'refused';
+	applicationDecision: 'granted' | 'refused' | 'not_received';
 	/**
 	 * The date of the original LPA application
 	 * @format date-time

--- a/packages/forms-web-app/src/controllers/selected-appeal/appeal-details/appeal-before-you-start-rows.js
+++ b/packages/forms-web-app/src/controllers/selected-appeal/appeal-details/appeal-before-you-start-rows.js
@@ -40,7 +40,10 @@ exports.bysRows = (caseData, lpaName) => [
 		condition: () => true
 	},
 	{
-		keyText: 'What is the date on the decision letter from the local planning authority?',
+		keyText:
+			caseData.applicationDecision == 'not_received'
+				? 'What date was your decision due from the local planning authority?'
+				: 'What is the date on the decision letter from the local planning authority?',
 		valueText: formatDateForDisplay(caseData.applicationDecisionDate),
 		condition: () => true
 	}

--- a/packages/forms-web-app/src/controllers/selected-appeal/appeal-details/appeal-before-you-start-rows.test.js
+++ b/packages/forms-web-app/src/controllers/selected-appeal/appeal-details/appeal-before-you-start-rows.test.js
@@ -57,4 +57,15 @@ describe('bys-rows', () => {
 		);
 		expect(rows[5].valueText).toEqual('1 Feb 2025');
 	});
+
+	it('should display when was decision due question when decision is not_receieved', () => {
+		const data = structuredClone(caseData);
+		data.applicationDecision = 'not_received';
+		// @ts-ignore
+		const rowData = bysRows(data, 'Test LPA');
+		expect(rowData[5].keyText).toEqual(
+			'What date was your decision due from the local planning authority?'
+		);
+		expect(rows[5].valueText).toEqual('1 Feb 2025');
+	});
 });


### PR DESCRIPTION

### Description of change
- Toggling application data question for not_received outcome
- Added unit test for this scenario 

<!-- Please describe the change -->

Ticket: https://pins-ds.atlassian.net/browse/A2-4149

### Checklist

- [x] Feature complete and ready for users, or behind feature-flag
- [x] Commit history is linear with no merge commits
- [ ] Requires infrastructure changes

### Important

Please do not merge from `main` (please only [rebase](https://github.com/Planning-Inspectorate/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
