### PR TITLE
fix(a2-4084): update error message for national landscape

### DIFF
--- a/packages/forms-web-app/src/dynamic-forms/questions.js
+++ b/packages/forms-web-app/src/dynamic-forms/questions.js
@@ -929,11 +929,7 @@ exports.questionProps = {
 		fieldName: 'areaOutstandingBeauty',
 		url: 'area-of-outstanding-natural-beauty',
 		hint: 'A national landscape used to be called an ‘area of outstanding natural beauty’.',
-		validators: [
-			new RequiredValidator(
-				'Select yes if the appeal site is in an area of outstanding natural beauty'
-			)
-		]
+		validators: [new RequiredValidator('Select yes if the site is in a national landscape')]
 	},
 	designatedSitesCheck: {
 		type: 'checkbox',

--- a/test-packages/platform-feature-tests/cypress/e2e/lpa-manage-appeals/full-appeal-questionnaire-validation.cy.js
+++ b/test-packages/platform-feature-tests/cypress/e2e/lpa-manage-appeals/full-appeal-questionnaire-validation.cy.js
@@ -420,7 +420,7 @@ describe('Full appleal questionnaire validation', { tags: '@S78-LPAQ-Validation-
 						.should('have.attr', 'href', '#areaOutstandingBeauty')
 						.and(
 							'contain.text',
-							'Select yes if the appeal site is in an area of outstanding natural beauty'
+							'Select yes if the site is in a national landscape'
 						);
 				} else if (linkText === 'Change') {
 					cy.get(basePage?._selectors.govukSummaryListKey)


### PR DESCRIPTION
### Description of change

Updates error message for national landscape page

Ticket: https://pins-ds.atlassian.net/browse/A2-4084

### Checklist

- [x] Feature complete and ready for users, or behind feature-flag
- [x] Commit history is linear with no merge commits
- [ ] Requires infrastructure changes

### Important

Please do not merge from `main` (please only [rebase](https://github.com/Planning-Inspectorate/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
