### PR TITLE
fix(a2-4587): hides v1 draft link for v2 appeals before deletion

### DIFF
--- a/packages/business-rules/src/schemas/components/appeal-details-validation/appeal-details-validation.js
+++ b/packages/business-rules/src/schemas/components/appeal-details-validation/appeal-details-validation.js
@@ -7,6 +7,7 @@ const lpaCodeValidation = require('./lpa-code/lpa-code-validation');
 const planningApplicationNumberValidation = require('./planning-application-number/planning-application-number-validation');
 const stateValidation = require('./state/state-validation');
 const typeOfPlanningApplicationValidation = require('./type-of-planning-application/type-of-planning-application-validation');
+const pinsYup = require('../../../lib/pins-yup');
 
 const appealDetailsValidation = () => {
 	return {
@@ -21,7 +22,8 @@ const appealDetailsValidation = () => {
 		state: stateValidation(),
 		appealType: appealTypeValidation(),
 		typeOfPlanningApplication: typeOfPlanningApplicationValidation(),
-		email: emailValidation()
+		email: emailValidation(),
+		hideFromDashboard: pinsYup.bool().nullable()
 	};
 };
 

--- a/packages/business-rules/src/schemas/householder-appeal/appeal-schema/index.js
+++ b/packages/business-rules/src/schemas/householder-appeal/appeal-schema/index.js
@@ -33,6 +33,7 @@ const appealValidationSchema = () => {
 			appealType: appealTypeValidation(),
 			typeOfPlanningApplication: typeOfPlanningApplicationValidation(),
 			email: emailValidation(),
+			hideFromDashboard: pinsYup.bool().nullable(),
 			eligibility: eligibilityValidation(),
 			aboutYouSection: aboutYouValidation(),
 			requiredDocumentsSection: requiredDocumentsValidation(),

--- a/packages/business-rules/src/schemas/householder-appeal/update.js
+++ b/packages/business-rules/src/schemas/householder-appeal/update.js
@@ -41,6 +41,7 @@ const update = pinsYup
 		submissionDate: pinsYup.date().transform(parseDateString).nullable(),
 		state: pinsYup.string().oneOf(Object.values(APPEAL_STATE)).required(),
 		email: pinsYup.string().email().max(255).required(),
+		hideFromDashboard: pinsYup.bool().nullable(),
 		eligibility: pinsYup
 			.object()
 			.shape({

--- a/packages/business-rules/test/data/full-appeal.js
+++ b/packages/business-rules/test/data/full-appeal.js
@@ -16,6 +16,7 @@ const appeal = {
 	appealType: '1005',
 	typeOfPlanningApplication: 'full-appeal',
 	email: 'testemail@example.com',
+	hideFromDashboard: true,
 	eligibility: {
 		applicationCategories: ['none_of_these'],
 		applicationDecision: 'granted',

--- a/packages/business-rules/test/data/householder-appeal.js
+++ b/packages/business-rules/test/data/householder-appeal.js
@@ -11,6 +11,7 @@ const appeal = {
 	typeOfPlanningApplication: 'householder-planning',
 	planningApplicationNumber: '12345',
 	email: 'test@example.com',
+	hideFromDashboard: true,
 	eligibility: {
 		applicationDecision: 'granted',
 		enforcementNotice: false,

--- a/packages/forms-web-app/__tests__/unit/controllers/appeal-householder-decision/email-address-confirmed.test.js
+++ b/packages/forms-web-app/__tests__/unit/controllers/appeal-householder-decision/email-address-confirmed.test.js
@@ -10,8 +10,10 @@ const {
 
 const { mockReq, mockRes } = require('../../mocks');
 const { isLpaInFeatureFlag } = require('#lib/is-lpa-in-feature-flag');
+const { hideFromDashboard } = require('#lib/hide-from-dashboard');
 
-jest.mock('../../../../src/lib/is-lpa-in-feature-flag');
+jest.mock('#lib/is-lpa-in-feature-flag');
+jest.mock('#lib/hide-from-dashboard');
 
 describe('controllers/appeal-householder-decision/email-address-confirmed', () => {
 	let req;
@@ -28,6 +30,7 @@ describe('controllers/appeal-householder-decision/email-address-confirmed', () =
 			isLpaInFeatureFlag.mockResolvedValueOnce(false);
 
 			await getEmailConfirmed(req, res);
+			expect(hideFromDashboard).not.toHaveBeenCalled();
 			expect(res.render).toHaveBeenCalledWith(EMAIL_CONFIRMED, {
 				listOfDocumentsUrl: 'list-of-documents'
 			});
@@ -37,6 +40,7 @@ describe('controllers/appeal-householder-decision/email-address-confirmed', () =
 			isLpaInFeatureFlag.mockResolvedValueOnce(true);
 
 			await getEmailConfirmed(req, res);
+			expect(hideFromDashboard).toHaveBeenCalled();
 			expect(res.render).toHaveBeenCalledWith(EMAIL_CONFIRMED, {
 				listOfDocumentsUrl: '/appeals/householder/appeal-form/before-you-start'
 			});

--- a/packages/forms-web-app/__tests__/unit/controllers/appeals/your-appeals.test.js
+++ b/packages/forms-web-app/__tests__/unit/controllers/appeals/your-appeals.test.js
@@ -132,5 +132,30 @@ describe('controllers/appeals/your-appeals', () => {
 				noToDoAppeals: true
 			});
 		});
+
+		it('hides appeals where hideFromDashboard is true', async () => {
+			req.appealsApiClient.getUserAppeals.mockResolvedValue([
+				{ appeal: { hideFromDashboard: true } },
+				{ appeal: { hideFromDashboard: false } },
+				{ test: 'hideFromDashboard not set' }
+			]);
+
+			mapToAppellantDashboardDisplayData.mockImplementation((data) => {
+				if (data.appeal?.hideFromDashboard === true)
+					throw new Error('Should not map hidden appeal');
+				return toDoData;
+			});
+			updateChildAppealDisplayData.mockImplementation((arr) => arr);
+			isToDoAppellantDashboard.mockReturnValue(true);
+
+			await get(req, res);
+
+			expect(mapToAppellantDashboardDisplayData).toHaveBeenCalledTimes(2);
+			expect(res.render).toHaveBeenCalledWith(VIEW.APPEALS.YOUR_APPEALS, {
+				toDoAppeals: [toDoData, toDoData],
+				waitingForReviewAppeals: [],
+				noToDoAppeals: false
+			});
+		});
 	});
 });

--- a/packages/forms-web-app/__tests__/unit/controllers/full-appeal/submit-appeal/email-address-confirmed.test.js
+++ b/packages/forms-web-app/__tests__/unit/controllers/full-appeal/submit-appeal/email-address-confirmed.test.js
@@ -8,13 +8,15 @@ const {
 	}
 } = require('../../../../../src/lib/views');
 const { isLpaInFeatureFlag } = require('#lib/is-lpa-in-feature-flag');
+const { hideFromDashboard } = require('#lib/hide-from-dashboard');
 
 const { mockReq, mockRes } = require('../../../mocks');
 const { APPEAL_ID, TYPE_OF_PLANNING_APPLICATION } = require('@pins/business-rules/src/constants');
 const config = require('../../../../../src/config');
 const { FLAG } = require('@pins/common/src/feature-flags');
 
-jest.mock('../../../../../src/lib/is-lpa-in-feature-flag');
+jest.mock('#lib/is-lpa-in-feature-flag');
+jest.mock('#lib/hide-from-dashboard');
 
 describe('controllers/full-appeal/submit-appeal/email-address-confirmed', () => {
 	let req;
@@ -37,6 +39,7 @@ describe('controllers/full-appeal/submit-appeal/email-address-confirmed', () => 
 			});
 
 			await getEmailConfirmed(req, res);
+			expect(hideFromDashboard).not.toHaveBeenCalled();
 			expect(res.render).toHaveBeenCalledWith(EMAIL_CONFIRMED, {
 				listOfDocumentsUrl: '/full-appeal/submit-appeal/list-of-documents',
 				bannerHtmlOverride
@@ -50,6 +53,7 @@ describe('controllers/full-appeal/submit-appeal/email-address-confirmed', () => 
 				return flag === FLAG.S78_APPEAL_FORM_V2;
 			});
 			await getEmailConfirmed(req, res);
+			expect(hideFromDashboard).toHaveBeenCalled();
 			expect(res.render).toHaveBeenCalledWith(EMAIL_CONFIRMED, {
 				listOfDocumentsUrl: '/appeals/full-planning/appeal-form/before-you-start',
 				bannerHtmlOverride
@@ -64,6 +68,7 @@ describe('controllers/full-appeal/submit-appeal/email-address-confirmed', () => 
 			});
 
 			await getEmailConfirmed(req, res);
+			expect(hideFromDashboard).toHaveBeenCalled();
 			expect(res.render).toHaveBeenCalledWith(EMAIL_CONFIRMED, {
 				listOfDocumentsUrl: '/appeals/listed-building/appeal-form/before-you-start',
 				bannerHtmlOverride:
@@ -81,6 +86,7 @@ describe('controllers/full-appeal/submit-appeal/email-address-confirmed', () => 
 			});
 
 			await getEmailConfirmed(req, res);
+			expect(hideFromDashboard).toHaveBeenCalled();
 			expect(res.render).toHaveBeenCalledWith(EMAIL_CONFIRMED, {
 				listOfDocumentsUrl: '/appeals/cas-planning/appeal-form/before-you-start',
 				bannerHtmlOverride:
@@ -96,6 +102,7 @@ describe('controllers/full-appeal/submit-appeal/email-address-confirmed', () => 
 			});
 
 			await getEmailConfirmed(req, res);
+			expect(hideFromDashboard).toHaveBeenCalled();
 			expect(res.render).toHaveBeenCalledWith(EMAIL_CONFIRMED, {
 				listOfDocumentsUrl: '/appeals/adverts/appeal-form/before-you-start',
 				bannerHtmlOverride:
@@ -112,6 +119,7 @@ describe('controllers/full-appeal/submit-appeal/email-address-confirmed', () => 
 			});
 
 			await getEmailConfirmed(req, res);
+			expect(hideFromDashboard).toHaveBeenCalled();
 			expect(res.render).toHaveBeenCalledWith(EMAIL_CONFIRMED, {
 				listOfDocumentsUrl: '/appeals/adverts/appeal-form/before-you-start',
 				bannerHtmlOverride:

--- a/packages/forms-web-app/src/controllers/appeal-householder-decision/email-address-confirmed.js
+++ b/packages/forms-web-app/src/controllers/appeal-householder-decision/email-address-confirmed.js
@@ -1,14 +1,19 @@
 const { FLAG } = require('@pins/common/src/feature-flags');
 const { isLpaInFeatureFlag } = require('#lib/is-lpa-in-feature-flag');
+const { hideFromDashboard } = require('#lib/hide-from-dashboard');
 
 const getEmailConfirmed = async (req, res) => {
 	const appeal = req.session.appeal;
 
 	const usingV2Form = await isLpaInFeatureFlag(appeal.lpaCode, FLAG.HAS_APPEAL_FORM_V2);
 
-	const listOfDocumentsUrl = usingV2Form
-		? '/appeals/householder/appeal-form/before-you-start'
-		: 'list-of-documents';
+	let listOfDocumentsUrl = 'list-of-documents';
+
+	if (usingV2Form) {
+		await hideFromDashboard(req, appeal);
+		listOfDocumentsUrl = '/appeals/householder/appeal-form/before-you-start';
+	}
+
 	res.render('appeal-householder-decision/email-address-confirmed', {
 		listOfDocumentsUrl
 	});

--- a/packages/forms-web-app/src/controllers/appeals/your-appeals.js
+++ b/packages/forms-web-app/src/controllers/appeals/your-appeals.js
@@ -23,6 +23,7 @@ exports.get = async (req, res) => {
 		logger.debug({ appeals }, 'appeals');
 
 		const undecidedAppeals = appeals
+			.filter((data) => data.appeal?.hideFromDashboard !== true)
 			.filter(isNotWithdrawn)
 			.filter(isNotTransferred)
 			.map(mapToAppellantDashboardDisplayData)

--- a/packages/forms-web-app/src/controllers/full-appeal/submit-appeal/email-address-confirmed.js
+++ b/packages/forms-web-app/src/controllers/full-appeal/submit-appeal/email-address-confirmed.js
@@ -10,6 +10,7 @@ const config = require('../../../config');
 const {
 	typeOfPlanningApplicationToAppealTypeMapper
 } = require('#lib/full-appeal/map-planning-application');
+const { hideFromDashboard } = require('#lib/hide-from-dashboard');
 
 const getEmailConfirmed = async (req, res) => {
 	const appeal = req.session.appeal;
@@ -27,19 +28,23 @@ const getEmailConfirmed = async (req, res) => {
 	switch (appeal.appealType) {
 		case APPEAL_ID.PLANNING_SECTION_78:
 			if (usingV2Form) {
+				await hideFromDashboard(req, appeal);
 				listOfDocumentsUrl = '/appeals/full-planning/appeal-form/before-you-start';
 			} else {
 				listOfDocumentsUrl = `/${LIST_OF_DOCUMENTS}`;
 			}
 			break;
 		case APPEAL_ID.PLANNING_LISTED_BUILDING:
+			await hideFromDashboard(req, appeal);
 			listOfDocumentsUrl = '/appeals/listed-building/appeal-form/before-you-start';
 			break;
 		case APPEAL_ID.MINOR_COMMERCIAL:
+			await hideFromDashboard(req, appeal);
 			listOfDocumentsUrl = '/appeals/cas-planning/appeal-form/before-you-start';
 			break;
 		case APPEAL_ID.ADVERTISEMENT:
 		case APPEAL_ID.MINOR_COMMERCIAL_ADVERTISEMENT:
+			await hideFromDashboard(req, appeal);
 			listOfDocumentsUrl = '/appeals/adverts/appeal-form/before-you-start';
 			break;
 	}

--- a/packages/forms-web-app/src/lib/hide-from-dashboard.js
+++ b/packages/forms-web-app/src/lib/hide-from-dashboard.js
@@ -1,0 +1,13 @@
+const { createOrUpdateAppeal } = require('#lib/appeals-api-wrapper');
+
+/**
+ * Sets flag to hide v1 appeal from dashboard
+ * @param {import('express')} req
+ * @param {any} appeal
+ */
+exports.hideFromDashboard = async (req, appeal) => {
+	if (!appeal.hideFromDashboard) {
+		appeal.hideFromDashboard = true;
+		req.session.appeal = await createOrUpdateAppeal(appeal);
+	}
+};

--- a/packages/forms-web-app/src/lib/hide-from-dashboard.test.js
+++ b/packages/forms-web-app/src/lib/hide-from-dashboard.test.js
@@ -1,0 +1,29 @@
+jest.mock('./appeals-api-wrapper');
+const { createOrUpdateAppeal } = require('./appeals-api-wrapper');
+const { hideFromDashboard } = require('./hide-from-dashboard');
+
+describe('hideFromDashboard', () => {
+	it('sets hideFromDashboard to true and updates session appeal', async () => {
+		const appeal = { id: 1 };
+		const req = {
+			session: {}
+		};
+
+		await hideFromDashboard(req, appeal);
+
+		expect(appeal.hideFromDashboard).toBe(true);
+		expect(createOrUpdateAppeal).toHaveBeenCalledWith(appeal);
+	});
+
+	it('does not reset hideFromDashboard', async () => {
+		const appeal = { id: 1, hideFromDashboard: true };
+		const req = {
+			session: {}
+		};
+
+		await hideFromDashboard(req, appeal);
+
+		expect(appeal.hideFromDashboard).toBe(true);
+		expect(createOrUpdateAppeal).not.toHaveBeenCalled();
+	});
+});


### PR DESCRIPTION
### Description of change

<!-- Please describe the change -->

Ticket: https://pins-ds.atlassian.net/browse/A2-4587

### Checklist

- [x] Feature complete and ready for users, or behind feature-flag
- [x] Commit history is linear with no merge commits
- [ ] Requires infrastructure changes

### Important

Please do not merge from `main` (please only [rebase](https://github.com/Planning-Inspectorate/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
