### PR TITLE
fix: add occupancyConditionsMet to ELB data model mapping

### DIFF
--- a/packages/appeals-service-api/src/routes/v2/appeal-cases/service.js
+++ b/packages/appeals-service-api/src/routes/v2/appeal-cases/service.js
@@ -462,6 +462,7 @@ const mapLDCDataModelToAppealCase = (caseProcessCode, dataModel) => ({
 const getEnforcementListedAppealFormFields = (dataModel) => {
 	return {
 		ownerOccupancyStatus: dataModel.ownerOccupancyStatus,
+		occupancyConditionsMet: dataModel.occupancyConditionsMet,
 		issueDateOfEnforcementNotice: dataModel.issueDateOfEnforcementNotice,
 		effectiveDateOfEnforcementNotice: dataModel.effectiveDateOfEnforcementNotice,
 		enforcementReference: dataModel.enforcementNoticeReference,


### PR DESCRIPTION
### Description of change

Very small change to add missing `occupancyConditionsMet` to `getEnforcementListedAppealFormFields` mapping from the data model

Ticket: https://pins-ds.atlassian.net/browse/A2-8037

### Checklist

- [x] Feature complete and ready for users, or behind feature-flag
- [x] Commit history is linear with no merge commits
- [ ] Requires infrastructure changes

### Important

Please do not merge from `main` (please only [rebase](https://github.com/Planning-Inspectorate/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
