### PR TITLE
fix(a2-4074): ignore delete requests for invalid docs

### DIFF
--- a/packages/integration-functions/__tests__/functions/appeal-document.test.js
+++ b/packages/integration-functions/__tests__/functions/appeal-document.test.js
@@ -150,4 +150,19 @@ describe('appeal-document', () => {
 		expect(ctx.log).toHaveBeenCalledWith(`Finished handling: ${testData.documentId}`);
 		expect(result).toEqual({});
 	});
+
+	it('Should ignore invalid delete documents requests as they wont exist in the database', async () => {
+		const result = await handler(
+			{ ...testData, datePublished: null },
+			{
+				...ctx,
+				triggerMetadata: { applicationProperties: { type: 'Delete' } }
+			}
+		);
+
+		expect(mockClient.deleteAppealDocument).not.toHaveBeenCalled();
+		expect(mockClient.putAppealDocument).not.toHaveBeenCalled();
+		expect(ctx.log).toHaveBeenCalledWith(`Invalid message status, skipping`);
+		expect(result).toEqual({});
+	});
 });

--- a/packages/integration-functions/src/functions/appeal-document.js
+++ b/packages/integration-functions/src/functions/appeal-document.js
@@ -34,16 +34,16 @@ const handler = async (message, context) => {
  * @param {AppealDocument} documentMessage
  */
 async function processDocumentMetadata(context, documentMessage) {
+	if (!checkMessageIsValid(documentMessage, context)) {
+		context.log('Invalid message status, skipping');
+		return;
+	}
+
 	const client = await createApiClient();
 	if (documentShouldBeDeleted(context)) {
 		context.log('Sending delete request to API');
 		await client.deleteAppealDocument(documentMessage.documentId);
 		context.log(`Finished handling: ${documentMessage.documentId}`);
-		return;
-	}
-
-	if (!checkMessageIsValid(documentMessage, context)) {
-		context.log('Invalid message status, skipping');
 		return;
 	}
 


### PR DESCRIPTION
### Description of change

Ignore invalid messages for delete messages as they won't have been imported

Ticket: https://pins-ds.atlassian.net/browse/A2-4074

### Checklist

- [x] Feature complete and ready for users, or behind feature-flag
- [x] Commit history is linear with no merge commits
- [ ] Requires infrastructure changes

### Important

Please do not merge from `main` (please only [rebase](https://github.com/Planning-Inspectorate/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
