### PR TITLE
fix(a2-4244): switch unix rule to logging mode

### DIFF
--- a/infrastructure/front-door.tf
+++ b/infrastructure/front-door.tf
@@ -443,6 +443,13 @@ resource "azurerm_cdn_frontdoor_firewall_policy" "wfe" {
         enabled = true
         rule_id = "932100"
       }
+
+      rule {
+        # Remote Command Execution: Unix Command Injection
+        action  = "Log"
+        enabled = true
+        rule_id = "932105"
+      }
     }
 
     override {


### PR DESCRIPTION
### Description of change

Further testing with prod example has found the other unix injection rule is also likely to be triggered by normal users

Ticket: https://pins-ds.atlassian.net/browse/A2-4244

### Checklist

- [x] Feature complete and ready for users, or behind feature-flag
- [x] Commit history is linear with no merge commits
- [ ] Requires infrastructure changes

### Important

Please do not merge from `main` (please only [rebase](https://github.com/Planning-Inspectorate/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
