### PR TITLE
fix(A2-8322): return appellantStatementSubmittedDate for appellant da…

### DIFF
--- a/packages/appeals-service-api/src/routes/v2/appeals/repo.js
+++ b/packages/appeals-service-api/src/routes/v2/appeals/repo.js
@@ -67,6 +67,7 @@ class UserAppealsRepository {
 											caseReference: true,
 											appellantCommentsSubmittedDate: true,
 											appellantProofsSubmittedDate: true,
+											appellantStatementSubmittedDate: true,
 											finalCommentsDueDate: true,
 											proofsOfEvidenceDueDate: true,
 											statementDueDate: true,

--- a/packages/forms-web-app/src/lib/dashboard-functions.test.js
+++ b/packages/forms-web-app/src/lib/dashboard-functions.test.js
@@ -617,7 +617,7 @@ describe('lib/dashboard-functions', () => {
 					caseReference: testCaseRef,
 					appealTypeCode: processCode,
 					caseStatus: APPEAL_CASE_STATUS.STATEMENTS,
-					AppellantStatementSubmittedDate: null
+					appellantStatementSubmittedDate: null
 				};
 
 				calculateDueInDays.mockReturnValue(5);


### PR DESCRIPTION
…shboard

### Description of change

Statement remained on 'to-do' page on appellant dashboard after statement submission.  Added appellantStatementSubmittedDate to getUSerAppeals return objects, as this is used in the check for whether statements are open and was not being returned, so statements remain open.

Ticket: https://pins-ds.atlassian.net/browse/A2-8322

### Checklist

- [X] Feature complete and ready for users, or behind feature-flag
- [X] Commit history is linear with no merge commits
- [ ] Requires infrastructure changes

### Important

Please do not merge from `main` (please only [rebase](https://github.com/Planning-Inspectorate/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
