### PR TITLE
feat(a2-4323): remove consultation questions from cas planning

### DIFF
--- a/packages/forms-web-app/src/dynamic-forms/cas-planning-questionnaire/journey.js
+++ b/packages/forms-web-app/src/dynamic-forms/cas-planning-questionnaire/journey.js
@@ -47,10 +47,6 @@ const makeSections = (response) => [
 		.withCondition(() => questionHasAnswer(response, questions.howYouNotifiedPeople, 'advert'))
 		.addQuestion(questions.appealNotification),
 	new Section('Consultation responses and representations', 'consultation')
-		.addQuestion(questions.statutoryConsultees)
-		.addQuestion(questions.consultationResponses)
-		.addQuestion(questions.consultationResponsesUpload)
-		.withCondition(() => questionHasAnswer(response, questions.consultationResponses, 'yes'))
 		.addQuestion(questions.representationsFromOthers)
 		.addQuestion(questions.representationUpload)
 		.withCondition(

--- a/packages/forms-web-app/src/dynamic-forms/docs/cas-planning-lpaq-journey.md
+++ b/packages/forms-web-app/src/dynamic-forms/docs/cas-planning-lpaq-journey.md
@@ -47,14 +47,6 @@ condition: () => questionHasAnswer(response, questions.howYouNotifiedPeople, 'ad
 
 ## Consultation responses and representations
 
-- radio `/statutory-consultees/` Did you consult all the relevant statutory consultees about the development?
-- boolean `/consultation-responses/` Do you have any consultation responses or standing advice from statutory consultees to upload?
-- multi-file-upload `/upload-consultation-responses/` Upload the consultation responses and standing advice
-
-```js
-condition: () => questionHasAnswer(response, questions.consultationResponses, 'yes');
-```
-
 - boolean `/representations/` Did you receive representations from members of the public or other parties?
 - multi-file-upload `/upload-representations/` Upload the representations
 

--- a/packages/forms-web-app/src/journeys/__snapshots__/index.test.js.snap
+++ b/packages/forms-web-app/src/journeys/__snapshots__/index.test.js.snap
@@ -12815,52 +12815,6 @@ exports[`Dynamic forms journey tests lpa Commercial planning (CAS) Commercial pl
 </main>"
 `;
 
-exports[`Dynamic forms journey tests lpa Commercial planning (CAS) Commercial planning (CAS) should render the consultation-responses question 1`] = `
-"<main id="main-content" role="main" class="govuk-main-wrapper govuk-main-wrapper--auto-spacing">
-    <div class="govuk-grid-row">
-        <div class="govuk-grid-column-two-thirds"></div>
-    </div>
-    <div class="govuk-grid-row">
-        <div class="govuk-grid-column-two-thirds"><span class="govuk-caption-l"> Consultation responses and representations</span>
-        </div>
-    </div>
-    <div class="govuk-grid-row">
-        <div class="govuk-grid-column-two-thirds">
-            <form action="" method="post" novalidate=null>
-                <div class="govuk-form-group">
-                    <fieldset class="govuk-fieldset" aria-describedby="consultationResponses-hint">
-                        <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
-                            <h1 class="govuk-fieldset__heading"> Do you have any consultation responses or standing advice from statutory consultees to upload?</h1>
-                        </legend>
-                        <div id="consultationResponses-hint" class="govuk-hint"></div>
-                        <div class="govuk-radios govuk-radios" data-module="govuk-radios">
-                            <div class="govuk-radios__item">
-                                <input class="govuk-radios__input" id="consultationResponses" name="consultationResponses"
-                                type="radio" value="yes" data-cy="answer-yes">
-                                <label class="govuk-label govuk-radios__label" for="consultationResponses">Yes</label>
-                            </div>
-                            <div class="govuk-radios__item">
-                                <input class="govuk-radios__input" id="consultationResponses-2" name="consultationResponses"
-                                type="radio" value="no" data-cy="answer-no">
-                                <label class="govuk-label govuk-radios__label" for="consultationResponses-2">No</label>
-                            </div>
-                        </div>
-                    </fieldset>
-                </div>
-                <button type="submit" class="govuk-button" data-module="govuk-button"
-                data-cy="button-save-and-continue">Continue</button>
-            </form>
-        </div>
-    </div>
-    <div class="govuk-grid-row">
-        <div class="govuk-grid-column-two-thirds">
-            <p class="govuk-body"><a href="/manage-appeals/questionnaire/appeal-ref" class="govuk-link">Return to questionnaire homepage</a>
-            </p>
-        </div>
-    </div>
-</main>"
-`;
-
 exports[`Dynamic forms journey tests lpa Commercial planning (CAS) Commercial planning (CAS) should render the correct-appeal-type question 1`] = `
 "<main id="main-content" role="main" class="govuk-main-wrapper govuk-main-wrapper--auto-spacing">
     <div class="govuk-grid-row">
@@ -13423,62 +13377,6 @@ exports[`Dynamic forms journey tests lpa Commercial planning (CAS) Commercial pl
 </main>"
 `;
 
-exports[`Dynamic forms journey tests lpa Commercial planning (CAS) Commercial planning (CAS) should render the statutory-consultees question 1`] = `
-"<main id="main-content" role="main" class="govuk-main-wrapper govuk-main-wrapper--auto-spacing">
-    <div class="govuk-grid-row">
-        <div class="govuk-grid-column-two-thirds"></div>
-    </div>
-    <div class="govuk-grid-row">
-        <div class="govuk-grid-column-two-thirds"><span class="govuk-caption-l"> Consultation responses and representations</span>
-        </div>
-    </div>
-    <div class="govuk-grid-row">
-        <div class="govuk-grid-column-two-thirds">
-            <form action="" method="post" novalidate=null>
-                <fieldset class="govuk-fieldset">
-                    <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
-                        <h1 class="govuk-fieldset__heading"> Did you consult all the relevant statutory consultees about the development?</h1>
-                    </legend>
-                    <div class="govuk-form-group">
-                        <div class="govuk-radios govuk-radios" data-module="govuk-radios">
-                            <div class="govuk-radios__item">
-                                <input class="govuk-radios__input" id="statutoryConsultees" name="statutoryConsultees"
-                                type="radio" value="yes" data-aria-controls="conditional-statutoryConsultees"
-                                data-cy="answer-yes">
-                                <label class="govuk-label govuk-radios__label" for="statutoryConsultees">Yes</label>
-                            </div>
-                            <div class="govuk-radios__conditional govuk-radios__conditional--hidden"
-                            id="conditional-statutoryConsultees">
-                                <div class="govuk-form-group">
-                                    <label class="govuk-label" for="statutoryConsultees_consultedBodiesDetails">Which bodies did you consult?</label>
-                                    <div id="statutoryConsultees_consultedBodiesDetails-hint"
-                                    class="govuk-hint"></div>
-                                    <textarea class="govuk-textarea" id="statutoryConsultees_consultedBodiesDetails"
-                                    name="statutoryConsultees_consultedBodiesDetails" rows="5" aria-describedby="statutoryConsultees_consultedBodiesDetails-hint"></textarea>
-                                </div>
-                            </div>
-                            <div class="govuk-radios__item">
-                                <input class="govuk-radios__input" id="statutoryConsultees-2" name="statutoryConsultees"
-                                type="radio" value="no" data-cy="answer-no">
-                                <label class="govuk-label govuk-radios__label" for="statutoryConsultees-2">No</label>
-                            </div>
-                        </div>
-                    </div>
-                </fieldset>
-                <button type="submit" class="govuk-button" data-module="govuk-button"
-                data-cy="button-save-and-continue">Continue</button>
-            </form>
-        </div>
-    </div>
-    <div class="govuk-grid-row">
-        <div class="govuk-grid-column-two-thirds">
-            <p class="govuk-body"><a href="/manage-appeals/questionnaire/appeal-ref" class="govuk-link">Return to questionnaire homepage</a>
-            </p>
-        </div>
-    </div>
-</main>"
-`;
-
 exports[`Dynamic forms journey tests lpa Commercial planning (CAS) Commercial planning (CAS) should render the supplementary-planning-documents question 1`] = `
 "<main id="main-content" role="main" class="govuk-main-wrapper govuk-main-wrapper--auto-spacing">
     <div class="govuk-grid-row">
@@ -13558,51 +13456,6 @@ exports[`Dynamic forms journey tests lpa Commercial planning (CAS) Commercial pl
                                 <input class="govuk-file-upload moj-multi-file-upload__input"
                                 id="uploadConservation" name="uploadConservation" type="file" aria-describedby="uploadConservation-hint"
                                 multiple="">
-                            </div>
-                            <button value="upload-and-remain-on-page" type="submit" name="upload-and-remain-on-page"
-                            class="govuk-button govuk-button--secondary moj-multi-file-upload__button"
-                            data-module="govuk-button" data-cy="button-upload-file">Upload file</button>
-                        </div>
-                    </div>
-                    <div class="govuk-button-group">
-                        <button type="submit" class="govuk-button" data-module="govuk-button"
-                        data-cy="button-save-and-continue">Continue</button>
-                    </div>
-                </form>
-        </div>
-    </div>
-    <div class="govuk-grid-row">
-        <div class="govuk-grid-column-two-thirds">
-            <p class="govuk-body"><a href="/manage-appeals/questionnaire/appeal-ref" class="govuk-link">Return to questionnaire homepage</a>
-            </p>
-        </div>
-    </div>
-</main>"
-`;
-
-exports[`Dynamic forms journey tests lpa Commercial planning (CAS) Commercial planning (CAS) should render the upload-consultation-responses question 1`] = `
-"<main id="main-content" role="main" class="govuk-main-wrapper govuk-main-wrapper--auto-spacing">
-    <div class="govuk-grid-row">
-        <div class="govuk-grid-column-two-thirds"><span class="govuk-caption-l">Consultation responses and representations</span>
-            <h1
-            class="govuk-heading-l">Upload the consultation responses and standing advice</h1>
-                <form action=""
-                method="post" novalidate=null enctype="multipart/form-data">
-                    <div class="moj-multi-file-upload">
-                        <div class="moj-multi-file__uploaded-files" aria-live="polite">
-                            <div class="moj-multi-file__uploaded-files-container moj-hidden">
-                                <h2 class="govuk-heading-m" id="-uploaded-files-heading">Files added</h2>
-                                <ul class="govuk-summary-list moj-multi-file-upload__list"></ul>
-                            </div>
-                        </div>
-                        <div class="moj-multi-file-upload__upload">
-                            <div class="govuk-form-group">
-                                <label class="govuk-label govuk-label--m" for="uploadConsultationResponses">Upload files</label>
-                                <div id="uploadConsultationResponses-hint" class="govuk-hint">The files must be a DOC, DOCX, PDF, TIF, JPG or PNG and be smaller than
-                                    1GB</div>
-                                <input class="govuk-file-upload moj-multi-file-upload__input"
-                                id="uploadConsultationResponses" name="uploadConsultationResponses" type="file"
-                                aria-describedby="uploadConsultationResponses-hint" multiple="">
                             </div>
                             <button value="upload-and-remain-on-page" type="submit" name="upload-and-remain-on-page"
                             class="govuk-button govuk-button--secondary moj-multi-file-upload__button"
@@ -14076,17 +13929,6 @@ exports[`Dynamic forms journey tests lpa Commercial planning (CAS) renders listi
                         <h2 class="govuk-heading-m"><span class="app-task-list__section-number">3. </span> Consultation responses and representations<strong class="govuk-tag govuk-tag--grey moj-task-list__task-completed"> Not started</strong></h2>
                     </div>
                     <dl class="govuk-summary-list">
-                        <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Statutory consultees</dt>
-                            <dd class="govuk-summary-list__value">Not started</dd>
-                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/manage-appeals/questionnaire/appeal-ref/consultation/statutory-consultees">Answer<span class="govuk-visually-hidden"> Did you consult all the relevant statutory consultees about the development?</span></a>
-                            </dd>
-                        </div>
-                        <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Responses or standing advice to upload</dt>
-                            <dd
-                            class="govuk-summary-list__value">Not started</dd>
-                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/manage-appeals/questionnaire/appeal-ref/consultation/consultation-responses">Answer<span class="govuk-visually-hidden"> Do you have any consultation responses or standing advice from statutory consultees to upload?</span></a>
-                                </dd>
-                        </div>
                         <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Representations from other parties</dt>
                             <dd
                             class="govuk-summary-list__value">Not started</dd>


### PR DESCRIPTION
### Description of change

Remove questions from cas planning LPAQ that were added by mistake

Ticket: https://pins-ds.atlassian.net/browse/A2-4323

### Checklist

- [x] Feature complete and ready for users, or behind feature-flag
- [x] Commit history is linear with no merge commits
- [ ] Requires infrastructure changes

### Important

Please do not merge from `main` (please only [rebase](https://github.com/Planning-Inspectorate/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
