### PR TITLE
A2-8037 fix add writtenOrVerbalPermission to ELB appellant submission

### DIFF
--- a/packages/appeals-service-api/src/services/back-office-v2/formatters/utils.js
+++ b/packages/appeals-service-api/src/services/back-office-v2/formatters/utils.js
@@ -969,6 +969,9 @@ exports.getEnforcementListedAppellantSubmissionFields = (appellantSubmission) =>
 		namedIndividuals: getNamedIndividuals(),
 		planningObligation: appellantSubmission.planningObligation ?? null,
 		statusPlanningObligation: planningObligationStatus ?? null,
+		writtenOrVerbalPermission: appellantSubmission.hasPermissionToUseLand
+			? exports.boolToYesNo(appellantSubmission.hasPermissionToUseLand)
+			: null,
 		...getInterestInLand()
 	};
 };


### PR DESCRIPTION
### Description of change

This change updates the submission mapping so enforcement-listed appeals now include `writtenOrVerbalPermission` , based on `hasPermissionToUseLand` in the back-office formatter.

Ticket: https://pins-ds.atlassian.net/browse/A2-8037 

### Checklist

- [x] Feature complete and ready for users, or behind feature-flag
- [x] Commit history is linear with no merge commits
- [ ] Requires infrastructure changes

### Important

Please do not merge from `main` (please only [rebase](https://github.com/Planning-Inspectorate/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
