### PR TITLE
fix(a2-8365): no decision date format fix

### DIFF
--- a/packages/business-rules/src/utils/calculate-deadline-before-you-start.js
+++ b/packages/business-rules/src/utils/calculate-deadline-before-you-start.js
@@ -5,7 +5,7 @@ const { parseISO } = require('date-fns');
  * @param {Object} params
  * @param {{
  * 	appealType: string,
- *  decisionDate: string|null,
+ *  decisionDate: string|Date|null,
  *  eligibility: {
  *   applicationDecision: string|null,
  *   isListedBuilding: boolean|undefined,
@@ -17,8 +17,12 @@ const { parseISO } = require('date-fns');
  * @throws {BusinessRulesError}
  */
 const calculateDeadlineFromBeforeYouStart = ({ appeal }) => {
+	let date = null;
+	if (typeof appeal.decisionDate === 'string') date = parseISO(appeal.decisionDate);
+	else if (appeal.decisionDate instanceof Date) date = appeal.decisionDate;
+
 	return deadlineDate({
-		decisionDate: appeal.decisionDate ? parseISO(appeal.decisionDate) : null,
+		decisionDate: date,
 		appealType: appeal.appealType,
 		applicationDecision: appeal.eligibility?.applicationDecision,
 		isListedBuilding: appeal.eligibility?.isListedBuilding,

--- a/packages/business-rules/src/utils/calculate-deadline-before-you-start.test.js
+++ b/packages/business-rules/src/utils/calculate-deadline-before-you-start.test.js
@@ -3,11 +3,29 @@ const { APPEAL_ID, APPLICATION_DECISION } = require('../constants');
 
 describe('calculateDeadlineFromBeforeYouStart', () => {
 	describe('householder appeal', () => {
-		it('calculates deadline from before-you-start appeal data', () => {
+		it('calculates deadline from before-you-start appeal data with iso string', () => {
 			const result = calculateDeadlineFromBeforeYouStart({
 				appeal: {
 					appealType: APPEAL_ID.HOUSEHOLDER,
 					decisionDate: '2020-10-20T00:00:00.000Z',
+					eligibility: {
+						applicationDecision: APPLICATION_DECISION.REFUSED,
+						isListedBuilding: undefined,
+						enforcementEffectiveDate: null,
+						hasContactedPlanningInspectorate: null
+					}
+				}
+			});
+
+			expect(result).toBeInstanceOf(Date);
+			expect(result.toISOString()).toEqual('2021-01-12T23:59:59.999Z');
+		});
+
+		it('calculates deadline from before-you-start appeal data with date object', () => {
+			const result = calculateDeadlineFromBeforeYouStart({
+				appeal: {
+					appealType: APPEAL_ID.HOUSEHOLDER,
+					decisionDate: new Date('2020-10-20T00:00:00.000Z'),
 					eligibility: {
 						applicationDecision: APPLICATION_DECISION.REFUSED,
 						isListedBuilding: undefined,

--- a/packages/business-rules/src/utils/calculate-is-within-deadline-before-you-start.js
+++ b/packages/business-rules/src/utils/calculate-is-within-deadline-before-you-start.js
@@ -5,7 +5,7 @@ const { parseISO } = require('date-fns');
  * @param {Object} params
  * @param {{
  * 	appealType: string|null,
- *  decisionDate: string|null,
+ *  decisionDate: string|Date|null,
  *  eligibility: {
  *   applicationDecision: string|null,
  *   isListedBuilding: boolean|undefined,
@@ -17,8 +17,12 @@ const { parseISO } = require('date-fns');
  * @throws {BusinessRulesError}
  */
 const calculateWithinDeadlineFromBeforeYouStart = ({ appeal }) => {
+	let date = null;
+	if (typeof appeal.decisionDate === 'string') date = parseISO(appeal.decisionDate);
+	else if (appeal.decisionDate instanceof Date) date = appeal.decisionDate;
+
 	return validation.appeal.decisionDate.isWithinDecisionDateExpiryPeriod({
-		givenDate: appeal.decisionDate ? parseISO(appeal.decisionDate) : null,
+		givenDate: date,
 		appealType: appeal.appealType,
 		applicationDecision: appeal.eligibility?.applicationDecision,
 		isListedBuilding: appeal.eligibility?.isListedBuilding,

--- a/packages/business-rules/src/utils/calculate-is-within-deadline-before-you-start.test.js
+++ b/packages/business-rules/src/utils/calculate-is-within-deadline-before-you-start.test.js
@@ -7,11 +7,28 @@ const { subWeeks } = require('date-fns');
 describe('calculateWithinDeadlineFromBeforeYouStart', () => {
 	const now = new Date();
 
-	it('returns true when within deadline period', () => {
+	it('returns true when within deadline period with iso string', () => {
 		const result = calculateWithinDeadlineFromBeforeYouStart({
 			appeal: {
 				appealType: APPEAL_ID.HOUSEHOLDER,
 				decisionDate: now.toISOString(),
+				eligibility: {
+					applicationDecision: APPLICATION_DECISION.REFUSED,
+					isListedBuilding: undefined,
+					enforcementEffectiveDate: null,
+					hasContactedPlanningInspectorate: null
+				}
+			}
+		});
+
+		expect(result).toBe(true);
+	});
+
+	it('returns true when within deadline period with date', () => {
+		const result = calculateWithinDeadlineFromBeforeYouStart({
+			appeal: {
+				appealType: APPEAL_ID.HOUSEHOLDER,
+				decisionDate: now,
 				eligibility: {
 					applicationDecision: APPLICATION_DECISION.REFUSED,
 					isListedBuilding: undefined,

--- a/packages/forms-web-app/__tests__/unit/controllers/full-appeal/date-decision-due.test.js
+++ b/packages/forms-web-app/__tests__/unit/controllers/full-appeal/date-decision-due.test.js
@@ -104,7 +104,7 @@ describe('controllers/full-appeal/date-decision-due', () => {
 
 			expect(createOrUpdateAppeal).toHaveBeenCalledWith({
 				...appeal,
-				decisionDate: new Date('2019-10-10T12:00:00.000Z')
+				decisionDate: new Date('2019-10-10T12:00:00.000Z').toISOString()
 			});
 
 			expect(res.redirect).toHaveBeenCalledWith(navigationPage.shutterPage);

--- a/packages/forms-web-app/src/controllers/full-appeal/date-decision-due.js
+++ b/packages/forms-web-app/src/controllers/full-appeal/date-decision-due.js
@@ -73,7 +73,7 @@ exports.postDateDecisionDue = async (req, res) => {
 
 	const decisionDate = body['decision-date'];
 
-	appeal.decisionDate = new Date(`${decisionDate}T12:00:00.000Z`);
+	appeal.decisionDate = new Date(`${decisionDate}T12:00:00.000Z`).toISOString();
 
 	try {
 		req.session.appeal = await createOrUpdateAppeal(appeal);


### PR DESCRIPTION
### Description of change

Date from granted/refused was ISO string, no decision was date object
Standardised and ensure lookups can handle either

Ticket: https://pins-ds.atlassian.net/browse/A2-8365

### Checklist

- [x] Feature complete and ready for users, or behind feature-flag
- [x] Commit history is linear with no merge commits
- [ ] Requires infrastructure changes

### Important

Please do not merge from `main` (please only [rebase](https://github.com/Planning-Inspectorate/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
