### PR TITLE
fix(A2-7791): update caseReference on update representation

### DIFF
--- a/packages/appeals-service-api/src/routes/v2/appeal-cases/_caseReference/representations/repo.js
+++ b/packages/appeals-service-api/src/routes/v2/appeal-cases/_caseReference/representations/repo.js
@@ -145,7 +145,10 @@ class RepresentationsRepository {
 				...mappedData,
 				AppealCase: { connect: { caseReference: data.caseReference } }
 			},
-			update: mappedData,
+			update: {
+				...mappedData,
+				AppealCase: { connect: { caseReference: data.caseReference } }
+			},
 			where: {
 				representationId
 			}


### PR DESCRIPTION
### Description of change

When updating an existing representation the caseReference will also be updated if the rep is moving to a difference case.

Ticket: https://pins-ds.atlassian.net/browse/A2-7719

### Checklist

- [X] Feature complete and ready for users, or behind feature-flag
- [ ] Commit history is linear with no merge commits
- [ ] Requires infrastructure changes

### Important

Please do not merge from `main` (please only [rebase](https://github.com/Planning-Inspectorate/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
