### PR TITLE
fix(a2-4440): use correct WAF rule group name

### DIFF
--- a/infrastructure/front-door.tf
+++ b/infrastructure/front-door.tf
@@ -162,7 +162,7 @@ resource "azurerm_cdn_frontdoor_firewall_policy" "wfe" {
     }
 
     override {
-      rule_group_name = "Protocol"
+      rule_group_name = "PROTOCOL-ATTACK"
 
       rule {
         # 921110 – HTTP Request Smuggling Attack


### PR DESCRIPTION
### Description of change

Wrong group name used

Ticket: https://pins-ds.atlassian.net/browse/A2-4440

### Checklist

- [x] Feature complete and ready for users, or behind feature-flag
- [x] Commit history is linear with no merge commits
- [ ] Requires infrastructure changes

### Important

Please do not merge from `main` (please only [rebase](https://github.com/Planning-Inspectorate/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
