### PR TITLE
feat(A2-7879): display of representations for enforcement child linke…

### DIFF
--- a/packages/business-rules/src/rules/appeal-case/case-due-dates.js
+++ b/packages/business-rules/src/rules/appeal-case/case-due-dates.js
@@ -143,6 +143,7 @@ exports.isRule6ProofsOfEvidenceOpen = (appealCaseData) =>
  * @returns {boolean}
  */
 const finalCommentsAreOpen = (appealCaseData) =>
+	!isChildLinkedAppeal(appealCaseData) &&
 	!deadlineHasPassed(appealCaseData.finalCommentsDueDate) &&
 	appealCaseData.caseStatus === APPEAL_CASE_STATUS.FINAL_COMMENTS;
 
@@ -152,9 +153,7 @@ const finalCommentsAreOpen = (appealCaseData) =>
  * @returns {boolean}
  */
 exports.isAppellantFinalCommentOpen = (appealCaseData) =>
-	!isChildLinkedAppeal(appealCaseData) &&
-	finalCommentsAreOpen(appealCaseData) &&
-	!appealCaseData.appellantCommentsSubmittedDate;
+	finalCommentsAreOpen(appealCaseData) && !appealCaseData.appellantCommentsSubmittedDate;
 
 /**
  * final comment is open for LPA
@@ -162,6 +161,4 @@ exports.isAppellantFinalCommentOpen = (appealCaseData) =>
  * @returns {boolean}
  */
 exports.isLPAFinalCommentOpen = (appealCaseData) =>
-	!isChildLinkedAppeal(appealCaseData) &&
-	finalCommentsAreOpen(appealCaseData) &&
-	!appealCaseData.LPACommentsSubmittedDate;
+	finalCommentsAreOpen(appealCaseData) && !appealCaseData.LPACommentsSubmittedDate;

--- a/packages/forms-web-app/src/controllers/selected-appeal/appellant-sections.js
+++ b/packages/forms-web-app/src/controllers/selected-appeal/appellant-sections.js
@@ -11,6 +11,7 @@ const {
 } = require('@pins/common/src/constants');
 const { formatSubmissionDate } = require('@pins/common/src/lib/format-appeal-details');
 const config = require('../../config');
+const { isEnforcementChildLinkedAppeal } = require('@pins/common/src/lib/linked-appeals');
 
 /**
  * @type {import("@pins/common/src/view-model-maps/sections/def").Sections}
@@ -55,6 +56,7 @@ exports.sections = [
 				},
 				condition: (appealCase) =>
 					config.featureFlag.appellantStatementEnabled &&
+					!isEnforcementChildLinkedAppeal(appealCase) &&
 					representationExists(appealCase.Representations, {
 						type: REPRESENTATION_TYPES.STATEMENT,
 						owned: true,
@@ -65,6 +67,7 @@ exports.sections = [
 				url: '/lpa-statement',
 				text: 'View local planning authority statement',
 				condition: (appealCase) =>
+					!isEnforcementChildLinkedAppeal(appealCase) &&
 					representationPublished(appealCase.Representations, {
 						type: REPRESENTATION_TYPES.STATEMENT,
 						owned: false,
@@ -90,6 +93,7 @@ exports.sections = [
 				url: '/interested-party-comments',
 				text: 'View interested party comments',
 				condition: (appealCase) =>
+					!isEnforcementChildLinkedAppeal(appealCase) &&
 					representationPublished(appealCase.Representations, {
 						type: REPRESENTATION_TYPES.INTERESTED_PARTY_COMMENT
 					})
@@ -103,6 +107,7 @@ exports.sections = [
 				url: '/final-comments',
 				text: 'View your final comments',
 				condition: (appealCase) =>
+					!isEnforcementChildLinkedAppeal(appealCase) &&
 					representationExists(appealCase.Representations, {
 						type: REPRESENTATION_TYPES.FINAL_COMMENT,
 						owned: true,
@@ -113,6 +118,7 @@ exports.sections = [
 				url: '/lpa-final-comments',
 				text: 'View local planning authority final comments',
 				condition: (appealCase) =>
+					!isEnforcementChildLinkedAppeal(appealCase) &&
 					representationPublished(appealCase.Representations, {
 						type: REPRESENTATION_TYPES.FINAL_COMMENT,
 						owned: false,

--- a/packages/forms-web-app/src/controllers/selected-appeal/lpa-user-sections.js
+++ b/packages/forms-web-app/src/controllers/selected-appeal/lpa-user-sections.js
@@ -11,6 +11,7 @@ const {
 } = require('@pins/common/src/constants');
 const { formatSubmissionDate } = require('@pins/common/src/lib/format-appeal-details');
 const config = require('../../config');
+const { isEnforcementChildLinkedAppeal } = require('@pins/common/src/lib/linked-appeals');
 
 /**
  * @type {import("@pins/common/src/view-model-maps/sections/def").Sections}
@@ -62,6 +63,7 @@ exports.sections = [
 						)
 				},
 				condition: (appealCase) =>
+					!isEnforcementChildLinkedAppeal(appealCase) &&
 					representationExists(appealCase.Representations, {
 						type: REPRESENTATION_TYPES.STATEMENT,
 						owned: true,
@@ -73,6 +75,7 @@ exports.sections = [
 				text: 'View appellant statement',
 				condition: (appealCase) =>
 					config.featureFlag.appellantStatementEnabled &&
+					!isEnforcementChildLinkedAppeal(appealCase) &&
 					representationPublished(appealCase.Representations, {
 						type: REPRESENTATION_TYPES.STATEMENT,
 						owned: false,
@@ -98,6 +101,7 @@ exports.sections = [
 				url: '/interested-party-comments',
 				text: 'View interested party comments',
 				condition: (appealCase) =>
+					!isEnforcementChildLinkedAppeal(appealCase) &&
 					representationPublished(appealCase.Representations, {
 						type: REPRESENTATION_TYPES.INTERESTED_PARTY_COMMENT
 					})
@@ -122,6 +126,7 @@ exports.sections = [
 						)
 				},
 				condition: (appealCase) =>
+					!isEnforcementChildLinkedAppeal(appealCase) &&
 					representationExists(appealCase.Representations, {
 						type: REPRESENTATION_TYPES.FINAL_COMMENT,
 						owned: true,
@@ -132,6 +137,7 @@ exports.sections = [
 				url: '/appellant-final-comments',
 				text: 'View appellant final comments',
 				condition: (appealCase) =>
+					!isEnforcementChildLinkedAppeal(appealCase) &&
 					representationPublished(appealCase.Representations, {
 						type: REPRESENTATION_TYPES.FINAL_COMMENT,
 						owned: false,

--- a/packages/forms-web-app/src/controllers/selected-appeal/user-sections.test.js
+++ b/packages/forms-web-app/src/controllers/selected-appeal/user-sections.test.js
@@ -6,6 +6,7 @@ const {
 	REPRESENTATION_TYPES,
 	LPA_USER_ROLE
 } = require('@pins/common/src/constants');
+const { CASE_TYPES } = require('@pins/common/src/database/data-static');
 const { APPEAL_REPRESENTATION_STATUS } = require('@planning-inspectorate/data-model');
 
 const { addDays } = require('date-fns');
@@ -17,6 +18,7 @@ describe('LPA and Appellant Sections', () => {
 	beforeEach(() => {
 		appealCase = {
 			caseValidDate: '2023-09-01',
+			caseReference: 'testCaseReference',
 			// statusPlanningObligation: 'finalised',
 
 			// lpaq
@@ -119,6 +121,24 @@ describe('LPA and Appellant Sections', () => {
 				expect(link?.condition(appealCase)).toBe(false);
 			});
 
+			it('should not show "View your statement" when enforcement child linked appeal', () => {
+				const testCase = structuredClone(appealCase);
+
+				testCase.Representations = [
+					{
+						submittingPartyType: LPA_USER_ROLE,
+						representationStatus: APPEAL_REPRESENTATION_STATUS.PUBLISHED,
+						userOwnsRepresentation: true,
+						representationType: REPRESENTATION_TYPES.STATEMENT
+					}
+				];
+				testCase.appealTypeCode = CASE_TYPES.ENFORCEMENT.processCode;
+				testCase.linkedCases = [{ childCaseReference: appealCase.caseReference }];
+				const section = findSectionByHeading(lpaSections, 'Statements');
+				const link = findLinkByUrl(section, '/statement');
+				expect(link?.condition(testCase)).toBe(false);
+			});
+
 			it('should show "View other party statements" when a rule6Statement is published', () => {
 				appealCase.Representations = [
 					{
@@ -160,6 +180,22 @@ describe('LPA and Appellant Sections', () => {
 				const section = findSectionByHeading(lpaSections, 'Interested party comments');
 				const link = findLinkByUrl(section, '/interested-party-comments');
 				expect(link?.condition(appealCase)).toBe(false);
+			});
+
+			it('should not show "View interested party comments" when enforcement child linked appeal', () => {
+				const testCase = structuredClone(appealCase);
+				testCase.Representations = [
+					{
+						representationStatus: APPEAL_REPRESENTATION_STATUS.PUBLISHED,
+						representationType: REPRESENTATION_TYPES.INTERESTED_PARTY_COMMENT
+					}
+				];
+				testCase.appealTypeCode = CASE_TYPES.ENFORCEMENT.processCode;
+				testCase.linkedCases = [{ childCaseReference: appealCase.caseReference }];
+
+				const section = findSectionByHeading(lpaSections, 'Interested party comments');
+				const link = findLinkByUrl(section, '/interested-party-comments');
+				expect(link?.condition(testCase)).toBe(false);
 			});
 		});
 
@@ -209,6 +245,24 @@ describe('LPA and Appellant Sections', () => {
 				expect(link?.condition(appealCase)).toBe(false);
 			});
 
+			it('should not show "View your final comments" when enforcement linked child appeal', () => {
+				const testCase = structuredClone(appealCase);
+
+				testCase.Representations = [
+					{
+						submittingPartyType: LPA_USER_ROLE,
+						representationStatus: APPEAL_REPRESENTATION_STATUS.PUBLISHED,
+						userOwnsRepresentation: true,
+						representationType: REPRESENTATION_TYPES.FINAL_COMMENT
+					}
+				];
+				testCase.appealTypeCode = CASE_TYPES.ENFORCEMENT.processCode;
+				testCase.linkedCases = [{ childCaseReference: appealCase.caseReference }];
+				const section = findSectionByHeading(lpaSections, 'Final comments');
+				const link = findLinkByUrl(section, '/final-comments');
+				expect(link?.condition(testCase)).toBe(false);
+			});
+
 			it('should show "View appellant final comments" when appellant comment is published ', () => {
 				appealCase.Representations = [
 					{
@@ -229,6 +283,24 @@ describe('LPA and Appellant Sections', () => {
 				const section = findSectionByHeading(lpaSections, 'Final comments');
 				const link = findLinkByUrl(section, '/appellant-final-comments');
 				expect(link?.condition(appealCase)).toBe(false);
+			});
+
+			it('should not show "View appellant final comments" when enforcement linked child appeal', () => {
+				const testCase = structuredClone(appealCase);
+
+				testCase.Representations = [
+					{
+						submittingPartyType: APPEAL_USER_ROLES.APPELLANT,
+						representationStatus: APPEAL_REPRESENTATION_STATUS.PUBLISHED,
+						userOwnsRepresentation: false,
+						representationType: REPRESENTATION_TYPES.FINAL_COMMENT
+					}
+				];
+				testCase.appealTypeCode = CASE_TYPES.ENFORCEMENT.processCode;
+				testCase.linkedCases = [{ childCaseReference: appealCase.caseReference }];
+				const section = findSectionByHeading(lpaSections, 'Final comments');
+				const link = findLinkByUrl(section, '/final-comments');
+				expect(link?.condition(testCase)).toBe(false);
 			});
 		});
 
@@ -353,6 +425,24 @@ describe('LPA and Appellant Sections', () => {
 				expect(link?.condition(appealCase)).toBe(false);
 			});
 
+			it('should not show "View local planning authority statement" when enforcement linked child appeal', () => {
+				const testCase = structuredClone(appealCase);
+
+				testCase.Representations = [
+					{
+						submittingPartyType: LPA_USER_ROLE,
+						representationStatus: APPEAL_REPRESENTATION_STATUS.PUBLISHED,
+						userOwnsRepresentation: false,
+						representationType: REPRESENTATION_TYPES.STATEMENT
+					}
+				];
+				testCase.appealTypeCode = CASE_TYPES.ENFORCEMENT.processCode;
+				testCase.linkedCases = [{ childCaseReference: appealCase.caseReference }];
+				const section = findSectionByHeading(appellantSections, 'Statements');
+				const link = findLinkByUrl(section, '/lpa-statement');
+				expect(link?.condition(testCase)).toBe(false);
+			});
+
 			it('should show "View other party statements" when any other statement is published', () => {
 				appealCase.Representations = [
 					{
@@ -395,6 +485,22 @@ describe('LPA and Appellant Sections', () => {
 				const section = findSectionByHeading(appellantSections, 'Interested party comments');
 				const link = findLinkByUrl(section, '/interested-party-comments');
 				expect(link?.condition(appealCase)).toBe(false);
+			});
+
+			it('should not show "View interested party comments" when enforcement child linked appeal', () => {
+				const testCase = structuredClone(appealCase);
+				testCase.Representations = [
+					{
+						representationStatus: APPEAL_REPRESENTATION_STATUS.PUBLISHED,
+						representationType: REPRESENTATION_TYPES.INTERESTED_PARTY_COMMENT
+					}
+				];
+				testCase.appealTypeCode = CASE_TYPES.ENFORCEMENT.processCode;
+				testCase.linkedCases = [{ childCaseReference: appealCase.caseReference }];
+
+				const section = findSectionByHeading(lpaSections, 'Interested party comments');
+				const link = findLinkByUrl(section, '/interested-party-comments');
+				expect(link?.condition(testCase)).toBe(false);
 			});
 		});
 
@@ -444,6 +550,24 @@ describe('LPA and Appellant Sections', () => {
 				expect(link?.condition(appealCase)).toBe(false);
 			});
 
+			it('should not show "View your final comments" when enforcement child linked appeal', () => {
+				const testCase = structuredClone(appealCase);
+
+				testCase.Representations = [
+					{
+						submittingPartyType: APPEAL_USER_ROLES.APPELLANT,
+						representationStatus: APPEAL_REPRESENTATION_STATUS.PUBLISHED,
+						userOwnsRepresentation: true,
+						representationType: REPRESENTATION_TYPES.FINAL_COMMENT
+					}
+				];
+				testCase.appealTypeCode = CASE_TYPES.ENFORCEMENT.processCode;
+				testCase.linkedCases = [{ childCaseReference: appealCase.caseReference }];
+				const section = findSectionByHeading(appellantSections, 'Final comments');
+				const link = findLinkByUrl(section, '/final-comments');
+				expect(link?.condition(testCase)).toBe(false);
+			});
+
 			it('should show "View local planning authority final comments" when lpaFinalCommentsPublished is true', () => {
 				appealCase.Representations = [
 					{
@@ -464,6 +588,24 @@ describe('LPA and Appellant Sections', () => {
 				const section = findSectionByHeading(appellantSections, 'Final comments');
 				const link = findLinkByUrl(section, '/lpa-final-comments');
 				expect(link?.condition(appealCase)).toBe(false);
+			});
+
+			it('should not show "View local planning authority final comments" when enforcement child linked appeal', () => {
+				const testCase = structuredClone(appealCase);
+
+				testCase.Representations = [
+					{
+						submittingPartyType: LPA_USER_ROLE,
+						representationStatus: APPEAL_REPRESENTATION_STATUS.PUBLISHED,
+						userOwnsRepresentation: false,
+						representationType: REPRESENTATION_TYPES.FINAL_COMMENT
+					}
+				];
+				testCase.appealTypeCode = CASE_TYPES.ENFORCEMENT.processCode;
+				testCase.linkedCases = [{ childCaseReference: appealCase.caseReference }];
+				const section = findSectionByHeading(appellantSections, 'Final comments');
+				const link = findLinkByUrl(section, '/lpa-final-comments');
+				expect(link?.condition(testCase)).toBe(false);
 			});
 		});
 


### PR DESCRIPTION
…d cases

### Description of change

Prevent submission of representations on enforcement child linked appeals. 

Prevent display of representations on appeal page of enforcement child linked appeals.

Ticket: https://pins-ds.atlassian.net/browse/A2-7676
https://pins-ds.atlassian.net/browse/A2-7750
https://pins-ds.atlassian.net/browse/A2-7828
https://pins-ds.atlassian.net/browse/A2-7879
https://pins-ds.atlassian.net/browse/A2-7882
https://pins-ds.atlassian.net/browse/A2-7885
https://pins-ds.atlassian.net/browse/A2-7887

### Checklist

- [X] Feature complete and ready for users, or behind feature-flag
- [X] Commit history is linear with no merge commits
- [ ] Requires infrastructure changes

### Important

Please do not merge from `main` (please only [rebase](https://github.com/Planning-Inspectorate/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
