### PR TITLE
fix(forms): removed status planning obligation for s78 expedite 

### DIFF
--- a/packages/forms-web-app/src/dynamic-forms/s78-appeal-form-part-1/journey.js
+++ b/packages/forms-web-app/src/dynamic-forms/s78-appeal-form-part-1/journey.js
@@ -159,19 +159,8 @@ const makeSections = (response) => {
 			.addQuestion(questions.uploadApplicationDecisionLetter)
 			.withCondition(() => shouldDisplayUploadDecisionLetter(response))
 			.addQuestion(questions.planningObligationPart1)
-			.addQuestion(questions.planningObligationStatus)
-			.withCondition(() => questionHasAnswer(response, questions.planningObligationPart1, 'yes'))
 			.addQuestion(questions.uploadPlanningObligation)
-			.withCondition(() =>
-				questionsHaveAnswers(
-					response,
-					[
-						[questions.planningObligationPart1, 'yes'],
-						[questions.planningObligationStatus, 'finalised']
-					],
-					{ logicalCombinator: 'and' }
-				)
-			)
+			.withCondition(() => questionHasAnswer(response, questions.planningObligationPart1, 'yes'))
 			.addQuestion(questions.separateOwnershipCert)
 			.addQuestion(questions.uploadSeparateOwnershipCert)
 			.withCondition(() => questionHasAnswer(response, questions.separateOwnershipCert, 'yes'))


### PR DESCRIPTION

### Description of change

- Removed question Whats the status of planning obligation for s78 expedite

Ticket: https://pins-ds.atlassian.net/browse/A2-7581

### Checklist

- [ ] Feature complete and ready for users, or behind feature-flag
- [ ] Commit history is linear with no merge commits
- [ ] Requires infrastructure changes

### Important

Please do not merge from `main` (please only [rebase](https://github.com/Planning-Inspectorate/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
