### PR TITLE
fix(forms): removed upload appellant statement for s78 expedite (A2-8008)

### DIFF
--- a/packages/forms-web-app/src/dynamic-forms/s78-appeal-form-part-1/journey.js
+++ b/packages/forms-web-app/src/dynamic-forms/s78-appeal-form-part-1/journey.js
@@ -164,7 +164,6 @@ const makeSections = (response) => {
 			.addQuestion(questions.separateOwnershipCert)
 			.addQuestion(questions.uploadSeparateOwnershipCert)
 			.withCondition(() => questionHasAnswer(response, questions.separateOwnershipCert, 'yes'))
-			.addQuestion(questions.uploadAppellantStatement)
 			.addQuestion(questions.uploadChangeOfDescriptionEvidence)
 			.withCondition(() =>
 				questionHasAnswer(response, questions.updateDevelopmentDescription, 'yes')


### PR DESCRIPTION

### Description of change

- Removed Upload appellant statement question for s78 expedite

Ticket: https://pins-ds.atlassian.net/browse/A2-8008

### Checklist

- [ ] Feature complete and ready for users, or behind feature-flag
- [ ] Commit history is linear with no merge commits
- [ ] Requires infrastructure changes

### Important

Please do not merge from `main` (please only [rebase](https://github.com/Planning-Inspectorate/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
