### PR TITLE
feat(A2-7820): add new document mapping for environemental statement

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
 				"@azure/service-bus": "^7.9.1",
 				"@azure/storage-blob": "^12.29.1",
 				"@ministryofjustice/frontend": "^1.6.4",
-				"@planning-inspectorate/data-model": "^2.29.0",
+				"@planning-inspectorate/data-model": "^2.31.2",
 				"@prisma/adapter-mssql": "^7.6.0",
 				"@prisma/client": "^7.6.0",
 				"accessible-autocomplete": "^3.0.1",
@@ -6210,9 +6210,9 @@
 			}
 		},
 		"node_modules/@planning-inspectorate/data-model": {
-			"version": "2.29.0",
-			"resolved": "https://registry.npmjs.org/@planning-inspectorate/data-model/-/data-model-2.29.0.tgz",
-			"integrity": "sha512-JMhhBJcid3Zvq3hfaUPucFBPXJPQtTPMRHXG54Kg27XM3fRWV986ca/TT1tAxpG1/+Aa+STujkaJVYymxv5lEw==",
+			"version": "2.31.2",
+			"resolved": "https://registry.npmjs.org/@planning-inspectorate/data-model/-/data-model-2.31.2.tgz",
+			"integrity": "sha512-p/0Pka6OqLrlIHX49DzRMxAAf0ExwZG2x867dRIuXyIooDXD8IzJo1WQX7GvCYG97eVIztpJG2wTeVvgdBFGiw==",
 			"license": "MIT",
 			"dependencies": {
 				"jsonc-parser": "^3.3.1"
@@ -13192,6 +13192,7 @@
 			"version": "2.3.3",
 			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
 			"integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+			"dev": true,
 			"hasInstallScript": true,
 			"license": "MIT",
 			"optional": true,

--- a/package.json
+++ b/package.json
@@ -108,7 +108,7 @@
 		"@azure/service-bus": "^7.9.1",
 		"@azure/storage-blob": "^12.29.1",
 		"@ministryofjustice/frontend": "^1.6.4",
-		"@planning-inspectorate/data-model": "^2.29.0",
+		"@planning-inspectorate/data-model": "^2.31.2",
 		"@prisma/adapter-mssql": "^7.6.0",
 		"@prisma/client": "^7.6.0",
 		"accessible-autocomplete": "^3.0.1",

--- a/packages/common/src/document-types.js
+++ b/packages/common/src/document-types.js
@@ -470,7 +470,7 @@ const documentTypes = {
 	},
 	appellantEnvironmentalStatement: {
 		name: 'appellantEnvironmentalStatement',
-		dataModelName: APPEAL_DOCUMENT_TYPE.ENVIRONMENTAL_ASSESSMENT,
+		dataModelName: APPEAL_DOCUMENT_TYPE.EIA_ENVIRONMENTAL_STATEMENT_APPELLANT,
 		multiple: true,
 		displayName: 'Environmental statement',
 		involvement: 'Appellant',


### PR DESCRIPTION
### Description of change

Update document type for appellant environmental statement
Update data-model version
Ticket: https://pins-ds.atlassian.net/browse/A2-7820

### Checklist

- [x] Feature complete and ready for users, or behind feature-flag
- [x] Commit history is linear with no merge commits
- [ ] Requires infrastructure changes

### Important

Please do not merge from `main` (please only [rebase](https://github.com/Planning-Inspectorate/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
