### PR TITLE
fix: improve service user lookups with batched queries

### DIFF
--- a/packages/appeals-service-api/src/repositories/sql/service-user-repository.js
+++ b/packages/appeals-service-api/src/repositories/sql/service-user-repository.js
@@ -2,6 +2,7 @@ const { createPrismaClient } = require('#db-client');
 const { APPEAL_USER_ROLES } = require('@pins/common/src/constants');
 const { SERVICE_USER_TYPE } = require('@planning-inspectorate/data-model');
 const { AppealUserRepository } = require('#repositories/sql/appeal-user-repository');
+const { chunkArray } = require('@pins/common/src/database/chunk-array');
 
 /**
  * @typedef {import('@pins/database/src/client/client').ServiceUser} ServiceUser
@@ -59,6 +60,82 @@ class ServiceUserRepository {
 				emailAddress: true,
 				serviceUserType: true,
 				organisation: true
+			}
+		});
+	}
+
+	/**
+	 * @param {Array<{serviceUserIds: string[], caseReference: string}>} lookups
+	 * @returns {Promise<Array<{caseReference: string, users: BasicServiceUser[]}>>}
+	 */
+	async getServiceUsersForMultipleCases(lookups) {
+		if (!lookups || lookups.length === 0) {
+			return [];
+		}
+
+		const BATCH_SIZE = 250;
+		const MAX_CONCURRENT = 4;
+		// batch service user lookups to avoid 2100 param limit
+		const batches = chunkArray(lookups, BATCH_SIZE);
+
+		/** @type {Array<{id: string, emailAddress: string|null, serviceUserType: string, organisation: string|null, caseReference: string}>} */
+		const serviceUsers = [];
+
+		// limit promise.all concurrency
+		for (let i = 0; i < batches.length; i += MAX_CONCURRENT) {
+			const concurrentBatches = batches.slice(i, i + MAX_CONCURRENT);
+			const results = await Promise.all(
+				concurrentBatches.map((batch) => this._getServiceUsersBatch(batch))
+			);
+			serviceUsers.push(...results.flat());
+		}
+
+		// Group by caseReference
+		const grouped = new Map();
+		for (const user of serviceUsers) {
+			if (!grouped.has(user.caseReference)) {
+				grouped.set(user.caseReference, []);
+			}
+			grouped.get(user.caseReference).push({
+				id: user.id,
+				emailAddress: user.emailAddress,
+				serviceUserType: user.serviceUserType,
+				organisation: user.organisation
+			});
+		}
+
+		return Array.from(grouped.entries()).map(([caseReference, users]) => ({
+			caseReference,
+			users
+		}));
+	}
+
+	/**
+	 * @param {Array<{serviceUserIds: string[], caseReference: string}>} batchLookups
+	 * @returns {Promise<Array<{id: string, emailAddress: string|null, serviceUserType: string, organisation: string|null, caseReference: string}>>}
+	 */
+	async _getServiceUsersBatch(batchLookups) {
+		if (!batchLookups || batchLookups.length === 0) {
+			return [];
+		}
+
+		return this.dbClient.serviceUser.findMany({
+			where: {
+				OR: batchLookups.map((lookup) => ({
+					AND: {
+						id: {
+							in: lookup.serviceUserIds
+						},
+						caseReference: lookup.caseReference
+					}
+				}))
+			},
+			select: {
+				id: true,
+				emailAddress: true,
+				serviceUserType: true,
+				organisation: true,
+				caseReference: true
 			}
 		});
 	}

--- a/packages/appeals-service-api/src/routes/v2/appeals/service.js
+++ b/packages/appeals-service-api/src/routes/v2/appeals/service.js
@@ -6,7 +6,7 @@ const { appendLinkedCasesForMultipleAppeals } = require('../appeal-cases/service
 const {
 	addOwnershipAndSubmissionDetailsToRepresentations
 } = require('@pins/common/src/access/representation-ownership');
-const { getServiceUsersWithEmailsByIdAndCaseReference } = require('../service-users/service');
+const { getServiceUsersForMultipleCases } = require('../service-users/service');
 
 const repo = new UserAppealsRepository();
 const cosmosAppeals = new AppealsRepository();
@@ -55,25 +55,34 @@ async function getAppealsForUser(userId, role) {
 	// check for linked cases
 	const enhancedCases = await appendLinkedCasesForMultipleAppeals(cases);
 
-	await Promise.all(
-		enhancedCases.map(async (appealCase) => {
-			if (appealCase.Representations && appealCase.Representations.length > 0) {
-				const serviceUserIds = [
-					...new Set(appealCase.Representations.map((r) => r.serviceUserId).filter(Boolean))
-				];
-				const usersWithEmails = await getServiceUsersWithEmailsByIdAndCaseReference(
-					serviceUserIds,
-					appealCase.caseReference
-				);
-				appealCase.Representations = addOwnershipAndSubmissionDetailsToRepresentations(
-					appealCase.Representations,
-					user.email,
-					false,
-					usersWithEmails
-				);
-			}
-		})
+	// cases with representations
+	const lookups = enhancedCases
+		.filter((appealCase) => appealCase.Representations && appealCase.Representations.length > 0)
+		.map((appealCase) => ({
+			serviceUserIds: [
+				...new Set(appealCase.Representations.map((r) => r.serviceUserId).filter(Boolean))
+			],
+			caseReference: appealCase.caseReference
+		}))
+		.filter((lookup) => lookup.serviceUserIds.length > 0);
+
+	const allServiceUsers = await getServiceUsersForMultipleCases(lookups);
+
+	const usersByCase = new Map(
+		allServiceUsers.map((result) => [result.caseReference, result.users])
 	);
+
+	enhancedCases.forEach((appealCase) => {
+		if (appealCase.Representations && appealCase.Representations.length > 0) {
+			const usersWithEmails = usersByCase.get(appealCase.caseReference) || [];
+			appealCase.Representations = addOwnershipAndSubmissionDetailsToRepresentations(
+				appealCase.Representations,
+				user.email,
+				false,
+				usersWithEmails
+			);
+		}
+	});
 
 	// fetch drafts from Cosmos
 	const draftSubmissions = await Promise.all(

--- a/packages/appeals-service-api/src/routes/v2/appeals/service.test.js
+++ b/packages/appeals-service-api/src/routes/v2/appeals/service.test.js
@@ -1,6 +1,6 @@
 const { getAppealsForUser } = require('./service');
 const { UserAppealsRepository } = require('./repo');
-const { getServiceUsersWithEmailsByIdAndCaseReference } = require('../service-users/service');
+const { getServiceUsersForMultipleCases } = require('../service-users/service');
 const {
 	addOwnershipAndSubmissionDetailsToRepresentations
 } = require('@pins/common/src/access/representation-ownership');
@@ -42,8 +42,11 @@ describe('appeals service v2', () => {
 
 			UserAppealsRepository.prototype.listAppealsForUser.mockResolvedValue(mockUser);
 			appendLinkedCasesForMultipleAppeals.mockImplementation((cases) => Promise.resolve(cases));
-			getServiceUsersWithEmailsByIdAndCaseReference.mockResolvedValue([
-				{ id: '20000000143', emailAddress: userEmail }
+			getServiceUsersForMultipleCases.mockResolvedValue([
+				{
+					caseReference: '0000001',
+					users: [{ id: '20000000143', emailAddress: userEmail }]
+				}
 			]);
 			addOwnershipAndSubmissionDetailsToRepresentations.mockReturnValue([
 				{ id: 'rep1', serviceUserId: '20000000143', userOwnsRepresentation: true }
@@ -52,10 +55,12 @@ describe('appeals service v2', () => {
 			const result = await getAppealsForUser(userId, role);
 
 			expect(UserAppealsRepository.prototype.listAppealsForUser).toHaveBeenCalledWith(userId, role);
-			expect(getServiceUsersWithEmailsByIdAndCaseReference).toHaveBeenCalledWith(
-				['20000000143'],
-				'0000001'
-			);
+			expect(getServiceUsersForMultipleCases).toHaveBeenCalledWith([
+				{
+					serviceUserIds: ['20000000143'],
+					caseReference: '0000001'
+				}
+			]);
 			expect(addOwnershipAndSubmissionDetailsToRepresentations).toHaveBeenCalledWith(
 				expect.any(Array),
 				userEmail,
@@ -84,10 +89,11 @@ describe('appeals service v2', () => {
 
 			UserAppealsRepository.prototype.listAppealsForUser.mockResolvedValue(mockUser);
 			appendLinkedCasesForMultipleAppeals.mockImplementation((cases) => Promise.resolve(cases));
+			getServiceUsersForMultipleCases.mockResolvedValue([]);
 
 			const result = await getAppealsForUser(userId, role);
 
-			expect(getServiceUsersWithEmailsByIdAndCaseReference).not.toHaveBeenCalled();
+			expect(getServiceUsersForMultipleCases).toHaveBeenCalledWith([]);
 			expect(result[0].Representations).toEqual([]);
 		});
 
@@ -117,8 +123,11 @@ describe('appeals service v2', () => {
 
 			UserAppealsRepository.prototype.listAppealsForUser.mockResolvedValue(mockUser);
 			appendLinkedCasesForMultipleAppeals.mockImplementation((cases) => Promise.resolve(cases));
-			getServiceUsersWithEmailsByIdAndCaseReference.mockResolvedValue([
-				{ id: '20000000143', emailAddress: userEmail }
+			getServiceUsersForMultipleCases.mockResolvedValue([
+				{
+					caseReference: '0000002',
+					users: [{ id: '20000000143', emailAddress: userEmail }]
+				}
 			]);
 			addOwnershipAndSubmissionDetailsToRepresentations.mockReturnValue([
 				{

--- a/packages/appeals-service-api/src/routes/v2/service-users/service.js
+++ b/packages/appeals-service-api/src/routes/v2/service-users/service.js
@@ -33,3 +33,12 @@ exports.getServiceUsersWithEmailsByIdAndCaseReference = (serviceUserIds, caseRef
 		caseReference
 	);
 };
+
+/**
+ * Get service users for multiple case references in a single query
+ * @param {Array<{serviceUserIds: string[], caseReference: string}>} lookups
+ * @returns {Promise<Array<{caseReference: string, users: any[]}>>}
+ */
+exports.getServiceUsersForMultipleCases = (lookups) => {
+	return serviceUserRepository.getServiceUsersForMultipleCases(lookups);
+};

--- a/packages/common/src/database/chunk-array.js
+++ b/packages/common/src/database/chunk-array.js
@@ -1,7 +1,8 @@
 /**
- * @param {any} myArray
+ * @template T
+ * @param {T[]} myArray
  * @param {number} chunk_size
- * @returns {Promise<any>}
+ * @returns {T[][]}
  */
 const chunkArray = (myArray, chunk_size) => {
 	let index = 0;


### PR DESCRIPTION
### Description of change

Resolving performance issues in staging env from e2e tests
- query to service user per appeal on user dashboard
- current max counts for appeals are 200 in prod, 1500 in staging
- reduces multiple single queries down to a combined query, batched to avoid 2100 param limit in sql server

Before, 1 per case
```sql
SELECT [dbo].[ServiceUser].[internalId], [dbo].[ServiceUser].[id], [dbo].[ServiceUser].[emailAddress], [dbo].[ServiceUser].[serviceUserType], [dbo].[ServiceUser].[organisation] FROM [dbo].[ServiceUser] WHERE ([dbo].[ServiceUser].[id] IN (@P1,@P2) AND [dbo].[ServiceUser].[caseReference] = @P3)
```

After
```sql
SELECT [dbo].[ServiceUser].[internalId], [dbo].[ServiceUser].[id], [dbo].[ServiceUser].[emailAddress], [dbo].[ServiceUser].[serviceUserType], [dbo].[ServiceUser].[organisation], [dbo].[ServiceUser].[caseReference] FROM [dbo].[ServiceUser] WHERE (([dbo].[ServiceUser].[id] IN (@P1,@P2,@P3,@P4) AND [dbo].[ServiceUser].[caseReference] = @P5) OR ([dbo].[ServiceUser].[id] IN (@P6,@P7) AND [dbo].[ServiceUser].[caseReference] = @P8) OR ([dbo].[ServiceUser].[id] IN (@P9,@P10,@P11) AND [dbo].[ServiceUser].[caseReference] = @P12))
```

Ticket: https://pins-ds.atlassian.net/browse/A2-7976

### Checklist

- [x] Feature complete and ready for users, or behind feature-flag
- [x] Commit history is linear with no merge commits
- [ ] Requires infrastructure changes

### Important

Please do not merge from `main` (please only [rebase](https://github.com/Planning-Inspectorate/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
