### PR TITLE
feat: a2-3725 grid reference question

### DIFF
--- a/packages/appeals-service-api/src/spec/api-types.d.ts
+++ b/packages/appeals-service-api/src/spec/api-types.d.ts
@@ -93,7 +93,7 @@ export interface AppealCase {
 	/** The unique identifier of the LPA application */
 	applicationReference: string;
 	/** The outcome of the original LPA decision */
-	applicationDecision: 'granted' | 'refused' | 'not_received';
+	applicationDecision: 'granted' | 'refused';
 	/**
 	 * The date of the original LPA application
 	 * @format date-time
@@ -153,8 +153,6 @@ export interface AppealCase {
 	advertisedAppeal?: boolean;
 	/** Indicates if the appellant has informed other owners of the site */
 	ownersInformed?: boolean;
-	/** The original description of the type */
-	majorMinorDevelopment?: 'major' | 'minor' | 'other';
 	/** The original description of the development, as provided by the appellant */
 	originalDevelopmentDescription?: string;
 	developmentType?:
@@ -671,6 +669,8 @@ export interface AppellantSubmission {
 	uploadPlanningObligation?: boolean | null;
 	SubmissionDocumentUpload?: object[];
 	siteAddress?: boolean;
+	siteGridReferenceEasting?: string;
+	siteGridReferenceNorthing?: string;
 	highwayLand?: boolean;
 	advertInPosition?: boolean;
 	landownerPermission?: boolean;

--- a/packages/appeals-service-api/src/spec/appellant-submission.yaml
+++ b/packages/appeals-service-api/src/spec/appellant-submission.yaml
@@ -196,6 +196,12 @@ components:
         siteAddress:
           type: boolean
 
+        siteGridReferenceEasting:
+          type: string
+
+        siteGridReferenceNorthing:
+          type: string
+
         highwayLand:
           type: boolean
 

--- a/packages/database/src/migrations/20250917121532_adds_grid_reference_to_appellant_submission/migration.sql
+++ b/packages/database/src/migrations/20250917121532_adds_grid_reference_to_appellant_submission/migration.sql
@@ -1,0 +1,20 @@
+BEGIN TRY
+
+BEGIN TRAN;
+
+-- AlterTable
+ALTER TABLE [dbo].[AppellantSubmission] ADD [siteGridReferenceEasting] NVARCHAR(1000),
+[siteGridReferenceNorthing] NVARCHAR(1000);
+
+COMMIT TRAN;
+
+END TRY
+BEGIN CATCH
+
+IF @@TRANCOUNT > 0
+BEGIN
+    ROLLBACK TRAN;
+END;
+THROW
+
+END CATCH

--- a/packages/database/src/schema.prisma
+++ b/packages/database/src/schema.prisma
@@ -794,9 +794,11 @@ model AppellantSubmission {
   SubmissionDocumentUpload          SubmissionDocumentUpload[]
 
   // addresses
-  siteAddress              Boolean?
-  SubmissionAddress        SubmissionAddress[]
-  SubmissionListedBuilding SubmissionListedBuilding[]
+  siteAddress               Boolean?
+  SubmissionAddress         SubmissionAddress[]
+  SubmissionListedBuilding  SubmissionListedBuilding[]
+  siteGridReferenceEasting  String?
+  siteGridReferenceNorthing String?
 }
 
 /// LPAQuestionnaireSubmission represents the questionnaire responses from an LPAUser

--- a/packages/dynamic-forms/src/dynamic-components/multi-field-input/index.njk
+++ b/packages/dynamic-forms/src/dynamic-components/multi-field-input/index.njk
@@ -63,8 +63,11 @@
                             text: errors[inputField.fieldName].msg
                         },
                         value: inputField.value,
-                        classes: "govuk-input-!-width-three-quarters",
-                        attributes: inputField.attributes
+                        classes: inputField.classes | default("govuk-input-!-width-three-quarters"),
+                        attributes: inputField.attributes,
+                        hint: {
+                            text: inputField.hint 
+                        } if inputField.hint
                     }) }}
                 {% endfor %}
                 

--- a/packages/dynamic-forms/src/dynamic-components/multi-field-input/question.js
+++ b/packages/dynamic-forms/src/dynamic-components/multi-field-input/question.js
@@ -14,6 +14,8 @@ const { nl2br } = require('../../lib/string-functions');
  * @typedef {Object} InputField
  * @property {string} fieldName
  * @property {string} label
+ * @property {string} [hint]
+ * @property {string} [classes]
  * @property {string} [formatJoinString] optional property, used by formatAnswerForSummary (eg task list display), effective default to line break
  * @property {Record<string, string>} [attributes] optional property, used to add html attributes to the field
  */
@@ -44,6 +46,7 @@ class MultiFieldInputQuestion extends Question {
 		title,
 		question,
 		fieldName,
+		description,
 		url,
 		hint,
 		validators,
@@ -56,6 +59,7 @@ class MultiFieldInputQuestion extends Question {
 			title,
 			viewFolder: 'multi-field-input',
 			fieldName,
+			description,
 			url,
 			question,
 			validators,

--- a/packages/dynamic-forms/src/question-props.d.ts
+++ b/packages/dynamic-forms/src/question-props.d.ts
@@ -1,6 +1,6 @@
 import { JourneyResponse } from './journey-response';
-import BaseValidator from './validator/base-validator';
 import { QuestionVariables } from './question';
+import BaseValidator from './validator/base-validator';
 
 type QuestionTypes =
 	| 'checkbox'
@@ -69,6 +69,7 @@ export type Option = OptionWithoutDivider | { divider: string };
 interface InputField {
 	fieldName: string;
 	label: string;
+	hint?: string;
 	formatJoinString?: string; // optional property, used by formatAnswerForSummary (eg task list display), effective default to line break
 	attributes?: Record<string, string>;
 }

--- a/packages/forms-web-app/src/dynamic-forms/adverts-appeal-form/journey.js
+++ b/packages/forms-web-app/src/dynamic-forms/adverts-appeal-form/journey.js
@@ -33,7 +33,8 @@ const makeSections = (response) => [
 		.addQuestion(questions.contactDetails)
 		.addQuestion(questions.contactPhoneNumber)
 		.addQuestion(questions.appealSiteAddress)
-		// grid reference question placeholder
+		// TODO - remove question from sections once linking with appealSiteAddress complete
+		.addQuestion(questions.appealSiteGridReference)
 		.addQuestion(questions.highwayLand)
 		.addQuestion(questions.advertInPosition)
 		.addQuestion(questions.appellantGreenBelt)

--- a/packages/forms-web-app/src/dynamic-forms/docs/adverts-appeal-form-journey.md
+++ b/packages/forms-web-app/src/dynamic-forms/docs/adverts-appeal-form-journey.md
@@ -12,6 +12,7 @@ condition: () => questionHasAnswer(response, questions.applicationName, 'no');
 - multi-field-input `/contact-details/` Contact details
 - single-line-input `/phone-number/` What is your phone number?
 - address-entry `/appeal-site-address/` What is the address of the appeal site?
+- multi-field-input `/appeal-site-grid-reference/` Enter the grid reference
 - boolean `/highway-land/` Is the appeal site on highway land?
 - boolean `/advertisement-position/` Is the advertisement in position?
 - boolean `/green-belt/` Is the appeal site in a green belt?

--- a/packages/forms-web-app/src/dynamic-forms/questions.js
+++ b/packages/forms-web-app/src/dynamic-forms/questions.js
@@ -1843,6 +1843,34 @@ exports.questionProps = {
 		viewFolder: 'address-entry',
 		validators: [new AddressValidator(defaultAddressValidatorParams)]
 	},
+	appealSiteGridReference: {
+		type: 'multi-field-input',
+		title: 'Enter the grid reference',
+		question: 'Enter the grid reference',
+		url: 'appeal-site-grid-reference',
+		viewFolder: 'grid-reference',
+		fieldName: 'gridReference',
+		description:
+			'The grid reference should match what is on the application to the local planning authority. You can enter an address instead',
+		formatType: 'standard',
+		inputFields: [
+			{
+				fieldName: 'siteGridReferenceEasting',
+				label: 'Eastings',
+				hint: 'For example, 359608',
+				classes: 'govuk-!-width-one-quarter',
+				formatJoinString: ' '
+			},
+			{
+				fieldName: 'siteGridReferenceNorthing',
+				label: 'Northings',
+				hint: 'For example, 172607',
+				classes: 'govuk-!-width-one-quarter',
+				formatJoinString: ' '
+			}
+		],
+		validators: []
+	},
 	s78SiteArea: {
 		type: 'unit-option',
 		title: 'What is the area of the appeal site?',

--- a/packages/forms-web-app/src/journeys/__snapshots__/index.test.js.snap
+++ b/packages/forms-web-app/src/journeys/__snapshots__/index.test.js.snap
@@ -154,6 +154,53 @@ exports[`Dynamic forms journey tests appellant Advertisement Advertisement shoul
 </main>"
 `;
 
+exports[`Dynamic forms journey tests appellant Advertisement Advertisement should render the appeal-site-grid-reference question 1`] = `
+"<main id="main-content" role="main" class="govuk-main-wrapper govuk-main-wrapper--auto-spacing">
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds"></div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds"><span class="govuk-caption-l"> Prepare appeal</span>
+        </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+            <form action="" method="post" novalidate=null>
+                <fieldset class="govuk-fieldset">
+                    <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+                        <h1 class="govuk-fieldset__heading"> Enter the grid reference</h1>
+                    </legend>
+                    <p class="govuk-body">The grid reference should match what is on the application to the local
+                        planning authority. You can enter an address instead</p>
+                    <div class="govuk-form-group">
+                        <label class="govuk-label govuk-label" for="siteGridReferenceEasting">Eastings</label>
+                        <div id="siteGridReferenceEasting-hint" class="govuk-hint">For example, 359608</div>
+                        <input class="govuk-input govuk-!-width-one-quarter"
+                        id="siteGridReferenceEasting" name="siteGridReferenceEasting" type="text"
+                        aria-describedby="siteGridReferenceEasting-hint">
+                    </div>
+                    <div class="govuk-form-group">
+                        <label class="govuk-label govuk-label" for="siteGridReferenceNorthing">Northings</label>
+                        <div id="siteGridReferenceNorthing-hint" class="govuk-hint">For example, 172607</div>
+                        <input class="govuk-input govuk-!-width-one-quarter"
+                        id="siteGridReferenceNorthing" name="siteGridReferenceNorthing" type="text"
+                        aria-describedby="siteGridReferenceNorthing-hint">
+                    </div>
+                </fieldset>
+                <button type="submit" class="govuk-button" data-module="govuk-button"
+                data-cy="button-save-and-continue">Continue</button>
+            </form>
+        </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+            <p class="govuk-body"><a href="/appeals/adverts/appeal-form/your-appeal?id=appeal-ref" class="govuk-link">Return to your appeal</a>
+            </p>
+        </div>
+    </div>
+</main>"
+`;
+
 exports[`Dynamic forms journey tests appellant Advertisement Advertisement should render the applicant-name question 1`] = `
 "<main id="main-content" role="main" class="govuk-main-wrapper govuk-main-wrapper--auto-spacing">
     <div class="govuk-grid-row">
@@ -1592,6 +1639,12 @@ exports[`Dynamic forms journey tests appellant Advertisement renders listing pag
                                 <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals/adverts/prepare-appeal/appeal-site-address?id=appeal-ref">Answer<span class="govuk-visually-hidden"> What is the address of the appeal site?</span></a>
                                 </dd>
                         </div>
+                        <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Enter the grid reference</dt>
+                            <dd
+                            class="govuk-summary-list__value">Not started</dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals/adverts/prepare-appeal/appeal-site-grid-reference?id=appeal-ref">Answer<span class="govuk-visually-hidden"> Enter the grid reference</span></a>
+                                </dd>
+                        </div>
                         <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Is the appeal site on highway land?</dt>
                             <dd
                             class="govuk-summary-list__value">Not started</dd>
@@ -1871,6 +1924,53 @@ exports[`Dynamic forms journey tests appellant Commercial advertisement (CAS) Co
                     <button type="submit" class="govuk-button" data-module="govuk-button"
                     data-cy="button-save-and-continue">Continue</button>
                 </fieldset>
+            </form>
+        </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+            <p class="govuk-body"><a href="/appeals/adverts/appeal-form/your-appeal?id=appeal-ref" class="govuk-link">Return to your appeal</a>
+            </p>
+        </div>
+    </div>
+</main>"
+`;
+
+exports[`Dynamic forms journey tests appellant Commercial advertisement (CAS) Commercial advertisement (CAS) should render the appeal-site-grid-reference question 1`] = `
+"<main id="main-content" role="main" class="govuk-main-wrapper govuk-main-wrapper--auto-spacing">
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds"></div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds"><span class="govuk-caption-l"> Prepare appeal</span>
+        </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+            <form action="" method="post" novalidate=null>
+                <fieldset class="govuk-fieldset">
+                    <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+                        <h1 class="govuk-fieldset__heading"> Enter the grid reference</h1>
+                    </legend>
+                    <p class="govuk-body">The grid reference should match what is on the application to the local
+                        planning authority. You can enter an address instead</p>
+                    <div class="govuk-form-group">
+                        <label class="govuk-label govuk-label" for="siteGridReferenceEasting">Eastings</label>
+                        <div id="siteGridReferenceEasting-hint" class="govuk-hint">For example, 359608</div>
+                        <input class="govuk-input govuk-!-width-one-quarter"
+                        id="siteGridReferenceEasting" name="siteGridReferenceEasting" type="text"
+                        aria-describedby="siteGridReferenceEasting-hint">
+                    </div>
+                    <div class="govuk-form-group">
+                        <label class="govuk-label govuk-label" for="siteGridReferenceNorthing">Northings</label>
+                        <div id="siteGridReferenceNorthing-hint" class="govuk-hint">For example, 172607</div>
+                        <input class="govuk-input govuk-!-width-one-quarter"
+                        id="siteGridReferenceNorthing" name="siteGridReferenceNorthing" type="text"
+                        aria-describedby="siteGridReferenceNorthing-hint">
+                    </div>
+                </fieldset>
+                <button type="submit" class="govuk-button" data-module="govuk-button"
+                data-cy="button-save-and-continue">Continue</button>
             </form>
         </div>
     </div>
@@ -3319,6 +3419,12 @@ exports[`Dynamic forms journey tests appellant Commercial advertisement (CAS) re
                             <dd
                             class="govuk-summary-list__value">Not started</dd>
                                 <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals/adverts/prepare-appeal/appeal-site-address?id=appeal-ref">Answer<span class="govuk-visually-hidden"> What is the address of the appeal site?</span></a>
+                                </dd>
+                        </div>
+                        <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Enter the grid reference</dt>
+                            <dd
+                            class="govuk-summary-list__value">Not started</dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals/adverts/prepare-appeal/appeal-site-grid-reference?id=appeal-ref">Answer<span class="govuk-visually-hidden"> Enter the grid reference</span></a>
                                 </dd>
                         </div>
                         <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Is the appeal site on highway land?</dt>


### PR DESCRIPTION
### Description of change

- Adds grid reference fields to AppellantSubmission table
- Adds grid reference question
- Small edits to multi-field-input template and question to handle hints, classes and descriptions
- Temporarily added grid reference question to adverts appeal form journey for testing - to be removed when correctly linked with site address in [Ticket A2-4303](https://pins-ds.atlassian.net/browse/A2-4303)

### Screenshots
<img width="702" height="579" alt="Screenshot 2025-09-18 at 12 01 51" src="https://github.com/user-attachments/assets/d87d7220-e5a2-4968-b09f-81f1658d2974" />


Ticket: https://pins-ds.atlassian.net/browse/A2-3725

### Checklist

- [x] Feature complete and ready for users, or behind feature-flag
- [x] Commit history is linear with no merge commits
- [ ] Requires infrastructure changes

### Important

Please do not merge from `main` (please only [rebase](https://github.com/Planning-Inspectorate/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
