### PR TITLE
feat(a2-7145, a2-7265): display costs docs on appeal details pages

### DIFF
--- a/packages/appeals-service-api/__tests__/developer/fixtures/appeals-document-data.js
+++ b/packages/appeals-service-api/__tests__/developer/fixtures/appeals-document-data.js
@@ -1,0 +1,30 @@
+const crypto = require('node:crypto');
+
+/**
+ * @param {string} caseReference
+ * @param {string} documentType
+ * @param {Object} options
+ * @param {boolean} [options.published]
+ * @param {boolean} [options.redacted]
+ * @returns {import('@pins/database/src/client/client').Prisma.DocumentCreateInputWithoutAppealCase}
+ */
+exports.createTestDocData = (
+	caseReference,
+	documentType,
+	{ published = true, redacted = true } = {}
+) => ({
+	caseReference,
+	documentType,
+	published,
+	redacted,
+	id: crypto.randomUUID(),
+	filename: `${documentType}.pdf`,
+	originalFilename: `${documentType}.pdf`,
+	mime: 'application/pdf',
+	size: 1234,
+	documentURI: `http://example.com/${documentType}.pdf`,
+	publishedDocumentURI: published ? `http://example.com/${documentType}.pdf` : null,
+	dateCreated: new Date(),
+	virusCheckStatus: 'scanned',
+	version: 1
+});

--- a/packages/appeals-service-api/__tests__/developer/fixtures/representation-data.js
+++ b/packages/appeals-service-api/__tests__/developer/fixtures/representation-data.js
@@ -23,7 +23,7 @@ function createTestRepresentationPayload(
 		invalidOrIncompleteDetails: null,
 		otherInvalidOrIncompleteDetails: null,
 		source,
-		serviceUserId: null,
+		serviceUserId: source === 'lpa' ? null : 'test-service-user-id',
 		representationType,
 		dateReceived: new Date(),
 		documentIds: ['01956ca1-1213-7107-a4ab-be56f597485d']

--- a/packages/appeals-service-api/src/routes/v2/appeal-cases/_caseReference/costs/controller.js
+++ b/packages/appeals-service-api/src/routes/v2/appeal-cases/_caseReference/costs/controller.js
@@ -1,0 +1,114 @@
+const { getAppealCaseWithCostsByType } = require('./service');
+const logger = require('#lib/logger');
+const ApiError = require('#errors/apiError');
+const { checkDocAccess } = require('@pins/common/src/access/document-access');
+const { APPEAL_DOCUMENT_TYPE } = require('@planning-inspectorate/data-model');
+
+const { AppealCaseRepository } = require('../../repo');
+const caseRepo = new AppealCaseRepository();
+
+const { LPAQuestionnaireSubmissionRepository } = require('../lpa-questionnaire-submission/repo');
+const submissionRepo = new LPAQuestionnaireSubmissionRepository();
+
+/**
+ * @type {import('express').Handler}
+ */
+async function getAppealCaseWithCosts(req, res) {
+	const { caseReference } = req.params;
+	const { types } = req.query;
+	const { email, lpaCode } = req.id_token;
+	const isLpa = !!lpaCode;
+
+	if (!caseReference) {
+		throw ApiError.withMessage(400, 'case reference required');
+	}
+
+	if (!types) {
+		throw ApiError.withMessage(400, 'cost types required');
+	}
+	const validCostTypes = new Set([
+		APPEAL_DOCUMENT_TYPE.LPA_COSTS_APPLICATION,
+		APPEAL_DOCUMENT_TYPE.LPA_COSTS_CORRESPONDENCE,
+		APPEAL_DOCUMENT_TYPE.LPA_COSTS_DECISION_LETTER,
+		APPEAL_DOCUMENT_TYPE.LPA_COSTS_WITHDRAWAL,
+		APPEAL_DOCUMENT_TYPE.APPELLANT_COSTS_APPLICATION,
+		APPEAL_DOCUMENT_TYPE.APPELLANT_COSTS_CORRESPONDENCE,
+		APPEAL_DOCUMENT_TYPE.APPELLANT_COSTS_DECISION_LETTER,
+		APPEAL_DOCUMENT_TYPE.APPELLANT_COSTS_WITHDRAWAL
+	]);
+	const typesToSearch = types.split(',');
+	if (!typesToSearch.every((type) => validCostTypes.has(type))) {
+		throw ApiError.withMessage(400, 'invalid cost type(s) provided');
+	}
+
+	if (!email) {
+		throw ApiError.withMessage(400, 'logged-in email required');
+	}
+
+	/** @type { Array<import('@pins/database/src/client/client').AppealToUser> } */
+	let appealUserRoles = [];
+
+	if (isLpa) {
+		try {
+			await submissionRepo.lpaCanModifyCase({
+				caseReference: caseReference,
+				userLpa: lpaCode
+			});
+		} catch (error) {
+			logger.error({ error }, 'get costs: invalid user access');
+			throw ApiError.forbidden();
+		}
+	} else {
+		try {
+			const result = await caseRepo.userCanModifyCase({
+				caseReference: caseReference,
+				userId: req.auth?.payload.sub
+			});
+			appealUserRoles = result.roles;
+		} catch (error) {
+			logger.error({ error }, 'get costs: invalid user access');
+			throw ApiError.forbidden();
+		}
+	}
+
+	try {
+		const caseWithCosts = await getAppealCaseWithCostsByType(caseReference, typesToSearch);
+
+		caseWithCosts.Documents = filterDocuments(
+			caseWithCosts,
+			appealUserRoles,
+			req.auth?.payload,
+			req.id_token
+		);
+
+		res.status(200).send(caseWithCosts);
+	} catch (error) {
+		logger.error(`Failed to get case with costs for ${caseReference}: ${error}`);
+		throw error;
+	}
+}
+
+function filterDocuments(caseWithCosts, appealUserRoles, access_token, id_token) {
+	if (!caseWithCosts.Documents || caseWithCosts.Documents.length === 0) {
+		return caseWithCosts.Documents;
+	}
+
+	const simpleCase = {
+		LPACode: caseWithCosts.LPACode,
+		appealId: caseWithCosts.appealId,
+		appealTypeCode: caseWithCosts.appealTypeCode
+	};
+
+	return caseWithCosts.Documents.filter((document) =>
+		checkDocAccess({
+			documentWithAppeal: { ...document, AppealCase: simpleCase },
+			appealUserRoles: appealUserRoles,
+			access_token: access_token,
+			id_token: id_token
+		})
+	);
+}
+
+module.exports = {
+	getAppealCaseWithCosts
+};

--- a/packages/appeals-service-api/src/routes/v2/appeal-cases/_caseReference/costs/costs.spec.js
+++ b/packages/appeals-service-api/src/routes/v2/appeal-cases/_caseReference/costs/costs.spec.js
@@ -1,0 +1,137 @@
+const { APPEAL_USER_ROLES } = require('@pins/common/src/constants');
+const { SERVICE_USER_TYPE, APPEAL_DOCUMENT_TYPE } = require('@planning-inspectorate/data-model');
+
+const crypto = require('node:crypto');
+const {
+	createTestAppealCase
+} = require('../../../../../../__tests__/developer/fixtures/appeals-case-data');
+const {
+	createTestDocData
+} = require('../../../../../../__tests__/developer/fixtures/appeals-document-data');
+let validUserId = '';
+let invalidUserId = '';
+const email = crypto.randomUUID() + '@example.com';
+const invalidUserEmail = crypto.randomUUID() + '@example.com';
+const validLpa = 'Q9999';
+const testCase1 = '5737623';
+const testCase2 = '9826749';
+const testCase3 = '2571571';
+
+/**
+ * @param {Object} dependencies
+ * @param {function(): import('@pins/database/src/client/client').PrismaClient} dependencies.getSqlClient
+ * @param {function(string): void} dependencies.setCurrentSub
+ * @param {function(string|undefined, string|undefined): void} dependencies.setCurrentLpa
+ * @param {import('supertest').Agent} dependencies.appealsApi
+ */
+module.exports = ({ getSqlClient, setCurrentSub, setCurrentLpa, appealsApi }) => {
+	const sqlClient = getSqlClient();
+
+	beforeAll(async () => {
+		const invalidUser = await sqlClient.appealUser.create({
+			data: {
+				email: invalidUserEmail
+			}
+		});
+		const user = await sqlClient.appealUser.create({
+			data: {
+				email
+			}
+		});
+		await sqlClient.serviceUser.createMany({
+			data: [
+				{
+					internalId: crypto.randomUUID(),
+					emailAddress: email,
+					id: crypto.randomUUID(),
+					serviceUserType: SERVICE_USER_TYPE.APPELLANT,
+					caseReference: testCase1
+				}
+			]
+		});
+		invalidUserId = invalidUser.id;
+		validUserId = user.id;
+	});
+
+	beforeEach(() => {
+		setCurrentSub(validUserId);
+		setCurrentLpa(validLpa, email);
+	});
+
+	/**
+	 * @returns {Promise<string>}
+	 */
+	const createAppeal = async (caseRef) => {
+		const appeal = await sqlClient.appeal.create({
+			include: {
+				AppealCase: true
+			},
+			data: {
+				Users: {
+					create: {
+						userId: validUserId,
+						role: APPEAL_USER_ROLES.APPELLANT
+					}
+				},
+				AppealCase: {
+					create: createTestAppealCase(caseRef, 'S78', validLpa)
+				}
+			}
+		});
+		return appeal.AppealCase?.caseReference;
+	};
+
+	describe('/appeal-cases/{caseReference}/costs', () => {
+		describe('get', () => {
+			it('should error for user with no roles', async () => {
+				await createAppeal(testCase1);
+
+				setCurrentSub(invalidUserId);
+				setCurrentLpa(undefined, invalidUserEmail);
+
+				const response = await appealsApi.get(
+					`/api/v2/appeal-cases/${testCase1}/costs?types=${APPEAL_DOCUMENT_TYPE.APPELLANT_COSTS_APPLICATION}`
+				);
+				expect(response.status).toEqual(403);
+			});
+
+			it('should error for user with different LPA', async () => {
+				await createAppeal(testCase2);
+
+				setCurrentSub(invalidUserId);
+				setCurrentLpa('NOPE', invalidUserEmail);
+
+				const response = await appealsApi.get(
+					`/api/v2/appeal-cases/${testCase2}/costs?types=${APPEAL_DOCUMENT_TYPE.APPELLANT_COSTS_APPLICATION}`
+				);
+				expect(response.status).toEqual(403);
+			});
+
+			const costTypes = [
+				APPEAL_DOCUMENT_TYPE.APPELLANT_COSTS_APPLICATION,
+				APPEAL_DOCUMENT_TYPE.LPA_COSTS_APPLICATION,
+				APPEAL_DOCUMENT_TYPE.APPELLANT_COSTS_CORRESPONDENCE,
+				APPEAL_DOCUMENT_TYPE.LPA_COSTS_CORRESPONDENCE
+			];
+
+			it('should retrieve costs filtered by type', async () => {
+				await createAppeal(testCase3);
+				await sqlClient.document.create({
+					data: createTestDocData(testCase3, 'randomType')
+				});
+				await sqlClient.document.createMany({
+					data: costTypes.map((type) => ({
+						...createTestDocData(testCase3, type)
+					}))
+				});
+
+				const response = await appealsApi.get(
+					`/api/v2/appeal-cases/${testCase3}/costs?types=${costTypes.join(',')}`
+				);
+				console.log(response.body);
+				expect(response.status).toEqual(200);
+				expect(response.body.Documents.length).toBe(4);
+			});
+		});
+	});
+};

--- a/packages/appeals-service-api/src/routes/v2/appeal-cases/_caseReference/costs/index.js
+++ b/packages/appeals-service-api/src/routes/v2/appeal-cases/_caseReference/costs/index.js
@@ -1,0 +1,29 @@
+const express = require('express');
+const { getAppealCaseWithCosts } = require('./controller');
+const { AUTH } = require('@pins/common/src/constants');
+const config = require('../../../../../configuration/config');
+const { auth } = require('express-oauth2-jwt-bearer');
+const { validateToken } = require('@pins/common/src/middleware/validate-token');
+
+const asyncHandler = require('@pins/common/src/middleware/async-handler');
+const router = express.Router({ mergeParams: true });
+
+router.use(
+	auth({
+		issuerBaseURL: `${config.auth.authServerUrl}${AUTH.OIDC_ENDPOINT}`,
+		audience: AUTH.RESOURCE
+	})
+);
+
+router.use(
+	validateToken({
+		headerName: 'authentication',
+		reqPropertyName: 'id_token',
+		jwksUri: `${config.auth.authServerUrl}${AUTH.JWKS_ENDPOINT}`,
+		enforceToken: false
+	})
+);
+
+router.get('/', asyncHandler(getAppealCaseWithCosts));
+
+module.exports = { router };

--- a/packages/appeals-service-api/src/routes/v2/appeal-cases/_caseReference/costs/repo.js
+++ b/packages/appeals-service-api/src/routes/v2/appeal-cases/_caseReference/costs/repo.js
@@ -1,0 +1,55 @@
+const { createPrismaClient } = require('#db-client');
+const { Prisma } = require('@pins/database/src/client/client');
+const { dashboardSelect, DocumentsArgs } = require('../../repo');
+
+/**
+ * @typedef {import('@pins/database/src/client/client').AppealCase} AppealCase
+ * @typedef {import('@pins/database/src/client/client').Document} Document
+ * @typedef {AppealCase & { Documents?: Array.<Document>}} AppealWithDocuments
+ */
+
+class CostsRepository {
+	dbClient;
+
+	constructor() {
+		this.dbClient = createPrismaClient();
+	}
+
+	/**
+	 * Get all costs for a given case reference
+	 *
+	 * @param {string} caseReference
+	 * @param {string[]} costTypes
+	 * @returns {Promise<AppealWithRepresentations|null>}
+	 */
+	async getAppealCaseWithCostsByType(caseReference, costTypes) {
+		try {
+			return await this.dbClient.appealCase.findUnique({
+				where: {
+					caseReference
+				},
+				select: {
+					...dashboardSelect,
+					Documents: {
+						...DocumentsArgs,
+						where: {
+							documentType: {
+								in: costTypes
+							}
+						}
+					}
+				}
+			});
+		} catch (e) {
+			if (e instanceof Prisma.PrismaClientKnownRequestError) {
+				if (e.code === 'P2023') {
+					// probably an invalid ID/GUID
+					return null;
+				}
+			}
+			throw e;
+		}
+	}
+}
+
+module.exports = { CostsRepository };

--- a/packages/appeals-service-api/src/routes/v2/appeal-cases/_caseReference/costs/service.js
+++ b/packages/appeals-service-api/src/routes/v2/appeal-cases/_caseReference/costs/service.js
@@ -1,0 +1,26 @@
+const { CostsRepository } = require('./repo');
+const { appendAppellantAndAgent, appendLinkedCases } = require('../../service');
+const ApiError = require('#errors/apiError');
+const repo = new CostsRepository();
+
+/**
+ *
+ * @param {string} caseReference
+ * @param {string[]} types
+ * @returns {Promise<import('./repo').AppealWithDocuments>}
+ */
+async function getAppealCaseWithCostsByType(caseReference, types) {
+	const appealCaseWithDocuments = await repo.getAppealCaseWithCostsByType(caseReference, types);
+
+	if (!appealCaseWithDocuments) throw ApiError.appealsCaseDataNotFound();
+
+	const appealCaseWithApplicant = await appendAppellantAndAgent(appealCaseWithDocuments);
+
+	const appealCaseWithLinkedCases = await appendLinkedCases(appealCaseWithApplicant);
+
+	return appealCaseWithLinkedCases;
+}
+
+module.exports = {
+	getAppealCaseWithCostsByType
+};

--- a/packages/appeals-service-api/src/routes/v2/appeal-cases/_caseReference/representations/repo.js
+++ b/packages/appeals-service-api/src/routes/v2/appeal-cases/_caseReference/representations/repo.js
@@ -1,6 +1,11 @@
 const { createPrismaClient } = require('#db-client');
 const { Prisma } = require('@pins/database/src/client/client');
-const { dashboardSelect, DocumentsArgsPublishedOnly } = require('../../repo');
+const { dashboardSelect, DocumentsArgsPublishedOnly, DocumentsArgs } = require('../../repo');
+const {
+	APPEAL_REPRESENTATION_TYPE,
+	APPEAL_DOCUMENT_TYPE
+} = require('@planning-inspectorate/data-model');
+
 const ApiError = require('#errors/apiError');
 
 /**
@@ -65,20 +70,58 @@ class RepresentationsRepository {
 	 */
 	async getAppealCaseWithAllRepresentations(caseReference) {
 		try {
-			return await this.dbClient.appealCase.findUnique({
-				where: {
-					caseReference
-				},
-				select: {
-					...dashboardSelect,
-					Documents: { ...DocumentsArgsPublishedOnly },
-					Representations: {
-						include: {
-							RepresentationDocuments: true
+			const [appealCase, documents] = await Promise.all([
+				this.dbClient.appealCase.findUnique({
+					where: {
+						caseReference
+					},
+					select: {
+						...dashboardSelect,
+						Representations: {
+							select: {
+								source: true,
+								serviceUserId: true,
+								representationType: true,
+								representationStatus: true,
+								dateReceived: true
+							}
 						}
 					}
-				}
-			});
+				}),
+				this.dbClient.document.findMany({
+					...DocumentsArgs,
+					where: {
+						caseReference: caseReference,
+						documentType: {
+							in: [
+								// decision
+								APPEAL_DOCUMENT_TYPE.CASE_DECISION_LETTER,
+
+								// lpa costs
+								APPEAL_DOCUMENT_TYPE.LPA_COSTS_APPLICATION,
+								APPEAL_DOCUMENT_TYPE.LPA_COSTS_CORRESPONDENCE,
+								APPEAL_DOCUMENT_TYPE.LPA_COSTS_DECISION_LETTER,
+								// APPEAL_DOCUMENT_TYPE.LPA_COSTS_WITHDRAWAL,
+
+								// appellant costs
+								APPEAL_DOCUMENT_TYPE.APPELLANT_COSTS_APPLICATION,
+								APPEAL_DOCUMENT_TYPE.APPELLANT_COSTS_CORRESPONDENCE,
+								APPEAL_DOCUMENT_TYPE.APPELLANT_COSTS_DECISION_LETTER
+								// APPEAL_DOCUMENT_TYPE.APPELLANT_COSTS_WITHDRAWAL
+							]
+						}
+					}
+				})
+			]);
+
+			if (!appealCase) {
+				return null;
+			}
+
+			return {
+				...appealCase,
+				Documents: documents
+			};
 		} catch (e) {
 			if (e instanceof Prisma.PrismaClientKnownRequestError) {
 				if (e.code === 'P2023') {
@@ -98,6 +141,37 @@ class RepresentationsRepository {
 	 * @returns {Promise<AppealCase|null>}
 	 */
 	async getAppealCaseWithRepresentationsByType(caseReference, type) {
+		/** @type {string[]} */
+		let documentTypes = [];
+
+		switch (type) {
+			case APPEAL_REPRESENTATION_TYPE.FINAL_COMMENT:
+				documentTypes.push(
+					APPEAL_DOCUMENT_TYPE.APPELLANT_FINAL_COMMENT,
+					APPEAL_DOCUMENT_TYPE.LPA_FINAL_COMMENT
+				);
+				break;
+			case APPEAL_REPRESENTATION_TYPE.STATEMENT:
+				documentTypes.push(
+					APPEAL_DOCUMENT_TYPE.APPELLANT_STATEMENT,
+					APPEAL_DOCUMENT_TYPE.LPA_STATEMENT,
+					APPEAL_DOCUMENT_TYPE.RULE_6_STATEMENT
+				);
+				break;
+			case APPEAL_REPRESENTATION_TYPE.PROOFS_EVIDENCE:
+				documentTypes.push(
+					APPEAL_DOCUMENT_TYPE.APPELLANT_PROOF_OF_EVIDENCE,
+					APPEAL_DOCUMENT_TYPE.LPA_PROOF_OF_EVIDENCE,
+					APPEAL_DOCUMENT_TYPE.RULE_6_PROOF_OF_EVIDENCE
+				);
+				break;
+			case APPEAL_REPRESENTATION_TYPE.COMMENT:
+				documentTypes.push(APPEAL_DOCUMENT_TYPE.INTERESTED_PARTY_COMMENT);
+				break;
+			default:
+				throw new Error('unknown doc type for representation type');
+		}
+
 		try {
 			return await this.dbClient.appealCase.findUnique({
 				where: {
@@ -105,13 +179,25 @@ class RepresentationsRepository {
 				},
 				select: {
 					...dashboardSelect,
-					Documents: { ...DocumentsArgsPublishedOnly },
+					Documents: {
+						...DocumentsArgsPublishedOnly,
+						where: {
+							...DocumentsArgsPublishedOnly.where,
+							documentType: {
+								in: documentTypes
+							}
+						}
+					},
 					Representations: {
 						where: {
 							representationType: type
 						},
 						include: {
-							RepresentationDocuments: true
+							RepresentationDocuments: {
+								select: {
+									documentId: true
+								}
+							}
 						}
 					}
 				}

--- a/packages/appeals-service-api/src/routes/v2/appeal-cases/_caseReference/representations/representations.spec.js
+++ b/packages/appeals-service-api/src/routes/v2/appeal-cases/_caseReference/representations/representations.spec.js
@@ -156,16 +156,18 @@ module.exports = ({ getSqlClient, setCurrentSub, setCurrentLpa, appealsApi }) =>
 				expect(response.body.Representations).toEqual(
 					expect.arrayContaining([
 						expect.objectContaining({
-							caseReference: testCase2,
-							representationId: testRepId1,
 							source: 'lpa',
-							representationType: REPRESENTATION_TYPES.STATEMENT
+							serviceUserId: null,
+							representationType: REPRESENTATION_TYPES.STATEMENT,
+							representationStatus: 'published',
+							dateReceived: expect.any(String)
 						}),
 						expect.objectContaining({
-							caseReference: testCase2,
-							representationId: testRepId2,
 							source: 'citizen',
-							representationType: REPRESENTATION_TYPES.FINAL_COMMENT
+							serviceUserId: expect.any(String),
+							representationType: REPRESENTATION_TYPES.FINAL_COMMENT,
+							representationStatus: 'published',
+							dateReceived: expect.any(String)
 						})
 					])
 				);

--- a/packages/appeals-service-api/src/routes/v2/appeal-cases/repo.js
+++ b/packages/appeals-service-api/src/routes/v2/appeal-cases/repo.js
@@ -1,10 +1,10 @@
 const { createPrismaClient } = require('#db-client');
 const {
+	CASE_TYPES,
 	CASE_RELATION_TYPES,
 	LISTED_RELATION_TYPES
 } = require('@pins/common/src/database/data-static');
 const { APPEAL_USER_ROLES } = require('@pins/common/src/constants');
-const { CASE_TYPES } = require('@pins/common/src/database/data-static');
 const { subYears } = require('date-fns');
 const logger = require('#lib/logger');
 const ApiError = require('#errors/apiError');
@@ -92,11 +92,8 @@ const dashboardSelect = {
 };
 
 /** @type {import('@pins/database/src/client/client').Prisma.AppealCase$DocumentsArgs} */
-const DocumentsArgsPublishedOnly = {
+const DocumentsArgs = {
 	// Important, changes made here should be reflected in the Document_caseRef_published_filter index
-	where: {
-		published: true
-	},
 	select: {
 		id: true,
 		publishedDocumentURI: true,
@@ -105,6 +102,15 @@ const DocumentsArgsPublishedOnly = {
 		datePublished: true,
 		redacted: true,
 		virusCheckStatus: true,
+		published: true
+	}
+};
+
+/** @type {import('@pins/database/src/client/client').Prisma.AppealCase$DocumentsArgs} */
+const DocumentsArgsPublishedOnly = {
+	// Important, changes made here should be reflected in the Document_caseRef_published_filter index
+	...DocumentsArgs,
+	where: {
 		published: true
 	}
 };
@@ -869,4 +875,9 @@ function addCaseStatusToQuery(whereArray, caseStatus) {
 	whereArray.push({ caseStatus: caseStatus });
 }
 
-module.exports = { AppealCaseRepository, DocumentsArgsPublishedOnly, dashboardSelect };
+module.exports = {
+	AppealCaseRepository,
+	DocumentsArgs,
+	DocumentsArgsPublishedOnly,
+	dashboardSelect
+};

--- a/packages/common/src/client/appeals-api-client.js
+++ b/packages/common/src/client/appeals-api-client.js
@@ -611,6 +611,19 @@ class AppealsApiClient {
 
 	/**
 	 * @param {string} caseReference
+	 * @param {string[]|string} types
+	 * @returns {Promise<AppealCaseDetailed>}
+	 */
+	async getAppealCaseWithCostsByType(caseReference, types) {
+		const urlParams = new URLSearchParams();
+		urlParams.append('types', Array.isArray(types) ? types.join(',') : types);
+		const endpoint = `${v2}/appeal-cases/${caseReference}/costs?${urlParams.toString()}`;
+		const response = await this.#makeGetRequest(endpoint);
+		return response.json();
+	}
+
+	/**
+	 * @param {string} caseReference
 	 * @returns {Promise<(AppellantFinalCommentSubmission)>}
 	 */
 	async getAppellantFinalCommentSubmission(caseReference) {

--- a/packages/common/src/client/appeals-api-client.test.js
+++ b/packages/common/src/client/appeals-api-client.test.js
@@ -378,6 +378,25 @@ describe('appeals-api-client', () => {
 		});
 	});
 
+	describe('getAppealCaseWithCostsByType', () => {
+		it('should get document details by id', async () => {
+			const testCaseReference = 'abc';
+			fetch.mockResponseOnce(JSON.stringify({ a: 1 }));
+			const createResponse = await apiClient.getAppealCaseWithCostsByType(testCaseReference, [
+				'a',
+				'b'
+			]);
+
+			expect(fetch).toHaveBeenCalledWith(
+				`${TEST_BASEURL}${v2}/appeal-cases/${testCaseReference}/costs?types=a%2Cb`,
+				expect.objectContaining({
+					method: 'GET'
+				})
+			);
+			expect(createResponse).toEqual({ a: 1 });
+		});
+	});
+
 	describe('getAppealCaseWithRepresentationsByType', () => {
 		it('should handle type', async () => {
 			const testCaseReference = 'abc';

--- a/packages/common/src/document-types.js
+++ b/packages/common/src/document-types.js
@@ -567,6 +567,39 @@ const documentTypes = {
 		horizonDocumentType: '', // Does not exist in horizon
 		horizonDocumentGroupType: '' // Does not exist in horizon
 	},
+	appellantCostsCorrespondence: {
+		name: 'appellantCostsCorrespondence',
+		dataModelName: APPEAL_DOCUMENT_TYPE.APPELLANT_COSTS_CORRESPONDENCE,
+		multiple: true,
+		displayName: '',
+		involvement: '',
+		owner: (_appealTypeCode) => appellantOwner,
+		publiclyAccessible: false,
+		horizonDocumentType: '', // Does not exist in horizon
+		horizonDocumentGroupType: '' // Does not exist in horizon
+	},
+	lpaCostsApplication: {
+		name: 'lpaCostsApplication',
+		dataModelName: APPEAL_DOCUMENT_TYPE.LPA_COSTS_APPLICATION,
+		multiple: true,
+		displayName: '',
+		involvement: '',
+		owner: (_appealTypeCode) => lpaOwner,
+		publiclyAccessible: false,
+		horizonDocumentType: '', // Does not exist in horizon
+		horizonDocumentGroupType: '' // Does not exist in horizon
+	},
+	lpaCostsCorrespondence: {
+		name: 'lpaCostsCorrespondence',
+		dataModelName: APPEAL_DOCUMENT_TYPE.LPA_COSTS_CORRESPONDENCE,
+		multiple: true,
+		displayName: '',
+		involvement: '',
+		owner: (_appealTypeCode) => lpaOwner,
+		publiclyAccessible: false,
+		horizonDocumentType: '', // Does not exist in horizon
+		horizonDocumentGroupType: '' // Does not exist in horizon
+	},
 	uploadPlanningObligation: {
 		name: 'uploadPlanningObligation',
 		dataModelName: APPEAL_DOCUMENT_TYPE.PLANNING_OBLIGATION,

--- a/packages/database/src/migrations/20260601180649_update_document_indexes_for_costs/migration.sql
+++ b/packages/database/src/migrations/20260601180649_update_document_indexes_for_costs/migration.sql
@@ -1,0 +1,33 @@
+BEGIN TRY
+
+BEGIN TRAN;
+
+-- DropIndex
+DROP INDEX [Document_caseReference_idx] ON [dbo].[Document];
+
+-- DropIndex
+DROP INDEX [Document_caseReference_stage_documentType_idx] ON [dbo].[Document];
+
+-- CreateIndex
+CREATE NONCLUSTERED INDEX [Document_caseReference_published_idx] ON [dbo].[Document]([caseReference], [published]);
+
+-- CreateIndex
+CREATE NONCLUSTERED INDEX [Document_caseReference_stage_published_idx] ON [dbo].[Document]([caseReference], [stage], [published]);
+
+-- Manual index
+CREATE NONCLUSTERED INDEX [Document_caseRef_type_idx]
+ON [dbo].[Document] ([caseReference], [documentType])
+INCLUDE (id, publishedDocumentURI, filename, datePublished, redacted, virusCheckStatus, published)
+
+COMMIT TRAN;
+
+END TRY
+BEGIN CATCH
+
+IF @@TRANCOUNT > 0
+BEGIN
+    ROLLBACK TRAN;
+END;
+THROW
+
+END CATCH

--- a/packages/database/src/schema.prisma
+++ b/packages/database/src/schema.prisma
@@ -715,11 +715,12 @@ model Document {
   AppealCase    AppealCase @relation(fields: [caseReference], references: [caseReference])
 
   // indexes
-  // additional filtered index added manually, as include not supported by Prisma https://www.prisma.io/docs/orm/prisma-schema/data-model/indexes
+  // additional covering/filtered indexes added manually, as include not supported by Prisma https://www.prisma.io/docs/orm/prisma-schema/data-model/indexes
   // NONCLUSTERED INDEX (caseReference) INCLUDE (id, publishedDocumentURI, filename, documentType, datePublished, redacted, virusCheckStatus, published) WHERE published = 1
-  @@index([caseReference])
+  // NONCLUSTERED INDEX ([caseReference], [documentType]) INCLUDE (id, publishedDocumentURI, filename, datePublished, redacted, virusCheckStatus, published)
+  @@index([caseReference, published])
   @@index([documentURI]) // for documentsApi lookups
-  @@index([caseReference, stage, documentType]) // for documentsApi zip generation
+  @@index([caseReference, stage, published]) // for documentsApi zip generation
 }
 
 // This table stores unedited IP submissions at the point of submission to BO

--- a/packages/forms-web-app/src/controllers/selected-appeal/appellant-sections.js
+++ b/packages/forms-web-app/src/controllers/selected-appeal/appellant-sections.js
@@ -12,6 +12,9 @@ const {
 const { formatSubmissionDate } = require('@pins/common/src/lib/format-appeal-details');
 const config = require('../../config');
 const { isEnforcementChildLinkedAppeal } = require('@pins/common/src/lib/linked-appeals');
+const { APPEAL_DOCUMENT_TYPE } = require('@planning-inspectorate/data-model');
+
+/** @typedef {function({documentType: string, published: boolean}): boolean} CostsCondition */
 
 /**
  * @type {import("@pins/common/src/view-model-maps/sections/def").Sections}
@@ -181,6 +184,49 @@ exports.sections = [
 						owned: false,
 						submitter: APPEAL_USER_ROLES.RULE_6_PARTY
 					})
+			}
+		]
+	},
+	{
+		heading: 'Costs',
+		links: [
+			{
+				url: '/appellant-cost-application',
+				text: 'View your costs applications',
+				condition: (appealCase) =>
+					appealCase.Documents.some(
+						/** @type {CostsCondition} */
+						(doc) => doc.documentType === APPEAL_DOCUMENT_TYPE.APPELLANT_COSTS_APPLICATION
+					)
+			},
+			{
+				url: '/lpa-cost-application',
+				text: 'View local planning authority cost applications',
+				condition: (appealCase) =>
+					appealCase.Documents.some(
+						/** @type {CostsCondition} */
+						(doc) =>
+							doc.documentType === APPEAL_DOCUMENT_TYPE.LPA_COSTS_APPLICATION && doc.published
+					)
+			},
+			{
+				url: '/appellant-cost-comments',
+				text: 'View your costs comments',
+				condition: (appealCase) =>
+					appealCase.Documents.some(
+						/** @type {CostsCondition} */
+						(doc) => doc.documentType === APPEAL_DOCUMENT_TYPE.APPELLANT_COSTS_CORRESPONDENCE
+					)
+			},
+			{
+				url: '/lpa-cost-comments',
+				text: 'View local planning authority costs comments',
+				condition: (appealCase) =>
+					appealCase.Documents.some(
+						/** @type {CostsCondition} */
+						(doc) =>
+							doc.documentType === APPEAL_DOCUMENT_TYPE.LPA_COSTS_CORRESPONDENCE && doc.published
+					)
 			}
 		]
 	}

--- a/packages/forms-web-app/src/controllers/selected-appeal/costs/costs-controller.test.js
+++ b/packages/forms-web-app/src/controllers/selected-appeal/costs/costs-controller.test.js
@@ -1,0 +1,182 @@
+const costsController = require('./index');
+const { VIEW } = require('../../../lib/views');
+const { mockRes } = require('../../../../__tests__/unit/mocks');
+const { getDepartmentFromCode } = require('../../../services/department.service');
+const { formatTitleSuffix } = require('#lib/selected-appeal-page-setup');
+const { getParentPathLink } = require('#lib/get-user-back-links');
+const { formatDocumentLink } = require('#lib/representation-functions');
+const logger = require('#lib/logger');
+const { formatHeadlineData } = require('@pins/common');
+const { APPEAL_USER_ROLES, LPA_USER_ROLE } = require('@pins/common/src/constants');
+const { APPEAL_DOCUMENT_TYPE } = require('@planning-inspectorate/data-model');
+
+jest.mock('../../../services/department.service');
+jest.mock('#lib/selected-appeal-page-setup');
+jest.mock('#lib/get-user-back-links');
+jest.mock('#lib/representation-functions');
+jest.mock('#lib/logger');
+jest.mock('@pins/common');
+
+describe('controllers/selected-appeal/costs', () => {
+	const mockGetDepartmentFromCode =
+		/** @type {jest.MockedFunction<typeof getDepartmentFromCode>} */ (getDepartmentFromCode);
+	const mockFormatTitleSuffix = formatTitleSuffix;
+	const mockGetParentPathLink = getParentPathLink;
+	const mockFormatDocumentLink = formatDocumentLink;
+	const mockFormatHeadlineData = formatHeadlineData;
+	const appealNumber = 'ABC123';
+	const testDocument = {
+		id: 'document-1',
+		filename: 'costs.pdf',
+		documentType: APPEAL_DOCUMENT_TYPE.APPELLANT_COSTS_APPLICATION
+	};
+	const formattedDocumentLink = '/documents/document-1';
+	const headlineData = [{ key: { text: 'LPA' }, value: { text: 'Test LPA' } }];
+	const caseData = {
+		LPACode: 'Q9999',
+		Documents: [testDocument]
+	};
+
+	const mockReq = () => ({
+		originalUrl: '/appeals/ABC123/appellant-costs-applications',
+		params: { appealNumber },
+		appealsApiClient: {
+			getAppealCaseWithCostsByType: jest.fn()
+		}
+	});
+
+	/** @type {any} */
+	let req;
+	/** @type {any} */
+	let res;
+	/** @type {import('express').NextFunction} */
+	let next;
+
+	beforeEach(() => {
+		jest.resetAllMocks();
+		req = mockReq();
+		res = mockRes();
+		next = jest.fn();
+		res.status.mockReturnThis();
+
+		req.appealsApiClient.getAppealCaseWithCostsByType.mockResolvedValue(caseData);
+		mockGetParentPathLink.mockReturnValue('/appeals/ABC123');
+		mockGetDepartmentFromCode.mockResolvedValue({ name: 'Test LPA' });
+		mockFormatHeadlineData.mockReturnValue(headlineData);
+		mockFormatTitleSuffix.mockReturnValue('test title suffix');
+		mockFormatDocumentLink.mockReturnValue(formattedDocumentLink);
+	});
+
+	it('renders appellant costs applications with expected view context', async () => {
+		const handler = costsController.get(
+			{
+				userType: APPEAL_USER_ROLES.APPELLANT,
+				costsType: APPEAL_DOCUMENT_TYPE.APPELLANT_COSTS_APPLICATION,
+				submittingParty: APPEAL_USER_ROLES.APPELLANT
+			},
+			'layouts/test/test.njk'
+		);
+
+		await handler(req, res, next);
+
+		expect(req.appealsApiClient.getAppealCaseWithCostsByType).toHaveBeenCalledWith(appealNumber, [
+			APPEAL_DOCUMENT_TYPE.APPELLANT_COSTS_APPLICATION
+		]);
+		expect(getDepartmentFromCode).toHaveBeenCalledWith('Q9999');
+		expect(formatHeadlineData).toHaveBeenCalledWith({
+			caseData,
+			lpaName: 'Test LPA',
+			role: APPEAL_USER_ROLES.APPELLANT
+		});
+		expect(formatDocumentLink).toHaveBeenCalledWith(testDocument);
+		expect(formatTitleSuffix).toHaveBeenCalledWith(APPEAL_USER_ROLES.APPELLANT);
+		expect(res.render).toHaveBeenCalledWith(VIEW.SELECTED_APPEAL.APPEAL_COSTS, {
+			layoutTemplate: 'layouts/test/test.njk',
+			backToAppealOverviewLink: '/appeals/ABC123',
+			titleSuffix: 'test title suffix',
+			heading: 'Your costs applications',
+			appeal: {
+				appealNumber,
+				headlineData,
+				documents: [formattedDocumentLink]
+			}
+		});
+	});
+
+	it('renders lpa costs comments copy for lpa user', async () => {
+		req.originalUrl = '/manage-appeals/ABC123/lpa-costs-comments';
+		mockGetParentPathLink.mockReturnValue('/manage-appeals/ABC123');
+
+		const handler = costsController.get(
+			{
+				userType: LPA_USER_ROLE,
+				costsType: APPEAL_DOCUMENT_TYPE.LPA_COSTS_CORRESPONDENCE,
+				submittingParty: LPA_USER_ROLE
+			},
+			'layouts/lpa-dashboard/main.njk'
+		);
+
+		await handler(req, res, next);
+
+		expect(res.render).toHaveBeenCalledWith(VIEW.SELECTED_APPEAL.APPEAL_COSTS, {
+			layoutTemplate: 'layouts/lpa-dashboard/main.njk',
+			backToAppealOverviewLink: '/manage-appeals/ABC123',
+			titleSuffix: 'test title suffix',
+			heading: 'Your costs comments',
+			appeal: {
+				appealNumber,
+				headlineData,
+				documents: [formattedDocumentLink]
+			}
+		});
+	});
+
+	it('renders not found when no costs documents exist', async () => {
+		req.appealsApiClient.getAppealCaseWithCostsByType.mockResolvedValue({
+			...caseData,
+			Documents: []
+		});
+
+		const handler = costsController.get({
+			userType: APPEAL_USER_ROLES.APPELLANT,
+			costsType: APPEAL_DOCUMENT_TYPE.APPELLANT_COSTS_APPLICATION,
+			submittingParty: APPEAL_USER_ROLES.APPELLANT
+		});
+
+		await handler(req, res, next);
+
+		expect(logger.error).toHaveBeenCalledWith(
+			'No costs documents found: Appellant|appellantCostsApplication'
+		);
+		expect(res.status).toHaveBeenCalledWith(404);
+		expect(res.render).toHaveBeenCalledWith('error/not-found');
+		expect(getDepartmentFromCode).not.toHaveBeenCalled();
+	});
+
+	it('throws when user type is missing', async () => {
+		const handler = costsController.get(
+			/** @type {any} */ ({
+				userType: null,
+				costsType: APPEAL_DOCUMENT_TYPE.APPELLANT_COSTS_APPLICATION,
+				submittingParty: APPEAL_USER_ROLES.APPELLANT
+			})
+		);
+
+		await expect(handler(req, res, next)).rejects.toThrow('Unknown role: null');
+		expect(req.appealsApiClient.getAppealCaseWithCostsByType).not.toHaveBeenCalled();
+	});
+
+	it('throws when costs type is unknown', async () => {
+		const handler = costsController.get(
+			/** @type {any} */ ({
+				userType: APPEAL_USER_ROLES.APPELLANT,
+				costsType: 'unknownCostsType',
+				submittingParty: APPEAL_USER_ROLES.APPELLANT
+			})
+		);
+
+		await expect(handler(req, res, next)).rejects.toThrow('Unknown costs type: unknownCostsType');
+		expect(getDepartmentFromCode).toHaveBeenCalledWith('Q9999');
+		expect(formatDocumentLink).not.toHaveBeenCalled();
+	});
+});

--- a/packages/forms-web-app/src/controllers/selected-appeal/costs/index.js
+++ b/packages/forms-web-app/src/controllers/selected-appeal/costs/index.js
@@ -1,0 +1,97 @@
+const { formatHeadlineData } = require('@pins/common');
+const { LPA_USER_ROLE } = require('@pins/common/src/constants');
+const logger = require('#lib/logger');
+const {
+	VIEW: {
+		SELECTED_APPEAL: { APPEAL_COSTS: costsView }
+	}
+} = require('#lib/views');
+const { formatDocumentLink } = require('#lib/representation-functions');
+const { formatTitleSuffix } = require('#lib/selected-appeal-page-setup');
+const { getDepartmentFromCode } = require('../../../services/department.service');
+const { getParentPathLink } = require('#lib/get-user-back-links');
+const { APPEAL_DOCUMENT_TYPE } = require('@planning-inspectorate/data-model');
+
+/**
+ * @typedef {import('@pins/common/src/constants').AppealToUserRoles} AppealToUserRoles
+ * @typedef {import('@pins/common/src/constants').LpaUserRole} LpaUserRole
+ */
+
+/**
+ * @typedef {Object} CostsParams
+ * @property {AppealToUserRoles|LpaUserRole} userType // the user
+ * @property {string} costsType //
+ * @property {AppealToUserRoles|LpaUserRole} submittingParty  // the party submitting the representation
+ * @property {boolean | null} [rule6OwnRepresentations] // optional param passed when a rule 6 party is viewing own (true) or other rule 6 party (false) reps
+ */
+
+/**
+ * Shared controller for costs
+ * @param {CostsParams} costsParams
+ * @param {string} layoutTemplate - njk template to extend
+ * @returns {import('express').RequestHandler}
+ */
+exports.get = (costsParams, layoutTemplate = 'layouts/no-banner-link/main.njk') => {
+	return async (req, res) => {
+		const appealNumber = req.params.appealNumber;
+
+		const { userType, costsType } = costsParams;
+
+		if (!userType) {
+			throw new Error(`Unknown role: ${userType}`);
+		}
+
+		const caseData = await req.appealsApiClient.getAppealCaseWithCostsByType(appealNumber, [
+			costsType
+		]);
+
+		if (caseData.Documents.length === 0) {
+			logger.error(`No costs documents found: ${userType}|${costsType}`);
+			return res.status(404).render('error/not-found');
+		}
+
+		const backToAppealOverviewLink = getParentPathLink(req.originalUrl);
+		const lpa = await getDepartmentFromCode(caseData.LPACode);
+		const headlineData = formatHeadlineData({ caseData, lpaName: lpa.name, role: userType });
+
+		/** @type {string} */
+		let costsTypeName = '';
+
+		const isLpa = userType === LPA_USER_ROLE;
+
+		switch (costsType) {
+			case APPEAL_DOCUMENT_TYPE.APPELLANT_COSTS_APPLICATION:
+				costsTypeName = isLpa ? 'Appellant costs applications' : 'Your costs applications';
+				break;
+			case APPEAL_DOCUMENT_TYPE.LPA_COSTS_APPLICATION:
+				costsTypeName = isLpa
+					? 'Your costs applications'
+					: 'Local planning authority costs applications';
+				break;
+			case APPEAL_DOCUMENT_TYPE.APPELLANT_COSTS_CORRESPONDENCE:
+				costsTypeName = isLpa ? 'Appellant costs comments' : 'Your costs comments';
+				break;
+			case APPEAL_DOCUMENT_TYPE.LPA_COSTS_CORRESPONDENCE:
+				costsTypeName = isLpa ? 'Your costs comments' : 'Local planning authority costs comments';
+				break;
+			default:
+				throw new Error(`Unknown costs type: ${costsType}`);
+		}
+
+		const formattedDocumentLinks = caseData.Documents.map((doc) => formatDocumentLink(doc));
+
+		const viewContext = {
+			layoutTemplate,
+			backToAppealOverviewLink,
+			titleSuffix: formatTitleSuffix(userType),
+			heading: costsTypeName,
+			appeal: {
+				appealNumber,
+				headlineData,
+				documents: formattedDocumentLinks
+			}
+		};
+
+		res.render(costsView, viewContext);
+	};
+};

--- a/packages/forms-web-app/src/controllers/selected-appeal/index.js
+++ b/packages/forms-web-app/src/controllers/selected-appeal/index.js
@@ -181,6 +181,10 @@ const filterDecisionDocuments = (documents) => {
 	};
 
 	const decisionDocuments = documents.filter((document) => {
+		if (!document.published) {
+			return false;
+		}
+
 		if (
 			document.documentType === APPEAL_DOCUMENT_TYPE.CASE_DECISION_LETTER ||
 			document.documentType === APPEAL_DOCUMENT_TYPE.LPA_COSTS_DECISION_LETTER ||

--- a/packages/forms-web-app/src/controllers/selected-appeal/index.test.js
+++ b/packages/forms-web-app/src/controllers/selected-appeal/index.test.js
@@ -89,6 +89,16 @@ describe('get', () => {
 					redacted: true,
 					virusCheckStatus: 'scanned',
 					published: true
+				},
+				{
+					id: '41c354b1-287b-4492-92d7-4e23e3aa211e',
+					publishedDocumentURI: 'https://example.com/published/doc_001',
+					filename: 'cost-decision-doc.txt',
+					documentType: 'appellantCostsDecisionLetter',
+					datePublished: null,
+					redacted: true,
+					virusCheckStatus: 'scanned',
+					published: false
 				}
 			]
 		});
@@ -107,13 +117,26 @@ describe('get', () => {
 					baseUrl: '/appeals/123',
 					decisionDocuments: expect.arrayContaining([
 						expect.objectContaining({
-							documentType: expect.stringMatching(
-								/^(lpaCostsDecisionLetter|appellantCostsDecisionLetter)$/
-							)
+							id: '31c354b1-287b-4492-92d7-4e23e3aa211c',
+							documentType: 'lpaCostsDecisionLetter'
+						}),
+						expect.objectContaining({
+							id: '31c354b1-287b-4492-92d7-4e23e3aa211e',
+							documentType: 'appellantCostsDecisionLetter'
 						})
 					])
 				})
 			})
+		);
+
+		const renderContext = res.render.mock.calls[0][1];
+		expect(renderContext.appeal.decisionDocuments).toHaveLength(2);
+		expect(renderContext.appeal.decisionDocuments).not.toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({
+					id: '41c354b1-287b-4492-92d7-4e23e3aa211e'
+				})
+			])
 		);
 	});
 });

--- a/packages/forms-web-app/src/controllers/selected-appeal/lpa-user-sections.js
+++ b/packages/forms-web-app/src/controllers/selected-appeal/lpa-user-sections.js
@@ -12,11 +12,13 @@ const {
 const { formatSubmissionDate } = require('@pins/common/src/lib/format-appeal-details');
 const config = require('../../config');
 const { isEnforcementChildLinkedAppeal } = require('@pins/common/src/lib/linked-appeals');
+const { APPEAL_DOCUMENT_TYPE } = require('@planning-inspectorate/data-model');
+
+/** @typedef {function({documentType: string, published: boolean}): boolean} CostsCondition */
 
 /**
  * @type {import("@pins/common/src/view-model-maps/sections/def").Sections}
  */
-
 exports.sections = [
 	{
 		heading: 'Appeal details',
@@ -200,6 +202,50 @@ exports.sections = [
 						owned: false,
 						submitter: APPEAL_USER_ROLES.RULE_6_PARTY
 					})
+			}
+		]
+	},
+	{
+		heading: 'Costs',
+		links: [
+			{
+				url: '/lpa-cost-application',
+				text: 'View your costs applications',
+				condition: (appealCase) =>
+					appealCase.Documents.some(
+						/** @type {CostsCondition} */
+						(doc) => doc.documentType === APPEAL_DOCUMENT_TYPE.LPA_COSTS_APPLICATION
+					)
+			},
+			{
+				url: '/appellant-cost-application',
+				text: 'View the appellant costs applications',
+				condition: (appealCase) =>
+					appealCase.Documents.some(
+						/** @type {CostsCondition} */
+						(doc) =>
+							doc.documentType === APPEAL_DOCUMENT_TYPE.APPELLANT_COSTS_APPLICATION && doc.published
+					)
+			},
+			{
+				url: '/lpa-cost-comments',
+				text: 'View your costs comments',
+				condition: (appealCase) =>
+					appealCase.Documents.some(
+						/** @type {CostsCondition} */
+						(doc) => doc.documentType === APPEAL_DOCUMENT_TYPE.LPA_COSTS_CORRESPONDENCE
+					)
+			},
+			{
+				url: '/appellant-cost-comments',
+				text: 'View the appellant costs comments',
+				condition: (appealCase) =>
+					appealCase.Documents.some(
+						/** @type {CostsCondition} */
+						(doc) =>
+							doc.documentType === APPEAL_DOCUMENT_TYPE.APPELLANT_COSTS_CORRESPONDENCE &&
+							doc.published
+					)
 			}
 		]
 	}

--- a/packages/forms-web-app/src/lib/representation-functions.js
+++ b/packages/forms-web-app/src/lib/representation-functions.js
@@ -356,5 +356,6 @@ const isProofsDocument = (document) => {
 module.exports = {
 	filterRepresentationsForDisplay,
 	formatRepresentationHeading,
-	formatRepresentations
+	formatRepresentations,
+	formatDocumentLink
 };

--- a/packages/forms-web-app/src/lib/views.js
+++ b/packages/forms-web-app/src/lib/views.js
@@ -225,6 +225,7 @@ const VIEW = {
 	SELECTED_APPEAL: {
 		APPEAL_OVERVIEW: '/appeals',
 		APPEAL: 'selected-appeal/appeal',
+		APPEAL_COSTS: 'selected-appeal/costs',
 		APPEAL_DETAILS: 'selected-appeal/appeal-details',
 		APPEAL_QUESTIONNAIRE: 'selected-appeal/questionnaire-details',
 		APPEAL_IP_COMMENTS: 'selected-appeal/ip-comment-details',

--- a/packages/forms-web-app/src/routes/appeals/selected-appeal/selected-appeal.js
+++ b/packages/forms-web-app/src/routes/appeals/selected-appeal/selected-appeal.js
@@ -1,9 +1,11 @@
 const express = require('express');
+const { APPEAL_DOCUMENT_TYPE } = require('@planning-inspectorate/data-model');
 
 const selectedAppealController = require('../../../controllers/selected-appeal');
 const appealDetailsController = require('../../../controllers/selected-appeal/appeal-details');
 const questionnaireDetailsController = require('../../../controllers/selected-appeal/questionnaire-details');
 const planningObligationDetailsController = require('../../../controllers/selected-appeal/planning-obligation-details');
+const costsController = require('../../../controllers/selected-appeal/costs/');
 const downloadDocumentsController = require('../../../controllers/selected-appeal/downloads/documents');
 
 const representationsController = require('../../../controllers/selected-appeal/representations');
@@ -105,6 +107,24 @@ router.get(
 );
 
 router.get('/:appealNumber/planning-obligation', planningObligationDetailsController.get());
+
+// costs
+router.get(
+	'/:appealNumber/appellant-cost-application',
+	costsController.get({ userType, costsType: APPEAL_DOCUMENT_TYPE.APPELLANT_COSTS_APPLICATION })
+);
+router.get(
+	'/:appealNumber/lpa-cost-application',
+	costsController.get({ userType, costsType: APPEAL_DOCUMENT_TYPE.LPA_COSTS_APPLICATION })
+);
+router.get(
+	'/:appealNumber/appellant-cost-comments',
+	costsController.get({ userType, costsType: APPEAL_DOCUMENT_TYPE.APPELLANT_COSTS_CORRESPONDENCE })
+);
+router.get(
+	'/:appealNumber/lpa-cost-comments',
+	costsController.get({ userType, costsType: APPEAL_DOCUMENT_TYPE.LPA_COSTS_CORRESPONDENCE })
+);
 
 router.get(
 	`/:appealNumber/download/:documentsLocation/documents/:appealCaseStage`,

--- a/packages/forms-web-app/src/routes/lpa-dashboard/selected-appeal.js
+++ b/packages/forms-web-app/src/routes/lpa-dashboard/selected-appeal.js
@@ -6,6 +6,7 @@ const {
 	APPEAL_USER_ROLES,
 	REPRESENTATION_TYPES
 } = require('@pins/common/src/constants');
+const { APPEAL_DOCUMENT_TYPE } = require('@planning-inspectorate/data-model');
 
 const selectedAppealController = require('../../controllers/selected-appeal');
 const appealDetailsController = require('../../controllers/selected-appeal/appeal-details');
@@ -13,6 +14,7 @@ const questionnaireDetailsController = require('../../controllers/selected-appea
 const planningObligationDetailsController = require('../../controllers/selected-appeal/planning-obligation-details');
 const downloadDocumentsController = require('../../controllers/selected-appeal/downloads/documents');
 const representationsController = require('../../controllers/selected-appeal/representations');
+const costsController = require('../../controllers/selected-appeal/costs/');
 
 const userType = LPA_USER_ROLE;
 
@@ -128,6 +130,24 @@ router.get(
 router.get(
 	'/:appealNumber/appellant-planning-obligation',
 	planningObligationDetailsController.get('layouts/lpa-dashboard/main.njk')
+);
+
+// costs
+router.get(
+	'/:appealNumber/appellant-cost-application',
+	costsController.get({ userType, costsType: APPEAL_DOCUMENT_TYPE.APPELLANT_COSTS_APPLICATION })
+);
+router.get(
+	'/:appealNumber/lpa-cost-application',
+	costsController.get({ userType, costsType: APPEAL_DOCUMENT_TYPE.LPA_COSTS_APPLICATION })
+);
+router.get(
+	'/:appealNumber/appellant-cost-comments',
+	costsController.get({ userType, costsType: APPEAL_DOCUMENT_TYPE.APPELLANT_COSTS_CORRESPONDENCE })
+);
+router.get(
+	'/:appealNumber/lpa-cost-comments',
+	costsController.get({ userType, costsType: APPEAL_DOCUMENT_TYPE.LPA_COSTS_CORRESPONDENCE })
 );
 
 module.exports = router;

--- a/packages/forms-web-app/src/views/selected-appeal/costs.njk
+++ b/packages/forms-web-app/src/views/selected-appeal/costs.njk
@@ -1,0 +1,38 @@
+{% extends layoutTemplate %}
+{% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
+{% set title="Costs " + appeal.appealNumber + " - " + titleSuffix + " - GOV.UK" %}
+{% block backButton %}
+    {{ govukBackLink({
+		text: "Back",
+		href: backToAppealOverviewLink,
+		attributes: {
+			'data-cy': 'back'
+		}
+	}) }}
+{% endblock %}
+{% block pageTitle %}
+    {{ title }}
+{% endblock %}
+{% block content %}
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-full">
+            <span class="govuk-caption-xl">Appeal {{ appeal.appealNumber }}</span>
+            <h1 class="govuk-heading-xl">{{ heading }}</h1>
+            {{ govukSummaryList({
+				classes: "appeal-headlines govuk-summary-list--no-border",
+				rows: appeal.headlineData
+			}) }}
+            <hr class="govuk-section-break govuk-section-break--visible govuk-section-break--m"/>
+            <div class="govuk-summary-list__row">
+                <dt class="govuk-summary-list__key">{{ heading }}</dt>
+                <dd class="govuk-summary-list__value">
+                    <ul class="govuk-list govuk-list--bullet">
+                        {% for document in appeal.documents %}
+                            <li>{{ document | safe }}</li>
+                        {% endfor %}
+                    </ul>
+                </dd>
+            </div>
+        </div>
+    </div>
+{% endblock %}


### PR DESCRIPTION
### Description of change

<!-- Please describe the change -->

- Adds costs pages that allow appellant/lpa to view cost correspondence and applications
- Relies on published flag being false until shared in back office
- improves performance of lookups for details pages, reducing document/rep data returned

[Part 2](https://github.com/Planning-Inspectorate/appeal-planning-decision/pull/5427) - will include zip download

Ticket: https://pins-ds.atlassian.net/browse/a2-7145
https://pins-ds.atlassian.net/browse/a2-7265

### Checklist

- [x] Feature complete and ready for users, or behind feature-flag
- [x] Commit history is linear with no merge commits
- [ ] Requires infrastructure changes

### Important

Please do not merge from `main` (please only [rebase](https://github.com/Planning-Inspectorate/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
