### PR TITLE
fix(a2-8060): westmorland lpa name

### DIFF
--- a/packages/appeals-service-api/data/lpa-list.csv
+++ b/packages/appeals-service-api/data/lpa-list.csv
@@ -409,7 +409,7 @@
 ;;F3925;West Wiltshire District Council;;;FALSE\n
 ;;K3930;Wiltshire County Council Pre 010409;;;FALSE\n
 ;E1855;E1855;Worcestershire County Council;DevControlTeam@worcestershire.gov.uk;worcestershire.gov.uk;TRUE\n
-;K0940;K0940;West Morland and Furness Council;appeals4@westmorlandandfurness.gov.uk;westmorlandandfurness.gov.uk;TRUE\n
+;K0940;K0940;Westmorland and Furness Council;appeals4@westmorlandandfurness.gov.uk;westmorlandandfurness.gov.uk;TRUE\n
 ;E3335;E3335;Somerset Council;planningappeals@somerset.gov.uk;somerset.gov.uk;TRUE\n
 ;F0935;F0935;Cumberland;planning.appeals@cumberland.gov.uk;cumberland.gov.uk;TRUE\n
 ;U2750;U2750;North Yorkshire Council;NYCplanningappeals@northyorks.gov.uk;northyorks.gov.uk;TRUE\n


### PR DESCRIPTION
### Description of change

Update westmorland lpa name

Ticket: https://pins-ds.atlassian.net/browse/A2-8060

### Checklist

- [x] Feature complete and ready for users, or behind feature-flag
- [x] Commit history is linear with no merge commits
- [ ] Requires infrastructure changes

### Important

Please do not merge from `main` (please only [rebase](https://github.com/Planning-Inspectorate/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
