### PR TITLE
fix(database): corrected string char limit (A2-7139)

### DIFF
--- a/packages/database/src/migrations/20260416145056_increased_string_size_for_why_are_you_appealing_field/migration.sql
+++ b/packages/database/src/migrations/20260416145056_increased_string_size_for_why_are_you_appealing_field/migration.sql
@@ -1,0 +1,19 @@
+BEGIN TRY
+
+BEGIN TRAN;
+
+-- AlterTable
+ALTER TABLE [dbo].[AppellantSubmission] ALTER COLUMN [whyAreYouAppealing] NVARCHAR(max) NULL;
+
+COMMIT TRAN;
+
+END TRY
+BEGIN CATCH
+
+IF @@TRANCOUNT > 0
+BEGIN
+    ROLLBACK TRAN;
+END;
+THROW
+
+END CATCH

--- a/packages/database/src/schema.prisma
+++ b/packages/database/src/schema.prisma
@@ -870,7 +870,7 @@ model AppellantSubmission {
   anySignificantChanges_nationalPolicySignificantChanges String? @db.NVarChar(MAX)
   anySignificantChanges_courtJudgementSignificantChanges String? @db.NVarChar(MAX)
   siteUseAtTimeOfApplication                             String?
-  whyAreYouAppealing                                     String?
+  whyAreYouAppealing                                     String? @db.NVarChar(MAX)
 
   // number entries
   siteAreaSquareMetres            Decimal?


### PR DESCRIPTION
### Description of change

- Added char limit to whyAreYouAppealing field after issue adding chars between 175-200 (limit should be 250)

Ticket: https://pins-ds.atlassian.net/browse/A2-7139

### Checklist

- [ ] Feature complete and ready for users, or behind feature-flag
- [ ] Commit history is linear with no merge commits
- [ ] Requires infrastructure changes

### Important

Please do not merge from `main` (please only [rebase](https://github.com/Planning-Inspectorate/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
