### PR TITLE
feat(flags): enable advert appellant statement with flag

### DIFF
--- a/packages/appeals-service-api/src/lib/notify.js
+++ b/packages/appeals-service-api/src/lib/notify.js
@@ -7,6 +7,8 @@ const {
 const NotifyBuilder = require('@pins/common/src/lib/notify/notify-builder');
 const NotifyService = require('@pins/common/src/lib/notify/notify-service');
 const config = require('../configuration/config');
+const { isFeatureActive } = require('../configuration/featureFlag');
+const { FLAG } = require('@pins/common/src/feature-flags');
 const logger = require('./logger');
 const LpaService = require('../services/lpa.service');
 const { parseISO } = require('date-fns');
@@ -415,7 +417,11 @@ const sendLpaStatementSubmissionReceivedEmailToLpaV2 = async (lpaStatementSubmis
 			enforcementReference: enforcementReference || '',
 			isEnforcement: isEnforcement(appealTypeCode),
 			hasAppellantStatementJourney:
-				caseTypeLookup(appealTypeCode, 'processCode')?.hasAppellantStatementJourney ?? false
+				caseTypeLookup(appealTypeCode, 'processCode', {
+					[FLAG.ADVERT_APPELLANT_STATEMENT_ENABLED]: await isFeatureActive(
+						FLAG.ADVERT_APPELLANT_STATEMENT_ENABLED
+					)
+				})?.hasAppellantStatementJourney ?? false
 		};
 
 		logger.debug({ lpaEmail, variables, reference }, 'Sending email to LPA');

--- a/packages/business-rules/src/rules/appeal-case/case-due-dates.js
+++ b/packages/business-rules/src/rules/appeal-case/case-due-dates.js
@@ -70,11 +70,13 @@ exports.isLPAStatementOpen = (appealCaseData) =>
 /**
  * statement is open for Appellant
  * @param {AppealCaseDetailed} appealCaseData
+ * @param {Record<string, boolean>} featureFlags feature flags to check
  * @returns {boolean}
  */
-exports.isAppellantStatementOpen = (appealCaseData) =>
+exports.isAppellantStatementOpen = (appealCaseData, featureFlags) =>
 	process.env.APPELLANT_STATEMENT_ENABLED === 'true' &&
-	!!caseTypeLookup(appealCaseData.appealTypeCode, 'processCode')?.hasAppellantStatementJourney &&
+	!!caseTypeLookup(appealCaseData.appealTypeCode, 'processCode', featureFlags)
+		?.hasAppellantStatementJourney &&
 	statementsAreOpen(appealCaseData) &&
 	!appealCaseData.AppellantStatementSubmittedDate &&
 	!representationExists(appealCaseData.Representations, {

--- a/packages/common/src/database/data-static.js
+++ b/packages/common/src/database/data-static.js
@@ -1,4 +1,5 @@
 const { APPEAL_USER_ROLES } = require('../constants');
+const { FLAG } = require('../feature-flags');
 const {
 	APPEAL_CASE_PROCEDURE,
 	APPEAL_CASE_TYPE,
@@ -90,7 +91,7 @@ const CASE_TYPES = Object.freeze({
 		friendlyUrl: 'adverts', // shares appeal form with CAS_ADVERTS
 		expedited: false,
 		usesEnforcementContact: false,
-		hasAppellantStatementJourney: false
+		hasAppellantStatementJourney: true
 	},
 	CAS_ADVERTS: {
 		id: 1007,
@@ -152,9 +153,10 @@ const CASE_TYPES = Object.freeze({
 /**
  * @param {any} value value to lookup
  * @param {'processCode'|'id'|'type'} lookupProp property to check
+ * @param {Record<string, boolean>} featureFlags feature flags to check
  * @returns {CASE_TYPE|undefined} result based on the returnProp
  */
-const caseTypeLookup = (value, lookupProp) => {
+const caseTypeLookup = (value, lookupProp, featureFlags) => {
 	// ensure lookup is on a unique value
 	if (!['processCode', 'id', 'type', 'key'].includes(lookupProp)) {
 		throw new Error(`Invalid lookup property: ${lookupProp}`);
@@ -165,7 +167,24 @@ const caseTypeLookup = (value, lookupProp) => {
 		value = parseInt(value, 10);
 	}
 
-	return Object.values(CASE_TYPES).find((caseType) => caseType[lookupProp] === value);
+	const appeal = Object.values(CASE_TYPES).find((caseType) => caseType[lookupProp] === value);
+	if (!appeal) return undefined;
+
+	// modify static data based on current flags
+	if (!featureFlags) return appeal;
+
+	// if feature flag is not on, flip advert hasAppellantStatementJourney to false
+	if (
+		!featureFlags[FLAG.ADVERT_APPELLANT_STATEMENT_ENABLED] &&
+		appeal.processCode === CASE_TYPES.ADVERTS.processCode
+	) {
+		return {
+			...appeal,
+			hasAppellantStatementJourney: false
+		};
+	}
+
+	return appeal;
 };
 
 /**

--- a/packages/common/src/feature-flags.js
+++ b/packages/common/src/feature-flags.js
@@ -3,7 +3,8 @@ const FLAG = {
 	ENFORCEMENT_APPEAL_FORM_V2: 'enforcement-appeal-form-v2',
 	ENFORCEMENT_LISTED_APPEAL_FORM_V2: 'enforcement-listed-appeal-form-v2',
 	LDC_APPEAL_FORM_V2: 'ldc-appeal-form-v2',
-	APPLICATION_API_LOOKUP: 'enable-application-api-lookup'
+	APPLICATION_API_LOOKUP: 'enable-application-api-lookup',
+	ADVERT_APPELLANT_STATEMENT_ENABLED: 'enable-advert-appellant-statement'
 };
 
 module.exports = {

--- a/packages/forms-web-app/src/controllers/appeals/your-appeals.js
+++ b/packages/forms-web-app/src/controllers/appeals/your-appeals.js
@@ -17,6 +17,8 @@ const {
 
 const { filterAppealsWithinGivenDate } = require('../../lib/filter-decided-appeals');
 const { filterTime } = require('../../config');
+const { FLAG } = require('@pins/common/src/feature-flags');
+const { isFeatureActive } = require('../../featureFlag');
 
 exports.get = async (req, res) => {
 	let viewContext = {};
@@ -28,11 +30,17 @@ exports.get = async (req, res) => {
 			return;
 		}
 
+		const flags = {
+			[FLAG.ADVERT_APPELLANT_STATEMENT_ENABLED]: await isFeatureActive(
+				FLAG.ADVERT_APPELLANT_STATEMENT_ENABLED
+			)
+		};
+
 		logger.debug({ appeals }, 'appeals');
 
 		const withdrawnAppealsCount = appeals
 			.filter((appeal) => appeal.caseWithdrawnDate)
-			.map(mapToAppellantDashboardDisplayData)
+			.map((a) => mapToAppellantDashboardDisplayData(a, flags))
 			.filter(Boolean)
 			.filter((appeal) =>
 				filterAppealsWithinGivenDate(
@@ -48,7 +56,7 @@ exports.get = async (req, res) => {
 			.filter(isNotTransferred);
 
 		const mappedAppeals = validAppeals
-			.map((a) => mapToAppellantDashboardDisplayData(a))
+			.map((a) => mapToAppellantDashboardDisplayData(a, flags))
 			.filter(Boolean);
 
 		const decidedAppealsCount = mappedAppeals

--- a/packages/forms-web-app/src/controllers/appeals/your-appeals/decided-appeals.js
+++ b/packages/forms-web-app/src/controllers/appeals/your-appeals/decided-appeals.js
@@ -5,14 +5,22 @@ const { sortByDateFieldDesc } = require('@pins/common/src/lib/appeal-sorting');
 const { filterAppealsWithinGivenDate } = require('#lib/filter-decided-appeals');
 const { filterTime } = require('../../../config');
 const { APPEAL_USER_ROLES } = require('@pins/common/src/constants');
+const { FLAG } = require('@pins/common/src/feature-flags');
+const { isFeatureActive } = require('../../../featureFlag');
 
 exports.get = async (req, res) => {
 	let viewContext = {};
+	const flags = {
+		[FLAG.ADVERT_APPELLANT_STATEMENT_ENABLED]: await isFeatureActive(
+			FLAG.ADVERT_APPELLANT_STATEMENT_ENABLED
+		)
+	};
+
 	try {
 		const appeals = await req.appealsApiClient.getUserAppeals(APPEAL_USER_ROLES.APPELLANT);
 		if (appeals?.length > 0) {
 			const decidedAppeals = appeals
-				.map(mapToAppellantDashboardDisplayData)
+				.map((a) => mapToAppellantDashboardDisplayData(a, flags))
 				.filter(Boolean)
 				.filter((appeal) => appeal.appealDecision)
 				.filter((appeal) =>

--- a/packages/forms-web-app/src/controllers/appeals/your-appeals/withdrawn-appeals.js
+++ b/packages/forms-web-app/src/controllers/appeals/your-appeals/withdrawn-appeals.js
@@ -5,18 +5,26 @@ const { filterAppealsWithinGivenDate } = require('../../../lib/filter-decided-ap
 const { filterTime } = require('../../../config');
 const { sortByDateFieldDesc } = require('@pins/common/src/lib/appeal-sorting');
 const { APPEAL_USER_ROLES } = require('@pins/common/src/constants');
+const { FLAG } = require('@pins/common/src/feature-flags');
+const { isFeatureActive } = require('../../../featureFlag');
 
 exports.get = async (req, res) => {
 	let viewContext = { withdrawnAppeals: [] };
 	try {
 		const appeals = await req.appealsApiClient.getUserAppeals(APPEAL_USER_ROLES.APPELLANT);
 
+		const flags = {
+			[FLAG.ADVERT_APPELLANT_STATEMENT_ENABLED]: await isFeatureActive(
+				FLAG.ADVERT_APPELLANT_STATEMENT_ENABLED
+			)
+		};
+
 		logger.debug('Total appeals from API:', appeals?.length);
 
 		if (appeals?.length > 0) {
 			const withdrawnAppeals = appeals
 				.filter((appeal) => appeal.caseWithdrawnDate)
-				.map(mapToAppellantDashboardDisplayData)
+				.map((a) => mapToAppellantDashboardDisplayData(a, flags))
 				.filter(Boolean)
 				.filter((appeal) =>
 					filterAppealsWithinGivenDate(

--- a/packages/forms-web-app/src/controllers/selected-appeal/index.js
+++ b/packages/forms-web-app/src/controllers/selected-appeal/index.js
@@ -37,6 +37,8 @@ const config = require('../../config');
 const { formatDateForDisplay } = require('@pins/common/src/lib/format-date');
 const { formatDashboardLinkedCaseDetails } = require('@pins/common/src/lib/linked-appeals');
 const { CASE_TYPES } = require('@pins/common/src/database/data-static');
+const { FLAG } = require('@pins/common/src/feature-flags');
+const { isFeatureActive } = require('../../featureFlag');
 
 /** @type {Partial<import('@pins/common/src/view-model-maps/sections/def').UserSectionsDict>} */
 const userSectionsDict = {
@@ -97,6 +99,12 @@ exports.get = (layoutTemplate = 'layouts/no-banner-link/main.njk') => {
 				);
 		}
 
+		const flags = {
+			[FLAG.ADVERT_APPELLANT_STATEMENT_ENABLED]: await isFeatureActive(
+				FLAG.ADVERT_APPELLANT_STATEMENT_ENABLED
+			)
+		};
+
 		const viewContext = {
 			layoutTemplate,
 			titleSuffix: formatTitleSuffix(userType),
@@ -111,7 +119,8 @@ exports.get = (layoutTemplate = 'layouts/no-banner-link/main.njk') => {
 				isAppellant && isAppellantProofsOfEvidenceOpen(caseData),
 			shouldDisplayFinalCommentsDueBannerAppellant:
 				isAppellant && isAppellantFinalCommentOpen(caseData),
-			shouldDisplayStatementsDueBannerAppellant: isAppellant && isAppellantStatementOpen(caseData),
+			shouldDisplayStatementsDueBannerAppellant:
+				isAppellant && isAppellantStatementOpen(caseData, flags),
 
 			shouldDisplayStatementsDueBannerRule6: isRule6 && isRule6StatementOpen(caseData),
 			shouldDisplayProofEvidenceDueBannerRule6: isRule6 && isRule6ProofsOfEvidenceOpen(caseData),

--- a/packages/forms-web-app/src/dynamic-forms/middleware/get-journey-response-for-appellant-statement.js
+++ b/packages/forms-web-app/src/dynamic-forms/middleware/get-journey-response-for-appellant-statement.js
@@ -1,5 +1,8 @@
 const { JourneyResponse } = require('@pins/dynamic-forms/src/journey-response');
 const { JOURNEY_TYPES } = require('@pins/common/src/dynamic-forms/journey-types');
+const { FLAG } = require('@pins/common/src/feature-flags');
+const { isFeatureActive } = require('../../featureFlag');
+
 const logger = require('#lib/logger');
 const { mapDBResponseToJourneyResponseFormat } = require('./utils');
 const {
@@ -22,8 +25,14 @@ module.exports =
 		const referenceId = req.params.referenceId;
 		const appealOverviewUrl = `${APPEAL_OVERVIEW}/${referenceId}`;
 		let result;
+		const flags = {
+			[FLAG.ADVERT_APPELLANT_STATEMENT_ENABLED]: await isFeatureActive(
+				FLAG.ADVERT_APPELLANT_STATEMENT_ENABLED
+			)
+		};
+
 		const appeal = await req.appealsApiClient.getAppealCaseByCaseRef(referenceId);
-		if (checkSubmitted && !isAppellantStatementOpen(appeal)) {
+		if (checkSubmitted && !isAppellantStatementOpen(appeal, flags)) {
 			req.session.navigationHistory.shift();
 			return res.redirect(appealOverviewUrl);
 		}

--- a/packages/forms-web-app/src/lib/dashboard-functions.js
+++ b/packages/forms-web-app/src/lib/dashboard-functions.js
@@ -136,7 +136,7 @@ const mapToLPADashboardDisplayData = (appealCaseData) => {
  * @param {AppealSubmission | AppealCaseDetailed} appealData
  * @returns {DashboardDisplayData|null}
  */
-const mapToAppellantDashboardDisplayData = (appealData) => {
+const mapToAppellantDashboardDisplayData = (appealData, featureFlags) => {
 	const id = isAppealSubmission(appealData) ? appealData._id : appealData.id;
 
 	const hasAddress =
@@ -162,7 +162,7 @@ const mapToAppellantDashboardDisplayData = (appealData) => {
 					: appealData.caseReference,
 			address: escapedAddress.replace(/\n/g, '<br>'),
 			appealType: getAppealType(appealData),
-			nextJourneyDue: determineJourneyToDisplayAppellantDashboard(appealData),
+			nextJourneyDue: determineJourneyToDisplayAppellantDashboard(appealData, featureFlags),
 			isDraft: isAppealSubmission(appealData) || isV2Submission(appealData),
 			displayInvalid: displayInvalidAppeal(appealData),
 			appealDecision: isAppealSubmission(appealData)
@@ -346,7 +346,7 @@ const determineJourneyToDisplayLPADashboard = (appealCaseData) => {
  * @param {AppealCaseDetailed | AppealSubmission} caseOrSubmission
  * @returns {DueJourneyType} object containing details of next due journey
  */
-const determineJourneyToDisplayAppellantDashboard = (caseOrSubmission) => {
+const determineJourneyToDisplayAppellantDashboard = (caseOrSubmission, featureFlags) => {
 	if (isAppealSubmission(caseOrSubmission)) {
 		const deadline = calculateAppealDueDeadline(caseOrSubmission);
 		return {
@@ -378,7 +378,7 @@ const determineJourneyToDisplayAppellantDashboard = (caseOrSubmission) => {
 			dueInDays: -100000,
 			journeyDue: SUBMISSIONS.INVALID
 		};
-	} else if (isAppellantStatementOpen(caseOrSubmission)) {
+	} else if (isAppellantStatementOpen(caseOrSubmission, featureFlags)) {
 		return {
 			deadline: caseOrSubmission.statementDueDate,
 			dueInDays: calculateDueInDays(caseOrSubmission.statementDueDate),


### PR DESCRIPTION
### Description of change

Enables appellant statement for adverts with feature flag check

Ticket: https://pins-ds.atlassian.net/browse/A2-8026

### Checklist

- [x] Feature complete and ready for users, or behind feature-flag
- [x] Commit history is linear with no merge commits
- [ ] Requires infrastructure changes

### Important

Please do not merge from `main` (please only [rebase](https://github.com/Planning-Inspectorate/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
