### PR TITLE
fix(a2-3882): add caseTransferredDate to dashboard display data

### DIFF
--- a/packages/appeals-service-api/src/routes/v2/appeal-cases/repo.js
+++ b/packages/appeals-service-api/src/routes/v2/appeal-cases/repo.js
@@ -60,6 +60,7 @@ const dashboardSelect = {
 	caseStartedDate: true,
 	casePublishedDate: true,
 	caseWithdrawnDate: true,
+	caseTransferredDate: true,
 	caseDecisionOutcomeDate: true,
 
 	// lpaq dates

--- a/packages/appeals-service-api/src/routes/v2/appeals/repo.js
+++ b/packages/appeals-service-api/src/routes/v2/appeals/repo.js
@@ -64,6 +64,7 @@ class UserAppealsRepository {
 											proofsOfEvidenceDueDate: true,
 											statementDueDate: true,
 											caseWithdrawnDate: true,
+											caseTransferredDate: true,
 											caseStatus: true,
 											siteAddressLine1: true,
 											siteAddressLine2: true,


### PR DESCRIPTION
### Description of change

Add caseTransferredDate to data retrieved for purpose of dashboard displays.

Ticket: https://pins-ds.atlassian.net/browse/A2-3882

### Checklist

- [X] Feature complete and ready for users, or behind feature-flag
- [X] Commit history is linear with no merge commits
- [ ] Requires infrastructure changes

### Important

Please do not merge from `main` (please only [rebase](https://github.com/Planning-Inspectorate/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
