### PR TITLE
fix: stop commit validation on merge queues

### DIFF
--- a/infrastructure/pipelines/terraform-ci-commit.yaml
+++ b/infrastructure/pipelines/terraform-ci-commit.yaml
@@ -1,9 +1,3 @@
-trigger:
-  branches:
-    include:
-      # trigger for merge queue branches
-      - gh-readonly-queue/*
-
 pr:
   branches:
     include:


### PR DESCRIPTION
### Description of change

Don't run commit lint on merge queue

### Checklist

- [x] Feature complete and ready for users, or behind feature-flag
- [x] Commit history is linear with no merge commits
- [ ] Requires infrastructure changes

### Important

Please do not merge from `main` (please only [rebase](https://github.com/Planning-Inspectorate/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
