### PR TITLE
fix: back links on comment-planning-appeal pages (A2-7989)

### DIFF
--- a/packages/forms-web-app/src/lib/get-user-back-links.js
+++ b/packages/forms-web-app/src/lib/get-user-back-links.js
@@ -15,6 +15,8 @@ const getUserDashboardLink = (baseUrl) => {
 		return `/${VIEW.LPA_DASHBOARD.DASHBOARD}`;
 	} else if (baseUrl.startsWith('/rule-6/')) {
 		return `/${VIEW.RULE_6.DASHBOARD}`;
+	} else if (baseUrl.startsWith('/comment-planning-appeal/')) {
+		return `/${VIEW.INTERESTED_PARTY_COMMENTS.ENTER_APPEAL_REFERENCE}`;
 	} else {
 		throw new Error(`unknown baseUrl: ${baseUrl}`);
 	}

--- a/packages/forms-web-app/src/routes/file-based-router/comment-planning-appeal/enter-appeal-reference/controller.js
+++ b/packages/forms-web-app/src/routes/file-based-router/comment-planning-appeal/enter-appeal-reference/controller.js
@@ -1,6 +1,13 @@
 /** @type {import('express').RequestHandler} */
 const enterAppealReferenceGet = (req, res) => {
-	res.render(`comment-planning-appeal/enter-appeal-reference/index`);
+	const previousUrl = req?.session?.navigationHistory[1]?.trim();
+	const backLink =
+		!previousUrl || previousUrl === '/comment-planning-appeal'
+			? 'https://www.gov.uk/'
+			: previousUrl;
+	res.render(`comment-planning-appeal/enter-appeal-reference/index`, {
+		backLink: backLink
+	});
 };
 
 /** @type {import('express').RequestHandler} */

--- a/packages/forms-web-app/src/routes/file-based-router/comment-planning-appeal/enter-appeal-reference/controller.js
+++ b/packages/forms-web-app/src/routes/file-based-router/comment-planning-appeal/enter-appeal-reference/controller.js
@@ -1,6 +1,12 @@
 /** @type {import('express').RequestHandler} */
 const enterAppealReferenceGet = (req, res) => {
-	res.render(`comment-planning-appeal/enter-appeal-reference/index`);
+	const previousUrlBYS =
+		req?.session?.navigationHistory?.length > 1 &&
+		req?.session?.navigationHistory[1]?.trim() === '/before-you-start';
+	const backLink = previousUrlBYS ? 'https://www.gov.uk/' : req?.session?.navigationHistory[1];
+	res.render(`comment-planning-appeal/enter-appeal-reference/index`, {
+		backLink: backLink
+	});
 };
 
 /** @type {import('express').RequestHandler} */

--- a/packages/forms-web-app/src/routes/file-based-router/comment-planning-appeal/enter-appeal-reference/controller.test.js
+++ b/packages/forms-web-app/src/routes/file-based-router/comment-planning-appeal/enter-appeal-reference/controller.test.js
@@ -21,7 +21,8 @@ describe('enterAppealReference Controller Tests', () => {
 			enterAppealReferenceGet(req, res);
 
 			expect(res.render).toHaveBeenCalledWith(
-				'comment-planning-appeal/enter-appeal-reference/index'
+				'comment-planning-appeal/enter-appeal-reference/index',
+				{ backLink: 'https://www.gov.uk/' }
 			);
 		});
 	});

--- a/packages/forms-web-app/src/routes/file-based-router/comment-planning-appeal/enter-appeal-reference/controller.test.js
+++ b/packages/forms-web-app/src/routes/file-based-router/comment-planning-appeal/enter-appeal-reference/controller.test.js
@@ -8,6 +8,9 @@ describe('enterAppealReference Controller Tests', () => {
 			body: {},
 			appealsApiClient: {
 				appealCaseRefExists: jest.fn()
+			},
+			session: {
+				navigationHistory: ['/before-you-start', '/before-you-start']
 			}
 		};
 		res = {
@@ -21,7 +24,8 @@ describe('enterAppealReference Controller Tests', () => {
 			enterAppealReferenceGet(req, res);
 
 			expect(res.render).toHaveBeenCalledWith(
-				'comment-planning-appeal/enter-appeal-reference/index'
+				'comment-planning-appeal/enter-appeal-reference/index',
+				{ backLink: 'https://www.gov.uk/' }
 			);
 		});
 	});

--- a/packages/forms-web-app/src/routes/file-based-router/comment-planning-appeal/enter-postcode/controller.js
+++ b/packages/forms-web-app/src/routes/file-based-router/comment-planning-appeal/enter-postcode/controller.js
@@ -1,10 +1,20 @@
 const { fullPostcodeRegex, partialPostcodeRegex } = require('@pins/common/src/regex');
 const { resetInterestedPartySession } = require('../../../../services/interested-party.service');
+const { getUserDashboardLink } = require('#lib/get-user-back-links');
 
 /** @type {import('express').RequestHandler} */
 const enterPostcodeGet = (req, res) => {
 	resetInterestedPartySession(req);
-	res.render(`comment-planning-appeal/enter-postcode/index`);
+	const trailingSlashRegex = /\/$/;
+	const userRouteUrl = req.originalUrl.replace(trailingSlashRegex, '');
+	const backLinkToDashboard = getUserDashboardLink(userRouteUrl);
+	const previousUrl =
+		req?.session?.navigationHistory?.length > 0
+			? req?.session?.navigationHistory[1]
+			: backLinkToDashboard;
+	res.render(`comment-planning-appeal/enter-postcode/index`, {
+		backLink: previousUrl
+	});
 };
 
 /** @type {import('express').RequestHandler} */

--- a/packages/forms-web-app/src/routes/file-based-router/comment-planning-appeal/enter-postcode/controller.js
+++ b/packages/forms-web-app/src/routes/file-based-router/comment-planning-appeal/enter-postcode/controller.js
@@ -4,7 +4,13 @@ const { resetInterestedPartySession } = require('../../../../services/interested
 /** @type {import('express').RequestHandler} */
 const enterPostcodeGet = (req, res) => {
 	resetInterestedPartySession(req);
-	res.render(`comment-planning-appeal/enter-postcode/index`);
+	const previousUrlBYS =
+		req?.session?.navigationHistory?.length > 1 &&
+		req?.session?.navigationHistory[1]?.trim() === '/before-you-start';
+	const backLink = previousUrlBYS ? 'https://www.gov.uk/' : req?.session?.navigationHistory[1];
+	res.render(`comment-planning-appeal/enter-postcode/index`, {
+		backLink: backLink
+	});
 };
 
 /** @type {import('express').RequestHandler} */

--- a/packages/forms-web-app/src/routes/file-based-router/comment-planning-appeal/enter-postcode/controller.test.js
+++ b/packages/forms-web-app/src/routes/file-based-router/comment-planning-appeal/enter-postcode/controller.test.js
@@ -9,7 +9,8 @@ describe('enterPostcode Controller Tests', () => {
 
 	beforeEach(() => {
 		req = {
-			body: {}
+			body: {},
+			originalUrl: '/comment-planning-appeal/enter-postcode'
 		};
 		res = {
 			render: jest.fn(),
@@ -22,7 +23,9 @@ describe('enterPostcode Controller Tests', () => {
 			req.session = {};
 			enterPostcodeGet(req, res);
 
-			expect(res.render).toHaveBeenCalledWith('comment-planning-appeal/enter-postcode/index');
+			expect(res.render).toHaveBeenCalledWith('comment-planning-appeal/enter-postcode/index', {
+				backLink: '/comment-planning-appeal/enter-appeal-reference'
+			});
 			expect(resetInterestedPartySession).toHaveBeenCalledWith(req);
 		});
 	});

--- a/packages/forms-web-app/src/routes/file-based-router/comment-planning-appeal/enter-postcode/controller.test.js
+++ b/packages/forms-web-app/src/routes/file-based-router/comment-planning-appeal/enter-postcode/controller.test.js
@@ -9,7 +9,11 @@ describe('enterPostcode Controller Tests', () => {
 
 	beforeEach(() => {
 		req = {
-			body: {}
+			body: {},
+			originalUrl: '/comment-planning-appeal/enter-postcode',
+			session: {
+				navigationHistory: ['/before-you-start', '/comment-planning-appeal/enter-appeal-reference']
+			}
 		};
 		res = {
 			render: jest.fn(),
@@ -19,10 +23,11 @@ describe('enterPostcode Controller Tests', () => {
 
 	describe('enterPostcodeGet', () => {
 		it('should render the enter-postcode page and reset interested party session', () => {
-			req.session = {};
 			enterPostcodeGet(req, res);
 
-			expect(res.render).toHaveBeenCalledWith('comment-planning-appeal/enter-postcode/index');
+			expect(res.render).toHaveBeenCalledWith('comment-planning-appeal/enter-postcode/index', {
+				backLink: '/comment-planning-appeal/enter-appeal-reference'
+			});
 			expect(resetInterestedPartySession).toHaveBeenCalledWith(req);
 		});
 	});

--- a/packages/forms-web-app/src/views/layouts/comment-planning-appeal/main.njk
+++ b/packages/forms-web-app/src/views/layouts/comment-planning-appeal/main.njk
@@ -43,7 +43,7 @@
     {% block backButton %}
       {{ govukBackLink({
           text: "Back",
-          href: navigation[1],
+          href: backLink or navigation[1],
           attributes: {
             'data-cy': 'back'
           }

--- a/packages/forms-web-app/src/views/layouts/comment-planning-appeal/main.njk
+++ b/packages/forms-web-app/src/views/layouts/comment-planning-appeal/main.njk
@@ -43,11 +43,12 @@
     {% block backButton %}
       {{ govukBackLink({
           text: "Back",
-          href: navigation[1],
+          href: backLink or navigation[1],
           attributes: {
             'data-cy': 'back'
           }
       }) }}
+
     {% endblock backButton %}
 
     <main id="main-content" role="main" {% if mainLang %}lang="{{ mainLang }}"{% endif %} class="govuk-main-wrapper {{ mainClasses }}">


### PR DESCRIPTION
### Description of change

Changes in this PR: 

- Fixes "back" link behaviour across comment-planning-appeal pages so that enter appeal ref back link goes to GOV.uk page and enter postcode back to enter appeal ref 
- Refactors controllers to supply explicit back link context to the views/templates.
- Updates templates to use the new back link logic for consistent user navigation.
- Modifies and updates related tests to cover new back link implementation.

<!-- Please describe the change -->

Ticket: https://pins-ds.atlassian.net/browse/A2-7989

### Checklist

- [x] Feature complete and ready for users, or behind feature-flag
- [x] Commit history is linear with no merge commits
- [ ] Requires infrastructure changes

### Important

Please do not merge from `main` (please only [rebase](https://github.com/Planning-Inspectorate/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
