### PR TITLE
fix: force .sh line endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,4 @@
 *.md text eol=lf
+*.sh text eol=lf
+.husky/commit-msg text eol=lf
+.husky/pre-commit text eol=lf


### PR DESCRIPTION
### Description of change

Forces line endings for shell scripts

### Checklist

- [x] Feature complete and ready for users, or behind feature-flag
- [x] Commit history is linear with no merge commits
- [ ] Requires infrastructure changes

### Important

Please do not merge from `main` (please only [rebase](https://github.com/Planning-Inspectorate/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
