### PR TITLE
fix(A2-8193): update check for isAppellantStatementOpen

### DIFF
--- a/packages/business-rules/src/rules/appeal-case/case-due-dates.js
+++ b/packages/business-rules/src/rules/appeal-case/case-due-dates.js
@@ -78,7 +78,7 @@ exports.isAppellantStatementOpen = (appealCaseData, featureFlags) =>
 	!!caseTypeLookup(appealCaseData.appealTypeCode, 'processCode', featureFlags)
 		?.hasAppellantStatementJourney &&
 	statementsAreOpen(appealCaseData) &&
-	!appealCaseData.AppellantStatementSubmittedDate &&
+	!appealCaseData.appellantStatementSubmittedDate &&
 	!representationExists(appealCaseData.Representations, {
 		type: APPEAL_REPRESENTATION_TYPE.STATEMENT,
 		owned: true,

--- a/packages/business-rules/src/rules/appeal-case/case-due-dates.test.js
+++ b/packages/business-rules/src/rules/appeal-case/case-due-dates.test.js
@@ -245,25 +245,27 @@ describe('case-due-dates', () => {
 			});
 
 			it('should return false if statements are not open', () => {
-				expect(isLPAStatementOpen(appealCaseData)).toBe(false);
+				expect(isAppellantStatementOpen(appealCaseData)).toBe(false);
 			});
 
 			it('should return false if the case status is INVALID', () => {
-				// as seen in test above the first three attributes would lead to return of true
+				// as seen in test above the first four attributes would lead to return of true
+				appealCaseData.appealTypeCode = CASE_TYPES.LDC.processCode;
 				appealCaseData.statementDueDate = '2025-03-01';
 				deadlineHasPassed.mockReturnValueOnce(false);
 				appealCaseData.lpaQuestionnaireValidationOutcomeDate = '2025-03-01';
 				// case status set to invalid
 				appealCaseData.caseStatus = APPEAL_CASE_STATUS.INVALID;
-				expect(isLPAStatementOpen(appealCaseData)).toBe(false);
+				expect(isAppellantStatementOpen(appealCaseData)).toBe(false);
 			});
 
-			it('should return false if AppellantStatementSubmittedDate is set', () => {
+			it('should return false if appellantStatementSubmittedDate is set', () => {
+				appealCaseData.appealTypeCode = CASE_TYPES.LDC.processCode;
 				appealCaseData.statementDueDate = '2025-03-01';
 				deadlineHasPassed.mockReturnValue(false);
 				appealCaseData.caseStatus = APPEAL_CASE_STATUS.STATEMENTS;
-				appealCaseData.LPAStatementSubmittedDate = '2025-03-02';
-				expect(isLPAStatementOpen(appealCaseData)).toBe(false);
+				appealCaseData.appellantStatementSubmittedDate = '2025-03-02';
+				expect(isAppellantStatementOpen(appealCaseData)).toBe(false);
 			});
 
 			it('should return false if representation exists for appellant statement', () => {
@@ -294,7 +296,7 @@ describe('case-due-dates', () => {
 						leadCaseReference: 'testLeadReference'
 					}
 				];
-				expect(isLPAStatementOpen(appealCaseData)).toBe(false);
+				expect(isAppellantStatementOpen(appealCaseData)).toBe(false);
 			});
 		});
 


### PR DESCRIPTION
### Description of change

Updates check for isAppellantStatementOpen

Ticket: https://pins-ds.atlassian.net/browse/A2-8193

### Checklist

- [X] Feature complete and ready for users, or behind feature-flag
- [X] Commit history is linear with no merge commits
- [ ] Requires infrastructure changes

### Important

Please do not merge from `main` (please only [rebase](https://github.com/Planning-Inspectorate/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
