### PR TITLE
feat(A2-7912): amend enforcement can use service summary screen

### DIFF
--- a/packages/forms-web-app/__tests__/unit/controllers/before-you-start/can-use-service.test.js
+++ b/packages/forms-web-app/__tests__/unit/controllers/before-you-start/can-use-service.test.js
@@ -556,10 +556,14 @@ describe('controllers/before-you-start/can-use-service', () => {
 	describe('getCanUseService - enforcement notice', () => {
 		it('renders page - enforcement - effective date not passed', async () => {
 			req = mockReq(enforcementNotice);
+			//for NEW BYS flow flag
+			isLpaInFeatureFlag.mockResolvedValue(true);
 
 			await getCanUseService(req, res);
 
 			expect(res.render).toHaveBeenCalledWith(canUseServiceEnforcementView, {
+				isNewBYSFlow: true,
+				appealTypeText: 'Enforcement notice',
 				deadlineDate: { date: 3, day: 'Tuesday', month: 'May', year: 2022 },
 				appealLPD: 'Bradford',
 				enforcementNotice: 'Yes',
@@ -580,10 +584,14 @@ describe('controllers/before-you-start/can-use-service', () => {
 			enforcementNotice.eligibility.hasContactedPlanningInspectorate = true;
 			enforcementNotice.eligibility.contactPlanningInspectorateDate = '2022-05-04T10:55:46.164Z';
 			req = mockReq(enforcementNotice);
+			//for NEW BYS flow flag
+			isLpaInFeatureFlag.mockResolvedValue(true);
 
 			await getCanUseService(req, res);
 
 			expect(res.render).toHaveBeenCalledWith(canUseServiceEnforcementView, {
+				isNewBYSFlow: true,
+				appealTypeText: 'Enforcement notice',
 				deadlineDate: { date: 10, day: 'Tuesday', month: 'May', year: 2022 },
 				appealLPD: 'Bradford',
 				enforcementNotice: 'Yes',
@@ -605,10 +613,14 @@ describe('controllers/before-you-start/can-use-service', () => {
 		it('renders page - enforcement listed building - effective date not passed', async () => {
 			enforcementNotice.eligibility.enforcementNoticeListedBuilding = true;
 			req = mockReq(enforcementNotice);
+			//for NEW BYS flow flag
+			isLpaInFeatureFlag.mockResolvedValue(true);
 
 			await getCanUseService(req, res);
 
 			expect(res.render).toHaveBeenCalledWith(canUseServiceEnforcementView, {
+				isNewBYSFlow: true,
+				appealTypeText: 'Enforcement listed building and conservation area',
 				deadlineDate: { date: 3, day: 'Tuesday', month: 'May', year: 2022 },
 				appealLPD: 'Bradford',
 				enforcementNotice: 'Yes',
@@ -632,10 +644,14 @@ describe('controllers/before-you-start/can-use-service', () => {
 			enforcementNotice.eligibility.hasContactedPlanningInspectorate = true;
 			enforcementNotice.eligibility.contactPlanningInspectorateDate = '2022-05-04T10:55:46.164Z';
 			req = mockReq(enforcementNotice);
+			//for NEW BYS flow flag
+			isLpaInFeatureFlag.mockResolvedValue(true);
 
 			await getCanUseService(req, res);
 
 			expect(res.render).toHaveBeenCalledWith(canUseServiceEnforcementView, {
+				isNewBYSFlow: true,
+				appealTypeText: 'Enforcement listed building and conservation area',
 				deadlineDate: { date: 10, day: 'Tuesday', month: 'May', year: 2022 },
 				appealLPD: 'Bradford',
 				enforcementNotice: 'Yes',

--- a/packages/forms-web-app/src/controllers/before-you-start/can-use-service.js
+++ b/packages/forms-web-app/src/controllers/before-you-start/can-use-service.js
@@ -44,6 +44,8 @@ const config = require('../../config');
 const changeLpaUrl = '/before-you-start/local-planning-authority';
 const { caseTypeLookup } = require('@pins/common/src/database/data-static');
 const formatDate = require('#lib/format-date-check-your-answers');
+const { isLpaInFeatureFlag } = require('#lib/is-lpa-in-feature-flag');
+const { FLAG } = require('@pins/common/src/feature-flags');
 
 const canUseServiceHouseholderPlanning = async (req, res) => {
 	const { appeal } = req.session;
@@ -249,7 +251,16 @@ const canUseServiceEnforcement = async (req, res) => {
 		? 'ENFORCEMENT_LISTED_BUILDING'
 		: 'ENFORCEMENT';
 
+	const isNewBYSFlow = await isLpaInFeatureFlag(appeal.lpaCode, FLAG.NEW_BYS_ENFORCEMENT);
+
+	const appealTypeText =
+		appealType === 'ENFORCEMENT_LISTED_BUILDING'
+			? 'Enforcement listed building and conservation area'
+			: 'Enforcement notice';
+
 	res.render(canUseServiceEnforcementView, {
+		isNewBYSFlow,
+		appealTypeText,
 		deadlineDate,
 		appealLPD,
 		enforcementNotice,

--- a/packages/forms-web-app/src/views/before-you-start/enforcement-can-use-service.njk
+++ b/packages/forms-web-app/src/views/before-you-start/enforcement-can-use-service.njk
@@ -46,6 +46,70 @@
 	{% set contactPlanningInspectorateDateRow = null %}
 {% endif %}
 
+{% if isNewBYSFlow %}
+	{% set whatIsYourAppealAboutRow = {
+		key: {
+			text: "What is your appeal about?"
+		},
+		value: {
+			text: summaryField(appealTypeText, { 'data-cy': "what-is-appeal-about" })
+		},
+		actions: {
+			items: [
+				{
+					href: "/before-you-start/type-of-planning-application",
+					text: "Change",
+					visuallyHiddenText: "What is your appeal about?",
+					attributes: { "data-cy":"appealType"}
+				}
+			]
+		}
+	}
+	%}
+	{% set enforcementNoticeRow = null %}
+	{% set enforcementNoticeListedBuildingRow = null %}
+{% else %}
+	{% set whatIsYourAppealAboutRow = null %}
+	{% set enforcementNoticeRow = {
+		key: {
+			text: "Have you received an enforcement notice?"
+		},
+		value: {
+				text: summaryField(enforcementNotice, { 'data-cy': "enforcement-notice" })
+		},
+		actions: {
+			items: [
+				{
+					href: "/before-you-start/enforcement-notice",
+					text: "Change",
+					visuallyHiddenText: "Have you received an enforcement notice?",
+					attributes: { "data-cy":"enforcementNotice"}
+				}
+			]
+		}
+	}
+	%}
+	{% set enforcementNoticeListedBuildingRow = {
+		key: {
+			text: "Is your enforcement notice about a listed building?"
+		},
+		value: {
+			text: summaryField(enforcementNoticeListedBuilding, { 'data-cy': "application-type" })
+		},
+		actions: {
+			items: [
+				{
+					href: "/before-you-start/enforcement-notice-listed-building",
+					text: "Change",
+					visuallyHiddenText: "Is your enforcement notice about a listed building?",
+					attributes: { "data-cy":"enforcementNoticeListedBuilding"}
+				}
+			]
+		}
+	}
+	%}
+{% endif %}
+
 {% block canUseServiceSummaryList %}
 	{{ govukSummaryList({
 		classes: "govuk-summary-list govuk-!-margin-bottom-9",
@@ -68,42 +132,9 @@
 				]
 			}
 			},
-			{
-				key: {
-				text: "Have you received an enforcement notice?"
-			},
-				value: {
-				text: summaryField(enforcementNotice, { 'data-cy': "enforcement-notice" })
-			},
-				actions: {
-				items: [
-					{
-						href: "/before-you-start/enforcement-notice",
-						text: "Change",
-						visuallyHiddenText: "Have you received an enforcement notice?",
-						attributes: { "data-cy":"enforcementNotice"}
-					}
-				]
-			}
-			},
-			{
-				key: {
-				text: "Is your enforcement notice about a listed building?"
-			},
-				value: {
-				text: summaryField(enforcementNoticeListedBuilding, { 'data-cy': "application-type" })
-			},
-				actions: {
-				items: [
-					{
-						href: "/before-you-start/enforcement-notice-listed-building",
-						text: "Change",
-						visuallyHiddenText: "Is your enforcement notice about a listed building?",
-						attributes: { "data-cy":"enforcementNoticeListedBuilding"}
-					}
-				]
-			}
-			},
+			whatIsYourAppealAboutRow,
+			enforcementNoticeRow,
+			enforcementNoticeListedBuildingRow,
 			{
 				key: {
 				text: "What is the issue date on your enforcement notice?"


### PR DESCRIPTION
### Description of change

Amends the can use service screen for enforcement / elb appeals if new bys journey flag is on.

(Note, this should be merged after https://github.com/Planning-Inspectorate/appeal-planning-decision/pull/5420 )

Ticket: https://pins-ds.atlassian.net/browse/A2-7912

### Checklist

- [X] Feature complete and ready for users, or behind feature-flag
- [X] Commit history is linear with no merge commits
- [ ] Requires infrastructure changes

### Important

Please do not merge from `main` (please only [rebase](https://github.com/Planning-Inspectorate/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
