### PR TITLE
fix(a2-4541): check roles correctly on appeal representations api end…

### DIFF
--- a/packages/appeals-service-api/src/routes/v2/appeal-cases/repo.js
+++ b/packages/appeals-service-api/src/routes/v2/appeal-cases/repo.js
@@ -699,6 +699,9 @@ class AppealCaseRepository {
 				}
 			});
 
+			if (!caseAndRoles?.Appeal?.Users?.length)
+				throw new Error(`${userId} has no role on case: ${caseReference}`);
+
 			return {
 				canModify: true,
 				roles: caseAndRoles?.Appeal?.Users || []


### PR DESCRIPTION
…point

### Description of change

The get representations endpoint does not sufficiently check for user roles, allowing users without roles to call this endpoint

Ticket: https://pins-ds.atlassian.net/browse/A2-4541

### Checklist

- [x] Feature complete and ready for users, or behind feature-flag
- [x] Commit history is linear with no merge commits
- [ ] Requires infrastructure changes

### Important

Please do not merge from `main` (please only [rebase](https://github.com/Planning-Inspectorate/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
