### PR TITLE
fix(A2-8016): hide rule 6 party statements and site visits on child a…

### DIFF
--- a/packages/forms-web-app/src/controllers/selected-appeal/appellant-sections.js
+++ b/packages/forms-web-app/src/controllers/selected-appeal/appellant-sections.js
@@ -78,6 +78,7 @@ exports.sections = [
 				url: '/other-party-statements',
 				text: 'View other party statements',
 				condition: (appealCase) =>
+					!isEnforcementChildLinkedAppeal(appealCase) &&
 					representationPublished(appealCase.Representations, {
 						type: REPRESENTATION_TYPES.STATEMENT,
 						owned: false,

--- a/packages/forms-web-app/src/controllers/selected-appeal/index.js
+++ b/packages/forms-web-app/src/controllers/selected-appeal/index.js
@@ -35,7 +35,10 @@ const { getDepartmentFromCode } = require('../../services/department.service');
 const logger = require('#lib/logger');
 const config = require('../../config');
 const { formatDateForDisplay } = require('@pins/common/src/lib/format-date');
-const { formatDashboardLinkedCaseDetails } = require('@pins/common/src/lib/linked-appeals');
+const {
+	formatDashboardLinkedCaseDetails,
+	isChildLinkedAppeal
+} = require('@pins/common/src/lib/linked-appeals');
 const { CASE_TYPES } = require('@pins/common/src/database/data-static');
 const { FLAG } = require('@pins/common/src/feature-flags');
 const { isFeatureActive } = require('../../featureFlag');
@@ -85,6 +88,8 @@ exports.get = (layoutTemplate = 'layouts/no-banner-link/main.njk') => {
 
 		const isEnforcement = caseData.appealTypeCode === CASE_TYPES.ENFORCEMENT.processCode;
 
+		const siteVisits = isChildLinkedAppeal(caseData) ? [] : formatSiteVisits(events, userType);
+
 		const linkedCaseDetails = formatDashboardLinkedCaseDetails(caseData);
 
 		const sections = userSectionsDict[userType];
@@ -128,7 +133,7 @@ exports.get = (layoutTemplate = 'layouts/no-banner-link/main.njk') => {
 			appeal: {
 				appealNumber,
 				headlineData,
-				siteVisits: formatSiteVisits(events, userType),
+				siteVisits,
 				inquiries: formatInquiries(events, userType),
 				hearings: formatHearings(events, userType),
 				sections: formatSections({ caseData, sections }),

--- a/packages/forms-web-app/src/controllers/selected-appeal/lpa-user-sections.js
+++ b/packages/forms-web-app/src/controllers/selected-appeal/lpa-user-sections.js
@@ -86,6 +86,7 @@ exports.sections = [
 				url: '/other-party-statements',
 				text: 'View other party statements',
 				condition: (appealCase) =>
+					!isEnforcementChildLinkedAppeal(appealCase) &&
 					representationPublished(appealCase.Representations, {
 						type: REPRESENTATION_TYPES.STATEMENT,
 						owned: false,


### PR DESCRIPTION
…ppeals

### Description of change

Manage display of representations and site vistis for child appeals:
- hide rule 6 party reps for child enforcement appeals
- hide site visits for all child appeals

Ticket: https://pins-ds.atlassian.net/browse/A2-7986
https://pins-ds.atlassian.net/browse/A2-8016

### Checklist

- [X] Feature complete and ready for users, or behind feature-flag
- [X] Commit history is linear with no merge commits
- [ ] Requires infrastructure changes

### Important

Please do not merge from `main` (please only [rebase](https://github.com/Planning-Inspectorate/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
