### PR TITLE
feat(a2-4307): show linked case status on decided appeals dashboard

### DIFF
--- a/packages/forms-web-app/src/views/appeals/your-appeals/decided-appeals.njk
+++ b/packages/forms-web-app/src/views/appeals/your-appeals/decided-appeals.njk
@@ -54,6 +54,9 @@
                     <a href="/appeals/{{item.appealNumber}}" class="govuk-link">
                       {{ item.appealNumber }}
                     </a>
+										{% if item.linkedCaseDetails %}
+											<p><strong class='govuk-tag govuk-tag--grey'>{{item.linkedCaseDetails.linkedCaseStatusLabel}}</strong></p>
+                    {% endif %}
                   </td>
                   <td>
                      {{ item.address | safe }}

--- a/packages/forms-web-app/src/views/manage-appeals/decided-appeals.njk
+++ b/packages/forms-web-app/src/views/manage-appeals/decided-appeals.njk
@@ -51,6 +51,9 @@
                    {{appeal.appealNumber}}
                   </a>
                 </td>
+								{% if appeal.linkedCaseDetails %}
+									<p><strong class='govuk-tag govuk-tag--grey'>{{appeal.linkedCaseDetails.linkedCaseStatusLabel}}</strong></p>
+                {% endif %}
                 <td class="govuk-table__cell">{{appeal.address}}</td>
                 <td class="govuk-table__cell">{{appeal.caseDecisionOutcomeDate}}</td>
 								<td class="govuk-table__cell">{{appeal.appealType}}</td>


### PR DESCRIPTION
### Description of change

Show 'Lead' and 'Child' tags on decided appeal dashboards for Appellant and LPA

Ticket: https://pins-ds.atlassian.net/browse/A2-4307

### Checklist

- [X] Feature complete and ready for users, or behind feature-flag
- [X] Commit history is linear with no merge commits
- [ ] Requires infrastructure changes

### Important

Please do not merge from `main` (please only [rebase](https://github.com/Planning-Inspectorate/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
