### PR TITLE
feat(a2-3882): filter transferred cases from display on dashboards

### DIFF
--- a/packages/business-rules/src/lib/filter-transferred-appeal.js
+++ b/packages/business-rules/src/lib/filter-transferred-appeal.js
@@ -1,0 +1,11 @@
+const { APPEAL_CASE_STATUS } = require('@planning-inspectorate/data-model');
+
+/**
+ * @param {import('appeals-service-api').Api.AppealCaseDetailed} appeal
+ * @returns {boolean}
+ */
+const isNotTransferred = (appeal) => {
+	return !(appeal.caseTransferredDate && appeal.caseStatus === APPEAL_CASE_STATUS.TRANSFERRED);
+};
+
+module.exports = { isNotTransferred };

--- a/packages/business-rules/src/lib/filter-transferred-appeal.test.js
+++ b/packages/business-rules/src/lib/filter-transferred-appeal.test.js
@@ -1,0 +1,63 @@
+const { isNotTransferred } = require('./filter-transferred-appeal');
+const { APPEAL_CASE_STATUS } = require('@planning-inspectorate/data-model');
+
+const date1 = new Date('2024-05-06T00:00:00.000Z');
+const date2 = new Date('2024-05-04T00:00:00.000Z');
+
+const transferredAppeal = {
+	caseTransferredDate: date1,
+	caseStatus: APPEAL_CASE_STATUS.TRANSFERRED
+};
+const transferredAppeal2 = {
+	caseTransferredDate: date2,
+	caseStatus: APPEAL_CASE_STATUS.TRANSFERRED
+};
+const notTransferred = { caseTransferredDate: null, caseStatus: APPEAL_CASE_STATUS.READY_TO_START };
+const notTransferred2 = { caseTransferredDate: null, caseStatus: null };
+const mismatchedData1 = { caseTransferredDate: null, caseStatus: APPEAL_CASE_STATUS.TRANSFERRED };
+const mismatchedData2 = {
+	caseTransferredDate: date2,
+	caseStatus: APPEAL_CASE_STATUS.READY_TO_START
+};
+
+describe('isNotTransferred', () => {
+	it('filters appeals that have both the transferred date set and status set to transferred', () => {
+		const appeals = [transferredAppeal];
+		const result = appeals.filter(isNotTransferred);
+		expect(result).toEqual([]);
+	});
+
+	it('does not filter appeals that only have the transferred date set', () => {
+		const appeals = [mismatchedData2];
+		const result = appeals.filter(isNotTransferred);
+		expect(result).toEqual([mismatchedData2]);
+	});
+
+	it('does not filter appeals that only have the status set to transferred', () => {
+		const appeals = [mismatchedData1];
+		const result = appeals.filter(isNotTransferred);
+		expect(result).toEqual([mismatchedData1]);
+	});
+
+	it('does not filter appeals that are not transferred', () => {
+		const appeals = [notTransferred, notTransferred2];
+		const result = appeals.filter(isNotTransferred);
+		expect(result).toEqual([notTransferred, notTransferred2]);
+	});
+
+	it('filters all appeals correctly', () => {
+		const appeals = [
+			transferredAppeal,
+			notTransferred,
+			mismatchedData1,
+			transferredAppeal2,
+			notTransferred2,
+			mismatchedData2
+		];
+		const result = appeals.filter(isNotTransferred);
+		expect(result).toEqual(
+			expect.arrayContaining([notTransferred, notTransferred2, mismatchedData1, mismatchedData2])
+		);
+		expect(result).not.toEqual(expect.arrayContaining([transferredAppeal2, transferredAppeal]));
+	});
+});

--- a/packages/forms-web-app/src/controllers/appeals/your-appeals.js
+++ b/packages/forms-web-app/src/controllers/appeals/your-appeals.js
@@ -7,6 +7,7 @@ const { VIEW } = require('../../lib/views');
 const logger = require('../../lib/logger');
 const { arrayHasItems } = require('@pins/common/src/lib/array-has-items');
 const { isNotWithdrawn } = require('@pins/business-rules/src/lib/filter-withdrawn-appeal');
+const { isNotTransferred } = require('@pins/business-rules/src/lib/filter-transferred-appeal');
 const { APPEAL_USER_ROLES } = require('@pins/common/src/constants');
 
 exports.get = async (req, res) => {
@@ -23,6 +24,7 @@ exports.get = async (req, res) => {
 
 		const undecidedAppeals = appeals
 			.filter(isNotWithdrawn)
+			.filter(isNotTransferred)
 			.map(mapToAppellantDashboardDisplayData)
 			.filter(Boolean)
 			.filter((appeal) => !appeal.appealDecision || appeal.displayInvalid);

--- a/packages/forms-web-app/src/controllers/lpa-dashboard/your-appeals.js
+++ b/packages/forms-web-app/src/controllers/lpa-dashboard/your-appeals.js
@@ -9,6 +9,7 @@ const {
 const { arrayHasItems } = require('@pins/common/src/lib/array-has-items');
 
 const { isNotWithdrawn } = require('@pins/business-rules/src/lib/filter-withdrawn-appeal');
+const { isNotTransferred } = require('@pins/business-rules/src/lib/filter-transferred-appeal');
 const {
 	VIEW: {
 		LPA_DASHBOARD: { DASHBOARD, ADD_REMOVE_USERS, APPEAL_DETAILS, DECIDED_APPEALS }
@@ -34,6 +35,7 @@ const getYourAppeals = async (req, res) => {
 
 	const appealsForDisplay = [...appealsCaseData, ...invalidAppeals]
 		.filter(isNotWithdrawn)
+		.filter(isNotTransferred)
 		.map(mapToLPADashboardDisplayData);
 
 	const appealsWithUpdatedChildAppealDisplayData = updateChildAppealDisplayData(appealsForDisplay);

--- a/packages/forms-web-app/src/controllers/rule-6/your-appeals.js
+++ b/packages/forms-web-app/src/controllers/rule-6/your-appeals.js
@@ -5,6 +5,7 @@ const {
 const logger = require('../../lib/logger');
 const { arrayHasItems } = require('@pins/common/src/lib/array-has-items');
 const { isNotWithdrawn } = require('@pins/business-rules/src/lib/filter-withdrawn-appeal');
+const { isNotTransferred } = require('@pins/business-rules/src/lib/filter-transferred-appeal');
 const {
 	VIEW: {
 		RULE_6: { DASHBOARD }
@@ -27,6 +28,7 @@ const getYourAppealsR6 = async (req, res) => {
 
 		const undecidedAppeals = appeals
 			.filter(isNotWithdrawn)
+			.filter(isNotTransferred)
 			.map(mapToRule6DashboardDisplayData)
 			.filter(Boolean)
 			.filter((appeal) => !appeal.appealDecision);


### PR DESCRIPTION
### Description of change

Add filter for transferred appeals and apply on dashboards

Ticket: https://pins-ds.atlassian.net/browse/A2-3882

### Checklist

- [X] Feature complete and ready for users, or behind feature-flag
- [X] Commit history is linear with no merge commits
- [ ] Requires infrastructure changes

### Important

Please do not merge from `main` (please only [rebase](https://github.com/Planning-Inspectorate/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
