### PR TITLE
feat(deps): bump data model to 1.18.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
 				"@azure/service-bus": "^7.9.1",
 				"@azure/storage-blob": "^12.28.0",
 				"@ministryofjustice/frontend": "^1.6.4",
-				"@planning-inspectorate/data-model": "^1.15.0",
+				"@planning-inspectorate/data-model": "^1.18.0",
 				"@prisma/client": "^6.13.0",
 				"accessible-autocomplete": "^3.0.1",
 				"ajv": "^8.14.0",
@@ -6485,9 +6485,9 @@
 			}
 		},
 		"node_modules/@planning-inspectorate/data-model": {
-			"version": "1.15.0",
-			"resolved": "https://registry.npmjs.org/@planning-inspectorate/data-model/-/data-model-1.15.0.tgz",
-			"integrity": "sha512-y2hGhGG0qjlLTsoirdAyECcHumKdqhbebrDTZC39233iWab0wXDnwCvExDafSUyNHJ/clmPDsO+koqzZsajvQw==",
+			"version": "1.18.0",
+			"resolved": "https://registry.npmjs.org/@planning-inspectorate/data-model/-/data-model-1.18.0.tgz",
+			"integrity": "sha512-JQYVoCahTCvv+6xbt09JuxQQgM6aSDsGGO+6/f36nttPThhc0gjhfX7LrZFOH4RLyWOBM1vw9/0yHvei1u3mhQ==",
 			"license": "MIT",
 			"dependencies": {
 				"jsonc-parser": "^3.3.1"

--- a/package.json
+++ b/package.json
@@ -108,7 +108,7 @@
 		"@azure/service-bus": "^7.9.1",
 		"@azure/storage-blob": "^12.28.0",
 		"@ministryofjustice/frontend": "^1.6.4",
-		"@planning-inspectorate/data-model": "^1.15.0",
+		"@planning-inspectorate/data-model": "^1.18.0",
 		"@prisma/client": "^6.13.0",
 		"accessible-autocomplete": "^3.0.1",
 		"ajv": "^8.14.0",

--- a/packages/appeals-service-api/__tests__/developer/fixtures/appeals-S78-data-model.js
+++ b/packages/appeals-service-api/__tests__/developer/fixtures/appeals-S78-data-model.js
@@ -64,7 +64,7 @@ const exampleS78DataModel = {
 	reasonForNeighbourVisits: 'velit enim elit tempor cillum',
 	numberOfResidencesNetChange: null,
 	siteGridReferenceEasting: null,
-	siteGridReferenceNorthing: 'et sit id eiusmod',
+	siteGridReferenceNorthing: null,
 	siteViewableFromRoad: null,
 	siteWithinSSSI: false,
 	typeOfPlanningApplication: null


### PR DESCRIPTION
### Description of change

Bump data model for CAS/Adverts updates
Easting/Northing now pattern validated

### Checklist

- [x] Feature complete and ready for users, or behind feature-flag
- [x] Commit history is linear with no merge commits
- [ ] Requires infrastructure changes

### Important

Please do not merge from `main` (please only [rebase](https://github.com/Planning-Inspectorate/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
