### PR TITLE
fix(forms): fix content to match design (A2-7139)

### DIFF
--- a/packages/forms-web-app/src/views/includes/sensitive-information.njk
+++ b/packages/forms-web-app/src/views/includes/sensitive-information.njk
@@ -1,28 +1,28 @@
 {% from "govuk/components/details/macro.njk" import govukDetails %}
-
 {% set sensitiveInformation %}
-    <p class="govuk-!-margin-bottom-2">Sensitive information refers to:</p>
-    <ul class="govuk-list govuk-list--bullet govuk-!-margin-bottom-0">
-        <li>comments from children</li>
-        <li>information relating to children</li>
-        <li>information relating to health</li>
-        <li>information relating to crime</li>
-        <li>any information relating to an individual&rsquo;s:
-            <ul class="govuk-list govuk-list--bullet govuk-!-margin-bottom-0">
-                <li>race</li>
-                <li>ethnic origin</li>
-                <li>politics</li>
-                <li>religion</li>
-                <li>trade union membership</li>
-                <li>genetics</li>
-                <li>physical characteristics</li>
-                <li>sex life</li>
-                <li>sexual orientation</li>
-            </ul>
-        </li>
-    </ul>
+	<p class="govuk-!-margin-bottom-2">Sensitive information refers to:</p>
+	<ul class="govuk-list govuk-list--bullet govuk-!-margin-bottom-0">
+		<li>comments from children</li>
+		<li>information relating to children</li>
+		<li>information relating to health</li>
+		<li>information relating to crime</li>
+	</ul>
+	<p class="govuk-!-margin-bottom-2 govuk-!-margin-top-2">
+		It also includes any information relating to an individual&rsquo;s:
+	</p>
+	<ul class="govuk-list govuk-list--bullet govuk-!-margin-bottom-0">
+		<li>race</li>
+		<li>ethnic origin</li>
+		<li>politics</li>
+		<li>religion</li>
+		<li>trade union membership</li>
+		<li>genetics</li>
+		<li>physical characteristics</li>
+		<li>sex life</li>
+		<li>sexual orientation</li>
+	</ul>
 {% endset -%}
 {{ govukDetails({
-    summaryHtml: 'What is sensitive information?',
-    html: sensitiveInformation
+	summaryHtml: 'What is sensitive information?',
+	html: sensitiveInformation
 }) }}


### PR DESCRIPTION
### Description of change

- Updated content to match design

Before
<img width="414" height="456" alt="image" src="https://github.com/user-attachments/assets/3ebb9107-8a86-41a6-befb-0973c54913b5" />

After
<img width="547" height="429" alt="Screenshot 2026-04-13 at 11 43 12" src="https://github.com/user-attachments/assets/40f65d21-d740-44c0-8356-b1b79d926e33" />


Ticket: https://pins-ds.atlassian.net/browse/A2-7139

### Checklist

- [ ] Feature complete and ready for users, or behind feature-flag
- [ ] Commit history is linear with no merge commits
- [ ] Requires infrastructure changes

### Important

Please do not merge from `main` (please only [rebase](https://github.com/Planning-Inspectorate/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
