### PR TITLE
feat(a2-7858): resolve comment planning appeal issues from bot scans

### DIFF
--- a/packages/appeals-service-api/src/routes/v2/appeal-cases/appeal-cases.spec.js
+++ b/packages/appeals-service-api/src/routes/v2/appeal-cases/appeal-cases.spec.js
@@ -37,6 +37,7 @@ const {
 } = require('../../../../__tests__/developer/fixtures/appeals-enforcement-listed-data-model');
 
 const { appendLinkedCasesForMultipleAppeals } = require('./service');
+const { APPEAL_DOCUMENT_TYPE } = require('@planning-inspectorate/data-model');
 
 /**
  * @param {Object} dependencies
@@ -279,6 +280,111 @@ module.exports = ({ getSqlClient, setCurrentLpa, mockNotifyClient, appealsApi })
 					expect(response.status).toBe(404);
 				});
 			}
+
+			it(`handles select in query string`, async () => {
+				const response = await appealsApi
+					.get(
+						`/api/v2/appeal-cases/${publishedTestCases[0].caseReference}?fields=${encodeURIComponent(JSON.stringify({ caseReference: true, LPACode: true }))}`
+					)
+					.send();
+				expect(response.status).toBe(200);
+				expect(response.body).toEqual({
+					caseReference: publishedTestCases[0].caseReference,
+					LPACode: publishedTestCases[0].LPACode,
+					caseValidationIncompleteDetails: [],
+					caseValidationInvalidDetails: [],
+					designatedSitesNames: [],
+					lpaQuestionnaireValidationDetails: [],
+					siteAccessDetails: [],
+					siteSafetyDetails: []
+				});
+			});
+
+			it(`handles select comment planning appeal select`, async () => {
+				const testCase = publishedTestCases[0];
+
+				const response = await appealsApi
+					.get(
+						`/api/v2/appeal-cases/${testCase.caseReference}?fields=${encodeURIComponent(
+							JSON.stringify({
+								// case data
+								caseReference: true,
+								appealTypeCode: true,
+								LPACode: true,
+								caseProcedure: true,
+								caseStatus: true,
+								applicationReference: true,
+								enforcementReference: true,
+
+								// address
+								siteAddressLine1: true,
+								siteAddressLine2: true,
+								siteAddressTown: true,
+								siteAddressPostcode: true,
+								siteGridReferenceEasting: true,
+								siteGridReferenceNorthing: true,
+
+								// decision
+								caseDecisionOutcome: true,
+								caseDecisionOutcomeDate: true,
+
+								// due dates
+								interestedPartyRepsDueDate: true,
+
+								// includes:
+								Documents: {
+									select: {
+										id: true,
+										filename: true,
+										documentType: true
+									},
+									where: {
+										documentType: APPEAL_DOCUMENT_TYPE.CASE_DECISION_LETTER
+									}
+								},
+								Events: {
+									select: {
+										type: true,
+										startDate: true
+									}
+								},
+
+								// extras
+								users: true,
+								linkedCases: true
+							})
+						)}`
+					)
+					.send();
+				expect(response.status).toBe(200);
+				expect(response.body).toEqual({
+					Documents: [],
+					Events: [],
+					LPACode: testCase.LPACode,
+					appealTypeCode: testCase.CaseType?.connect?.processCode ?? null,
+					applicationReference: testCase.applicationReference,
+					caseDecisionOutcome: testCase.CaseDecisionOutcome?.connect?.key ?? null,
+					caseDecisionOutcomeDate: testCase.caseDecisionOutcomeDate,
+					caseProcedure: testCase.ProcedureType?.connect?.key ?? null,
+					caseReference: testCase.caseReference,
+					caseStatus: testCase.CaseStatus?.connect?.key ?? null,
+					caseValidationIncompleteDetails: [],
+					caseValidationInvalidDetails: [],
+					designatedSitesNames: [],
+					enforcementReference: testCase.enforcementReference,
+					interestedPartyRepsDueDate: testCase.interestedPartyRepsDueDate ?? null,
+					lpaQuestionnaireValidationDetails: [],
+					siteAccessDetails: [],
+					siteAddressLine1: testCase.siteAddressLine1,
+					siteAddressLine2: testCase.siteAddressLine2 ?? null,
+					siteAddressPostcode: testCase.siteAddressPostcode,
+					siteAddressTown: testCase.siteAddressTown,
+					siteGridReferenceEasting: testCase.siteGridReferenceEasting ?? null,
+					siteGridReferenceNorthing: testCase.siteGridReferenceNorthing ?? null,
+					siteSafetyDetails: [],
+					users: []
+				});
+			});
 
 			it(`returns 404 when not found`, async () => {
 				const response = await appealsApi.get(`/api/v2/appeal-cases/abcdefg`).send();

--- a/packages/appeals-service-api/src/routes/v2/appeal-cases/controller.js
+++ b/packages/appeals-service-api/src/routes/v2/appeal-cases/controller.js
@@ -16,13 +16,15 @@ const repo = new AppealCaseRepository();
  */
 async function getByCaseReference(req, res) {
 	const { caseReference } = req.params;
+	const { fields } = req.query;
 
 	if (!caseReference) {
 		throw ApiError.withMessage(400, 'case reference is required');
 	}
 	try {
+		const caseSelectFields = fields ? JSON.parse(fields) : undefined;
 		// only check published cases
-		const appealCase = await getCaseAndAppellant({ caseReference });
+		const appealCase = await getCaseAndAppellant({ caseReference, fields: caseSelectFields });
 		if (!appealCase) {
 			throw ApiError.withMessage(404, 'not found');
 		}

--- a/packages/appeals-service-api/src/routes/v2/appeal-cases/repo.js
+++ b/packages/appeals-service-api/src/routes/v2/appeal-cases/repo.js
@@ -121,14 +121,12 @@ class AppealCaseRepository {
 	 * todo: inefficient - cache this and refresh on put?
 	 * @param {object} opts
 	 * @param {string} opts.caseReference
+	 * @param {{ select?: import('@pins/database/src/client/client').Prisma.AppealCaseSelect }} [opts.fields]
 	 * @returns {Promise<AppealCase|null>}
 	 */
-	getByCaseReference({ caseReference }) {
-		return this.dbClient.appealCase.findUnique({
-			where: {
-				caseReference,
-				casePublishedDate: { not: null }
-			},
+	getByCaseReference({ caseReference, fields }) {
+		/** @type {{select?: import('@pins/database/src/client/client').Prisma.AppealCaseSelect }| { include?: import('@pins/database/src/client/client').Prisma.AppealCaseInclude }} */
+		let returnFields = {
 			include: {
 				Documents: DocumentsArgsPublishedOnly,
 				ListedBuildings: true,
@@ -138,6 +136,18 @@ class AppealCaseRepository {
 				AdvertDetails: true,
 				EnforcementAppealGroundsDetails: true
 			}
+		};
+
+		if (fields) {
+			returnFields = fields;
+		}
+
+		return this.dbClient.appealCase.findUnique({
+			where: {
+				caseReference,
+				casePublishedDate: { not: null }
+			},
+			...returnFields
 		});
 	}
 

--- a/packages/appeals-service-api/src/routes/v2/appeal-cases/service.js
+++ b/packages/appeals-service-api/src/routes/v2/appeal-cases/service.js
@@ -62,22 +62,37 @@ const parseJSONFields = (caseData) => {
 };
 
 /**
+ * @typedef {import('@pins/database/src/client/client').Prisma.AppealCaseSelect & { users?: boolean, relations?: boolean, linkedCases?: boolean }} AppealCaseSelect
  * Get an appeal case and appellant by case reference
  *
  * @param {object} opts
  * @param {string} opts.caseReference
+ * @param {AppealCaseSelect} opts.fields
  * @returns {Promise<AppealCaseDetailed|null>}
  */
 async function getCaseAndAppellant(opts) {
-	let appeal = await repo.getByCaseReference(opts);
+	const { users, relations, linkedCases, ...repoFields } = opts?.fields || {};
+
+	const repoOpts = {
+		...opts,
+		fields: opts.fields ? { select: repoFields } : undefined
+	};
+
+	let appeal = await repo.getByCaseReference(repoOpts);
 
 	if (!appeal) {
 		return null;
 	}
 
-	appeal = await appendAppellantAndAgent(appeal);
-	appeal = await appendAppealRelations(appeal);
-	appeal = await appendLinkedCases(appeal);
+	if (!opts.fields || users === true) {
+		appeal = await appendAppellantAndAgent(appeal);
+	}
+	if (!opts.fields || relations === true) {
+		appeal = await appendAppealRelations(appeal);
+	}
+	if (!opts.fields || linkedCases === true) {
+		appeal = await appendLinkedCases(appeal);
+	}
 
 	return parseJSONFields(appeal);
 }

--- a/packages/appeals-service-api/src/routes/v2/appeal-cases/spec.yaml
+++ b/packages/appeals-service-api/src/routes/v2/appeal-cases/spec.yaml
@@ -31,6 +31,7 @@ paths:
       description: Get an appeal case by reference. 'Public' API, for interested parties. For other users, use the users appeal cases endpoint.
       parameters:
         - $ref: '#/components/parameters/caseReference'
+        - $ref: '#/components/parameters/caseFields'
       responses:
         200:
           description: Returns the appeal case
@@ -209,6 +210,13 @@ components:
         type: string
       example: '1010101'
       description: appeal case reference
+    caseFields:
+      name: fields
+      in: query
+      schema:
+        type: string
+      description: url encoded json object with prisma select properties to specify which fields to return
+      example: '{"caseReference":true}'
 
     lpa-code:
       name: lpa-code

--- a/packages/common/src/client/appeals-api-client.js
+++ b/packages/common/src/client/appeals-api-client.js
@@ -206,10 +206,15 @@ class AppealsApiClient {
 	 * 'Public' API, only returns published cases.
 	 *
 	 * @param {string} caseReference
+	 * @param {import('../../../appeals-service-api/src/routes/v2/appeal-cases/repo').AppealCaseReturnFields} [selectFields] - Object specifying which fields to select from the appeal case
 	 * @returns {Promise<AppealCaseDetailed>}
 	 */
-	async getAppealCaseByCaseRef(caseReference) {
-		const endpoint = `${v2}/appeal-cases/${caseReference}`;
+	async getAppealCaseByCaseRef(caseReference, selectFields) {
+		const urlParams = new URLSearchParams();
+		if (selectFields) {
+			urlParams.append('fields', JSON.stringify(selectFields));
+		}
+		const endpoint = `${v2}/appeal-cases/${encodeURIComponent(caseReference)}?${urlParams.toString()}`;
 		const response = await this.#makeGetRequest(endpoint);
 		return response.json();
 	}

--- a/packages/common/src/client/appeals-api-client.test.js
+++ b/packages/common/src/client/appeals-api-client.test.js
@@ -223,6 +223,145 @@ describe('appeals-api-client', () => {
 		});
 	});
 
+	describe('getAppealCaseByCaseRef', () => {
+		it('should get appeal case by case reference without selectFields', async () => {
+			const testCaseRef = '6000000';
+			const mockResponse = {
+				id: '123',
+				caseRef: testCaseRef,
+				status: 'in_progress'
+			};
+			fetch.mockResponseOnce(JSON.stringify(mockResponse));
+			const response = await apiClient.getAppealCaseByCaseRef(testCaseRef);
+
+			expect(fetch).toHaveBeenCalledWith(
+				`${TEST_BASEURL}${v2}/appeal-cases/${testCaseRef}?`,
+				expect.objectContaining({
+					method: 'GET'
+				})
+			);
+			expect(response).toEqual(mockResponse);
+		});
+
+		it('should get appeal case with selectFields parameter', async () => {
+			const testCaseRef = '1010107';
+			const selectFields = {
+				caseReference: true,
+				appealTypeCode: true,
+				LPACode: true,
+				caseProcedure: true,
+				caseStatus: true
+			};
+			const mockResponse = {
+				caseReference: testCaseRef,
+				appealTypeCode: 'S78',
+				LPACode: 'E09000033',
+				caseProcedure: 'Written',
+				caseStatus: 'issue_decision'
+			};
+			fetch.mockResponseOnce(JSON.stringify(mockResponse));
+			const response = await apiClient.getAppealCaseByCaseRef(testCaseRef, selectFields);
+
+			// URLSearchParams handles the encoding automatically
+			const urlParams = new URLSearchParams();
+			urlParams.append('fields', JSON.stringify(selectFields));
+			const expectedUrl = `${TEST_BASEURL}${v2}/appeal-cases/${testCaseRef}?${urlParams.toString()}`;
+
+			expect(fetch).toHaveBeenCalledWith(
+				expectedUrl,
+				expect.objectContaining({
+					method: 'GET'
+				})
+			);
+			expect(response).toEqual(mockResponse);
+		});
+
+		it('should encode special characters in case reference', async () => {
+			const testCaseRef = '6000000/1';
+			const mockResponse = { id: '123', caseRef: testCaseRef };
+			fetch.mockResponseOnce(JSON.stringify(mockResponse));
+			const response = await apiClient.getAppealCaseByCaseRef(testCaseRef);
+
+			expect(fetch).toHaveBeenCalledWith(
+				`${TEST_BASEURL}${v2}/appeal-cases/6000000%2F1?`,
+				expect.objectContaining({
+					method: 'GET'
+				})
+			);
+			expect(response).toEqual(mockResponse);
+		});
+
+		it('should handle complex selectFields with nested Prisma select', async () => {
+			const testCaseRef = '1010107';
+			const selectFields = {
+				caseReference: true,
+				Documents: {
+					select: {
+						id: true,
+						filename: true,
+						documentType: true
+					},
+					where: {
+						documentType: 'caseDecisionLetter'
+					}
+				},
+				Events: {
+					select: {
+						type: true,
+						startDate: true
+					}
+				}
+			};
+			const mockResponse = { caseReference: testCaseRef };
+			fetch.mockResponseOnce(JSON.stringify(mockResponse));
+			const response = await apiClient.getAppealCaseByCaseRef(testCaseRef, selectFields);
+
+			// URLSearchParams handles the encoding
+			const urlParams = new URLSearchParams();
+			urlParams.append('fields', JSON.stringify(selectFields));
+			const expectedUrl = `${TEST_BASEURL}${v2}/appeal-cases/${testCaseRef}?${urlParams.toString()}`;
+
+			expect(fetch).toHaveBeenCalledWith(
+				expectedUrl,
+				expect.objectContaining({
+					method: 'GET'
+				})
+			);
+			expect(response).toEqual(mockResponse);
+		});
+
+		it('should handle empty selectFields object', async () => {
+			const testCaseRef = '6000000';
+			const selectFields = {};
+			const mockResponse = { id: '123', caseRef: testCaseRef };
+			fetch.mockResponseOnce(JSON.stringify(mockResponse));
+			const response = await apiClient.getAppealCaseByCaseRef(testCaseRef, selectFields);
+
+			const urlParams = new URLSearchParams();
+			urlParams.append('fields', JSON.stringify(selectFields));
+			const expectedUrl = `${TEST_BASEURL}${v2}/appeal-cases/${testCaseRef}?${urlParams.toString()}`;
+
+			expect(fetch).toHaveBeenCalledWith(
+				expectedUrl,
+				expect.objectContaining({
+					method: 'GET'
+				})
+			);
+			expect(response).toEqual(mockResponse);
+		});
+
+		it('should throw when not found', async () => {
+			const testCaseRef = 'APP-NOTFOUND';
+			fetchMock.mockResponseOnce(JSON.stringify({ message: 'Not found' }), {
+				status: 404,
+				statusText: 'Not Found',
+				headers: { 'content-type': 'application/json' }
+			});
+
+			await expect(apiClient.getAppealCaseByCaseRef(testCaseRef)).rejects.toThrow();
+		});
+	});
+
 	describe('getAppealCaseWithRepresentations', () => {
 		it('should get document details by id', async () => {
 			const testCaseReference = 'abc';

--- a/packages/forms-web-app/src/middleware/load-appeal.js
+++ b/packages/forms-web-app/src/middleware/load-appeal.js
@@ -1,0 +1,22 @@
+/**
+ * Creates a middleware function to fetch appeal by caseRef, sets on req.appealCase, rendering 404 if not found
+ * @param {Function} getAppealNumber - Function that extracts appeal number from request (e.g., req => req.params.appealNumber)
+ * @param {import('../../../appeals-service-api/src/routes/v2/appeal-cases/service').AppealCaseSelect} [selectFields]
+ * @returns {import('express').Handler}
+ */
+const loadAppeal = (getAppealNumber, selectFields) => async (req, res, next) => {
+	try {
+		const appealNumber = getAppealNumber(req);
+		req.appealCase = await req.appealsApiClient.getAppealCaseByCaseRef(appealNumber, selectFields);
+		next();
+	} catch (error) {
+		if (error?.code === 404) {
+			res.status(404).render('error/not-found');
+			return;
+		} else {
+			next(error);
+		}
+	}
+};
+
+module.exports = { loadAppeal };

--- a/packages/forms-web-app/src/middleware/load-appeal.test.js
+++ b/packages/forms-web-app/src/middleware/load-appeal.test.js
@@ -1,0 +1,120 @@
+const { loadAppeal } = require('#middleware/load-appeal');
+
+describe('loadAppeal middleware', () => {
+	let req, res, next;
+	const mockAppealCase = {
+		id: '123',
+		caseRef: 'APP-2024-001',
+		status: 'in_progress'
+	};
+
+	beforeEach(() => {
+		req = {
+			appealsApiClient: {
+				getAppealCaseByCaseRef: jest.fn()
+			},
+			params: {
+				appealNumber: 'APP-2024-001'
+			}
+		};
+		res = {
+			status: jest.fn().mockReturnThis(),
+			render: jest.fn()
+		};
+		next = jest.fn();
+	});
+
+	afterEach(() => {
+		jest.clearAllMocks();
+	});
+
+	describe('successful cases', () => {
+		it('should fetch appeal case and set on req.appealCase', async () => {
+			req.appealsApiClient.getAppealCaseByCaseRef.mockResolvedValue(mockAppealCase);
+			const getAppealNumber = (req) => req.params.appealNumber;
+
+			const middleware = loadAppeal(getAppealNumber);
+			await middleware(req, res, next);
+
+			expect(req.appealsApiClient.getAppealCaseByCaseRef).toHaveBeenCalledWith(
+				'APP-2024-001',
+				undefined
+			);
+			expect(req.appealCase).toEqual(mockAppealCase);
+			expect(next).toHaveBeenCalledWith();
+		});
+
+		it('should fetch appeal case with selectFields parameter', async () => {
+			req.appealsApiClient.getAppealCaseByCaseRef.mockResolvedValue(mockAppealCase);
+			const selectFields = { id: true, caseRef: true };
+			const getAppealNumber = (req) => req.params.appealNumber;
+
+			const middleware = loadAppeal(getAppealNumber, selectFields);
+			await middleware(req, res, next);
+
+			expect(req.appealsApiClient.getAppealCaseByCaseRef).toHaveBeenCalledWith(
+				'APP-2024-001',
+				selectFields
+			);
+			expect(req.appealCase).toEqual(mockAppealCase);
+			expect(next).toHaveBeenCalledWith();
+		});
+
+		it('should work with custom getAppealNumber function', async () => {
+			req.appealsApiClient.getAppealCaseByCaseRef.mockResolvedValue(mockAppealCase);
+			req.query = { caseRef: 'APP-2024-002' };
+			const getAppealNumber = (req) => req.query.caseRef;
+
+			const middleware = loadAppeal(getAppealNumber);
+			await middleware(req, res, next);
+
+			expect(req.appealsApiClient.getAppealCaseByCaseRef).toHaveBeenCalledWith(
+				'APP-2024-002',
+				undefined
+			);
+			expect(req.appealCase).toEqual(mockAppealCase);
+			expect(next).toHaveBeenCalledWith();
+		});
+	});
+
+	describe('error cases', () => {
+		it('should render 404 page when appeal case not found', async () => {
+			const notFoundError = new Error('Not found');
+			notFoundError.code = 404;
+			req.appealsApiClient.getAppealCaseByCaseRef.mockRejectedValue(notFoundError);
+			const getAppealNumber = (req) => req.params.appealNumber;
+
+			const middleware = loadAppeal(getAppealNumber);
+			await middleware(req, res, next);
+
+			expect(res.status).toHaveBeenCalledWith(404);
+			expect(res.render).toHaveBeenCalledWith('error/not-found');
+			expect(next).not.toHaveBeenCalled();
+		});
+
+		it('should pass other errors to next error handler', async () => {
+			const serverError = new Error('Server error');
+			serverError.code = 500;
+			req.appealsApiClient.getAppealCaseByCaseRef.mockRejectedValue(serverError);
+			const getAppealNumber = (req) => req.params.appealNumber;
+
+			const middleware = loadAppeal(getAppealNumber);
+			await middleware(req, res, next);
+
+			expect(next).toHaveBeenCalledWith(serverError);
+			expect(res.status).not.toHaveBeenCalled();
+			expect(res.render).not.toHaveBeenCalled();
+		});
+
+		it('should pass error with undefined code to next error handler', async () => {
+			const error = new Error('Unknown error');
+			req.appealsApiClient.getAppealCaseByCaseRef.mockRejectedValue(error);
+			const getAppealNumber = (req) => req.params.appealNumber;
+
+			const middleware = loadAppeal(getAppealNumber);
+			await middleware(req, res, next);
+
+			expect(next).toHaveBeenCalledWith(error);
+		});
+	});
+});

--- a/packages/forms-web-app/src/routes/file-based-router/comment-planning-appeal/appeals/_appealNumber/controller.js
+++ b/packages/forms-web-app/src/routes/file-based-router/comment-planning-appeal/appeals/_appealNumber/controller.js
@@ -12,18 +12,17 @@ const {
 
 /** @type {import('express').Handler} */
 const selectedAppeal = async (req, res) => {
-	const appealNumber = req.params.appealNumber;
+	/** @type {import('appeals-service-api').Api.AppealCaseDetailed} */
+	const appeal = req.appealCase;
 
-	const appeal = await req.appealsApiClient.getAppealCaseByCaseRef(appealNumber);
-
-	createInterestedPartySession(req, appealNumber, appeal.siteAddressPostcode);
+	createInterestedPartySession(req, appeal.caseReference, appeal.siteAddressPostcode);
 
 	const lpa = await getDepartmentFromCode(appeal.LPACode);
 	const headlineData = formatHeadlineData({ caseData: appeal, lpaName: lpa.name });
 
 	const status = getAppealStatus(appeal);
 
-	const headlineText = formatCommentHeadlineText(appealNumber, status);
+	const headlineText = formatCommentHeadlineText(appeal.caseReference, status);
 
 	const deadlineText = formatCommentDeadlineText(appeal, status);
 

--- a/packages/forms-web-app/src/routes/file-based-router/comment-planning-appeal/appeals/_appealNumber/controller.test.js
+++ b/packages/forms-web-app/src/routes/file-based-router/comment-planning-appeal/appeals/_appealNumber/controller.test.js
@@ -27,8 +27,11 @@ describe('selectedAppeal Controller Tests', () => {
 	beforeEach(() => {
 		req = {
 			params: { appealNumber: '12345' },
-			appealsApiClient: {
-				getAppealCaseByCaseRef: jest.fn()
+			appealCase: {
+				caseReference: '12345',
+				LPACode: 'LPA123',
+				siteAddressPostcode: 'AB12 3CD',
+				Events: []
 			}
 		};
 		res = {
@@ -37,11 +40,6 @@ describe('selectedAppeal Controller Tests', () => {
 	});
 
 	it('should render the appeal page with formatted data', async () => {
-		const appeal = {
-			LPACode: 'LPA123',
-			siteAddressPostcode: 'AB12 3CD',
-			Events: []
-		};
 		const lpa = { name: 'Local Planning Authority' };
 		const status = 'In Progress';
 		const headlineText = 'Headline Text';
@@ -50,7 +48,6 @@ describe('selectedAppeal Controller Tests', () => {
 		const inquiries = [];
 		const hearings = [];
 
-		req.appealsApiClient.getAppealCaseByCaseRef.mockResolvedValue(appeal);
 		getDepartmentFromCode.mockResolvedValue(lpa);
 		getAppealStatus.mockReturnValue(status);
 		formatCommentHeadlineText.mockReturnValue(headlineText);
@@ -62,19 +59,24 @@ describe('selectedAppeal Controller Tests', () => {
 
 		await selectedAppeal(req, res);
 
-		expect(req.appealsApiClient.getAppealCaseByCaseRef).toHaveBeenCalledWith('12345');
 		expect(createInterestedPartySession).toHaveBeenCalledWith(req, '12345', 'AB12 3CD');
 		expect(getDepartmentFromCode).toHaveBeenCalledWith('LPA123');
-		expect(getAppealStatus).toHaveBeenCalledWith(appeal);
+		expect(getAppealStatus).toHaveBeenCalledWith(req.appealCase);
 		expect(formatCommentHeadlineText).toHaveBeenCalledWith('12345', status);
-		expect(formatCommentDeadlineText).toHaveBeenCalledWith(appeal, status);
-		expect(formatCommentDecidedData).toHaveBeenCalledWith(appeal);
-		expect(formatCommentInquiryText).toHaveBeenCalledWith(appeal.Events);
-		expect(formatCommentHearingText).toHaveBeenCalledWith(appeal.Events, appeal.caseStatus);
-		expect(formatHeadlineData).toHaveBeenCalledWith({ caseData: appeal, lpaName: lpa.name });
+		expect(formatCommentDeadlineText).toHaveBeenCalledWith(req.appealCase, status);
+		expect(formatCommentDecidedData).toHaveBeenCalledWith(req.appealCase);
+		expect(formatCommentInquiryText).toHaveBeenCalledWith(req.appealCase.Events);
+		expect(formatCommentHearingText).toHaveBeenCalledWith(
+			req.appealCase.Events,
+			req.appealCase.caseStatus
+		);
+		expect(formatHeadlineData).toHaveBeenCalledWith({
+			caseData: req.appealCase,
+			lpaName: lpa.name
+		});
 		expect(res.render).toHaveBeenCalledWith('comment-planning-appeal/appeals/_appealNumber/index', {
 			appeal: {
-				...appeal,
+				...req.appealCase,
 				status,
 				headlineText,
 				deadlineText,

--- a/packages/forms-web-app/src/routes/file-based-router/comment-planning-appeal/appeals/_appealNumber/index.js
+++ b/packages/forms-web-app/src/routes/file-based-router/comment-planning-appeal/appeals/_appealNumber/index.js
@@ -1,9 +1,61 @@
 const express = require('express');
 const { selectedAppeal } = require('./controller');
+const { loadAppeal } = require('#middleware/load-appeal');
 const asyncHandler = require('@pins/common/src/middleware/async-handler');
+const { APPEAL_DOCUMENT_TYPE } = require('@planning-inspectorate/data-model');
 
 const router = express.Router({ mergeParams: true });
 
-router.get('/', asyncHandler(selectedAppeal));
+router.get(
+	'/',
+	loadAppeal(/** @type {import('express').Handler} */ (req) => req.params.appealNumber, {
+		// case data
+		caseReference: true,
+		appealTypeCode: true,
+		LPACode: true,
+		caseProcedure: true,
+		caseStatus: true,
+		applicationReference: true,
+		enforcementReference: true,
+
+		// address
+		siteAddressLine1: true,
+		siteAddressLine2: true,
+		siteAddressTown: true,
+		siteAddressPostcode: true,
+		siteGridReferenceEasting: true,
+		siteGridReferenceNorthing: true,
+
+		// decision
+		caseDecisionOutcome: true,
+		caseDecisionOutcomeDate: true,
+
+		// due dates
+		interestedPartyRepsDueDate: true,
+
+		// includes:
+		Documents: {
+			select: {
+				id: true,
+				filename: true,
+				documentType: true
+			},
+			where: {
+				documentType: APPEAL_DOCUMENT_TYPE.CASE_DECISION_LETTER
+			}
+		},
+		Events: {
+			select: {
+				type: true,
+				startDate: true
+			}
+		},
+
+		// extras
+		users: true,
+		linkedCases: true
+	}),
+	asyncHandler(selectedAppeal)
+);
 
 module.exports = { router };


### PR DESCRIPTION
### Description of change

- Ensures calls to unknown appeals on the public comment planning appeal area gives 404 not 500
- Improves the performance of the queries on this page by only selecting data required for the page
- Sends the prisma select json url-encoded in the url

Ticket: https://pins-ds.atlassian.net/browse/A2-7858

### Checklist

- [x] Feature complete and ready for users, or behind feature-flag
- [x] Commit history is linear with no merge commits
- [ ] Requires infrastructure changes

### Important

Please do not merge from `main` (please only [rebase](https://github.com/Planning-Inspectorate/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
