### PR TITLE
feat(A2-7767): integration FO-BO initial setup

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
 				"@azure/service-bus": "^7.9.1",
 				"@azure/storage-blob": "^12.29.1",
 				"@ministryofjustice/frontend": "^1.6.4",
-				"@planning-inspectorate/data-model": "^2.33.0",
+				"@planning-inspectorate/data-model": "^2.37.0",
 				"@prisma/adapter-mssql": "^7.7.0",
 				"@prisma/client": "^7.7.0",
 				"accessible-autocomplete": "^3.0.1",
@@ -6210,9 +6210,9 @@
 			}
 		},
 		"node_modules/@planning-inspectorate/data-model": {
-			"version": "2.33.0",
-			"resolved": "https://registry.npmjs.org/@planning-inspectorate/data-model/-/data-model-2.33.0.tgz",
-			"integrity": "sha512-n/Z9DZTwWHozo8uMQnc6d9zoFb3mmwrPHr4uYMl7s0hCa4fCm4YYrrlAysL0wsO/jEKY8JvOo8QNy6dimFXeug==",
+			"version": "2.37.0",
+			"resolved": "https://registry.npmjs.org/@planning-inspectorate/data-model/-/data-model-2.37.0.tgz",
+			"integrity": "sha512-w5QHw8Cm4yHOsLgIlvo8shv6H8PT3yc3VG+YH4AcozZ6kNd3srvXb69VrirmPZiVx/BJQMtwh3aIdTwLZHe7Ew==",
 			"license": "MIT",
 			"dependencies": {
 				"jsonc-parser": "^3.3.1"

--- a/package.json
+++ b/package.json
@@ -108,7 +108,7 @@
 		"@azure/service-bus": "^7.9.1",
 		"@azure/storage-blob": "^12.29.1",
 		"@ministryofjustice/frontend": "^1.6.4",
-		"@planning-inspectorate/data-model": "^2.33.0",
+		"@planning-inspectorate/data-model": "^2.37.0",
 		"@prisma/adapter-mssql": "^7.7.0",
 		"@prisma/client": "^7.7.0",
 		"accessible-autocomplete": "^3.0.1",

--- a/packages/appeals-service-api/__tests__/developer/fixtures/appeals-HAS-data-model.js
+++ b/packages/appeals-service-api/__tests__/developer/fixtures/appeals-HAS-data-model.js
@@ -120,7 +120,8 @@ const exampleHASDataModel = {
 	],
 	affectedListedBuildingNumbers: ['1010101', '1010102', '9000009'],
 	appellantCostsAppliedFor: true,
-	lpaCostsAppliedFor: true
+	lpaCostsAppliedFor: true,
+	listOfDocumentsBeforeDecision: null
 };
 
 module.exports = { exampleHASDataModel };

--- a/packages/appeals-service-api/__tests__/developer/fixtures/appeals-S78-data-model.js
+++ b/packages/appeals-service-api/__tests__/developer/fixtures/appeals-S78-data-model.js
@@ -67,7 +67,8 @@ const exampleS78DataModel = {
 	siteGridReferenceNorthing: null,
 	siteViewableFromRoad: null,
 	siteWithinSSSI: false,
-	typeOfPlanningApplication: null
+	typeOfPlanningApplication: null,
+	listOfDocumentsBeforeDecision: 'test documents'
 };
 
 module.exports = { exampleS78DataModel };

--- a/packages/appeals-service-api/src/routes/v2/appeal-cases/_caseReference/lpa-questionnaire-submission/submit/index.test.js
+++ b/packages/appeals-service-api/src/routes/v2/appeal-cases/_caseReference/lpa-questionnaire-submission/submit/index.test.js
@@ -524,7 +524,9 @@ const formattedS78 = [
 			isPublicRightOfWay: true,
 			lpaProcedurePreferenceDetails: 'Hearing details',
 			lpaProcedurePreferenceDuration: null,
-			lpaQuestionnaireSubmittedDate: expect.any(String)
+			lpaQuestionnaireSubmittedDate: expect.any(String),
+			significantChangesAffectingApplicationLpa: null,
+			listOfDocumentsBeforeDecision: undefined
 		},
 		documents: [...expectedHAS.documents]
 	})

--- a/packages/appeals-service-api/src/routes/v2/appeal-cases/appeal-cases.spec.js
+++ b/packages/appeals-service-api/src/routes/v2/appeal-cases/appeal-cases.spec.js
@@ -765,7 +765,8 @@ module.exports = ({ getSqlClient, setCurrentLpa, mockNotifyClient, appealsApi })
 						siteUseAtTimeOfApplication: data.siteUseAtTimeOfApplication ?? null,
 						appealUnderActSection: data.appealUnderActSection ?? null,
 						lpaConsiderAppealInvalid: data.lpaConsiderAppealInvalid ?? null,
-						lpaAppealInvalidReasons: data.lpaAppealInvalidReasons ?? null
+						lpaAppealInvalidReasons: data.lpaAppealInvalidReasons ?? null,
+						listOfDocumentsBeforeDecision: data.listOfDocumentsBeforeDecision ?? null
 					});
 					expectEmails(email, testCaseRef);
 				});
@@ -1021,7 +1022,8 @@ module.exports = ({ getSqlClient, setCurrentLpa, mockNotifyClient, appealsApi })
 					siteUseAtTimeOfApplication: data.siteUseAtTimeOfApplication ?? null,
 					appealUnderActSection: data.appealUnderActSection ?? null,
 					lpaConsiderAppealInvalid: data.lpaConsiderAppealInvalid ?? null,
-					lpaAppealInvalidReasons: data.lpaAppealInvalidReasons ?? null
+					lpaAppealInvalidReasons: data.lpaAppealInvalidReasons ?? null,
+					listOfDocumentsBeforeDecision: data.listOfDocumentsBeforeDecision ?? null
 				});
 			});
 

--- a/packages/appeals-service-api/src/routes/v2/appeal-cases/service.js
+++ b/packages/appeals-service-api/src/routes/v2/appeal-cases/service.js
@@ -185,7 +185,8 @@ const mapCommonDataModelToAppealCase = (
 		appellantCostsAppliedFor,
 		lpaCostsAppliedFor,
 		typeOfPlanningApplication,
-		reasonForNeighbourVisits
+		reasonForNeighbourVisits,
+		listOfDocumentsBeforeDecision
 	}
 ) => ({
 	// custom mappings
@@ -280,7 +281,8 @@ const mapCommonDataModelToAppealCase = (
 	appellantCostsAppliedFor,
 	lpaCostsAppliedFor,
 	typeOfPlanningApplication,
-	reasonForNeighbourVisits
+	reasonForNeighbourVisits,
+	listOfDocumentsBeforeDecision
 });
 
 /**

--- a/packages/appeals-service-api/src/services/back-office-v2/formatters/s78/questionnaire.test.js
+++ b/packages/appeals-service-api/src/services/back-office-v2/formatters/s78/questionnaire.test.js
@@ -76,7 +76,12 @@ describe('formatter', () => {
 		// Appeal process
 		lpaProcedurePreference: APPEAL_LPA_PROCEDURE_PREFERENCE.INQUIRY,
 		lpaPreferInquiryDetails: 'lpaPreferInquiryDetails',
-		lpaProcedurePreference_lpaPreferInquiryDuration: '12'
+		lpaProcedurePreference_lpaPreferInquiryDuration: '12',
+
+		anySignificantChanges: 'local-plan,national-policy',
+		anySignificantChanges_localPlanSignificantChanges: 'local plan changes',
+		anySignificantChanges_nationalPolicySignificantChanges: 'national policy changes',
+		listOfDocumentsBeforeDecision: 'list of documents'
 	};
 
 	const formattedAnswers = {
@@ -135,7 +140,8 @@ describe('formatter', () => {
 			isPublicRightOfWay: undefined,
 			lpaProcedurePreference: 'written',
 			lpaProcedurePreferenceDetails: null,
-			lpaProcedurePreferenceDuration: null
+			lpaProcedurePreferenceDuration: null,
+			significantChangesAffectingApplicationLpa: null
 		},
 		documents: [1]
 	};
@@ -196,7 +202,19 @@ describe('formatter', () => {
 				lpaProcedurePreferenceDetails: s78Answers.lpaPreferInquiryDetails,
 				lpaProcedurePreferenceDuration: Number(
 					s78Answers.lpaProcedurePreference_lpaPreferInquiryDuration
-				)
+				),
+
+				significantChangesAffectingApplicationLpa: [
+					{
+						value: 'adopted-a-new-local-plan',
+						comment: 'local plan changes'
+					},
+					{
+						value: 'national-policy-change',
+						comment: 'national policy changes'
+					}
+				],
+				listOfDocumentsBeforeDecision: 'list of documents'
 			},
 			documents: [1]
 		});
@@ -315,7 +333,10 @@ describe('formatter', () => {
 				// preference
 				lpaProcedurePreference: 'written',
 				lpaProcedurePreferenceDetails: null,
-				lpaProcedurePreferenceDuration: null
+				lpaProcedurePreferenceDuration: null,
+
+				significantChangesAffectingApplicationLpa: null,
+				listOfDocumentsBeforeDecision: undefined
 			},
 			documents: [1]
 		});

--- a/packages/appeals-service-api/src/services/back-office-v2/formatters/utils.js
+++ b/packages/appeals-service-api/src/services/back-office-v2/formatters/utils.js
@@ -597,7 +597,7 @@ exports.getS78AppellantSubmissionFields = (appellantSubmission) => {
 
 /**
  * @param {FullAppellantSubmission} appellantSubmission
- * @returns {{value: string, comment?: string | null}[] | null}
+ * @returns {{value: "adopted-a-new-local-plan" | "national-policy-change" | "court-judgement" | "other" | null, comment?: string | null}[] | null}
  */
 exports.formatSignificantChanges = (appellantSubmission) => {
 	if (!appellantSubmission.anySignificantChanges) return null;
@@ -1202,6 +1202,11 @@ exports.getS78LPAQSubmissionFields = (answers) => {
 		// Planning officer’s report and supporting documents
 		hasEmergingPlan: answers.emergingPlan,
 		hasSupplementaryPlanningDocs: answers.supplementaryPlanningDocs,
+
+		// Appeal process
+		significantChangesAffectingApplicationLpa: exports.formatSignificantChanges(answers),
+
+		// Original Evidence
 		listOfDocumentsBeforeDecision: answers.listOfDocumentsBeforeDecision
 	};
 };

--- a/packages/appeals-service-api/src/services/back-office-v2/formatters/utils.test.js
+++ b/packages/appeals-service-api/src/services/back-office-v2/formatters/utils.test.js
@@ -12,7 +12,8 @@ const {
 	getDesignatedSiteNames,
 	siteAddressAndGridReferenceAreMissing,
 	getAdvertsAppellantSubmissionFields,
-	getS78AppellantSubmissionFields
+	getS78AppellantSubmissionFields,
+	getS78LPAQSubmissionFields
 } = require('./utils');
 const { LPA_NOTIFICATION_METHODS } = require('@pins/common/src/database/data-static');
 const {
@@ -606,6 +607,43 @@ describe('utils.js', () => {
 				appellantProcedurePreferenceDetails: undefined,
 				appellantProcedurePreferenceDuration: null,
 				appellantProcedurePreferenceWitnessCount: null
+			});
+		});
+	});
+	describe('getS78LPAQSubmissionFields', () => {
+		it('should return S78 fields', () => {
+			const answers = {
+				treePreservationOrder: true,
+				publicRightOfWay: true,
+				statutoryConsultees: 'yes',
+				statutoryConsultees_consultedBodiesDetails: 'details',
+				consultationResponses: true,
+				emergingPlan: true,
+				supplementaryPlanningDocs: true,
+				anySignificantChanges: 'local-plan,national-policy,court-judgment,other',
+				anySignificantChanges_otherSignificantChanges: 'other text',
+				anySignificantChanges_localPlanSignificantChanges: 'local plan text',
+				anySignificantChanges_nationalPolicySignificantChanges: 'national policy text',
+				anySignificantChanges_courtJudgementSignificantChanges: 'court judgment text',
+				listOfDocumentsBeforeDecision: 'list of docs'
+			};
+			const result = getS78LPAQSubmissionFields(answers);
+			expect(result).toEqual({
+				changedListedBuildingNumbers: [],
+				hasTreePreservationOrder: true,
+				isPublicRightOfWay: true,
+				hasStatutoryConsultees: true,
+				consultedBodiesDetails: 'details',
+				hasConsultationResponses: true,
+				hasEmergingPlan: true,
+				hasSupplementaryPlanningDocs: true,
+				significantChangesAffectingApplicationLpa: [
+					{ value: 'adopted-a-new-local-plan', comment: 'local plan text' },
+					{ value: 'national-policy-change', comment: 'national policy text' },
+					{ value: 'court-judgement', comment: 'court judgment text' },
+					{ value: 'other', comment: 'other text' }
+				],
+				listOfDocumentsBeforeDecision: 'list of docs'
 			});
 		});
 	});

--- a/packages/common/src/document-types.js
+++ b/packages/common/src/document-types.js
@@ -625,6 +625,39 @@ const documentTypes = {
 		horizonDocumentType: '', // Does not exist in horizon
 		horizonDocumentGroupType: '' // Does not exist in horizon
 	},
+	uploadPlansDrawingsLPA: {
+		name: 'uploadPlansDrawingsLPA',
+		dataModelName: APPEAL_DOCUMENT_TYPE.PLANS_DRAWINGS_LPA,
+		multiple: true,
+		displayName: '',
+		involvement: '',
+		owner: (_appealTypeCode) => lpaOwner,
+		publiclyAccessible: false,
+		horizonDocumentType: '',
+		horizonDocumentGroupType: ''
+	},
+	uploadDesignAccessStatementLPA: {
+		name: 'uploadDesignAccessStatementLPA',
+		dataModelName: APPEAL_DOCUMENT_TYPE.DESIGN_ACCESS_STATEMENT_LPA,
+		multiple: true,
+		displayName: '',
+		involvement: '',
+		owner: (_appealTypeCode) => lpaOwner,
+		publiclyAccessible: false,
+		horizonDocumentType: '',
+		horizonDocumentGroupType: ''
+	},
+	uploadAdditionalDocumentsLPA: {
+		name: 'uploadAdditionalDocumentsLPA',
+		dataModelName: APPEAL_DOCUMENT_TYPE.ADDITIONAL_DOCUMENTS_LPA,
+		multiple: true,
+		displayName: '',
+		involvement: '',
+		owner: (_appealTypeCode) => lpaOwner,
+		publiclyAccessible: false,
+		horizonDocumentType: '',
+		horizonDocumentGroupType: ''
+	},
 	uploadStatementCommonGround: {
 		name: 'uploadStatementCommonGround',
 		dataModelName: APPEAL_DOCUMENT_TYPE.STATEMENT_COMMON_GROUND,

--- a/packages/database/src/migrations/20260501145349_add_list_of_documents_before_decision_to_appealcase/migration.sql
+++ b/packages/database/src/migrations/20260501145349_add_list_of_documents_before_decision_to_appealcase/migration.sql
@@ -1,0 +1,19 @@
+BEGIN TRY
+
+BEGIN TRAN;
+
+-- AlterTable
+ALTER TABLE [dbo].[AppealCase] ADD [listOfDocumentsBeforeDecision] NVARCHAR(max);
+
+COMMIT TRAN;
+
+END TRY
+BEGIN CATCH
+
+IF @@TRANCOUNT > 0
+BEGIN
+    ROLLBACK TRAN;
+END;
+THROW
+
+END CATCH

--- a/packages/database/src/schema.prisma
+++ b/packages/database/src/schema.prisma
@@ -271,7 +271,8 @@ model AppealCase {
 
   reasonForNeighbourVisits String? /// Reason given for the need to visit neighbours
 
-  designatedSitesNames String? @db.NVarChar(MAX) /// A json array of designated site names
+  designatedSitesNames          String? @db.NVarChar(MAX) /// A json array of designated site names
+  listOfDocumentsBeforeDecision String? @db.NVarChar(MAX)
 
   //***************************************************************************
   // Environmental Impact Assesement fields

--- a/packages/forms-web-app/src/dynamic-forms/questions.js
+++ b/packages/forms-web-app/src/dynamic-forms/questions.js
@@ -2192,7 +2192,7 @@ exports.getQuestionProps = (response) => ({
 	uploadDesignAccessStatementPart1: {
 		type: 'multi-file-upload',
 		title: 'Design and access statement',
-		question: 'Upload the design and access statement submitted with the application',
+		question: 'Upload the design and access statement submitted for the application',
 		fieldName: 'uploadDesignAccessStatement',
 		url: 'design-access-statement-upload',
 		html: 'resources/plans-drawings/upload-design-access-part-1.html',
@@ -2200,7 +2200,7 @@ exports.getQuestionProps = (response) => ({
 			new RequiredFileUploadValidator('Select the design and access statement'),
 			new MultifileUploadValidator(defaultFileUploadValidatorParams)
 		],
-		documentType: documentTypes.uploadDesignAccessStatement,
+		documentType: documentTypes.uploadDesignAccessStatementLPA,
 		actionHiddenText: 'the design and access statement submitted with the application'
 	},
 	additionalDocumentsPart1: {
@@ -2222,7 +2222,7 @@ exports.getQuestionProps = (response) => ({
 			new RequiredFileUploadValidator('Select any other documents'),
 			new MultifileUploadValidator(defaultFileUploadValidatorParams)
 		],
-		documentType: documentTypes.uploadOtherNewDocuments,
+		documentType: documentTypes.uploadAdditionalDocumentsLPA,
 		actionHiddenText: 'any other documents submitted with the application'
 	},
 	listOfDocumentsBeforeDecision: {
@@ -4397,7 +4397,7 @@ exports.getQuestionProps = (response) => ({
 			),
 			new MultifileUploadValidator(defaultFileUploadValidatorParams)
 		],
-		documentType: documentTypes.otherRelevantMattersUpload,
+		documentType: documentTypes.uploadPlansDrawingsLPA,
 		actionHiddenText: 'plans and drawings'
 	},
 	submitEnvironmentStatementPart1: {

--- a/packages/forms-web-app/src/dynamic-forms/s78-questionnaire-part-1/journey.js
+++ b/packages/forms-web-app/src/dynamic-forms/s78-questionnaire-part-1/journey.js
@@ -10,7 +10,6 @@ const { QUESTION_VARIABLES } = require('@pins/common/src/dynamic-forms/question-
 const {
 	CASE_TYPES: { S78 }
 } = require('@pins/common/src/database/data-static');
-const config = require('../../config');
 const {
 	mapAppealTypeToDisplayText,
 	mapAppealTypeToDisplayTextWithAnOrA
@@ -105,31 +104,7 @@ const makeSections = (response) => {
 						{ logicalCombinator: 'or' }
 					)
 			)
-			.addQuestion(questions.scopingOpinion)
-			.withCondition(
-				() =>
-					questionsHaveAnswers(
-						response,
-						[
-							[questions.screeningOpinion, 'yes'],
-							[questions.screeningOpinionEnvironmentalStatement, 'yes']
-						],
-						{ logicalCombinator: 'and' }
-					) && config.featureFlag.scopingOpinionEnabled
-			)
-			.addQuestion(questions.scopingOpinionUpload)
-			.withCondition(
-				() =>
-					questionsHaveAnswers(
-						response,
-						[
-							[questions.scopingOpinion, 'yes'],
-							[questions.screeningOpinion, 'yes'],
-							[questions.screeningOpinionEnvironmentalStatement, 'yes']
-						],
-						{ logicalCombinator: 'and' }
-					) && config.featureFlag.scopingOpinionEnabled
-			)
+
 			.addQuestion(questions.submitEnvironmentalStatement)
 			.addQuestion(questions.uploadEnvironmentalStatement)
 			.withCondition(() =>
@@ -225,8 +200,7 @@ const makeSections = (response) => {
 			.addQuestion(questions.appealsNearSite)
 			.addQuestion(questions.nearbyAppeals)
 			.withCondition(() => questionHasAnswer(response, questions.appealsNearSite, 'yes'))
-			.addQuestion(questions.anySignificantChangesLPA)
-			.addQuestion(questions.addNewConditions),
+			.addQuestion(questions.anySignificantChangesLPA),
 		new Section('Original Evidence', 'original-evidence')
 			.addQuestion(questions.designAccessStatementPart1)
 			.addQuestion(questions.uploadDesignAccessStatementPart1)


### PR DESCRIPTION
### Description of change

Adds data mapping for sending the expedited LPAQ data to BO
Updates Data model version

Ticket: https://pins-ds.atlassian.net/browse/A2-7767

### Checklist

- [x] Feature complete and ready for users, or behind feature-flag
- [x] Commit history is linear with no merge commits
- [ ] Requires infrastructure changes

### Important

Please do not merge from `main` (please only [rebase](https://github.com/Planning-Inspectorate/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
