### PR TITLE
fix: add LDC section types to question (A2-7869)

### DIFF
--- a/packages/common/src/lib/format-appeal-details.js
+++ b/packages/common/src/lib/format-appeal-details.js
@@ -281,9 +281,9 @@ exports.formatActSection = (caseData, field) => {
 		case APPEAL_APPEAL_UNDER_ACT_SECTION.EXISTING_DEVELOPMENT:
 			return 'Existing development (section 191)';
 		case APPEAL_APPEAL_UNDER_ACT_SECTION.PROPOSED_CHANGES_TO_A_LISTED_BUILDING:
-			return 'Proposed changes to a listed building (section 192)';
+			return 'Proposed changes to a listed building (section 26H)';
 		case APPEAL_APPEAL_UNDER_ACT_SECTION.PROPOSED_USE_OF_A_DEVELOPMENT:
-			return 'Proposed use of a development (section 26H)';
+			return 'Proposed use of a development (section 192)';
 		default:
 			return answer;
 	}

--- a/packages/common/src/lib/format-appeal-details.test.js
+++ b/packages/common/src/lib/format-appeal-details.test.js
@@ -246,12 +246,12 @@ describe('format-appeal-details', () => {
 			{
 				input: { applicationMadeUnderActSection: 'proposed-changes-to-a-listed-building' },
 				field: 'applicationMadeUnderActSection',
-				expected: 'Proposed changes to a listed building (section 192)'
+				expected: 'Proposed changes to a listed building (section 26H)'
 			},
 			{
 				input: { applicationMadeUnderActSection: 'proposed-use-of-a-development' },
 				field: 'applicationMadeUnderActSection',
-				expected: 'Proposed use of a development (section 26H)'
+				expected: 'Proposed use of a development (section 192)'
 			},
 			{
 				input: { applicationMadeUnderActSection: 'unknown' },
@@ -266,12 +266,12 @@ describe('format-appeal-details', () => {
 			{
 				input: { appealUnderActSection: 'proposed-changes-to-a-listed-building' },
 				field: 'appealUnderActSection',
-				expected: 'Proposed changes to a listed building (section 192)'
+				expected: 'Proposed changes to a listed building (section 26H)'
 			},
 			{
 				input: { appealUnderActSection: 'proposed-use-of-a-development' },
 				field: 'appealUnderActSection',
-				expected: 'Proposed use of a development (section 26H)'
+				expected: 'Proposed use of a development (section 192)'
 			},
 			{
 				input: { appealUnderActSection: 'unknown' },

--- a/packages/forms-web-app/src/dynamic-forms/questions.js
+++ b/packages/forms-web-app/src/dynamic-forms/questions.js
@@ -146,15 +146,15 @@ const lawfulDevelopmentCertificateTypeBase = {
 	],
 	options: [
 		{
-			text: 'Existing development',
+			text: 'Existing development (section 191)',
 			value: fieldValues.lawfulDevelopmentCertificateType.EXISTING_DEVELOPMENT
 		},
 		{
-			text: 'Proposed use of a development',
+			text: 'Proposed use of a development (section 192)',
 			value: fieldValues.lawfulDevelopmentCertificateType.PROPOSED_USE_DEVELOPMENT
 		},
 		{
-			text: 'Proposed changes to a listed building',
+			text: 'Proposed changes to a listed building (section 26H)',
 			value: fieldValues.lawfulDevelopmentCertificateType.PROPOSED_CHANGES_LISTED_BUILDING
 		}
 	]

--- a/packages/forms-web-app/src/journeys/__snapshots__/index.test.js.snap
+++ b/packages/forms-web-app/src/journeys/__snapshots__/index.test.js.snap
@@ -14674,19 +14674,19 @@ exports[`Dynamic forms journey tests appellant Lawful development certificate La
                                 <input class="govuk-radios__input" id="applicationMadeUnderActSection"
                                 name="applicationMadeUnderActSection" type="radio" value="existing-development"
                                 data-cy="answer-existing-development">
-                                <label class="govuk-label govuk-radios__label" for="applicationMadeUnderActSection">Existing development</label>
+                                <label class="govuk-label govuk-radios__label" for="applicationMadeUnderActSection">Existing development (section 191)</label>
                             </div>
                             <div class="govuk-radios__item">
                                 <input class="govuk-radios__input" id="applicationMadeUnderActSection-2"
                                 name="applicationMadeUnderActSection" type="radio" value="proposed-use-of-a-development"
                                 data-cy="answer-proposed-use-of-a-development">
-                                <label class="govuk-label govuk-radios__label" for="applicationMadeUnderActSection-2">Proposed use of a development</label>
+                                <label class="govuk-label govuk-radios__label" for="applicationMadeUnderActSection-2">Proposed use of a development (section 192)</label>
                             </div>
                             <div class="govuk-radios__item">
                                 <input class="govuk-radios__input" id="applicationMadeUnderActSection-3"
                                 name="applicationMadeUnderActSection" type="radio" value="proposed-changes-to-a-listed-building"
                                 data-cy="answer-proposed-changes-to-a-listed-building">
-                                <label class="govuk-label govuk-radios__label" for="applicationMadeUnderActSection-3">Proposed changes to a listed building</label>
+                                <label class="govuk-label govuk-radios__label" for="applicationMadeUnderActSection-3">Proposed changes to a listed building (section 26H)</label>
                             </div>
                         </div>
                     </div>
@@ -37641,17 +37641,17 @@ exports[`Dynamic forms journey tests lpa Lawful development certificate Lawful d
                             <div class="govuk-radios__item">
                                 <input class="govuk-radios__input" id="appealUnderActSection" name="appealUnderActSection"
                                 type="radio" value="existing-development" data-cy="answer-existing-development">
-                                <label class="govuk-label govuk-radios__label" for="appealUnderActSection">Existing development</label>
+                                <label class="govuk-label govuk-radios__label" for="appealUnderActSection">Existing development (section 191)</label>
                             </div>
                             <div class="govuk-radios__item">
                                 <input class="govuk-radios__input" id="appealUnderActSection-2" name="appealUnderActSection"
                                 type="radio" value="proposed-use-of-a-development" data-cy="answer-proposed-use-of-a-development">
-                                <label class="govuk-label govuk-radios__label" for="appealUnderActSection-2">Proposed use of a development</label>
+                                <label class="govuk-label govuk-radios__label" for="appealUnderActSection-2">Proposed use of a development (section 192)</label>
                             </div>
                             <div class="govuk-radios__item">
                                 <input class="govuk-radios__input" id="appealUnderActSection-3" name="appealUnderActSection"
                                 type="radio" value="proposed-changes-to-a-listed-building" data-cy="answer-proposed-changes-to-a-listed-building">
-                                <label class="govuk-label govuk-radios__label" for="appealUnderActSection-3">Proposed changes to a listed building</label>
+                                <label class="govuk-label govuk-radios__label" for="appealUnderActSection-3">Proposed changes to a listed building (section 26H)</label>
                             </div>
                         </div>
                     </div>


### PR DESCRIPTION
### Description of change

This PR adds the LDC section types to the question 'What type of lawful development certificate is the appeal about?'

Tickets: https://pins-ds.atlassian.net/browse/A2-7869
Also has FO corrections to section types requested in this ticket https://pins-ds.atlassian.net/browse/A2-7870

### Checklist

- [x] Feature complete and ready for users, or behind feature-flag
- [x] Commit history is linear with no merge commits
- [ ] Requires infrastructure changes

### Important

Please do not merge from `main` (please only [rebase](https://github.com/Planning-Inspectorate/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
