### PR TITLE
fix(a2-8249): fix appellant statement open check

### DIFF
--- a/packages/business-rules/src/rules/appeal-case/case-due-dates.js
+++ b/packages/business-rules/src/rules/appeal-case/case-due-dates.js
@@ -78,12 +78,7 @@ exports.isAppellantStatementOpen = (appealCaseData, featureFlags) =>
 	!!caseTypeLookup(appealCaseData.appealTypeCode, 'processCode', featureFlags)
 		?.hasAppellantStatementJourney &&
 	statementsAreOpen(appealCaseData) &&
-	!appealCaseData.appellantStatementSubmittedDate &&
-	!representationExists(appealCaseData.Representations, {
-		type: APPEAL_REPRESENTATION_TYPE.STATEMENT,
-		owned: true,
-		submitter: APPEAL_USER_ROLES.APPELLANT
-	});
+	!appealCaseData.appellantStatementSubmittedDate;
 
 /**
  * Checks if statements are open for all rule 6 parties

--- a/packages/business-rules/src/rules/appeal-case/case-due-dates.test.js
+++ b/packages/business-rules/src/rules/appeal-case/case-due-dates.test.js
@@ -268,15 +268,6 @@ describe('case-due-dates', () => {
 				expect(isAppellantStatementOpen(appealCaseData)).toBe(false);
 			});
 
-			it('should return false if representation exists for appellant statement', () => {
-				appealCaseData.appealTypeCode = CASE_TYPES.LDC.processCode;
-				appealCaseData.statementDueDate = '2025-03-01';
-				deadlineHasPassed.mockReturnValue(false);
-				appealCaseData.caseStatus = APPEAL_CASE_STATUS.STATEMENTS;
-				representationExists.mockReturnValue(true);
-				expect(isAppellantStatementOpen(appealCaseData)).toBe(false);
-			});
-
 			it('should return false if appeal type is not allowed (e.g. S78)', () => {
 				appealCaseData.appealTypeCode = CASE_TYPES.S78.processCode;
 				appealCaseData.statementDueDate = '2025-03-01';


### PR DESCRIPTION
### Description of change

Appellant DB lookup no longer gets reps, needless check as the submitted date on case is enough

Ticket: https://pins-ds.atlassian.net/browse/A2-8249

### Checklist

- [x] Feature complete and ready for users, or behind feature-flag
- [x] Commit history is linear with no merge commits
- [ ] Requires infrastructure changes

### Important

Please do not merge from `main` (please only [rebase](https://github.com/Planning-Inspectorate/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
