### PR TITLE
fix(A2-8425): remove appellant statement from CAS planning

### DIFF
--- a/packages/forms-web-app/__tests__/unit/controllers/before-you-start/planning-application-about.test.js
+++ b/packages/forms-web-app/__tests__/unit/controllers/before-you-start/planning-application-about.test.js
@@ -140,7 +140,7 @@ describe('Planning Application About Controller', () => {
 					})
 				})
 			);
-			expect(res.redirect).toHaveBeenCalledWith('/before-you-start/granted-or-refused');
+			expect(res.redirect).toHaveBeenCalledWith('/before-you-start/application-date');
 		});
 
 		it('handles array input for planningApplicationAbout', async () => {

--- a/packages/forms-web-app/__tests__/unit/controllers/full-appeal/application-date.test.js
+++ b/packages/forms-web-app/__tests__/unit/controllers/full-appeal/application-date.test.js
@@ -78,6 +78,52 @@ describe('controllers/full-appeal/application-date', () => {
 			expect(res.redirect).toHaveBeenCalledWith(`/before-you-start/granted-or-refused`);
 		});
 
+		it('should save the appeal and redirect to decision-date if appealType is MINOR_COMMERCIAL_ADVERTISEMENT', async () => {
+			const applicationDate = addDays(subDays(startOfDay(new Date()), 181), 1);
+			const mockRequest = {
+				...req,
+				body: {
+					'application-date-year': getYear(applicationDate),
+					'application-date-month': getMonth(applicationDate) + 1,
+					'application-date-day': getDate(applicationDate)
+				},
+				session: {
+					appeal: {
+						...appeal,
+						appealType: constants.APPEAL_ID.MINOR_COMMERCIAL_ADVERTISEMENT,
+						typeOfPlanningApplication: constants.TYPE_OF_PLANNING_APPLICATION.ADVERTISEMENT
+					}
+				}
+			};
+
+			await postApplicationDate(mockRequest, res);
+
+			expect(res.redirect).toHaveBeenCalledWith('/before-you-start/decision-date');
+		});
+
+		it('should save the appeal and redirect to granted-or-refused if typeOfPlanningApplication is MINOR_COMMERCIAL_DEVELOPMENT', async () => {
+			const applicationDate = addDays(subDays(startOfDay(new Date()), 181), 1);
+			const mockRequest = {
+				...req,
+				body: {
+					'application-date-year': getYear(applicationDate),
+					'application-date-month': getMonth(applicationDate) + 1,
+					'application-date-day': getDate(applicationDate)
+				},
+				session: {
+					appeal: {
+						...appeal,
+						typeOfPlanningApplication:
+							constants.TYPE_OF_PLANNING_APPLICATION.MINOR_COMMERCIAL_DEVELOPMENT
+					}
+				}
+			};
+
+			await postApplicationDate(mockRequest, res);
+
+			expect(res.redirect).toHaveBeenCalledWith('/before-you-start/granted-or-refused');
+		});
+
 		it('should display the application date template with errors if any field is invalid', async () => {
 			const mockRequest = {
 				...req,

--- a/packages/forms-web-app/__tests__/unit/controllers/full-appeal/granted-or-refused.test.js
+++ b/packages/forms-web-app/__tests__/unit/controllers/full-appeal/granted-or-refused.test.js
@@ -196,7 +196,7 @@ describe('controllers/full-appeal/granted-or-refused', () => {
 
 				expect(createOrUpdateAppeal).toHaveBeenCalledWith(advertisementApplicationAppeal);
 
-				expect(res.redirect).toHaveBeenCalledWith('/before-you-start/decision-date');
+				expect(res.redirect).toHaveBeenCalledWith('/before-you-start/application-date');
 			});
 
 			it(`'should redirect to '/${DECISION_DATE}' with appeal type ADVERTISEMENT if 'applicationDecision' is 'granted'`, async () => {

--- a/packages/forms-web-app/__tests__/unit/controllers/full-appeal/type-of-planning-application.test.js
+++ b/packages/forms-web-app/__tests__/unit/controllers/full-appeal/type-of-planning-application.test.js
@@ -213,7 +213,7 @@ describe('controllers/full-appeal/type-of-planning-application', () => {
 					...updatedAppeal
 				});
 
-				expect(res.redirect).toHaveBeenCalledWith('/before-you-start/application-date');
+				expect(res.redirect).toHaveBeenCalledWith('/before-you-start/granted-or-refused');
 			}
 		);
 
@@ -287,7 +287,7 @@ describe('controllers/full-appeal/type-of-planning-application', () => {
 				...updatedAppeal
 			});
 
-			expect(res.redirect).toHaveBeenCalledWith('/before-you-start/application-date');
+			expect(res.redirect).toHaveBeenCalledWith('/before-you-start/planning-application-about');
 		});
 
 		it('should redirect to the listed building page and not change the listedBuilding response - ldc', async () => {

--- a/packages/forms-web-app/src/controllers/before-you-start/planning-application-about.js
+++ b/packages/forms-web-app/src/controllers/before-you-start/planning-application-about.js
@@ -71,6 +71,10 @@ exports.postApplicationAbout = async (req, res) => {
 		return;
 	}
 
+	if (isCASPlanning) {
+		return res.redirect('/before-you-start/application-date');
+	}
+
 	res.redirect('/before-you-start/granted-or-refused');
 };
 

--- a/packages/forms-web-app/src/controllers/full-appeal/application-date.js
+++ b/packages/forms-web-app/src/controllers/full-appeal/application-date.js
@@ -6,9 +6,7 @@ const {
 } = require('#lib/views');
 const { parseISO, isValid } = require('date-fns');
 const logger = require('#lib/logger');
-const {
-	constants: { TYPE_OF_PLANNING_APPLICATION }
-} = require('@pins/business-rules');
+const { TYPE_OF_PLANNING_APPLICATION, APPEAL_ID } = require('@pins/business-rules/src/constants');
 
 const getApplicationDate = async (req, res) => {
 	const { appeal } = req.session;
@@ -54,6 +52,10 @@ const postApplicationDate = async (req, res) => {
 			applicationDate: enteredDate.toISOString()
 		});
 
+		if (appeal.appealType === APPEAL_ID.MINOR_COMMERCIAL_ADVERTISEMENT) {
+			return res.redirect('/before-you-start/decision-date');
+		}
+
 		if (appeal.typeOfPlanningApplication === TYPE_OF_PLANNING_APPLICATION.HOUSEHOLDER_PLANNING) {
 			return res.redirect('/before-you-start/granted-or-refused-householder');
 		}
@@ -61,7 +63,7 @@ const postApplicationDate = async (req, res) => {
 		if (
 			appeal.typeOfPlanningApplication === TYPE_OF_PLANNING_APPLICATION.MINOR_COMMERCIAL_DEVELOPMENT
 		) {
-			return res.redirect('/before-you-start/planning-application-about');
+			return res.redirect('/before-you-start/granted-or-refused');
 		}
 
 		return res.redirect(`/before-you-start/granted-or-refused`);

--- a/packages/forms-web-app/src/controllers/full-appeal/granted-or-refused.js
+++ b/packages/forms-web-app/src/controllers/full-appeal/granted-or-refused.js
@@ -83,5 +83,9 @@ exports.postGrantedOrRefused = async (req, res) => {
 		return;
 	}
 
+	if (appeal.appealType === APPEAL_ID.MINOR_COMMERCIAL_ADVERTISEMENT) {
+		return res.redirect('/before-you-start/application-date');
+	}
+
 	res.redirect(`${this.forwardPage(selectedApplicationStatus)}`);
 };

--- a/packages/forms-web-app/src/controllers/full-appeal/type-of-planning-application.js
+++ b/packages/forms-web-app/src/controllers/full-appeal/type-of-planning-application.js
@@ -91,9 +91,11 @@ const postTypeOfPlanningApplication = async (req, res) => {
 
 	switch (typeOfPlanningApplication) {
 		case HOUSEHOLDER_PLANNING:
-		case MINOR_COMMERCIAL_DEVELOPMENT:
-		case ADVERTISEMENT:
 			return res.redirect('/before-you-start/application-date');
+		case MINOR_COMMERCIAL_DEVELOPMENT:
+			return res.redirect('/before-you-start/planning-application-about');
+		case ADVERTISEMENT:
+			return res.redirect('/before-you-start/granted-or-refused');
 		case LISTED_BUILDING:
 			return res.redirect('/before-you-start/granted-or-refused');
 		case LAWFUL_DEVELOPMENT_CERTIFICATE:

--- a/packages/forms-web-app/src/dynamic-forms/adverts-appeal-form/journey.js
+++ b/packages/forms-web-app/src/dynamic-forms/adverts-appeal-form/journey.js
@@ -97,6 +97,8 @@ const makeSections = (response) => {
 			.addQuestion(questions.inspectorAccess)
 			.addQuestion(questions.healthAndSafety)
 			.addQuestion(questions.enterApplicationReference)
+			.addQuestion(questions.planningApplicationDate)
+			.withCondition(() => shouldDisplayAdvertsQuestions(response))
 			.addQuestion(questions.enterAdvertisementDescription)
 			.addQuestion(questions.updateAdvertisementDescription)
 			.addQuestion(questions.uploadChangeOfAdvertisementEvidence)

--- a/packages/forms-web-app/src/dynamic-forms/adverts-appeal-form/journey.test.js
+++ b/packages/forms-web-app/src/dynamic-forms/adverts-appeal-form/journey.test.js
@@ -230,10 +230,10 @@ describe('ADVERTS Appeal Form Journey', () => {
 				response: { ...mockResponse, answers }
 			});
 			const uploadSection = journey.getSection('upload-documents');
-			const statementQuestion = uploadSection.questions.find(
+			const statementQuestion = uploadSection?.questions?.find(
 				(q) => q.fieldName === 'uploadAppellantStatement'
 			);
-			expect(statementQuestion.shouldDisplay(journey.response)).toBe(true);
+			expect(statementQuestion?.shouldDisplay(journey.response)).toBe(true);
 		});
 
 		it('should include uploadAppellantStatement for CAS adverts appeals if onApplicationDate is before April 1st 2026', () => {
@@ -246,10 +246,10 @@ describe('ADVERTS Appeal Form Journey', () => {
 				response: { ...mockResponse, answers }
 			});
 			const uploadSection = journey.getSection('upload-documents');
-			const statementQuestion = uploadSection.questions.find(
+			const statementQuestion = uploadSection?.questions?.find(
 				(q) => q.fieldName === 'uploadAppellantStatement'
 			);
-			expect(statementQuestion.shouldDisplay(journey.response)).toBe(true);
+			expect(statementQuestion?.shouldDisplay(journey.response)).toBe(true);
 		});
 
 		it('should not include uploadAppellantStatement for CAS adverts appeals if onApplicationDate is on or after April 1st 2026', () => {
@@ -262,10 +262,42 @@ describe('ADVERTS Appeal Form Journey', () => {
 				response: { ...mockResponse, answers }
 			});
 			const uploadSection = journey.getSection('upload-documents');
-			const statementQuestion = uploadSection.questions.find(
+			const statementQuestion = uploadSection?.questions?.find(
 				(q) => q.fieldName === 'uploadAppellantStatement'
 			);
-			expect(statementQuestion.shouldDisplay(journey.response)).toBe(false);
+			expect(statementQuestion?.shouldDisplay(journey.response)).toBe(false);
+		});
+	});
+
+	describe('planningApplicationDate condition', () => {
+		it('should include planningApplicationDate for non-CAS adverts appeals (application decision: GRANTED)', () => {
+			const answers = {
+				applicationDecision: APPLICATION_DECISION.GRANTED
+			};
+			const journey = new Journey({
+				...params,
+				response: { ...mockResponse, answers }
+			});
+			const prepareSection = journey.getSection('prepare-appeal');
+			const dateQuestion = prepareSection?.questions?.find(
+				(q) => q.fieldName === 'onApplicationDate'
+			);
+			expect(dateQuestion?.shouldDisplay(journey.response)).toBe(true);
+		});
+
+		it('should not include planningApplicationDate for CAS adverts appeals (application decision: REFUSED)', () => {
+			const answers = {
+				applicationDecision: APPLICATION_DECISION.REFUSED
+			};
+			const journey = new Journey({
+				...params,
+				response: { ...mockResponse, answers }
+			});
+			const prepareSection = journey.getSection('prepare-appeal');
+			const dateQuestion = prepareSection?.questions?.find(
+				(q) => q.fieldName === 'onApplicationDate'
+			);
+			expect(dateQuestion?.shouldDisplay(journey.response)).toBe(false);
 		});
 	});
 });

--- a/packages/forms-web-app/src/dynamic-forms/cas-planning-appeal-form/journey.js
+++ b/packages/forms-web-app/src/dynamic-forms/cas-planning-appeal-form/journey.js
@@ -12,7 +12,8 @@ const {
 } = require('@pins/dynamic-forms/src/dynamic-components/utils/question-has-answer');
 const {
 	shouldDisplayIdentifyingLandowners,
-	shouldDisplayTellingLandowners
+	shouldDisplayTellingLandowners,
+	shouldDisplayAppellantStatement
 } = require('../display-questions');
 
 /**
@@ -74,7 +75,6 @@ const makeSections = (response) => {
 			.addQuestion(questions.inspectorAccess)
 			.addQuestion(questions.healthAndSafety)
 			.addQuestion(questions.enterApplicationReference)
-			.addQuestion(questions.planningApplicationDate)
 			.addQuestion(questions.enterDevelopmentDescription)
 			.addQuestion(questions.updateDevelopmentDescription)
 			.addQuestion(questions.whyAreYouAppealingPart1)
@@ -90,6 +90,7 @@ const makeSections = (response) => {
 			)
 			.addQuestion(questions.uploadApplicationDecisionLetter)
 			.addQuestion(questions.uploadAppellantStatement)
+			.withCondition(() => shouldDisplayAppellantStatement(response))
 			.addQuestion(questions.costApplication)
 			.addQuestion(questions.uploadCostApplication)
 			.withCondition(() => questionHasAnswer(response, questions.costApplication, 'yes'))

--- a/packages/forms-web-app/src/dynamic-forms/cas-planning-appeal-form/journey.test.js
+++ b/packages/forms-web-app/src/dynamic-forms/cas-planning-appeal-form/journey.test.js
@@ -33,4 +33,54 @@ describe('CAS Appeal Form Journey', () => {
 		const journey = new Journey({ ...params, response: mockResponse });
 		expect(journey.journeyTitle).toBe('Appeal a planning decision');
 	});
+
+	describe('uploadAppellantStatement condition', () => {
+		it('should include uploadAppellantStatement if application date is before April 1st 2026', () => {
+			const answers = { onApplicationDate: '2026-03-30T12:00:00.000Z' };
+			const journey = new Journey({
+				...params,
+				response: {
+					...mockResponse,
+					answers
+				}
+			});
+			const uploadSection = journey.getSection('upload-documents');
+			const statementQuestion = uploadSection?.questions?.find(
+				(q) => q.fieldName === 'uploadAppellantStatement'
+			);
+			expect(statementQuestion?.shouldDisplay(journey.response)).toBe(true);
+		});
+
+		it('should not include uploadAppellantStatement if application date is on or after April 1st 2026', () => {
+			const answers = { onApplicationDate: '2026-04-01T00:00:00.000Z' };
+			const journey = new Journey({
+				...params,
+				response: {
+					...mockResponse,
+					answers
+				}
+			});
+			const uploadSection = journey.getSection('upload-documents');
+			const statementQuestion = uploadSection?.questions?.find(
+				(q) => q.fieldName === 'uploadAppellantStatement'
+			);
+			expect(statementQuestion?.shouldDisplay(journey.response)).toBe(false);
+		});
+
+		it('should include uploadAppellantStatement if application date is not set', () => {
+			const answers = {};
+			const journey = new Journey({
+				...params,
+				response: {
+					...mockResponse,
+					answers
+				}
+			});
+			const uploadSection = journey.getSection('upload-documents');
+			const statementQuestion = uploadSection?.questions?.find(
+				(q) => q.fieldName === 'uploadAppellantStatement'
+			);
+			expect(statementQuestion?.shouldDisplay(journey.response)).toBe(true);
+		});
+	});
 });

--- a/packages/forms-web-app/src/dynamic-forms/controller.js
+++ b/packages/forms-web-app/src/dynamic-forms/controller.js
@@ -525,7 +525,8 @@ exports.appellantBYSListOfDocuments = (req, res) => {
 			) &&
 			isExpeditedAppealDate(appeal.applicationDate)) ||
 		((appeal.appealType === APPEAL_ID.HOUSEHOLDER ||
-			appeal.appealType === APPEAL_ID.MINOR_COMMERCIAL) &&
+			appeal.appealType === APPEAL_ID.MINOR_COMMERCIAL ||
+			appeal.appealType === APPEAL_ID.MINOR_COMMERCIAL_ADVERTISEMENT) &&
 			isExpeditedAppealDate(appeal.applicationDate));
 
 	const optionalDocuments = generateOptionalDocuments(appeal.appealType, isExpeditedAppeal);

--- a/packages/forms-web-app/src/dynamic-forms/docs/adverts-appeal-form-journey.md
+++ b/packages/forms-web-app/src/dynamic-forms/docs/adverts-appeal-form-journey.md
@@ -90,6 +90,12 @@ condition: () => shouldDisplayTellingLandowners(response, questions);
 - radio `/inspector-need-access/` Will an inspector need to access your land or property?
 - radio `/health-safety-issues/` Health and safety issues
 - single-line-input `/reference-number/` What is the application reference number?
+- date `/application-date/` What date did you submit your application?
+
+```js
+condition: () => shouldDisplayAdvertsQuestions(response);
+```
+
 - text-entry `/description-advertisement/` Enter the description of the advertisement that you submitted in your application
 - boolean `/description-advertisement-correct/` Did the local planning authority change the description of the advertisement?
 - multi-file-upload `/upload-description-evidence/` Upload evidence of your agreement to change the description of the advertisement

--- a/packages/forms-web-app/src/dynamic-forms/docs/cas-planning-appeal-form-journey.md
+++ b/packages/forms-web-app/src/dynamic-forms/docs/cas-planning-appeal-form-journey.md
@@ -72,7 +72,6 @@ condition: () => shouldDisplayTellingLandowners(response, questions);
 - radio `/inspector-need-access/` Will an inspector need to access your land or property?
 - radio `/health-safety-issues/` Health and safety issues
 - single-line-input `/reference-number/` What is the application reference number?
-- date `/application-date/` What date did you submit your application?
 - text-entry `/enter-description-of-development/` Enter the description of development that you submitted in your application
 - boolean `/description-development-correct/` Did the local planning authority change the description of development?
 - text-entry `/why-are-you-appealing/` Why are you appealing?
@@ -95,6 +94,11 @@ condition: () => questionHasAnswer(response, questions.updateDevelopmentDescript
 
 - multi-file-upload `/upload-decision-letter/` Upload the decision letter from the local planning authority
 - multi-file-upload `/upload-appeal-statement/` Upload your appeal statement
+
+```js
+condition: () => shouldDisplayAppellantStatement(response);
+```
+
 - boolean `/apply-appeal-costs/` Do you want to apply for an award of appeal costs?
 - multi-file-upload `/upload-appeal-costs-application/` Upload your application for an award of appeal costs
 

--- a/packages/forms-web-app/src/journeys/__snapshots__/index.test.js.snap
+++ b/packages/forms-web-app/src/journeys/__snapshots__/index.test.js.snap
@@ -207,6 +207,65 @@ exports[`Dynamic forms journey tests appellant Advertisement Advertisement shoul
 </main>"
 `;
 
+exports[`Dynamic forms journey tests appellant Advertisement Advertisement should render the application-date question 1`] = `
+"<main id="main-content" role="main" class="govuk-main-wrapper govuk-main-wrapper--auto-spacing">
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds"></div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds"><span class="govuk-caption-l"> Prepare appeal</span>
+        </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+            <form action="/appeals/adverts/prepare-appeal/application-date?id=appeal-ref"
+            method="post" novalidate=null>
+                <div class="govuk-form-group">
+                    <fieldset class="govuk-fieldset" role="group" aria-describedby="onApplicationDate-hint">
+                        <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+                            <h1 class="govuk-fieldset__heading"> What date did you submit your application?</h1>
+                        </legend>
+                        <div id="onApplicationDate-hint" class="govuk-hint">For example, 5 6 2025</div>
+                        <div class="govuk-date-input" id="onApplicationDate">
+                            <div class="govuk-date-input__item">
+                                <div class="govuk-form-group">
+                                    <label class="govuk-label govuk-date-input__label" for="onApplicationDate_day">Day</label>
+                                    <input class="govuk-input govuk-date-input__input govuk-input--width-2"
+                                    id="onApplicationDate_day" name="onApplicationDate_day" type="text" inputmode="numeric">
+                                </div>
+                            </div>
+                            <div class="govuk-date-input__item">
+                                <div class="govuk-form-group">
+                                    <label class="govuk-label govuk-date-input__label" for="onApplicationDate_month">Month</label>
+                                    <input class="govuk-input govuk-date-input__input govuk-input--width-2"
+                                    id="onApplicationDate_month" name="onApplicationDate_month" type="text"
+                                    inputmode="numeric">
+                                </div>
+                            </div>
+                            <div class="govuk-date-input__item">
+                                <div class="govuk-form-group">
+                                    <label class="govuk-label govuk-date-input__label" for="onApplicationDate_year">Year</label>
+                                    <input class="govuk-input govuk-date-input__input govuk-input--width-4"
+                                    id="onApplicationDate_year" name="onApplicationDate_year" type="text" inputmode="numeric">
+                                </div>
+                            </div>
+                        </div>
+                    </fieldset>
+                </div>
+                <button type="submit" class="govuk-button" data-module="govuk-button"
+                data-cy="button-save-and-continue">Continue</button>
+            </form>
+        </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+            <p class="govuk-body"><a href="/appeals/adverts/appeal-form/your-appeal?id=appeal-ref" class="govuk-link">Return to your appeal</a>
+            </p>
+        </div>
+    </div>
+</main>"
+`;
+
 exports[`Dynamic forms journey tests appellant Advertisement Advertisement should render the application-name question 1`] = `
 "<main id="main-content" role="main" class="govuk-main-wrapper govuk-main-wrapper--auto-spacing">
     <div class="govuk-grid-row">
@@ -1867,6 +1926,12 @@ exports[`Dynamic forms journey tests appellant Advertisement renders listing pag
                                 <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals/adverts/prepare-appeal/reference-number?id=appeal-ref">Answer<span class="govuk-visually-hidden"> What is the application reference number?</span></a>
                                 </dd>
                         </div>
+                        <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> What date did you submit your application?</dt>
+                            <dd
+                            class="govuk-summary-list__value">Not started</dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals/adverts/prepare-appeal/application-date?id=appeal-ref">Answer<span class="govuk-visually-hidden"> What date did you submit your application?</span></a>
+                                </dd>
+                        </div>
                         <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Enter the description of the advertisement</dt>
                             <dd
                             class="govuk-summary-list__value">Not started</dd>
@@ -2137,6 +2202,65 @@ exports[`Dynamic forms journey tests appellant Commercial advertisement Commerci
                         id="appellantCompanyName" name="appellantCompanyName" type="text" spellcheck="false">
                     </div>
                 </fieldset>
+                <button type="submit" class="govuk-button" data-module="govuk-button"
+                data-cy="button-save-and-continue">Continue</button>
+            </form>
+        </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+            <p class="govuk-body"><a href="/appeals/adverts/appeal-form/your-appeal?id=appeal-ref" class="govuk-link">Return to your appeal</a>
+            </p>
+        </div>
+    </div>
+</main>"
+`;
+
+exports[`Dynamic forms journey tests appellant Commercial advertisement Commercial advertisement should render the application-date question 1`] = `
+"<main id="main-content" role="main" class="govuk-main-wrapper govuk-main-wrapper--auto-spacing">
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds"></div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds"><span class="govuk-caption-l"> Prepare appeal</span>
+        </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+            <form action="/appeals/adverts/prepare-appeal/application-date?id=appeal-ref"
+            method="post" novalidate=null>
+                <div class="govuk-form-group">
+                    <fieldset class="govuk-fieldset" role="group" aria-describedby="onApplicationDate-hint">
+                        <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+                            <h1 class="govuk-fieldset__heading"> What date did you submit your application?</h1>
+                        </legend>
+                        <div id="onApplicationDate-hint" class="govuk-hint">For example, 5 6 2025</div>
+                        <div class="govuk-date-input" id="onApplicationDate">
+                            <div class="govuk-date-input__item">
+                                <div class="govuk-form-group">
+                                    <label class="govuk-label govuk-date-input__label" for="onApplicationDate_day">Day</label>
+                                    <input class="govuk-input govuk-date-input__input govuk-input--width-2"
+                                    id="onApplicationDate_day" name="onApplicationDate_day" type="text" inputmode="numeric">
+                                </div>
+                            </div>
+                            <div class="govuk-date-input__item">
+                                <div class="govuk-form-group">
+                                    <label class="govuk-label govuk-date-input__label" for="onApplicationDate_month">Month</label>
+                                    <input class="govuk-input govuk-date-input__input govuk-input--width-2"
+                                    id="onApplicationDate_month" name="onApplicationDate_month" type="text"
+                                    inputmode="numeric">
+                                </div>
+                            </div>
+                            <div class="govuk-date-input__item">
+                                <div class="govuk-form-group">
+                                    <label class="govuk-label govuk-date-input__label" for="onApplicationDate_year">Year</label>
+                                    <input class="govuk-input govuk-date-input__input govuk-input--width-4"
+                                    id="onApplicationDate_year" name="onApplicationDate_year" type="text" inputmode="numeric">
+                                </div>
+                            </div>
+                        </div>
+                    </fieldset>
+                </div>
                 <button type="submit" class="govuk-button" data-module="govuk-button"
                 data-cy="button-save-and-continue">Continue</button>
             </form>
@@ -3811,6 +3935,12 @@ exports[`Dynamic forms journey tests appellant Commercial advertisement renders 
                                 <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals/adverts/prepare-appeal/reference-number?id=appeal-ref">Answer<span class="govuk-visually-hidden"> What is the application reference number?</span></a>
                                 </dd>
                         </div>
+                        <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> What date did you submit your application?</dt>
+                            <dd
+                            class="govuk-summary-list__value">Not started</dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals/adverts/prepare-appeal/application-date?id=appeal-ref">Answer<span class="govuk-visually-hidden"> What date did you submit your application?</span></a>
+                                </dd>
+                        </div>
                         <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Enter the description of the advertisement</dt>
                             <dd
                             class="govuk-summary-list__value">Not started</dd>
@@ -4151,66 +4281,6 @@ exports[`Dynamic forms journey tests appellant Commercial planning (CAS) Commerc
                         id="appellantCompanyName" name="appellantCompanyName" type="text" spellcheck="false">
                     </div>
                 </fieldset>
-                <button type="submit" class="govuk-button" data-module="govuk-button"
-                data-cy="button-save-and-continue">Continue</button>
-            </form>
-        </div>
-    </div>
-    <div class="govuk-grid-row">
-        <div class="govuk-grid-column-two-thirds">
-            <p class="govuk-body"><a href="/appeals/cas-planning/appeal-form/your-appeal?id=appeal-ref"
-                class="govuk-link">Return to your appeal</a>
-            </p>
-        </div>
-    </div>
-</main>"
-`;
-
-exports[`Dynamic forms journey tests appellant Commercial planning (CAS) Commercial planning (CAS) should render the application-date question 1`] = `
-"<main id="main-content" role="main" class="govuk-main-wrapper govuk-main-wrapper--auto-spacing">
-    <div class="govuk-grid-row">
-        <div class="govuk-grid-column-two-thirds"></div>
-    </div>
-    <div class="govuk-grid-row">
-        <div class="govuk-grid-column-two-thirds"><span class="govuk-caption-l"> Prepare appeal</span>
-        </div>
-    </div>
-    <div class="govuk-grid-row">
-        <div class="govuk-grid-column-two-thirds">
-            <form action="/appeals/cas-planning/prepare-appeal/application-date?id=appeal-ref"
-            method="post" novalidate=null>
-                <div class="govuk-form-group">
-                    <fieldset class="govuk-fieldset" role="group" aria-describedby="onApplicationDate-hint">
-                        <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
-                            <h1 class="govuk-fieldset__heading"> What date did you submit your application?</h1>
-                        </legend>
-                        <div id="onApplicationDate-hint" class="govuk-hint">For example, 5 6 2025</div>
-                        <div class="govuk-date-input" id="onApplicationDate">
-                            <div class="govuk-date-input__item">
-                                <div class="govuk-form-group">
-                                    <label class="govuk-label govuk-date-input__label" for="onApplicationDate_day">Day</label>
-                                    <input class="govuk-input govuk-date-input__input govuk-input--width-2"
-                                    id="onApplicationDate_day" name="onApplicationDate_day" type="text" inputmode="numeric">
-                                </div>
-                            </div>
-                            <div class="govuk-date-input__item">
-                                <div class="govuk-form-group">
-                                    <label class="govuk-label govuk-date-input__label" for="onApplicationDate_month">Month</label>
-                                    <input class="govuk-input govuk-date-input__input govuk-input--width-2"
-                                    id="onApplicationDate_month" name="onApplicationDate_month" type="text"
-                                    inputmode="numeric">
-                                </div>
-                            </div>
-                            <div class="govuk-date-input__item">
-                                <div class="govuk-form-group">
-                                    <label class="govuk-label govuk-date-input__label" for="onApplicationDate_year">Year</label>
-                                    <input class="govuk-input govuk-date-input__input govuk-input--width-4"
-                                    id="onApplicationDate_year" name="onApplicationDate_year" type="text" inputmode="numeric">
-                                </div>
-                            </div>
-                        </div>
-                    </fieldset>
-                </div>
                 <button type="submit" class="govuk-button" data-module="govuk-button"
                 data-cy="button-save-and-continue">Continue</button>
             </form>
@@ -5772,12 +5842,6 @@ exports[`Dynamic forms journey tests appellant Commercial planning (CAS) renders
                             <dd
                             class="govuk-summary-list__value">Not started</dd>
                                 <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals/cas-planning/prepare-appeal/reference-number?id=appeal-ref">Answer<span class="govuk-visually-hidden"> What is the application reference number?</span></a>
-                                </dd>
-                        </div>
-                        <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> What date did you submit your application?</dt>
-                            <dd
-                            class="govuk-summary-list__value">Not started</dd>
-                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals/cas-planning/prepare-appeal/application-date?id=appeal-ref">Answer<span class="govuk-visually-hidden"> What date did you submit your application?</span></a>
                                 </dd>
                         </div>
                         <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Enter the description of development that you submitted in your application</dt>


### PR DESCRIPTION
### Description of change

Fixing remove appellant statement from CAS planning and make application date conditional based of BYS journey

Added application date to relevant BYS journeys:
- For cas adverts add application date after lpa decision screen if efused is selected
- For cas planning add application date after about page if none is selected

Updated testing for above scenarios and manually tested in browser

Ticket: https://pins-ds.atlassian.net/browse/A2-835

### Checklist

- [x] Feature complete and ready for users, or behind feature-flag
- [x] Commit history is linear with no merge commits
- [ ] Requires infrastructure changes

### Important

Please do not merge from `main` (please only [rebase](https://github.com/Planning-Inspectorate/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
