### PR TITLE
feat(A2-8385): remove appellant statement from HAS and CAS appeals

### DIFF
--- a/packages/business-rules/src/schemas/householder-appeal/appeal-schema/index.js
+++ b/packages/business-rules/src/schemas/householder-appeal/appeal-schema/index.js
@@ -25,6 +25,7 @@ const appealValidationSchema = () => {
 			horizonId: horizonIdValidation(),
 			lpaCode: lpaCodeValidation(),
 			planningApplicationNumber: planningApplicationNumberValidation(),
+			applicationDate: dateValidation(),
 			decisionDate: dateValidation(),
 			createdAt: dateValidation(true),
 			updatedAt: dateValidation(true),

--- a/packages/business-rules/src/schemas/householder-appeal/insert.test.js
+++ b/packages/business-rules/src/schemas/householder-appeal/insert.test.js
@@ -113,6 +113,23 @@ describe('schemas/householder-appeal/insert', () => {
 			});
 		});
 
+		describe('applicationDate', () => {
+			it('should throw an error when given a value which is in an incorrect format', async () => {
+				appeal.applicationDate = '03/07/2021';
+
+				await expect(() => insert.validate(appeal, config)).rejects.toThrow(
+					'Invalid Date or string not ISO format'
+				);
+			});
+
+			it('should not throw an error when not given a value', async () => {
+				delete appeal.applicationDate;
+
+				const result = await insert.validate(appeal, config);
+				expect(result).toEqual(appeal);
+			});
+		});
+
 		describe('decisionDate', () => {
 			it('should throw an error when given a value which is in an incorrect format', async () => {
 				appeal.decisionDate = '03/07/2021';

--- a/packages/business-rules/src/schemas/householder-appeal/update.js
+++ b/packages/business-rules/src/schemas/householder-appeal/update.js
@@ -16,6 +16,7 @@ const update = pinsYup
 		horizonId: pinsYup.string().trim().max(20).nullable(),
 		lpaCode: pinsYup.string().trim().max(20).required(),
 		planningApplicationNumber: pinsYup.string().max(30).required(),
+		applicationDate: pinsYup.date().transform(parseDateString).nullable(),
 		appealType: pinsYup.lazy((appealType) => {
 			if (appealType) {
 				return pinsYup.string().oneOf(Object.values(APPEAL_ID));

--- a/packages/business-rules/src/schemas/householder-appeal/update.test.js
+++ b/packages/business-rules/src/schemas/householder-appeal/update.test.js
@@ -124,6 +124,23 @@ describe('schemas/householder-appeal/update', () => {
 			});
 		});
 
+		describe('applicationDate', () => {
+			it('should throw an error when given a value which is in an incorrect format', async () => {
+				appeal.applicationDate = '03/07/2021';
+
+				await expect(() => update.validate(appeal, config)).rejects.toThrow(
+					'Invalid Date or string not ISO format'
+				);
+			});
+
+			it('should not throw an error when not given a value', async () => {
+				delete appeal.applicationDate;
+
+				const result = await update.validate(appeal, config);
+				expect(result).toEqual(appeal);
+			});
+		});
+
 		describe('decisionDate', () => {
 			it('should throw an error when given a value which is in an incorrect format', async () => {
 				appeal.decisionDate = '03/07/2021';

--- a/packages/forms-web-app/__tests__/unit/controllers/full-appeal/type-of-planning-application.test.js
+++ b/packages/forms-web-app/__tests__/unit/controllers/full-appeal/type-of-planning-application.test.js
@@ -93,7 +93,7 @@ describe('controllers/full-appeal/type-of-planning-application', () => {
 				...updatedAppeal
 			});
 
-			expect(res.redirect).toHaveBeenCalledWith('/before-you-start/granted-or-refused-householder');
+			expect(res.redirect).toHaveBeenCalledWith('/before-you-start/application-date');
 		});
 
 		it('should redirect to the shutter page if something-else', async () => {
@@ -213,7 +213,7 @@ describe('controllers/full-appeal/type-of-planning-application', () => {
 					...updatedAppeal
 				});
 
-				expect(res.redirect).toHaveBeenCalledWith('/before-you-start/granted-or-refused');
+				expect(res.redirect).toHaveBeenCalledWith('/before-you-start/application-date');
 			}
 		);
 
@@ -287,7 +287,7 @@ describe('controllers/full-appeal/type-of-planning-application', () => {
 				...updatedAppeal
 			});
 
-			expect(res.redirect).toHaveBeenCalledWith('/before-you-start/planning-application-about');
+			expect(res.redirect).toHaveBeenCalledWith('/before-you-start/application-date');
 		});
 
 		it('should redirect to the listed building page and not change the listedBuilding response - ldc', async () => {

--- a/packages/forms-web-app/src/controllers/full-appeal/application-date.js
+++ b/packages/forms-web-app/src/controllers/full-appeal/application-date.js
@@ -6,6 +6,9 @@ const {
 } = require('#lib/views');
 const { parseISO, isValid } = require('date-fns');
 const logger = require('#lib/logger');
+const {
+	constants: { TYPE_OF_PLANNING_APPLICATION }
+} = require('@pins/business-rules');
 
 const getApplicationDate = async (req, res) => {
 	const { appeal } = req.session;
@@ -50,6 +53,16 @@ const postApplicationDate = async (req, res) => {
 			...appeal,
 			applicationDate: enteredDate.toISOString()
 		});
+
+		if (appeal.typeOfPlanningApplication === TYPE_OF_PLANNING_APPLICATION.HOUSEHOLDER_PLANNING) {
+			return res.redirect('/before-you-start/granted-or-refused-householder');
+		}
+
+		if (
+			appeal.typeOfPlanningApplication === TYPE_OF_PLANNING_APPLICATION.MINOR_COMMERCIAL_DEVELOPMENT
+		) {
+			return res.redirect('/before-you-start/planning-application-about');
+		}
 
 		return res.redirect(`/before-you-start/granted-or-refused`);
 	} catch (e) {

--- a/packages/forms-web-app/src/controllers/full-appeal/type-of-planning-application.js
+++ b/packages/forms-web-app/src/controllers/full-appeal/type-of-planning-application.js
@@ -91,17 +91,15 @@ const postTypeOfPlanningApplication = async (req, res) => {
 
 	switch (typeOfPlanningApplication) {
 		case HOUSEHOLDER_PLANNING:
-			return res.redirect('/before-you-start/granted-or-refused-householder');
+		case MINOR_COMMERCIAL_DEVELOPMENT:
+		case ADVERTISEMENT:
+			return res.redirect('/before-you-start/application-date');
 		case LISTED_BUILDING:
 			return res.redirect('/before-you-start/granted-or-refused');
-		case MINOR_COMMERCIAL_DEVELOPMENT:
-			return res.redirect('/before-you-start/planning-application-about');
 		case LAWFUL_DEVELOPMENT_CERTIFICATE:
 			return isV2forLDC
 				? res.redirect('/before-you-start/listed-building')
 				: res.redirect('/before-you-start/use-existing-service-application-type');
-		case ADVERTISEMENT:
-			return res.redirect('/before-you-start/granted-or-refused');
 		case PRIOR_APPROVAL:
 			return res.redirect('/before-you-start/prior-approval-existing-home');
 		case REMOVAL_OR_VARIATION_OF_CONDITIONS:

--- a/packages/forms-web-app/src/controllers/selected-appeal/appeal-details/appeal-documents-rows.js
+++ b/packages/forms-web-app/src/controllers/selected-appeal/appeal-details/appeal-documents-rows.js
@@ -7,7 +7,10 @@ const {
 	APPEAL_APPLICATION_MADE_UNDER_ACT_SECTION
 } = require('@planning-inspectorate/data-model');
 const { isNotUndefinedOrNull } = require('#lib/is-not-undefined-or-null');
-const { isExpeditedPart1Eligible } = require('#lib/is-expedited-part1-eligible');
+const {
+	isExpeditedPart1Eligible,
+	isExpeditedAppealDate
+} = require('#lib/is-expedited-part1-eligible');
 /**
  * @typedef {import('appeals-service-api').Api.AppealCaseDetailed} AppealCaseDetailed
  * @typedef {import("@pins/common/src/view-model-maps/rows/def").Rows} Rows
@@ -79,7 +82,16 @@ exports.documentsRows = (caseData) => {
 		{
 			keyText: 'Appeal statement',
 			valueText: formatDocumentDetails(documents, APPEAL_DOCUMENT_TYPE.APPELLANT_STATEMENT),
-			condition: () => true,
+			condition: () => {
+				if (
+					caseData &&
+					(caseData.appealTypeCode === CASE_TYPES.HAS.processCode ||
+						caseData.appealTypeCode === CASE_TYPES.CAS_PLANNING.processCode)
+				) {
+					return !isExpeditedAppealDate(caseData.applicationDate);
+				}
+				return true;
+			},
 			isEscaped: true
 		},
 		{

--- a/packages/forms-web-app/src/controllers/selected-appeal/appeal-details/appeal-documents-rows.test.js
+++ b/packages/forms-web-app/src/controllers/selected-appeal/appeal-details/appeal-documents-rows.test.js
@@ -357,3 +357,51 @@ describe('appeal-documents-rows - expedited part 1', () => {
 		expect(rows[6].condition(minimalCaseData)).toEqual(false);
 	});
 });
+
+describe('appeal-documents-rows - HAS and CAS conditional appeal statement', () => {
+	it('should display appeal statement for HAS and CAS if applicationDate is before April 1st 2026', () => {
+		const hasRows = documentsRows({
+			appealTypeCode: CASE_TYPES.HAS.processCode,
+			applicationDate: '2026-03-30T12:00:00.000Z'
+		});
+		const hasRow = hasRows.find((row) => row.keyText === 'Appeal statement');
+		expect(hasRow.condition()).toBe(true);
+
+		const casRows = documentsRows({
+			appealTypeCode: CASE_TYPES.CAS_PLANNING.processCode,
+			applicationDate: '2026-03-30T12:00:00.000Z'
+		});
+		const casRow = casRows.find((row) => row.keyText === 'Appeal statement');
+		expect(casRow.condition()).toBe(true);
+	});
+
+	it('should not display appeal statement for HAS and CAS if applicationDate is on or after April 1st 2026', () => {
+		const hasRows = documentsRows({
+			appealTypeCode: CASE_TYPES.HAS.processCode,
+			applicationDate: '2026-04-01T00:00:00.000Z'
+		});
+		const hasRow = hasRows.find((row) => row.keyText === 'Appeal statement');
+		expect(hasRow.condition()).toBe(false);
+
+		const casRows = documentsRows({
+			appealTypeCode: CASE_TYPES.CAS_PLANNING.processCode,
+			applicationDate: '2026-04-01T00:00:00.000Z'
+		});
+		const casRow = casRows.find((row) => row.keyText === 'Appeal statement');
+		expect(casRow.condition()).toBe(false);
+	});
+
+	it('should display appeal statement for HAS and CAS if applicationDate is not set', () => {
+		const hasRows = documentsRows({
+			appealTypeCode: CASE_TYPES.HAS.processCode
+		});
+		const hasRow = hasRows.find((row) => row.keyText === 'Appeal statement');
+		expect(hasRow.condition()).toBe(true);
+
+		const casRows = documentsRows({
+			appealTypeCode: CASE_TYPES.CAS_PLANNING.processCode
+		});
+		const casRow = casRows.find((row) => row.keyText === 'Appeal statement');
+		expect(casRow.condition()).toBe(true);
+	});
+});

--- a/packages/forms-web-app/src/dynamic-forms/adverts-appeal-form/journey.js
+++ b/packages/forms-web-app/src/dynamic-forms/adverts-appeal-form/journey.js
@@ -17,13 +17,25 @@ const {
 	shouldDisplayTellingLandowners,
 	shouldDisplayUploadDecisionLetter,
 	shouldDisplayGridReference,
-	shouldDisplayAdvertsQuestions
+	shouldDisplayAdvertsQuestions,
+	shouldDisplayAppellantStatement: displayAppellantStatement
 } = require('../display-questions');
 
 /**
  * @typedef {import('@pins/dynamic-forms/src/journey-response').JourneyResponse} JourneyResponse
  * @typedef {Omit<ConstructorParameters<typeof import('@pins/dynamic-forms/src/journey').Journey>[0], 'response'>} JourneyParameters
  */
+
+/**
+ * @param {JourneyResponse} response
+ * @returns {boolean}
+ */
+const shouldDisplayAppellantStatement = (response) => {
+	if (shouldDisplayAdvertsQuestions(response)) {
+		return true;
+	}
+	return displayAppellantStatement(response);
+};
 
 /**
  * @param {JourneyResponse} response
@@ -85,7 +97,6 @@ const makeSections = (response) => {
 			.addQuestion(questions.inspectorAccess)
 			.addQuestion(questions.healthAndSafety)
 			.addQuestion(questions.enterApplicationReference)
-			.addQuestion(questions.planningApplicationDate)
 			.addQuestion(questions.enterAdvertisementDescription)
 			.addQuestion(questions.updateAdvertisementDescription)
 			.addQuestion(questions.uploadChangeOfAdvertisementEvidence)
@@ -138,6 +149,7 @@ const makeSections = (response) => {
 			.addQuestion(questions.uploadApplicationDecisionLetter)
 			.withCondition(() => shouldDisplayUploadDecisionLetter(response))
 			.addQuestion(questions.uploadAppellantStatement)
+			.withCondition(() => shouldDisplayAppellantStatement(response))
 			.addQuestion(questions.costApplication)
 			.addQuestion(questions.uploadCostApplication)
 			.withCondition(() => questionHasAnswer(response, questions.costApplication, 'yes'))

--- a/packages/forms-web-app/src/dynamic-forms/adverts-appeal-form/journey.test.js
+++ b/packages/forms-web-app/src/dynamic-forms/adverts-appeal-form/journey.test.js
@@ -218,4 +218,54 @@ describe('ADVERTS Appeal Form Journey', () => {
 				})
 		).toBe(true);
 	});
+
+	describe('uploadAppellantStatement condition', () => {
+		it('should include uploadAppellantStatement for non-CAS adverts appeals (application decision: GRANTED)', () => {
+			const answers = {
+				applicationDecision: APPLICATION_DECISION.GRANTED,
+				onApplicationDate: '2026-04-01T00:00:00.000Z'
+			};
+			const journey = new Journey({
+				...params,
+				response: { ...mockResponse, answers }
+			});
+			const uploadSection = journey.getSection('upload-documents');
+			const statementQuestion = uploadSection.questions.find(
+				(q) => q.fieldName === 'uploadAppellantStatement'
+			);
+			expect(statementQuestion.shouldDisplay(journey.response)).toBe(true);
+		});
+
+		it('should include uploadAppellantStatement for CAS adverts appeals if onApplicationDate is before April 1st 2026', () => {
+			const answers = {
+				applicationDecision: APPLICATION_DECISION.REFUSED,
+				onApplicationDate: '2026-03-30T12:00:00.000Z'
+			};
+			const journey = new Journey({
+				...params,
+				response: { ...mockResponse, answers }
+			});
+			const uploadSection = journey.getSection('upload-documents');
+			const statementQuestion = uploadSection.questions.find(
+				(q) => q.fieldName === 'uploadAppellantStatement'
+			);
+			expect(statementQuestion.shouldDisplay(journey.response)).toBe(true);
+		});
+
+		it('should not include uploadAppellantStatement for CAS adverts appeals if onApplicationDate is on or after April 1st 2026', () => {
+			const answers = {
+				applicationDecision: APPLICATION_DECISION.REFUSED,
+				onApplicationDate: '2026-04-01T00:00:00.000Z'
+			};
+			const journey = new Journey({
+				...params,
+				response: { ...mockResponse, answers }
+			});
+			const uploadSection = journey.getSection('upload-documents');
+			const statementQuestion = uploadSection.questions.find(
+				(q) => q.fieldName === 'uploadAppellantStatement'
+			);
+			expect(statementQuestion.shouldDisplay(journey.response)).toBe(false);
+		});
+	});
 });

--- a/packages/forms-web-app/src/dynamic-forms/controller.js
+++ b/packages/forms-web-app/src/dynamic-forms/controller.js
@@ -30,6 +30,7 @@ const {
 	generateRequiredDocuments,
 	generateOptionalDocuments
 } = require('#lib/documents-for-submission');
+const { isExpeditedAppealDate } = require('#lib/is-expedited-part1-eligible');
 const {
 	VIEW: {
 		FULL_APPEAL: { LIST_OF_DOCUMENTS_V2 }
@@ -518,11 +519,14 @@ exports.appellantBYSListOfDocuments = (req, res) => {
 		config.generateBetaBannerFeedbackLink(config.getAppealTypeFeedbackUrl(appealType));
 
 	const isExpeditedAppeal =
-		appeal.appealType === APPEAL_ID.PLANNING_SECTION_78 &&
-		[APPLICATION_DECISION.GRANTED, APPLICATION_DECISION.REFUSED].includes(
-			appeal.eligibility?.applicationDecision
-		) &&
-		new Date(appeal.applicationDate) >= new Date(2026, 3, 1);
+		(appeal.appealType === APPEAL_ID.PLANNING_SECTION_78 &&
+			[APPLICATION_DECISION.GRANTED, APPLICATION_DECISION.REFUSED].includes(
+				appeal.eligibility?.applicationDecision
+			) &&
+			isExpeditedAppealDate(appeal.applicationDate)) ||
+		((appeal.appealType === APPEAL_ID.HOUSEHOLDER ||
+			appeal.appealType === APPEAL_ID.MINOR_COMMERCIAL) &&
+			isExpeditedAppealDate(appeal.applicationDate));
 
 	const optionalDocuments = generateOptionalDocuments(appeal.appealType, isExpeditedAppeal);
 

--- a/packages/forms-web-app/src/dynamic-forms/display-questions.js
+++ b/packages/forms-web-app/src/dynamic-forms/display-questions.js
@@ -5,6 +5,7 @@ const {
 } = require('@pins/dynamic-forms/src/dynamic-components/utils/question-has-answer.js');
 const { APPLICATION_DECISION } = require('@pins/business-rules/src/constants');
 const { fieldValues } = require('@pins/common/src/dynamic-forms/field-values');
+const { isExpeditedAppealDate } = require('#lib/is-expedited-part1-eligible');
 
 /**
  * @typedef {import('@pins/dynamic-forms/src/journey-response').JourneyResponse} JourneyResponse
@@ -100,6 +101,15 @@ exports.shouldDisplayUploadDecisionLetter = (response) => {
  */
 exports.shouldDisplayAdvertsQuestions = (response) => {
 	return response.answers.applicationDecision !== APPLICATION_DECISION.REFUSED;
+};
+
+/**
+ * @param {JourneyResponse} response
+ * @returns {boolean}
+ */
+exports.shouldDisplayAppellantStatement = (response) => {
+	const applicationDate = response.answers.onApplicationDate;
+	return !isExpeditedAppealDate(applicationDate);
 };
 
 /**

--- a/packages/forms-web-app/src/dynamic-forms/docs/adverts-appeal-form-journey.md
+++ b/packages/forms-web-app/src/dynamic-forms/docs/adverts-appeal-form-journey.md
@@ -90,7 +90,6 @@ condition: () => shouldDisplayTellingLandowners(response, questions);
 - radio `/inspector-need-access/` Will an inspector need to access your land or property?
 - radio `/health-safety-issues/` Health and safety issues
 - single-line-input `/reference-number/` What is the application reference number?
-- date `/application-date/` What date did you submit your application?
 - text-entry `/description-advertisement/` Enter the description of the advertisement that you submitted in your application
 - boolean `/description-advertisement-correct/` Did the local planning authority change the description of the advertisement?
 - multi-file-upload `/upload-description-evidence/` Upload evidence of your agreement to change the description of the advertisement
@@ -168,6 +167,11 @@ condition: () => shouldDisplayUploadDecisionLetter(response);
 ```
 
 - multi-file-upload `/upload-appeal-statement/` Upload your appeal statement
+
+```js
+condition: () => shouldDisplayAppellantStatement(response);
+```
+
 - boolean `/apply-appeal-costs/` Do you want to apply for an award of appeal costs?
 - multi-file-upload `/upload-appeal-costs-application/` Upload your application for an award of appeal costs
 

--- a/packages/forms-web-app/src/dynamic-forms/docs/has-appeal-form-journey.md
+++ b/packages/forms-web-app/src/dynamic-forms/docs/has-appeal-form-journey.md
@@ -72,7 +72,6 @@ condition: () => shouldDisplayTellingLandowners(response, questions);
 - radio `/inspector-need-access/` Will an inspector need to access your land or property?
 - radio `/health-safety-issues/` Health and safety issues
 - single-line-input `/reference-number/` What is the application reference number?
-- date `/application-date/` What date did you submit your application?
 - text-entry `/enter-description-of-development/` Enter the description of development that you submitted in your application
 - boolean `/description-development-correct/` Did the local planning authority change the description of development?
 - text-entry `/why-are-you-appealing/` Why are you appealing?
@@ -95,6 +94,11 @@ condition: () => questionHasAnswer(response, questions.updateDevelopmentDescript
 
 - multi-file-upload `/upload-decision-letter/` Upload the decision letter from the local planning authority
 - multi-file-upload `/upload-appeal-statement/` Upload your appeal statement
+
+```js
+condition: () => shouldDisplayAppellantStatement(response);
+```
+
 - boolean `/apply-appeal-costs/` Do you want to apply for an award of appeal costs?
 - multi-file-upload `/upload-appeal-costs-application/` Upload your application for an award of appeal costs
 

--- a/packages/forms-web-app/src/dynamic-forms/has-appeal-form/journey.js
+++ b/packages/forms-web-app/src/dynamic-forms/has-appeal-form/journey.js
@@ -11,13 +11,14 @@ const {
 const config = require('../../config');
 const {
 	shouldDisplayTellingLandowners,
-	shouldDisplayIdentifyingLandowners
+	shouldDisplayIdentifyingLandowners,
+	shouldDisplayAppellantStatement
 } = require('../display-questions');
 
 /**
  * @typedef {import('@pins/dynamic-forms/src/journey-response').JourneyResponse} JourneyResponse
  * @typedef {Omit<ConstructorParameters<typeof import('@pins/dynamic-forms/src/journey').Journey>[0], 'response'>} JourneyParameters
-` */
+ */
 
 /**
  * @param {JourneyResponse} response
@@ -73,7 +74,6 @@ const makeSections = (response) => {
 			.addQuestion(questions.inspectorAccess)
 			.addQuestion(questions.healthAndSafety)
 			.addQuestion(questions.enterApplicationReference)
-			.addQuestion(questions.planningApplicationDate)
 			.addQuestion(questions.enterDevelopmentDescription)
 			.addQuestion(questions.updateDevelopmentDescription)
 			.addQuestion(questions.whyAreYouAppealingPart1)
@@ -89,6 +89,7 @@ const makeSections = (response) => {
 			)
 			.addQuestion(questions.uploadApplicationDecisionLetter)
 			.addQuestion(questions.uploadAppellantStatement)
+			.withCondition(() => shouldDisplayAppellantStatement(response))
 			.addQuestion(questions.costApplication)
 			.addQuestion(questions.uploadCostApplication)
 			.withCondition(() => questionHasAnswer(response, questions.costApplication, 'yes'))

--- a/packages/forms-web-app/src/dynamic-forms/has-appeal-form/journey.test.js
+++ b/packages/forms-web-app/src/dynamic-forms/has-appeal-form/journey.test.js
@@ -33,4 +33,54 @@ describe('HAS Appeal Form Journey', () => {
 		const journey = new Journey({ ...params, response: mockResponse });
 		expect(journey.journeyTitle).toBe('Appeal a planning decision');
 	});
+
+	describe('uploadAppellantStatement condition', () => {
+		it('should include uploadAppellantStatement if application date is before April 1st 2026', () => {
+			const answers = { onApplicationDate: '2026-03-30T12:00:00.000Z' };
+			const journey = new Journey({
+				...params,
+				response: {
+					...mockResponse,
+					answers
+				}
+			});
+			const uploadSection = journey.getSection('upload-documents');
+			const statementQuestion = uploadSection.questions.find(
+				(q) => q.fieldName === 'uploadAppellantStatement'
+			);
+			expect(statementQuestion.shouldDisplay(journey.response)).toBe(true);
+		});
+
+		it('should not include uploadAppellantStatement if application date is on or after April 1st 2026', () => {
+			const answers = { onApplicationDate: '2026-04-01T00:00:00.000Z' };
+			const journey = new Journey({
+				...params,
+				response: {
+					...mockResponse,
+					answers
+				}
+			});
+			const uploadSection = journey.getSection('upload-documents');
+			const statementQuestion = uploadSection.questions.find(
+				(q) => q.fieldName === 'uploadAppellantStatement'
+			);
+			expect(statementQuestion.shouldDisplay(journey.response)).toBe(false);
+		});
+
+		it('should include uploadAppellantStatement if application date is not set', () => {
+			const answers = {};
+			const journey = new Journey({
+				...params,
+				response: {
+					...mockResponse,
+					answers
+				}
+			});
+			const uploadSection = journey.getSection('upload-documents');
+			const statementQuestion = uploadSection.questions.find(
+				(q) => q.fieldName === 'uploadAppellantStatement'
+			);
+			expect(statementQuestion.shouldDisplay(journey.response)).toBe(true);
+		});
+	});
 });

--- a/packages/forms-web-app/src/journeys/__snapshots__/index.test.js.snap
+++ b/packages/forms-web-app/src/journeys/__snapshots__/index.test.js.snap
@@ -207,65 +207,6 @@ exports[`Dynamic forms journey tests appellant Advertisement Advertisement shoul
 </main>"
 `;
 
-exports[`Dynamic forms journey tests appellant Advertisement Advertisement should render the application-date question 1`] = `
-"<main id="main-content" role="main" class="govuk-main-wrapper govuk-main-wrapper--auto-spacing">
-    <div class="govuk-grid-row">
-        <div class="govuk-grid-column-two-thirds"></div>
-    </div>
-    <div class="govuk-grid-row">
-        <div class="govuk-grid-column-two-thirds"><span class="govuk-caption-l"> Prepare appeal</span>
-        </div>
-    </div>
-    <div class="govuk-grid-row">
-        <div class="govuk-grid-column-two-thirds">
-            <form action="/appeals/adverts/prepare-appeal/application-date?id=appeal-ref"
-            method="post" novalidate=null>
-                <div class="govuk-form-group">
-                    <fieldset class="govuk-fieldset" role="group" aria-describedby="onApplicationDate-hint">
-                        <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
-                            <h1 class="govuk-fieldset__heading"> What date did you submit your application?</h1>
-                        </legend>
-                        <div id="onApplicationDate-hint" class="govuk-hint">For example, 5 6 2025</div>
-                        <div class="govuk-date-input" id="onApplicationDate">
-                            <div class="govuk-date-input__item">
-                                <div class="govuk-form-group">
-                                    <label class="govuk-label govuk-date-input__label" for="onApplicationDate_day">Day</label>
-                                    <input class="govuk-input govuk-date-input__input govuk-input--width-2"
-                                    id="onApplicationDate_day" name="onApplicationDate_day" type="text" inputmode="numeric">
-                                </div>
-                            </div>
-                            <div class="govuk-date-input__item">
-                                <div class="govuk-form-group">
-                                    <label class="govuk-label govuk-date-input__label" for="onApplicationDate_month">Month</label>
-                                    <input class="govuk-input govuk-date-input__input govuk-input--width-2"
-                                    id="onApplicationDate_month" name="onApplicationDate_month" type="text"
-                                    inputmode="numeric">
-                                </div>
-                            </div>
-                            <div class="govuk-date-input__item">
-                                <div class="govuk-form-group">
-                                    <label class="govuk-label govuk-date-input__label" for="onApplicationDate_year">Year</label>
-                                    <input class="govuk-input govuk-date-input__input govuk-input--width-4"
-                                    id="onApplicationDate_year" name="onApplicationDate_year" type="text" inputmode="numeric">
-                                </div>
-                            </div>
-                        </div>
-                    </fieldset>
-                </div>
-                <button type="submit" class="govuk-button" data-module="govuk-button"
-                data-cy="button-save-and-continue">Continue</button>
-            </form>
-        </div>
-    </div>
-    <div class="govuk-grid-row">
-        <div class="govuk-grid-column-two-thirds">
-            <p class="govuk-body"><a href="/appeals/adverts/appeal-form/your-appeal?id=appeal-ref" class="govuk-link">Return to your appeal</a>
-            </p>
-        </div>
-    </div>
-</main>"
-`;
-
 exports[`Dynamic forms journey tests appellant Advertisement Advertisement should render the application-name question 1`] = `
 "<main id="main-content" role="main" class="govuk-main-wrapper govuk-main-wrapper--auto-spacing">
     <div class="govuk-grid-row">
@@ -1926,12 +1867,6 @@ exports[`Dynamic forms journey tests appellant Advertisement renders listing pag
                                 <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals/adverts/prepare-appeal/reference-number?id=appeal-ref">Answer<span class="govuk-visually-hidden"> What is the application reference number?</span></a>
                                 </dd>
                         </div>
-                        <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> What date did you submit your application?</dt>
-                            <dd
-                            class="govuk-summary-list__value">Not started</dd>
-                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals/adverts/prepare-appeal/application-date?id=appeal-ref">Answer<span class="govuk-visually-hidden"> What date did you submit your application?</span></a>
-                                </dd>
-                        </div>
                         <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Enter the description of the advertisement</dt>
                             <dd
                             class="govuk-summary-list__value">Not started</dd>
@@ -2202,65 +2137,6 @@ exports[`Dynamic forms journey tests appellant Commercial advertisement Commerci
                         id="appellantCompanyName" name="appellantCompanyName" type="text" spellcheck="false">
                     </div>
                 </fieldset>
-                <button type="submit" class="govuk-button" data-module="govuk-button"
-                data-cy="button-save-and-continue">Continue</button>
-            </form>
-        </div>
-    </div>
-    <div class="govuk-grid-row">
-        <div class="govuk-grid-column-two-thirds">
-            <p class="govuk-body"><a href="/appeals/adverts/appeal-form/your-appeal?id=appeal-ref" class="govuk-link">Return to your appeal</a>
-            </p>
-        </div>
-    </div>
-</main>"
-`;
-
-exports[`Dynamic forms journey tests appellant Commercial advertisement Commercial advertisement should render the application-date question 1`] = `
-"<main id="main-content" role="main" class="govuk-main-wrapper govuk-main-wrapper--auto-spacing">
-    <div class="govuk-grid-row">
-        <div class="govuk-grid-column-two-thirds"></div>
-    </div>
-    <div class="govuk-grid-row">
-        <div class="govuk-grid-column-two-thirds"><span class="govuk-caption-l"> Prepare appeal</span>
-        </div>
-    </div>
-    <div class="govuk-grid-row">
-        <div class="govuk-grid-column-two-thirds">
-            <form action="/appeals/adverts/prepare-appeal/application-date?id=appeal-ref"
-            method="post" novalidate=null>
-                <div class="govuk-form-group">
-                    <fieldset class="govuk-fieldset" role="group" aria-describedby="onApplicationDate-hint">
-                        <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
-                            <h1 class="govuk-fieldset__heading"> What date did you submit your application?</h1>
-                        </legend>
-                        <div id="onApplicationDate-hint" class="govuk-hint">For example, 5 6 2025</div>
-                        <div class="govuk-date-input" id="onApplicationDate">
-                            <div class="govuk-date-input__item">
-                                <div class="govuk-form-group">
-                                    <label class="govuk-label govuk-date-input__label" for="onApplicationDate_day">Day</label>
-                                    <input class="govuk-input govuk-date-input__input govuk-input--width-2"
-                                    id="onApplicationDate_day" name="onApplicationDate_day" type="text" inputmode="numeric">
-                                </div>
-                            </div>
-                            <div class="govuk-date-input__item">
-                                <div class="govuk-form-group">
-                                    <label class="govuk-label govuk-date-input__label" for="onApplicationDate_month">Month</label>
-                                    <input class="govuk-input govuk-date-input__input govuk-input--width-2"
-                                    id="onApplicationDate_month" name="onApplicationDate_month" type="text"
-                                    inputmode="numeric">
-                                </div>
-                            </div>
-                            <div class="govuk-date-input__item">
-                                <div class="govuk-form-group">
-                                    <label class="govuk-label govuk-date-input__label" for="onApplicationDate_year">Year</label>
-                                    <input class="govuk-input govuk-date-input__input govuk-input--width-4"
-                                    id="onApplicationDate_year" name="onApplicationDate_year" type="text" inputmode="numeric">
-                                </div>
-                            </div>
-                        </div>
-                    </fieldset>
-                </div>
                 <button type="submit" class="govuk-button" data-module="govuk-button"
                 data-cy="button-save-and-continue">Continue</button>
             </form>
@@ -3933,12 +3809,6 @@ exports[`Dynamic forms journey tests appellant Commercial advertisement renders 
                             <dd
                             class="govuk-summary-list__value">Not started</dd>
                                 <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals/adverts/prepare-appeal/reference-number?id=appeal-ref">Answer<span class="govuk-visually-hidden"> What is the application reference number?</span></a>
-                                </dd>
-                        </div>
-                        <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> What date did you submit your application?</dt>
-                            <dd
-                            class="govuk-summary-list__value">Not started</dd>
-                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals/adverts/prepare-appeal/application-date?id=appeal-ref">Answer<span class="govuk-visually-hidden"> What date did you submit your application?</span></a>
                                 </dd>
                         </div>
                         <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Enter the description of the advertisement</dt>
@@ -12699,65 +12569,6 @@ exports[`Dynamic forms journey tests appellant Householder Householder should re
 </main>"
 `;
 
-exports[`Dynamic forms journey tests appellant Householder Householder should render the application-date question 1`] = `
-"<main id="main-content" role="main" class="govuk-main-wrapper govuk-main-wrapper--auto-spacing">
-    <div class="govuk-grid-row">
-        <div class="govuk-grid-column-two-thirds"></div>
-    </div>
-    <div class="govuk-grid-row">
-        <div class="govuk-grid-column-two-thirds"><span class="govuk-caption-l"> Prepare appeal</span>
-        </div>
-    </div>
-    <div class="govuk-grid-row">
-        <div class="govuk-grid-column-two-thirds">
-            <form action="/appeals/householder/prepare-appeal/application-date?id=appeal-ref"
-            method="post" novalidate=null>
-                <div class="govuk-form-group">
-                    <fieldset class="govuk-fieldset" role="group" aria-describedby="onApplicationDate-hint">
-                        <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
-                            <h1 class="govuk-fieldset__heading"> What date did you submit your application?</h1>
-                        </legend>
-                        <div id="onApplicationDate-hint" class="govuk-hint">For example, 5 6 2025</div>
-                        <div class="govuk-date-input" id="onApplicationDate">
-                            <div class="govuk-date-input__item">
-                                <div class="govuk-form-group">
-                                    <label class="govuk-label govuk-date-input__label" for="onApplicationDate_day">Day</label>
-                                    <input class="govuk-input govuk-date-input__input govuk-input--width-2"
-                                    id="onApplicationDate_day" name="onApplicationDate_day" type="text" inputmode="numeric">
-                                </div>
-                            </div>
-                            <div class="govuk-date-input__item">
-                                <div class="govuk-form-group">
-                                    <label class="govuk-label govuk-date-input__label" for="onApplicationDate_month">Month</label>
-                                    <input class="govuk-input govuk-date-input__input govuk-input--width-2"
-                                    id="onApplicationDate_month" name="onApplicationDate_month" type="text"
-                                    inputmode="numeric">
-                                </div>
-                            </div>
-                            <div class="govuk-date-input__item">
-                                <div class="govuk-form-group">
-                                    <label class="govuk-label govuk-date-input__label" for="onApplicationDate_year">Year</label>
-                                    <input class="govuk-input govuk-date-input__input govuk-input--width-4"
-                                    id="onApplicationDate_year" name="onApplicationDate_year" type="text" inputmode="numeric">
-                                </div>
-                            </div>
-                        </div>
-                    </fieldset>
-                </div>
-                <button type="submit" class="govuk-button" data-module="govuk-button"
-                data-cy="button-save-and-continue">Continue</button>
-            </form>
-        </div>
-    </div>
-    <div class="govuk-grid-row">
-        <div class="govuk-grid-column-two-thirds">
-            <p class="govuk-body"><a href="/appeals/householder/appeal-form/your-appeal?id=appeal-ref" class="govuk-link">Return to your appeal</a>
-            </p>
-        </div>
-    </div>
-</main>"
-`;
-
 exports[`Dynamic forms journey tests appellant Householder Householder should render the application-name question 1`] = `
 "<main id="main-content" role="main" class="govuk-main-wrapper govuk-main-wrapper--auto-spacing">
     <div class="govuk-grid-row">
@@ -14120,12 +13931,6 @@ exports[`Dynamic forms journey tests appellant Householder renders listing page 
                             <dd
                             class="govuk-summary-list__value">Not started</dd>
                                 <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals/householder/prepare-appeal/reference-number?id=appeal-ref">Answer<span class="govuk-visually-hidden"> What is the application reference number?</span></a>
-                                </dd>
-                        </div>
-                        <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> What date did you submit your application?</dt>
-                            <dd
-                            class="govuk-summary-list__value">Not started</dd>
-                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals/householder/prepare-appeal/application-date?id=appeal-ref">Answer<span class="govuk-visually-hidden"> What date did you submit your application?</span></a>
                                 </dd>
                         </div>
                         <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Enter the description of development that you submitted in your application</dt>

--- a/packages/forms-web-app/src/lib/documents-for-submission.js
+++ b/packages/forms-web-app/src/lib/documents-for-submission.js
@@ -35,6 +35,9 @@ const generateRequiredDocuments = (appealType) => {
 const generateOptionalDocuments = (appealType, isExpeditedAppeal) => {
 	switch (appealType) {
 		case APPEAL_ID.HOUSEHOLDER:
+			if (isExpeditedAppeal) {
+				return ['decision letter from the local planning authority'];
+			}
 			return [
 				'decision letter from the local planning authority',
 				'appeal statement (including the reason for your appeal and the reasons why you think the local planning authority’s decision is wrong)'
@@ -68,6 +71,9 @@ const generateOptionalDocuments = (appealType, isExpeditedAppeal) => {
 				'appeal statement (including the reason for your appeal and the reasons why you think the local planning authority’s decision is wrong)'
 			];
 		case APPEAL_ID.MINOR_COMMERCIAL:
+			if (isExpeditedAppeal) {
+				return ['decision letter from the local planning authority'];
+			}
 			return [
 				'decision letter from the local planning authority',
 				'design and access statement',

--- a/packages/forms-web-app/src/lib/documents-for-submission.test.js
+++ b/packages/forms-web-app/src/lib/documents-for-submission.test.js
@@ -150,4 +150,14 @@ describe('optional documents-for-submission', () => {
 			'an environment statement'
 		]);
 	});
+
+	it('should return correct required documents for expedited Householder appeal', () => {
+		const result = generateOptionalDocuments(APPEAL_ID.HOUSEHOLDER, true);
+		expect(result).toEqual(['decision letter from the local planning authority']);
+	});
+
+	it('should return correct required documents for expedited Minor Commercial appeal', () => {
+		const result = generateOptionalDocuments(APPEAL_ID.MINOR_COMMERCIAL, true);
+		expect(result).toEqual(['decision letter from the local planning authority']);
+	});
 });

--- a/packages/forms-web-app/src/lib/is-expedited-part1-eligible.js
+++ b/packages/forms-web-app/src/lib/is-expedited-part1-eligible.js
@@ -53,7 +53,23 @@ const isExpeditedPart1Eligible = (appeal) => {
 	);
 };
 
+/**
+ * @param {string|Date|undefined|null} value
+ * @returns {boolean}
+ */
+const isExpeditedAppealDate = (value) => {
+	const applicationDate = parseApplicationDate(value);
+	if (!applicationDate) {
+		return false;
+	}
+
+	return (
+		formatInTimeZone(applicationDate, UK_TIME_ZONE, 'yyyy-MM-dd') >= EXPEDITED_PART_1_CUTOFF_DATE
+	);
+};
+
 module.exports = {
 	EXPEDITED_PART_1_CUTOFF_DATE,
-	isExpeditedPart1Eligible
+	isExpeditedPart1Eligible,
+	isExpeditedAppealDate
 };

--- a/packages/forms-web-app/src/lib/is-expedited-part1-eligible.test.js
+++ b/packages/forms-web-app/src/lib/is-expedited-part1-eligible.test.js
@@ -2,7 +2,8 @@ const { APPLICATION_DECISION, TYPE_OF_PLANNING_APPLICATION } =
 	require('@pins/business-rules').constants;
 const {
 	EXPEDITED_PART_1_CUTOFF_DATE,
-	isExpeditedPart1Eligible
+	isExpeditedPart1Eligible,
+	isExpeditedAppealDate
 } = require('./is-expedited-part1-eligible');
 
 describe('isExpeditedPart1Eligible', () => {
@@ -82,6 +83,27 @@ describe('isExpeditedPart1Eligible', () => {
 					}
 				})
 			).toBe(false);
+		}
+	);
+});
+
+describe('isExpeditedAppealDate', () => {
+	it('returns true when the date is on the cutoff', () => {
+		expect(isExpeditedAppealDate('2026-04-01T00:00:00.000Z')).toBe(true);
+	});
+
+	it('returns true when the date is after the cutoff', () => {
+		expect(isExpeditedAppealDate('2026-04-02T10:30:00.000Z')).toBe(true);
+	});
+
+	it('returns false when the date is before the cutoff', () => {
+		expect(isExpeditedAppealDate('2026-03-30T12:00:00.000Z')).toBe(false);
+	});
+
+	it.each([undefined, null, 'not-a-date'])(
+		'returns false when the application date is %p',
+		(applicationDate) => {
+			expect(isExpeditedAppealDate(applicationDate)).toBe(false);
 		}
 	);
 });


### PR DESCRIPTION
### Description of change

Updates:
Removed appellant statement from CAS adverts and HAS appeals.
Added the application date to the BYS journey
Updated process for BYS journey to save the application date to the database for use in the appeal for HAS and Advert appeals.


Testing:
Updated/Added relevant tests where required
Manually tested in browser

Ticket: https://pins-ds.atlassian.net/browse/A2-8385

### Checklist

- [x] Feature complete and ready for users, or behind feature-flag
- [x] Commit history is linear with no merge commits
- [ ] Requires infrastructure changes

### Important

Please do not merge from `main` (please only [rebase](https://github.com/Planning-Inspectorate/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
