### PR TITLE
fix: performance improvements

### DIFF
--- a/packages/appeals-service-api/src/repositories/sql/service-user-repository.js
+++ b/packages/appeals-service-api/src/repositories/sql/service-user-repository.js
@@ -2,7 +2,7 @@ const { createPrismaClient } = require('#db-client');
 const { APPEAL_USER_ROLES } = require('@pins/common/src/constants');
 const { SERVICE_USER_TYPE } = require('@planning-inspectorate/data-model');
 const { AppealUserRepository } = require('#repositories/sql/appeal-user-repository');
-const { chunkArray } = require('@pins/common/src/database/chunk-array');
+const { chunkArray, runBatchWithPromise } = require('@pins/common/src/database/chunk-array');
 
 /**
  * @typedef {import('@pins/database/src/client/client').ServiceUser} ServiceUser
@@ -65,78 +65,26 @@ class ServiceUserRepository {
 	}
 
 	/**
-	 * @param {Array<{serviceUserIds: string[], caseReference: string}>} lookups
-	 * @returns {Promise<Array<{caseReference: string, users: BasicServiceUser[]}>>}
+	 * @param {string[]} caseReferences
+	 * @param {import('@pins/database/src/client/client').Prisma.ServiceUserSelect} select
+	 * @param {Array.<string>} [serviceUserTypes]
+	 * @returns {Promise<Array<Partial<import('@pins/database/src/client/client').ServiceUser>>>}
 	 */
-	async getServiceUsersForMultipleCases(lookups) {
-		if (!lookups || lookups.length === 0) {
-			return [];
-		}
+	async getServiceUsersForMultipleCases(caseReferences, select, serviceUserTypes) {
+		if (!caseReferences?.length) return [];
 
-		const BATCH_SIZE = 250;
-		const MAX_CONCURRENT = 4;
-		// batch service user lookups to avoid 2100 param limit
-		const batches = chunkArray(lookups, BATCH_SIZE);
+		const BATCH_SIZE = 100;
+		const MAX_CONCURRENT = 3;
+		const batches = chunkArray(caseReferences, BATCH_SIZE);
 
-		/** @type {Array<{id: string, emailAddress: string|null, serviceUserType: string, organisation: string|null, caseReference: string}>} */
-		const serviceUsers = [];
-
-		// limit promise.all concurrency
-		for (let i = 0; i < batches.length; i += MAX_CONCURRENT) {
-			const concurrentBatches = batches.slice(i, i + MAX_CONCURRENT);
-			const results = await Promise.all(
-				concurrentBatches.map((batch) => this._getServiceUsersBatch(batch))
-			);
-			serviceUsers.push(...results.flat());
-		}
-
-		// Group by caseReference
-		const grouped = new Map();
-		for (const user of serviceUsers) {
-			if (!grouped.has(user.caseReference)) {
-				grouped.set(user.caseReference, []);
-			}
-			grouped.get(user.caseReference).push({
-				id: user.id,
-				emailAddress: user.emailAddress,
-				serviceUserType: user.serviceUserType,
-				organisation: user.organisation
+		return runBatchWithPromise(batches, MAX_CONCURRENT, (batch) => {
+			return this.dbClient.serviceUser.findMany({
+				where: {
+					caseReference: { in: batch },
+					...(serviceUserTypes ? { serviceUserType: { in: serviceUserTypes } } : {})
+				},
+				select: select
 			});
-		}
-
-		return Array.from(grouped.entries()).map(([caseReference, users]) => ({
-			caseReference,
-			users
-		}));
-	}
-
-	/**
-	 * @param {Array<{serviceUserIds: string[], caseReference: string}>} batchLookups
-	 * @returns {Promise<Array<{id: string, emailAddress: string|null, serviceUserType: string, organisation: string|null, caseReference: string}>>}
-	 */
-	async _getServiceUsersBatch(batchLookups) {
-		if (!batchLookups || batchLookups.length === 0) {
-			return [];
-		}
-
-		return this.dbClient.serviceUser.findMany({
-			where: {
-				OR: batchLookups.map((lookup) => ({
-					AND: {
-						id: {
-							in: lookup.serviceUserIds
-						},
-						caseReference: lookup.caseReference
-					}
-				}))
-			},
-			select: {
-				id: true,
-				emailAddress: true,
-				serviceUserType: true,
-				organisation: true,
-				caseReference: true
-			}
 		});
 	}
 

--- a/packages/appeals-service-api/src/routes/v2/appeal-cases/service.js
+++ b/packages/appeals-service-api/src/routes/v2/appeal-cases/service.js
@@ -11,13 +11,13 @@ const {
 	sendSubmissionReceivedEmailToLpaV2
 } = require('#lib/notify');
 const sanitizePostcode = require('#lib/sanitize-postcode');
-const config = require('../../../configuration/config');
 
 const repo = new AppealCaseRepository();
 const serviceUserRepo = new ServiceUserRepository();
 const { SchemaValidator } = require('../../../services/back-office-v2/validate');
 const { getValidator } = new SchemaValidator();
 const logger = require('#lib/logger');
+const { chunkArray, runBatchWithPromise } = require('@pins/common/src/database/chunk-array');
 
 /**
  * @template Payload
@@ -724,7 +724,7 @@ async function listByLpaCodeWithAppellant(options) {
 	const appeals = await repo.listByLpaCode(options);
 
 	if (options.withAppellant) {
-		await Promise.all(appeals.map(appendAppellantAndAgent));
+		await appendAppellantAndAgentForMultiple(appeals);
 	}
 
 	const enhancedAppeals = await appendLinkedCasesForMultipleAppeals(appeals);
@@ -745,7 +745,7 @@ async function listByPostcodeWithAppellant(options) {
 	const appeals = await repo.listByPostCode(options);
 
 	if (options.withAppellant) {
-		await Promise.all(appeals.map(appendAppellantAndAgent));
+		await appendAppellantAndAgentForMultiple(appeals);
 	}
 
 	return appeals;
@@ -768,6 +768,46 @@ async function appendAppellantAndAgent(appeal) {
 	}
 	appeal.users = serviceUsers;
 	return appeal;
+}
+
+/**
+ * Add the service users to an appeal if there are any.
+ *
+ * @param {AppealCase[]} appeals
+ * @returns {Promise<AppealCase[] & {users?: Array.<ServiceUser>}>}
+ */
+async function appendAppellantAndAgentForMultiple(appeals) {
+	// find appeal users by roles
+	const caseReferences = appeals.map((appeal) => appeal.caseReference);
+	const allServiceUsers = await serviceUserRepo.getServiceUsersForMultipleCases(
+		caseReferences,
+		{
+			firstName: true,
+			lastName: true,
+			emailAddress: true,
+			organisation: true,
+			telephoneNumber: true,
+			serviceUserType: true,
+			id: true,
+			addressLine1: true,
+			addressLine2: true,
+			addressTown: true,
+			postcode: true
+		},
+		[ServiceUserType.Appellant, ServiceUserType.Agent]
+	);
+
+	const usersByCase = new Map(
+		allServiceUsers.map((result) => [result.caseReference, result.users])
+	);
+
+	return appeals.map((appeal) => {
+		const serviceUsers = usersByCase.get(appeal.caseReference);
+		if (serviceUsers) {
+			return { ...appeal, users: serviceUsers };
+		}
+		return appeal;
+	});
 }
 
 /**
@@ -819,10 +859,7 @@ async function appendLinkedCases(appeal) {
  */
 async function appendLinkedCasesForMultipleAppeals(appeals) {
 	const caseReferences = appeals.map((appealCase) => appealCase.caseReference);
-	const linkedCases =
-		caseReferences.length <= config.db.queryBatchSize
-			? await repo.getLinkedCases(caseReferences)
-			: await batchGetLinkedCases(caseReferences, config.db.queryBatchSize);
+	const linkedCases = await batchGetLinkedCases(caseReferences, 500);
 
 	if (!linkedCases || !linkedCases.length) {
 		return appeals;
@@ -867,16 +904,11 @@ async function appendLinkedCasesForMultipleAppeals(appeals) {
  * @returns {Promise<LinkedCase[]>}>}
  */
 async function batchGetLinkedCases(caseReferences, batchSize) {
-	let batchedCaseReferences = [];
-	for (var i = 0; i < caseReferences.length; i += batchSize) {
-		batchedCaseReferences.push(caseReferences.slice(i, i + batchSize));
-	}
-
-	const batchedLinkedCases = await Promise.all(
-		batchedCaseReferences.map(repo.getLinkedCases.bind(repo))
-	);
-
-	return batchedLinkedCases.flat().filter((linkedCase) => linkedCase !== null);
+	const MAX_CONCURRENT = 3;
+	const batches = chunkArray(caseReferences, batchSize);
+	return runBatchWithPromise(batches, MAX_CONCURRENT, (batch) => {
+		return repo.getLinkedCases(batch);
+	});
 }
 
 module.exports = {

--- a/packages/appeals-service-api/src/routes/v2/appeals/controller.js
+++ b/packages/appeals-service-api/src/routes/v2/appeals/controller.js
@@ -1,10 +1,26 @@
-const { getAppealsForUser } = require('./service');
+const { getAppealsForUser, getAppealDraft } = require('./service');
 const ApiError = require('#errors/apiError');
 const { APPEAL_USER_ROLES } = require('@pins/common/src/constants');
 
 /**
  * @typedef { 'Appellant' | 'Agent' | 'InterestedParty' | 'Rule6Party' } AppealToUserRoles
  */
+
+/**
+ * @type {import('express').Handler}
+ */
+async function getDraft(req, res) {
+	const userId = req.auth.payload.sub;
+	const appealId = req.params.id;
+
+	if (!userId) {
+		throw ApiError.invalidToken();
+	}
+
+	const draft = await getAppealDraft(userId, appealId);
+
+	res.status(200).send(draft);
+}
 
 /**
  * @type {import('express').Handler}
@@ -46,5 +62,6 @@ const permittedRole = (role) => {
 };
 
 module.exports = {
-	getUserAppeals
+	getUserAppeals,
+	getDraft
 };

--- a/packages/appeals-service-api/src/routes/v2/appeals/controller.test.js
+++ b/packages/appeals-service-api/src/routes/v2/appeals/controller.test.js
@@ -1,0 +1,195 @@
+const { getDraft } = require('./controller');
+const { getAppealDraft } = require('./service');
+const ApiError = require('#errors/apiError');
+
+jest.mock('./service');
+
+describe('appeals controller v2', () => {
+	beforeEach(() => {
+		jest.clearAllMocks();
+	});
+
+	describe('getDraft', () => {
+		it('should return a draft with 200 status', async () => {
+			const userId = 'user-1';
+			const appealId = 'appeal-123';
+			const mockDraft = {
+				id: appealId,
+				appealStatus: 'DRAFT',
+				appellant: {
+					firstName: 'John',
+					lastName: 'Doe'
+				}
+			};
+
+			const req = {
+				auth: {
+					payload: {
+						sub: userId
+					}
+				},
+				params: {
+					id: appealId
+				}
+			};
+
+			const res = {
+				status: jest.fn().mockReturnThis(),
+				send: jest.fn()
+			};
+
+			getAppealDraft.mockResolvedValue(mockDraft);
+
+			await getDraft(req, res);
+
+			expect(getAppealDraft).toHaveBeenCalledWith(userId, appealId);
+			expect(res.status).toHaveBeenCalledWith(200);
+			expect(res.send).toHaveBeenCalledWith(mockDraft);
+		});
+
+		it('should throw ApiError when userId is missing', async () => {
+			const appealId = 'appeal-123';
+
+			const req = {
+				auth: {
+					payload: {
+						sub: null
+					}
+				},
+				params: {
+					id: appealId
+				}
+			};
+
+			const res = {
+				status: jest.fn().mockReturnThis(),
+				send: jest.fn()
+			};
+
+			await expect(getDraft(req, res)).rejects.toEqual(ApiError.invalidToken());
+			expect(getAppealDraft).not.toHaveBeenCalled();
+		});
+
+		it('should throw ApiError from service when draft not found', async () => {
+			const userId = 'user-1';
+			const appealId = 'appeal-123';
+			const notFoundError = ApiError.appealNotFound(appealId);
+
+			const req = {
+				auth: {
+					payload: {
+						sub: userId
+					}
+				},
+				params: {
+					id: appealId
+				}
+			};
+
+			const res = {
+				status: jest.fn().mockReturnThis(),
+				send: jest.fn()
+			};
+
+			getAppealDraft.mockRejectedValue(notFoundError);
+
+			await expect(getDraft(req, res)).rejects.toEqual(notFoundError);
+		});
+
+		it('should throw ApiError from service when user is forbidden', async () => {
+			const userId = 'user-1';
+			const appealId = 'appeal-123';
+			const forbiddenError = ApiError.forbidden();
+
+			const req = {
+				auth: {
+					payload: {
+						sub: userId
+					}
+				},
+				params: {
+					id: appealId
+				}
+			};
+
+			const res = {
+				status: jest.fn().mockReturnThis(),
+				send: jest.fn()
+			};
+
+			getAppealDraft.mockRejectedValue(forbiddenError);
+
+			await expect(getDraft(req, res)).rejects.toEqual(forbiddenError);
+		});
+
+		it('should handle v2 draft submissions', async () => {
+			const userId = 'user-1';
+			const appealId = 'appeal-456';
+			const mockV2Draft = {
+				id: appealId,
+				AppellantSubmission: {
+					submitted: false,
+					submissionId: 'sub-456'
+				}
+			};
+
+			const req = {
+				auth: {
+					payload: {
+						sub: userId
+					}
+				},
+				params: {
+					id: appealId
+				}
+			};
+
+			const res = {
+				status: jest.fn().mockReturnThis(),
+				send: jest.fn()
+			};
+
+			getAppealDraft.mockResolvedValue(mockV2Draft);
+
+			await getDraft(req, res);
+
+			expect(getAppealDraft).toHaveBeenCalledWith(userId, appealId);
+			expect(res.status).toHaveBeenCalledWith(200);
+			expect(res.send).toHaveBeenCalledWith(mockV2Draft);
+		});
+
+		it('should handle legacy draft submissions from Cosmos', async () => {
+			const userId = 'user-1';
+			const appealId = 'appeal-789';
+			const mockLegacyDraft = {
+				id: appealId,
+				legacyAppealSubmissionId: 'legacy-sub-789',
+				legacyAppealSubmissionState: 'DRAFT'
+			};
+
+			const req = {
+				auth: {
+					payload: {
+						sub: userId
+					}
+				},
+				params: {
+					id: appealId
+				}
+			};
+
+			const res = {
+				status: jest.fn().mockReturnThis(),
+				send: jest.fn()
+			};
+
+			getAppealDraft.mockResolvedValue(mockLegacyDraft);
+
+			await getDraft(req, res);
+
+			expect(getAppealDraft).toHaveBeenCalledWith(userId, appealId);
+			expect(res.status).toHaveBeenCalledWith(200);
+			expect(res.send).toHaveBeenCalledWith(mockLegacyDraft);
+		});
+	});
+});

--- a/packages/appeals-service-api/src/routes/v2/appeals/index.js
+++ b/packages/appeals-service-api/src/routes/v2/appeals/index.js
@@ -1,5 +1,5 @@
 const express = require('express');
-const { getUserAppeals } = require('./controller');
+const { getUserAppeals, getDraft } = require('./controller');
 const { AUTH } = require('@pins/common/src/constants');
 const config = require('../../../configuration/config');
 const { auth } = require('express-oauth2-jwt-bearer');
@@ -15,5 +15,6 @@ router.use(
 );
 
 router.get('/', openApiValidatorMiddleware(), asyncHandler(getUserAppeals));
+router.get('/draft/:id', openApiValidatorMiddleware(), asyncHandler(getDraft));
 
 module.exports = { router };

--- a/packages/appeals-service-api/src/routes/v2/appeals/repo.js
+++ b/packages/appeals-service-api/src/routes/v2/appeals/repo.js
@@ -6,6 +6,8 @@ const { APPEAL_USER_ROLES } = require('@pins/common/src/constants');
  * @typedef {import('@pins/database/src/client/client').Prisma.AppealUserGetPayload<{include: {Appeals: {include: {Appeal: { include: {AppealCase: true }}}}}}>} UserWithAppeals
  * @typedef { 'Appellant' | 'Agent' | 'InterestedParty' | 'Rule6Party' } AppealToUserRoles
  * @typedef {import('@pins/database/src/client/client').Appeal} Appeal
+ * @typedef {import('@pins/database/src/client/client').AppealCase} AppealCase
+ * @typedef {import('@pins/database/src/client/client').AppellantSubmission} AppellantSubmission
  * @typedef {import('@pins/database/src/client/client').Prisma.AppealCreateInput} AppealCreateInput
  */
 
@@ -77,16 +79,21 @@ class UserAppealsRepository {
 											siteAddressPostcode: true,
 											siteGridReferenceEasting: true,
 											siteGridReferenceNorthing: true,
-											Representations: {
-												select: {
-													id: true,
-													representationType: true,
-													serviceUserId: true,
-													source: true,
-													representationStatus: true,
-													dateReceived: true
-												}
-											}
+											// reps only needed for rule 6 ownership check
+											...(role === APPEAL_USER_ROLES.RULE_6_PARTY
+												? {
+														Representations: {
+															select: {
+																id: true,
+																representationType: true,
+																serviceUserId: true,
+																source: true,
+																representationStatus: true,
+																dateReceived: true
+															}
+														}
+													}
+												: {})
 										}
 									},
 									AppellantSubmission: {
@@ -97,6 +104,60 @@ class UserAppealsRepository {
 											applicationDecisionDate: true,
 											siteAddress: true,
 											SubmissionAddress: true,
+											enforcementEffectiveDate: true
+										}
+									}
+								}
+							}
+						}
+					}
+				}
+			});
+		} catch (e) {
+			if (e instanceof Prisma.PrismaClientKnownRequestError) {
+				if (e.code === 'P2023') {
+					// probably an invalid ID/GUID
+					return null;
+				}
+			}
+			throw e;
+		}
+	}
+
+	/**
+	 * Get's a draft appeal
+	 *
+	 * @param {string} userId
+	 * @param {string} appealId
+	 * @returns {Promise<UserWithAppeals|null>}
+	 */
+	async getAppealDraft(userId, appealId) {
+		try {
+			return this.dbClient.appealUser.findUnique({
+				where: {
+					id: userId
+				},
+				select: {
+					Appeals: {
+						where: {
+							AND: {
+								appealId: appealId,
+								OR: [{ role: APPEAL_USER_ROLES.APPELLANT }, { role: APPEAL_USER_ROLES.AGENT }]
+							}
+						},
+						select: {
+							Appeal: {
+								select: {
+									id: true,
+									legacyAppealSubmissionId: true,
+									legacyAppealSubmissionDecisionDate: true,
+									legacyAppealSubmissionState: true,
+									AppellantSubmission: {
+										select: {
+											id: true,
+											submitted: true,
+											appealTypeCode: true,
+											applicationDecisionDate: true,
 											enforcementEffectiveDate: true
 										}
 									}

--- a/packages/appeals-service-api/src/routes/v2/appeals/service.js
+++ b/packages/appeals-service-api/src/routes/v2/appeals/service.js
@@ -1,3 +1,4 @@
+const ApiError = require('#errors/apiError');
 const { APPEAL_STATE } = require('@pins/business-rules/src/constants');
 const { UserAppealsRepository } = require('./repo');
 const { AppealsRepository } = require('#repositories/appeals-repository');
@@ -99,6 +100,48 @@ async function getAppealsForUser(userId, role) {
 }
 
 /**
+ * Get an appeal draft
+ *
+ * @param {string} userId
+ * @param {string} appealId
+ * @return {Promise<UserWithAppeals|null>}
+ */
+async function getAppealDraft(userId, appealId) {
+	const user = await repo.getAppealDraft(userId, appealId);
+
+	if (!user) {
+		throw ApiError.forbidden();
+	}
+
+	if (!user.Appeals || user.Appeals.length === 0) {
+		throw ApiError.appealNotFound(appealId);
+	}
+
+	const draftSubmissionIds = user.Appeals.filter(
+		(appealToUser) =>
+			appealToUser.Appeal?.legacyAppealSubmissionId &&
+			appealToUser.Appeal?.legacyAppealSubmissionState === APPEAL_STATE.DRAFT
+	)
+		.map((appealToUser) => appealToUser.Appeal?.legacyAppealSubmissionId)
+		.filter(filterNotNull);
+
+	if (draftSubmissionIds.length) {
+		return await cosmosAppeals.getById(draftSubmissionIds[0]);
+	}
+
+	// find v2 draft submissions
+	const v2Drafts = user.Appeals.filter(
+		(appealToUser) => appealToUser.Appeal?.AppellantSubmission?.submitted === false
+	).map((appealToUser) => appealToUser.Appeal);
+
+	if (v2Drafts.length) {
+		return v2Drafts[0];
+	}
+
+	throw ApiError.appealNotFound(appealId);
+}
+
+/**
  * create an appeal
  *
  * @param {AppealCreateInput} data
@@ -110,5 +153,6 @@ async function createAppeal(data) {
 
 module.exports = {
 	getAppealsForUser,
+	getAppealDraft,
 	createAppeal
 };

--- a/packages/appeals-service-api/src/routes/v2/appeals/service.test.js
+++ b/packages/appeals-service-api/src/routes/v2/appeals/service.test.js
@@ -1,5 +1,6 @@
-const { getAppealsForUser } = require('./service');
+const { getAppealsForUser, getAppealDraft } = require('./service');
 const { UserAppealsRepository } = require('./repo');
+const { AppealsRepository } = require('#repositories/appeals-repository');
 const { getServiceUsersForMultipleCases } = require('../service-users/service');
 const {
 	addOwnershipAndSubmissionDetailsToRepresentations
@@ -142,6 +143,187 @@ describe('appeals service v2', () => {
 
 			expect(result[0].Representations[0].userOwnsRepresentation).toBe(true);
 			expect(result[0].Representations[0].representationType).toBe('proofs_evidence');
+		});
+	});
+
+	describe('getAppealDraft', () => {
+		it('should return legacy draft submission from Cosmos', async () => {
+			const userId = 'user-1';
+			const appealId = 'appeal-123';
+			const legacyDraftId = 'legacy-draft-456';
+			const mockLegacyDraft = {
+				id: legacyDraftId,
+				legacyAppealSubmissionId: legacyDraftId,
+				legacyAppealSubmissionState: 'DRAFT',
+				appellant: { firstName: 'John' }
+			};
+			const mockUser = {
+				Appeals: [
+					{
+						Appeal: {
+							legacyAppealSubmissionId: legacyDraftId,
+							legacyAppealSubmissionState: 'DRAFT'
+						}
+					}
+				]
+			};
+
+			UserAppealsRepository.prototype.getAppealDraft.mockResolvedValue(mockUser);
+			AppealsRepository.prototype.getById.mockResolvedValue(mockLegacyDraft);
+
+			const result = await getAppealDraft(userId, appealId);
+
+			expect(UserAppealsRepository.prototype.getAppealDraft).toHaveBeenCalledWith(userId, appealId);
+			expect(AppealsRepository.prototype.getById).toHaveBeenCalledWith(legacyDraftId);
+			expect(result).toEqual(mockLegacyDraft);
+		});
+
+		it('should return v2 draft submission with AppellantSubmission', async () => {
+			const userId = 'user-1';
+			const appealId = 'appeal-789';
+			const mockV2Draft = {
+				id: appealId,
+				AppellantSubmission: {
+					submitted: false,
+					submissionId: 'sub-789'
+				},
+				appellant: { firstName: 'Jane' }
+			};
+			const mockUser = {
+				Appeals: [
+					{
+						Appeal: mockV2Draft
+					}
+				]
+			};
+
+			UserAppealsRepository.prototype.getAppealDraft.mockResolvedValue(mockUser);
+
+			const result = await getAppealDraft(userId, appealId);
+
+			expect(UserAppealsRepository.prototype.getAppealDraft).toHaveBeenCalledWith(userId, appealId);
+			expect(result).toEqual(mockV2Draft);
+		});
+
+		it('should prioritize legacy draft over v2 draft', async () => {
+			const userId = 'user-1';
+			const appealId = 'appeal-mixed';
+			const legacyDraftId = 'legacy-draft-999';
+			const mockLegacyDraft = {
+				id: legacyDraftId,
+				legacyAppealSubmissionState: 'DRAFT'
+			};
+			const mockUser = {
+				Appeals: [
+					{
+						Appeal: {
+							legacyAppealSubmissionId: legacyDraftId,
+							legacyAppealSubmissionState: 'DRAFT',
+							AppellantSubmission: {
+								submitted: false
+							}
+						}
+					}
+				]
+			};
+
+			UserAppealsRepository.prototype.getAppealDraft.mockResolvedValue(mockUser);
+			AppealsRepository.prototype.getById.mockResolvedValue(mockLegacyDraft);
+
+			const result = await getAppealDraft(userId, appealId);
+
+			// Should return legacy draft and not v2 draft
+			expect(AppealsRepository.prototype.getById).toHaveBeenCalled();
+			expect(result).toEqual(mockLegacyDraft);
+		});
+
+		it('should handle multiple appeals and return the first valid draft', async () => {
+			const userId = 'user-1';
+			const appealId = 'appeal-multi';
+			const mockV2Draft = {
+				id: 'appeal-2',
+				AppellantSubmission: {
+					submitted: false,
+					submissionId: 'sub-2'
+				}
+			};
+			const mockUser = {
+				Appeals: [
+					{
+						Appeal: {
+							id: 'appeal-1'
+							// no draft here
+						}
+					},
+					{
+						Appeal: mockV2Draft
+					}
+				]
+			};
+
+			UserAppealsRepository.prototype.getAppealDraft.mockResolvedValue(mockUser);
+
+			const result = await getAppealDraft(userId, appealId);
+
+			expect(result).toEqual(mockV2Draft);
+		});
+
+		it('should filter null draft submission ids and find the valid one', async () => {
+			const userId = 'user-1';
+			const appealId = 'appeal-filter';
+			const legacyDraftId = 'legacy-draft-111';
+			const mockLegacyDraft = {
+				id: legacyDraftId,
+				legacyAppealSubmissionState: 'DRAFT'
+			};
+			const mockUser = {
+				Appeals: [
+					{
+						Appeal: {
+							legacyAppealSubmissionId: null,
+							legacyAppealSubmissionState: 'DRAFT'
+						}
+					},
+					{
+						Appeal: {
+							legacyAppealSubmissionId: legacyDraftId,
+							legacyAppealSubmissionState: 'DRAFT'
+						}
+					}
+				]
+			};
+
+			UserAppealsRepository.prototype.getAppealDraft.mockResolvedValue(mockUser);
+			AppealsRepository.prototype.getById.mockResolvedValue(mockLegacyDraft);
+
+			const result = await getAppealDraft(userId, appealId);
+
+			expect(result).toEqual(mockLegacyDraft);
+		});
+
+		it('should handle v2 draft when AppellantSubmission.submitted is false', async () => {
+			const userId = 'user-1';
+			const appealId = 'appeal-v2-draft';
+			const mockV2Draft = {
+				id: appealId,
+				AppellantSubmission: {
+					submitted: false
+				}
+			};
+			const mockUser = {
+				Appeals: [
+					{
+						Appeal: mockV2Draft
+					}
+				]
+			};
+
+			UserAppealsRepository.prototype.getAppealDraft.mockResolvedValue(mockUser);
+
+			const result = await getAppealDraft(userId, appealId);
+
+			expect(result).toEqual(mockV2Draft);
+			expect(AppealsRepository.prototype.getById).not.toHaveBeenCalled();
 		});
 	});
 });

--- a/packages/appeals-service-api/src/routes/v2/appeals/spec.yaml
+++ b/packages/appeals-service-api/src/routes/v2/appeals/spec.yaml
@@ -46,7 +46,27 @@ paths:
           description: Bad request
         404:
           description: Appeal not found
-
+  /api/v2/appeals/owns/{id}:
+    get:
+      tags:
+        - appeals
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+          description: Appeal ID
+      description: Get an appeal draft
+      responses:
+        200:
+          description: Appeal Draft
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AppealSubmission'
+        404:
+          description: Appeal not found
 components:
   parameters:
     role:

--- a/packages/appeals-service-api/src/routes/v2/service-users/service.js
+++ b/packages/appeals-service-api/src/routes/v2/service-users/service.js
@@ -35,10 +35,15 @@ exports.getServiceUsersWithEmailsByIdAndCaseReference = (serviceUserIds, caseRef
 };
 
 /**
- * Get service users for multiple case references in a single query
- * @param {Array<{serviceUserIds: string[], caseReference: string}>} lookups
- * @returns {Promise<Array<{caseReference: string, users: any[]}>>}
+ * @param {string[]} caseReferences
+ * @param {import('@pins/database/src/client/client').Prisma.ServiceUserSelect} select
+ * @param {Array.<string>} [serviceUserTypes]
+ * @returns {Promise<Array<Partial<import('@pins/database/src/client/client').ServiceUser>>>}
  */
-exports.getServiceUsersForMultipleCases = (lookups) => {
-	return serviceUserRepository.getServiceUsersForMultipleCases(lookups);
+exports.getServiceUsersForMultipleCases = (caseReferences, select, serviceUserTypes) => {
+	return serviceUserRepository.getServiceUsersForMultipleCases(
+		caseReferences,
+		select,
+		serviceUserTypes
+	);
 };

--- a/packages/common/src/client/appeals-api-client.js
+++ b/packages/common/src/client/appeals-api-client.js
@@ -344,6 +344,16 @@ class AppealsApiClient {
 	}
 
 	/**
+	 * @param {string} id
+	 * @returns {Promise<AppealSubmission>}
+	 */
+	async getAppealDraft(id) {
+		const endpoint = `${v2}/appeals/draft/${id}`;
+		const response = await this.#makeGetRequest(endpoint);
+		return response.json();
+	}
+
+	/**
 	 * @param {string} lpaCode
 	 * @returns {Promise<AppealCase[]>}
 	 */

--- a/packages/common/src/database/chunk-array.js
+++ b/packages/common/src/database/chunk-array.js
@@ -17,6 +17,27 @@ const chunkArray = (myArray, chunk_size) => {
 	return tempArray;
 };
 
+/**
+ * @template T
+ * @param {T[][]} batch
+ * @param {number} concurrencyLimit
+ * @param {function(T[]): Promise<any>} fn
+ * @returns {Promise<any[]>}
+ */
+const runBatchWithPromise = async (batch, concurrencyLimit, fn) => {
+	/**@type {any[]} */
+	const results = [];
+
+	for (let i = 0; i < batch.length; i += concurrencyLimit) {
+		const concurrentBatches = batch.slice(i, i + concurrencyLimit);
+		const batchResults = await Promise.all(concurrentBatches.map(fn));
+		results.push(...batchResults.flat());
+	}
+
+	return results;
+};
+
 module.exports = {
-	chunkArray
+	chunkArray,
+	runBatchWithPromise
 };

--- a/packages/common/src/database/chunk-array.test.js
+++ b/packages/common/src/database/chunk-array.test.js
@@ -1,0 +1,177 @@
+const { chunkArray, runBatchWithPromise } = require('./chunk-array');
+
+describe('chunk-array utilities', () => {
+	describe('chunkArray', () => {
+		it('should chunk an array into equal parts', () => {
+			const array = [1, 2, 3, 4, 5, 6];
+			const result = chunkArray(array, 2);
+
+			expect(result).toEqual([
+				[1, 2],
+				[3, 4],
+				[5, 6]
+			]);
+			expect(result.length).toBe(3);
+		});
+
+		it('should chunk an array with remainder', () => {
+			const array = [1, 2, 3, 4, 5];
+			const result = chunkArray(array, 2);
+
+			expect(result).toEqual([[1, 2], [3, 4], [5]]);
+			expect(result.length).toBe(3);
+		});
+
+		it('should handle chunk size larger than array', () => {
+			const array = [1, 2, 3];
+			const result = chunkArray(array, 10);
+
+			expect(result).toEqual([[1, 2, 3]]);
+			expect(result.length).toBe(1);
+		});
+
+		it('should handle chunk size of 1', () => {
+			const array = [1, 2, 3];
+			const result = chunkArray(array, 1);
+
+			expect(result).toEqual([[1], [2], [3]]);
+			expect(result.length).toBe(3);
+		});
+
+		it('should handle empty array', () => {
+			const array = [];
+			const result = chunkArray(array, 2);
+
+			expect(result).toEqual([]);
+			expect(result.length).toBe(0);
+		});
+
+		it('should handle single item', () => {
+			const array = [42];
+			const result = chunkArray(array, 2);
+
+			expect(result).toEqual([[42]]);
+			expect(result.length).toBe(1);
+		});
+
+		it('should work with different data types', () => {
+			const array = ['a', 'b', 'c', 'd'];
+			const result = chunkArray(array, 2);
+
+			expect(result).toEqual([
+				['a', 'b'],
+				['c', 'd']
+			]);
+		});
+
+		it('should work with objects', () => {
+			const array = [{ id: 1 }, { id: 2 }, { id: 3 }];
+			const result = chunkArray(array, 2);
+
+			expect(result).toEqual([[{ id: 1 }, { id: 2 }], [{ id: 3 }]]);
+		});
+	});
+
+	describe('runBatchWithPromise', () => {
+		it('should execute all batches and return results', async () => {
+			const batch = [
+				[1, 2],
+				[3, 4],
+				[5, 6]
+			];
+			const fn = async (chunk) => chunk.reduce((sum, n) => sum + n, 0);
+
+			const result = await runBatchWithPromise(batch, 2, fn);
+
+			expect(result).toEqual([3, 7, 11]);
+		});
+
+		it('should handle empty batch', async () => {
+			const batch = [];
+			const fn = async (chunk) => chunk;
+
+			const result = await runBatchWithPromise(batch, 2, fn);
+
+			expect(result).toEqual([]);
+		});
+
+		it('should handle single batch', async () => {
+			const batch = [[1, 2, 3]];
+			const fn = async (chunk) => chunk;
+
+			const result = await runBatchWithPromise(batch, 2, fn);
+
+			expect(result).toEqual([1, 2, 3]);
+		});
+
+		it('should handle concurrency limit of 1', async () => {
+			const batch = [[1], [2], [3]];
+			const concurrencyTracker = { concurrent: 0, maxConcurrent: 0 };
+
+			const fn = async (chunk) => {
+				concurrencyTracker.concurrent++;
+				concurrencyTracker.maxConcurrent = Math.max(
+					concurrencyTracker.maxConcurrent,
+					concurrencyTracker.concurrent
+				);
+
+				await new Promise((resolve) => setTimeout(resolve, 5));
+				concurrencyTracker.concurrent--;
+
+				return chunk[0] * 2;
+			};
+
+			const result = await runBatchWithPromise(batch, 1, fn);
+
+			expect(result).toEqual([2, 4, 6]);
+			expect(concurrencyTracker.maxConcurrent).toBe(1);
+		});
+
+		it('should flatten results correctly', async () => {
+			const batch = [
+				[1, 2],
+				[3, 4]
+			];
+			const fn = async (chunk) => chunk; // returns arrays
+
+			const result = await runBatchWithPromise(batch, 2, fn);
+
+			expect(result).toEqual([1, 2, 3, 4]);
+		});
+
+		it('should handle async errors in function', async () => {
+			const batch = [[1], [2]];
+			const fn = async (chunk) => {
+				if (chunk[0] === 2) {
+					throw new Error('Test error');
+				}
+				return chunk[0];
+			};
+
+			await expect(runBatchWithPromise(batch, 1, fn)).rejects.toThrow('Test error');
+		});
+
+		it('should process batches in order', async () => {
+			const batch = [[1], [2], [3], [4], [5]];
+			const executionOrder = [];
+
+			const fn = async (chunk) => {
+				executionOrder.push(chunk[0]);
+				return chunk[0];
+			};
+
+			await runBatchWithPromise(batch, 2, fn);
+
+			expect(executionOrder).toEqual([1, 2, 3, 4, 5]);
+		});
+
+		it('should work with objects as batch items', async () => {
+			const batch = [[{ id: 1 }], [{ id: 2 }]];
+			const fn = async (chunk) => chunk.map((item) => item.id);
+
+			const result = await runBatchWithPromise(batch, 2, fn);
+
+			expect(result).toEqual([1, 2]);
+		});
+	});
+});

--- a/packages/forms-web-app/src/controllers/appeals/continue.js
+++ b/packages/forms-web-app/src/controllers/appeals/continue.js
@@ -1,7 +1,5 @@
 const { APPEAL_ID } = require('@pins/business-rules/src/constants');
 const { caseTypeLookup } = require('@pins/common/src/database/data-static');
-
-const { APPEAL_USER_ROLES } = require('@pins/common/src/constants');
 const { isAppealSubmission, isV2Submission } = require('@pins/common/src/lib/format-address');
 
 const appealSubmissionContinueUrls = {
@@ -22,11 +20,7 @@ exports.get = async (req, res) => {
 	if (!appealId)
 		throw new Error(`Continue your appeal cannot be invoked without specifying an appeal id`);
 
-	const userAppeals = await req.appealsApiClient.getUserAppeals(APPEAL_USER_ROLES.APPELLANT);
-
-	const appealSubmission = userAppeals.find(
-		(appeal) => appeal.id === appealId || appeal._id === appealId
-	);
+	const appealSubmission = await req.appealsApiClient.getAppealDraft(appealId);
 
 	if (!appealSubmission) throw new Error(`Appeal ${appealId} does not belong to user`);
 


### PR DESCRIPTION
### Description of change

- for continuing a draft, only looks up the individual appeal not the entire user list
- simplified lookup for service users on list calls, looks up all by caseRef rather than than also checking the id, avoids query plan cache misses/compilation due to varied params
- Stopped looking up all reps for dashboards, only added for rule6 but impacted all dashboard calls
- added utility function to limit promise.all concurrency to avoid eating up entire connection pool for a single user's requests

Ticket: https://pins-ds.atlassian.net/browse/A2-7976

### Checklist

- [x] Feature complete and ready for users, or behind feature-flag
- [x] Commit history is linear with no merge commits
- [ ] Requires infrastructure changes

### Important

Please do not merge from `main` (please only [rebase](https://github.com/Planning-Inspectorate/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
