### PR TITLE
fix(forms): added missing text on other documents page (A2-7582)

### DIFF
--- a/packages/forms-web-app/src/dynamic-forms/questions.js
+++ b/packages/forms-web-app/src/dynamic-forms/questions.js
@@ -2217,6 +2217,7 @@ exports.getQuestionProps = (response) => ({
 		question: 'Upload any other documents submitted with the application',
 		fieldName: 'uploadAdditionalDocuments',
 		url: 'upload-other-documents',
+		html: 'resources/upload-other-documents/content.html',
 		validators: [
 			new RequiredFileUploadValidator('Select any other documents'),
 			new MultifileUploadValidator(defaultFileUploadValidatorParams)

--- a/packages/forms-web-app/src/public/resources/upload-other-documents/content.html
+++ b/packages/forms-web-app/src/public/resources/upload-other-documents/content.html
@@ -1,0 +1,8 @@
+<p class="govuk-body">
+	Upload any additional documents, excluding the design and access statement and any plans and
+	drawings.
+</p>
+<p class="govuk-body">
+	This should include any documents that were considered when determining the application and any
+	additional evidence that you took into account.
+</p>


### PR DESCRIPTION
### Description of change

- Added HTML page to uploadAdditionalDocumentsPart1 question
Before
<img width="700" height="582" alt="image" src="https://github.com/user-attachments/assets/afd65a74-4045-48d2-81ae-0c15dbf27998" />

After
<img width="797" height="747" alt="Screenshot 2026-04-20 at 10 59 25" src="https://github.com/user-attachments/assets/f781c25e-371e-472c-96b6-0f73cacd20a6" />


Ticket: https://pins-ds.atlassian.net/browse/A2-7582

### Checklist

- [ ] Feature complete and ready for users, or behind feature-flag
- [ ] Commit history is linear with no merge commits
- [ ] Requires infrastructure changes

### Important

Please do not merge from `main` (please only [rebase](https://github.com/Planning-Inspectorate/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
