### PR TITLE
fix: only run infra commit validation on pr

### DIFF
--- a/infrastructure/pipelines/terraform-ci-commit.yaml
+++ b/infrastructure/pipelines/terraform-ci-commit.yaml
@@ -1,3 +1,5 @@
+trigger: none
+
 pr:
   branches:
     include:


### PR DESCRIPTION
### Description of change

Ensure infra commit pipeline only runs on PR