### PR TITLE
fix(a2-4433): remove non ascii apostrophe from email subjects

### DIFF
--- a/packages/appeals-service-api/__tests__/developer/external-dependencies/rest-apis/interactions/notify-interaction.js
+++ b/packages/appeals-service-api/__tests__/developer/external-dependencies/rest-apis/interactions/notify-interaction.js
@@ -101,7 +101,7 @@ module.exports = class NotifyInteraction {
 			.addJsonValueExpectation(JsonPathExpression.create('$.reference'), appeal.id)
 			.addJsonValueExpectation(
 				JsonPathExpression.create('$.personalisation.subject'),
-				`We’ve received a ${appealType} appeal`
+				`We've received a ${appealType} appeal`
 			)
 			.addJsonValueExpectation(
 				JsonPathExpression.create('$.personalisation.content'),

--- a/packages/appeals-service-api/src/lib/notify.js
+++ b/packages/appeals-service-api/src/lib/notify.js
@@ -349,7 +349,7 @@ const sendLpaStatementSubmissionReceivedEmailToLpaV2 = async (lpaStatementSubmis
 		);
 		await notifyService.sendEmail({
 			personalisation: {
-				subject: `We’ve received your statement: ${caseReference}`,
+				subject: `We've received your statement: ${caseReference}`,
 				content
 			},
 			destinationEmail: lpaEmail,
@@ -419,7 +419,7 @@ const sendLPAFinalCommentSubmissionEmailToLPAV2 = async (lpaFinalCommentSubmissi
 		);
 		await notifyService.sendEmail({
 			personalisation: {
-				subject: `We’ve received your final comments: ${caseReference}`,
+				subject: `We've received your final comments: ${caseReference}`,
 				content
 			},
 			destinationEmail: lpaEmail,
@@ -486,7 +486,7 @@ const sendLPAProofEvidenceSubmissionEmailToLPAV2 = async (lpaProofEvidenceSubmis
 		);
 		await notifyService.sendEmail({
 			personalisation: {
-				subject: `We’ve received your proof of evidence and witnesses: ${caseReference}`,
+				subject: `We've received your proof of evidence and witnesses: ${caseReference}`,
 				content
 			},
 			destinationEmail: lpaEmail,
@@ -555,7 +555,7 @@ const sendLPAHASQuestionnaireSubmittedEmailV2 = async (
 		);
 		await notifyService.sendEmail({
 			personalisation: {
-				subject: `We’ve received your questionnaire: ${variables.appealReferenceNumber}`,
+				subject: `We've received your questionnaire: ${variables.appealReferenceNumber}`,
 				content
 			},
 			destinationEmail: lpaEmailAddress,
@@ -747,7 +747,7 @@ const sendRule6ProofEvidenceSubmissionEmailToRule6PartyV2 = async (
 		);
 		await notifyService.sendEmail({
 			personalisation: {
-				subject: `We’ve received your proof of evidence and witnesses - ${variables.appealReferenceNumber}`,
+				subject: `We've received your proof of evidence and witnesses - ${variables.appealReferenceNumber}`,
 				content
 			},
 			destinationEmail: emailAddress,
@@ -901,7 +901,7 @@ const sendSubmissionReceivedEmailToLpa = async (appeal) => {
 		);
 		await notifyService.sendEmail({
 			personalisation: {
-				subject: `We’ve received a ${variables.appealType} appeal`,
+				subject: `We've received a ${variables.appealType} appeal`,
 				content
 			},
 			destinationEmail: lpaEmail,
@@ -1050,7 +1050,7 @@ const sendCommentSubmissionConfirmationEmailToIp = async (interestedPartySubmiss
 		);
 		await notifyService.sendEmail({
 			personalisation: {
-				subject: `We’ve received your comment: ${variables.appealReferenceNumber}`,
+				subject: `We've received your comment: ${variables.appealReferenceNumber}`,
 				content
 			},
 			destinationEmail: emailAddress,

--- a/packages/appeals-service-api/src/routes/v2/appeal-cases/_caseReference/lpa-final-comment-submission/submit/index.spec.js
+++ b/packages/appeals-service-api/src/routes/v2/appeal-cases/_caseReference/lpa-final-comment-submission/submit/index.spec.js
@@ -148,7 +148,7 @@ module.exports = ({
 				email,
 				{
 					personalisation: {
-						subject: `We’ve received your final comments: ${appealReferenceNumber}`,
+						subject: `We've received your final comments: ${appealReferenceNumber}`,
 						content: expect.stringContaining('We have received your final comments.')
 					},
 					reference: expect.any(String),

--- a/packages/appeals-service-api/src/routes/v2/appeal-cases/_caseReference/lpa-proof-evidence-submission/submit/index.spec.js
+++ b/packages/appeals-service-api/src/routes/v2/appeal-cases/_caseReference/lpa-proof-evidence-submission/submit/index.spec.js
@@ -189,7 +189,7 @@ module.exports = ({
 				email,
 				{
 					personalisation: {
-						subject: `We’ve received your proof of evidence and witnesses: ${appealReferenceNumber}`,
+						subject: `We've received your proof of evidence and witnesses: ${appealReferenceNumber}`,
 						content: expect.stringContaining('We’ve received your proof of evidence and witnesses.')
 					},
 					reference: expect.any(String),

--- a/packages/appeals-service-api/src/routes/v2/appeal-cases/_caseReference/lpa-questionnaire-submission/submit/index.test.js
+++ b/packages/appeals-service-api/src/routes/v2/appeal-cases/_caseReference/lpa-questionnaire-submission/submit/index.test.js
@@ -427,7 +427,7 @@ describe('/api/v2/appeal-cases/:caseReference/submit', () => {
 			email,
 			{
 				personalisation: {
-					subject: `We’ve received your questionnaire: ${appealReferenceNumber}`,
+					subject: `We've received your questionnaire: ${appealReferenceNumber}`,
 					content: expect.stringContaining(`We have received your questionnaire`)
 				},
 				reference: expect.any(String),

--- a/packages/appeals-service-api/src/routes/v2/appeal-cases/_caseReference/lpa-statement-submission/submit/index.spec.js
+++ b/packages/appeals-service-api/src/routes/v2/appeal-cases/_caseReference/lpa-statement-submission/submit/index.spec.js
@@ -147,7 +147,7 @@ module.exports = ({
 				email,
 				{
 					personalisation: {
-						subject: `We’ve received your statement: ${appealReferenceNumber}`,
+						subject: `We've received your statement: ${appealReferenceNumber}`,
 						content: expect.stringContaining('We’ve received your statement.')
 					},
 					reference: expect.any(String),

--- a/packages/appeals-service-api/src/routes/v2/appeal-cases/_caseReference/rule-6-proof-evidence-submission/submit/index.spec.js
+++ b/packages/appeals-service-api/src/routes/v2/appeal-cases/_caseReference/rule-6-proof-evidence-submission/submit/index.spec.js
@@ -146,7 +146,7 @@ module.exports = ({
 				validEmail,
 				{
 					personalisation: {
-						subject: `We’ve received your proof of evidence and witnesses - ${caseRef}`,
+						subject: `We've received your proof of evidence and witnesses - ${caseRef}`,
 						content: expect.stringContaining(
 							'We have received your proof of evidence and witnesses.'
 						)

--- a/packages/appeals-service-api/src/routes/v2/interested-party-submissions/index.spec.js
+++ b/packages/appeals-service-api/src/routes/v2/interested-party-submissions/index.spec.js
@@ -86,7 +86,7 @@ module.exports = ({ getSqlClient, appealsApi, mockNotifyClient, mockEventClient 
 				testIPSubmissionData.emailAddress,
 				{
 					personalisation: {
-						subject: `We’ve received your comment: ${caseRef}`,
+						subject: `We've received your comment: ${caseRef}`,
 						content: expect.stringContaining(
 							`The inspector will review all of the evidence. We will contact you by email when we make a decision.`
 						)


### PR DESCRIPTION
### Description of change

Removes non ascii characters from email subjects

Ticket: https://pins-ds.atlassian.net/browse/A2-4433

### Checklist

- [x] Feature complete and ready for users, or behind feature-flag
- [x] Commit history is linear with no merge commits
- [ ] Requires infrastructure changes

### Important

Please do not merge from `main` (please only [rebase](https://github.com/Planning-Inspectorate/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
