### PR TITLE
[A2-7733] Updating e2e tests with multi environment config 

### DIFF
--- a/test-packages/platform-feature-tests/README.md
+++ b/test-packages/platform-feature-tests/README.md
@@ -15,7 +15,18 @@ our current engineering team are skilled in Javascript, this means we do not nee
 to ensure features are complete. It also reduces the impedence to us as engineers since we're using 
 Javascript for everything.
 
-## What's the context for these texts?
+## Tests structure 
+
+The tests in this suite cover several applications that comprise the front office: 
+
+|                            |                                                                |
+|--------------------------- |----------------------------------------------------------------|
+| **appeals service**        | the main application used to submit a planning appeal          |
+| **appellant front office** | application used by an appellant to track their appeal         |
+| **lpa front office**       | application used by the LPA to track appeals                   |
+| **rule 6 front office**    | application used by rule 6 parties to track an application     | 
+
+These are localed within the `cypress/e2e` folder
 
 The tests here are intended to check behaviours exhibited by the whole platform i.e. if I upload an 
 appeal via the appeals web interface, does the correct information appear in Horizon? They're not 
@@ -26,8 +37,6 @@ These tests will always be the first ones to see a new feature: the "System Test
 local planning authority is used as a user in these tests, and this is always the first local 
 planning authority that a new feature is exposed to (see feature flag set-up on Azure and our 
 general process flow).
-
-## Can you explain your structure?
 
 Sure! Start off looking in the `e2e` directory, this directory contains the main test driver functions.
 Then, if you want to dig into details, check out `support/flows`, the files in here are flows through the
@@ -49,9 +58,48 @@ sections can contain somewhat repetitive actions, which are defined in `support/
 - We organize tests around user flows, rather than features since a user flow may contain 
 multiple features, so this results in less tests (more efficient tests, essentially).
 
-## How do I run these tests?
+## Running the tests 
 
-TL;DR
+The front office tests can be run in two different modes 
+
+
+### Headless 
+
+This will run all tests in a headless browser    
+
+This mode is good for 
+- speed compared to headed browser 
+- if want quick feedback on if tests are passing 
+
+You can use the following commands from the package.json for different environments 
+
+|         |                  |
+|---------|------------------|
+| local   | `cy:run`         |
+| dev     | `cy:run:dev`     |
+| test    | `cy:run:test`    |
+| staging | `cy:run:staging` | 
+
+
+### Interactive (or headed) mode 
+
+This will launch the cypress test explorer, from which you can browse and run the various tests 
+
+This mode is good for 
+- writing new tests to observe browser flow 
+- investigating and debugging failing tests 
+
+You can use the following commands from the package.json for different environments 
+
+|         |                   |
+|---------|-------------------|
+| local   | `cy:open`         |
+| dev     | `cy:open:dev`     |
+| test    | `cy:open:test`    |
+| staging | `cy:open:staging` | 
+
+
+## Installa and setup  
 
 - `npm install `
 - `npx cypress open`

--- a/test-packages/platform-feature-tests/README.md
+++ b/test-packages/platform-feature-tests/README.md
@@ -26,7 +26,7 @@ The tests in this suite cover several applications that comprise the front offic
 | **lpa front office**       | application used by the LPA to track appeals                   |
 | **rule 6 front office**    | application used by rule 6 parties to track an application     | 
 
-These are localed within the `cypress/e2e` folder
+These are located within the `cypress/e2e` folder
 
 The tests here are intended to check behaviours exhibited by the whole platform i.e. if I upload an 
 appeal via the appeals web interface, does the correct information appear in Horizon? They're not 
@@ -38,17 +38,19 @@ local planning authority is used as a user in these tests, and this is always th
 planning authority that a new feature is exposed to (see feature flag set-up on Azure and our 
 general process flow).
 
-Sure! Start off looking in the `e2e` directory, this directory contains the main test driver functions.
-Then, if you want to dig into details, check out `support/flows`, the files in here are flows through the
-platform. These flows are composed of sections, which can be found in `support/flows/sections`.
-The helper functions can be found in `support/flows/pages`.
-The dummy json data can be found in `fixtures`  
-The testcase flows can be found in `helpers`
-Utility files can be found in `utils`
-Test cases selector constants canbe be found in `page-obejcts` 
-Generated test reports can be found in `reports`
-Failure test screenshots can be found in `screenshots` folder, and
-Downloaded files can be verify in `downloads`
+Test structure 
+- Start off looking in the `e2e` directory, this directory contains the main test driver functions.
+- Then, if you want to dig into details, check out `support/flows`, the files in here are flows through the
+platform. 
+- These flows are composed of sections, which can be found in `support/flows/sections`.
+- The helper functions can be found in `support/flows/pages`.
+- The dummy json data can be found in `fixtures`  
+- The testcase flows can be found in `helpers`
+- Utility files can be found in `utils`
+- Test cases selector constants canbe be found in `page-obejcts` 
+- Generated test reports can be found in `reports`
+- Failure test screenshots can be found in `screenshots` folder, and
+- Downloaded files can be verify in `downloads`
 
 Finally,
 sections can contain somewhat repetitive actions, which are defined in `support/commands.js`.
@@ -56,7 +58,19 @@ sections can contain somewhat repetitive actions, which are defined in `support/
 ## What conventions are used here?
 
 - We organize tests around user flows, rather than features since a user flow may contain 
-multiple features, so this results in less tests (more efficient tests, essentially).
+multiple features, so this results in less tests (more efficient tests, essentially). 
+
+## Install and setup  
+
+To install and setup the e2e tests you can run the following command from within the `test-packages/platform-feature-tests` folder 
+
+`npm install `
+
+This should install the various dependencies and tools required to run the cypress tests 
+
+You will also need to ensure that a `.env` file is setup in the root of the test folder. This can be a copy of the `.env.example` file, though will need to reach out to one of the devs/QAs who can supply the actual values to use 
+
+It should now be possible to run the e2e tests, this can be done using commands listed in the next section  
 
 ## Running the tests 
 
@@ -98,12 +112,6 @@ You can use the following commands from the package.json for different environme
 | test    | `cy:open:test`    |
 | staging | `cy:open:staging` | 
 
-
-## Installa and setup  
-
-- `npm install `
-- `npx cypress open`
-- `select browser` 
 
 ## How to generate HTML reports?
 

--- a/test-packages/platform-feature-tests/cypress.config.dev.env.js
+++ b/test-packages/platform-feature-tests/cypress.config.dev.env.js
@@ -1,0 +1,21 @@
+// @ts-nocheck
+const { defineConfig } = require('cypress');
+const baseConfig = require('./cypress.config');
+
+require('dotenv').config();
+
+const e2eOverride = {
+	appeals_beta_base_url: 'https://appeals-service-dev.planninginspectorate.gov.uk',
+    back_office_base_url: 'https://back-office-appeals-dev.planninginspectorate.gov.uk',
+	apiBaseUrl: 'https://pins-app-appeals-bo-api-dev.azurewebsites.net/'
+};
+
+module.exports = defineConfig({
+    e2e: {
+        ...baseConfig.e2e,
+        ...e2eOverride
+    },
+    env: {
+        ...baseConfig.env
+    }
+});

--- a/test-packages/platform-feature-tests/cypress.config.local.env.js
+++ b/test-packages/platform-feature-tests/cypress.config.local.env.js
@@ -1,0 +1,27 @@
+// @ts-nocheck
+const { defineConfig } = require('cypress');
+const baseConfig = require('./cypress.config');
+
+require('dotenv').config();
+
+// use front office and backoffice defaults if not set
+if (!baseConfig.e2e.appeals_beta_base_url) {
+	baseConfig.e2e.appeals_beta_base_url = 'https://localhost:9003/';
+}
+
+if (!baseConfig.e2e.back_office_base_url) {
+	baseConfig.e2e.back_office_base_url = 'https://localhost:8080/';
+}
+
+if (!baseConfig.e2e.apiBaseUrl) {
+	baseConfig.e2e.apiBaseUrl = 'http://localhost:3000/';
+}
+
+module.exports = defineConfig({
+	e2e: {
+		...baseConfig.e2e
+	},
+	env: {
+		...baseConfig.env
+	}
+});

--- a/test-packages/platform-feature-tests/cypress.config.staging.env.js
+++ b/test-packages/platform-feature-tests/cypress.config.staging.env.js
@@ -1,0 +1,21 @@
+// @ts-nocheck
+const { defineConfig } = require('cypress');
+const baseConfig = require('./cypress.config');
+
+require('dotenv').config();
+
+const e2eOverride = {
+    appeals_beta_base_url: 'https://appeals-service-staging.planninginspectorate.gov.uk',
+    back_office_base_url: 'https://back-office-appeals-staging.planninginspectorate.gov.uk',
+    apiBaseUrl: 'https://pins-app-appeals-bo-api-staging.azurewebsites.net/'
+};
+
+module.exports = defineConfig({
+    e2e: {
+        ...baseConfig.e2e,
+        ...e2eOverride
+    },
+    env: {
+        ...baseConfig.env
+    }
+});

--- a/test-packages/platform-feature-tests/cypress.config.test.env.js
+++ b/test-packages/platform-feature-tests/cypress.config.test.env.js
@@ -1,0 +1,21 @@
+// @ts-nocheck
+const { defineConfig } = require('cypress');
+const baseConfig = require('./cypress.config');
+
+require('dotenv').config();
+
+const e2eOverride = {
+    appeals_beta_base_url: 'https://appeals-service-test.planninginspectorate.gov.uk',
+    back_office_base_url: 'https://back-office-appeals-test.planninginspectorate.gov.uk',
+    apiBaseUrl: 'https://pins-app-appeals-bo-api-test.azurewebsites.net/'
+};
+
+module.exports = defineConfig({
+    e2e: {
+        ...baseConfig.e2e,
+        ...e2eOverride
+    },
+    env: {
+        ...baseConfig.env
+    }
+});

--- a/test-packages/platform-feature-tests/package.json
+++ b/test-packages/platform-feature-tests/package.json
@@ -6,10 +6,20 @@
 	"scripts": {
 		"cy:ci": "npx cypress run --spec \"cypress/e2e/appellant-aapd/submit-householder-appeal/submit-householder-appeal-nodecision.cy.js\" --env grepTags=\"-smoke\"",
 		"cy:ci-smoke": "npx cypress run --spec \"cypress/e2e/appellant-aapd/submit-householder-appeal/submit-householder-appeal-nodecision.cy.js\" --env grepTags=\"smoke\"",
-		"cy:open": "npx cypress open --browser chrome --e2e",
 		"test": "echo \"Error: no test specified\" && exit 1",
 		"merge-reports": "mochawesome-merge cypress/reports/*.json > cypress/reports/reports.json",
-		"generate-report": "merge cypress/reports/report.json -f report -o cypress/reports"
+		"generate-report": "merge cypress/reports/report.json -f report -o cypress/reports",
+
+		"cy:open": "npx cypress open --browser chrome --e2e --config-file cypress.config.local.env.js",
+		"cy:open:dev": "npx cypress open --browser chrome --e2e --config-file cypress.config.dev.env.js",
+		"cy:open:test": "npx cypress open --browser chrome --e2e --config-file cypress.config.test.env.js",
+		"cy:open:staging": "npx cypress open --browser chrome --e2e --config-file cypress.config.staging.env.js", 
+
+		"cy:run": "npx cypress run --config-file cypress.config.local.env.js",
+		"cy:run:dev": "npx cypress run --config-file cypress.config.dev.env.js",
+		"cy:run:test": "npx cypress run --config-file cypress.config.test.env.js",
+		"cy:run:staging": "npx cypress run --config-file cypress.config.staging.env.js"
+
 	},
 	"author": "",
 	"license": "ISC",


### PR DESCRIPTION
### Description of change

Currently in order to run the frontoffice tests across multiple environments it requires repeated updating of values within the `.env` file (e.g. have to keep changing urls etc.) 
This could result in different configs being setup and commented/uncommented, leading to an env file that is messy and difficult to interpret 

This PR introduces a multi config setup similar to the one used in backoffice tests, which provides a cleaner way to maintain environment specific values. It also allows for corresponding scripts/commands to be setup in the package.json  

For example to run the tests in dev environment you can now run 
`cy:open:dev` (UI/explorer mode) 
`cy:run:dev` (headless mode) 

The 'default' commands (i.e. `cy:open` `cy:run`) will use local urls  

Also as part of this I have updated the readme to reflect these changes 

Are a couple of things that would be good if could check 
- I've tried running the commands for different environments and seems to work ok, though would be good if someone could check and confirm 
- I've based the urls on information that found in env and readme files, and also what I have bookmarked, would appreciate a check of these 


Ticket: https://pins-ds.atlassian.net/browse/A2-7733 

### Checklist

- [x] Feature complete and ready for users, or behind feature-flag
- [x] Commit history is linear with no merge commits
- [ ] Requires infrastructure changes

### Important

Please do not merge from `main` (please only [rebase](https://github.com/Planning-Inspectorate/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
