### PR TITLE
feat(A2-8049): update bys summary rows

### DIFF
--- a/packages/forms-web-app/__tests__/unit/controllers/before-you-start/can-use-service.test.js
+++ b/packages/forms-web-app/__tests__/unit/controllers/before-you-start/can-use-service.test.js
@@ -224,9 +224,10 @@ describe('controllers/before-you-start/can-use-service', () => {
 			await getCanUseService(req, res);
 
 			expect(res.render).toHaveBeenCalledWith(canUseServiceFullAppealUrl, {
+				isNewBYSFlow: false,
 				appealLPD: 'Bradford',
-				applicationAbout: null,
 				applicationDate: '04 May 2022',
+				applicationAbout: null,
 				applicationDecision: 'Granted with conditions',
 				applicationType: 'Full appeal',
 				deadlineDate: { date: 4, day: 'Friday', month: 'November', year: 2022 },
@@ -252,6 +253,7 @@ describe('controllers/before-you-start/can-use-service', () => {
 			await getCanUseService(req, res);
 
 			expect(res.render).toHaveBeenCalledWith(canUseServiceFullAppealUrl, {
+				isNewBYSFlow: false,
 				appealLPD: 'Bradford',
 				applicationAbout: null,
 				applicationDate: '04 May 2022',
@@ -288,6 +290,7 @@ describe('controllers/before-you-start/can-use-service', () => {
 			await getCanUseService(req, res);
 
 			expect(res.render).toHaveBeenCalledWith(canUseServiceFullAppealUrl, {
+				isNewBYSFlow: false,
 				appealLPD: 'Bradford',
 				applicationAbout: ['None of these'],
 				applicationDate: '04 May 2022',
@@ -326,6 +329,7 @@ describe('controllers/before-you-start/can-use-service', () => {
 			await getCanUseService(req, res);
 
 			expect(res.render).toHaveBeenCalledWith(canUseServiceFullAppealUrl, {
+				isNewBYSFlow: false,
 				appealLPD: 'Bradford',
 				applicationAbout: ['None of these'],
 				applicationDate: '04 May 2022',
@@ -355,6 +359,7 @@ describe('controllers/before-you-start/can-use-service', () => {
 			await getCanUseService(req, res);
 
 			expect(res.render).toHaveBeenCalledWith(canUseServiceFullAppealUrl, {
+				isNewBYSFlow: false,
 				appealLPD: 'Bradford',
 				applicationAbout: null,
 				applicationDate: '04 May 2022',
@@ -395,6 +400,7 @@ describe('controllers/before-you-start/can-use-service', () => {
 			await getCanUseService(req, res);
 
 			expect(res.render).toHaveBeenCalledWith(canUseServiceFullAppealUrl, {
+				isNewBYSFlow: false,
 				appealLPD: 'Bradford',
 				applicationAbout: null,
 				applicationDecision: 'Granted with conditions',
@@ -436,6 +442,7 @@ describe('controllers/before-you-start/can-use-service', () => {
 			await getCanUseService(req, res);
 
 			expect(res.render).toHaveBeenCalledWith(canUseServiceFullAppealUrl, {
+				isNewBYSFlow: false,
 				appealLPD: 'Bradford',
 				applicationAbout: ['None of these'],
 				applicationDecision: 'Refused',
@@ -477,6 +484,7 @@ describe('controllers/before-you-start/can-use-service', () => {
 			await getCanUseService(req, res);
 
 			expect(res.render).toHaveBeenCalledWith(canUseServiceFullAppealUrl, {
+				isNewBYSFlow: false,
 				appealLPD: 'Bradford',
 				applicationAbout: null,
 				applicationDecision: 'Granted with conditions',
@@ -517,6 +525,7 @@ describe('controllers/before-you-start/can-use-service', () => {
 			await getCanUseService(req, res);
 
 			expect(res.render).toHaveBeenCalledWith(canUseServiceFullAppealUrl, {
+				isNewBYSFlow: false,
 				appealLPD: 'Bradford',
 				applicationAbout: null,
 				applicationDecision: 'Refused',
@@ -675,6 +684,7 @@ describe('controllers/before-you-start/can-use-service', () => {
 			await getCanUseService(req, res);
 
 			expect(res.render).toHaveBeenCalledWith(canUseServiceFullAppealUrl, {
+				isNewBYSFlow: false,
 				appealLPD: 'Bradford',
 				applicationAbout: null,
 				applicationDecision: '',
@@ -714,6 +724,7 @@ describe('controllers/before-you-start/can-use-service', () => {
 			await getCanUseService(req, res);
 
 			expect(res.render).toHaveBeenCalledWith(canUseServiceFullAppealUrl, {
+				isNewBYSFlow: false,
 				appealLPD: 'Bradford',
 				applicationAbout: null,
 				applicationDecision: 'Refused',

--- a/packages/forms-web-app/src/controllers/before-you-start/can-use-service.js
+++ b/packages/forms-web-app/src/controllers/before-you-start/can-use-service.js
@@ -68,7 +68,10 @@ const canUseServiceHouseholderPlanning = async (req, res) => {
 
 	const appealType = caseTypeLookup(appeal.appealType, 'id')?.processCode;
 
+	const isNewBYSFlow = await isLpaInFeatureFlag(appeal.lpaCode, FLAG.NEW_BYS_ENFORCEMENT);
+
 	res.render(canUseServiceHouseholder, {
+		isNewBYSFlow,
 		deadlineDate: deadlineDate ? formatDate(deadlineDate) : null,
 		appealLPD,
 		planningApplicationNumber,
@@ -108,7 +111,10 @@ const canUseServiceFullAppeal = async (req, res) => {
 
 	const appealType = caseTypeLookup(appeal.appealType, 'id')?.processCode;
 
+	const isNewBYSFlow = await isLpaInFeatureFlag(appeal.lpaCode, FLAG.NEW_BYS_ENFORCEMENT);
+
 	res.render(canUseServiceFullAppealView, {
+		isNewBYSFlow,
 		deadlineDate: deadlineDate ? formatDate(deadlineDate) : null,
 		hideDeadlineDate,
 		appealLPD,
@@ -147,10 +153,13 @@ const canUseServicePriorApproval = async (req, res) => {
 		? 'Yes'
 		: 'No';
 
+	const isNewBYSFlow = await isLpaInFeatureFlag(appeal.lpaCode, FLAG.NEW_BYS_ENFORCEMENT);
+
 	if (appeal.eligibility.hasPriorApprovalForExistingHome) {
 		const deadlineDate = calculateDeadlineFromBeforeYouStart({ appeal });
 
 		res.render(canUseServicePriorApprovalHouseholder, {
+			isNewBYSFlow,
 			deadlineDate: deadlineDate ? formatDate(deadlineDate) : null,
 			appealLPD,
 			planningApplicationNumber,
@@ -167,6 +176,7 @@ const canUseServicePriorApproval = async (req, res) => {
 		const deadlineDate = calculateDeadlineFromBeforeYouStart({ appeal });
 
 		res.render(canUseServicePriorApprovalFull, {
+			isNewBYSFlow,
 			deadlineDate: deadlineDate ? formatDate(deadlineDate) : null,
 			appealLPD,
 			planningApplicationNumber,
@@ -201,10 +211,13 @@ const canUseServiceRemovalOrVariationOfConditions = async (req, res) => {
 
 	const isListedBuilding = appeal.eligibility.isListedBuilding ? 'Yes' : 'No';
 
+	const isNewBYSFlow = await isLpaInFeatureFlag(appeal.lpaCode, FLAG.NEW_BYS_ENFORCEMENT);
+
 	if (appeal.eligibility.hasHouseholderPermissionConditions) {
 		const deadlineDate = calculateDeadlineFromBeforeYouStart({ appeal });
 
 		res.render(canUseServiceRemovalOrVariationOfConditionsHouseholder, {
+			isNewBYSFlow,
 			deadlineDate: deadlineDate ? formatDate(deadlineDate) : null,
 			appealLPD,
 			planningApplicationNumber,
@@ -222,6 +235,7 @@ const canUseServiceRemovalOrVariationOfConditions = async (req, res) => {
 		const deadlineDate = calculateDeadlineFromBeforeYouStart({ appeal });
 
 		res.render(canUseServiceRemovalOrVariationOfConditionsFullAppeal, {
+			isNewBYSFlow,
 			deadlineDate: deadlineDate ? formatDate(deadlineDate) : null,
 			appealLPD,
 			planningApplicationNumber,

--- a/packages/forms-web-app/src/controllers/selected-appeal/appeal-details/appeal-before-you-start-rows.js
+++ b/packages/forms-web-app/src/controllers/selected-appeal/appeal-details/appeal-before-you-start-rows.js
@@ -9,9 +9,10 @@ const { CASE_TYPES } = require('@pins/common/src/database/data-static');
 /**
  * @param {AppealCaseDetailed} caseData
  * @param {string} lpaName
+ * @param {boolean} [isNewBYSFlow]
  * @returns {Rows}
  */
-exports.bysRows = (caseData, lpaName) => {
+exports.bysRows = (caseData, lpaName, isNewBYSFlow = false) => {
 	const isEnforcementListed = caseData.appealTypeCode === CASE_TYPES.ENFORCEMENT_LISTED.processCode;
 
 	const isEnforcement =
@@ -26,14 +27,14 @@ exports.bysRows = (caseData, lpaName) => {
 		{
 			keyText: 'Have you received an enforcement notice?',
 			valueText: caseData.enforcementNotice ? 'Yes' : 'No',
-			condition: () => true
+			condition: () => !isNewBYSFlow
 		},
 		{
-			keyText: 'What type of application is your appeal about?',
-			valueText: caseData.typeOfPlanningApplication
-				? applicationTypeMappings[caseData.typeOfPlanningApplication]
-				: '',
-			condition: () => !isEnforcement
+			keyText: isNewBYSFlow
+				? 'What is your appeal about?'
+				: 'What type of application is your appeal about?',
+			valueText: mapAppealTypeText(caseData.appealTypeCode, caseData.typeOfPlanningApplication),
+			condition: () => isNewBYSFlow || !isEnforcement
 		},
 		{
 			keyText: 'What date did you submit your application?',
@@ -59,7 +60,7 @@ exports.bysRows = (caseData, lpaName) => {
 		{
 			keyText: 'Is your enforcement notice about a listed building?',
 			valueText: isEnforcementListed ? 'Yes' : 'No',
-			condition: () => isEnforcement
+			condition: () => isEnforcement && !isNewBYSFlow
 		},
 		{
 			keyText: 'What is the issue date on your enforcement notice?',
@@ -110,4 +111,19 @@ const mapApplicationDecision = (/** @type {string | null | undefined} */ decisio
 	if (!decision) return;
 	if (decision === 'not_received') return 'I have not received a decision';
 	return decision.replace(/^\w/, (c) => c.toUpperCase());
+};
+
+/**
+ * @param {string} appealTypeCode
+ * @param {AppealCaseDetailed["typeOfPlanningApplication"] | undefined | null} typeOfPlanningApplication
+ * @returns {string}
+ */
+const mapAppealTypeText = (appealTypeCode, typeOfPlanningApplication) => {
+	if (appealTypeCode === CASE_TYPES.ENFORCEMENT_LISTED.processCode)
+		return 'Enforcement listed building and conservation area';
+	if (appealTypeCode === CASE_TYPES.ENFORCEMENT.processCode) return 'Enforcement notice';
+
+	if (typeOfPlanningApplication) return applicationTypeMappings[typeOfPlanningApplication];
+
+	return '';
 };

--- a/packages/forms-web-app/src/controllers/selected-appeal/appeal-details/appeal-before-you-start-rows.test.js
+++ b/packages/forms-web-app/src/controllers/selected-appeal/appeal-details/appeal-before-you-start-rows.test.js
@@ -2,7 +2,7 @@ const { CASE_TYPES } = require('@pins/common/src/database/data-static');
 const { bysRows } = require('./appeal-before-you-start-rows');
 const { APPLICATION_DECISION } = require('@pins/business-rules/src/constants');
 
-describe('bys-rows', () => {
+describe('bys-rows - non-enforcement, isNewBYSFlow === false', () => {
 	const caseData = {
 		caseReference: 'test-ref',
 		LPACode: '111111',
@@ -70,7 +70,75 @@ describe('bys-rows', () => {
 	});
 });
 
-describe('bys-rows - enforcement and enforcement listed', () => {
+describe('bys-rows - non-enforcement, isNewBYSFlow === true', () => {
+	const caseData = {
+		caseReference: 'test-ref',
+		LPACode: '111111',
+		appealTypeCode: CASE_TYPES.S78.processCode,
+		applicationReference: 'app-ref',
+		enforcementNotice: false,
+		typeOfPlanningApplication: 'full-appeal',
+		applicationDate: '2025-01-01T08:00:00.000Z',
+		applicationDecision: APPLICATION_DECISION.REFUSED,
+		applicationDecisionDate: '2025-02-01T08:00:00.000Z',
+		siteAddressLine1: '1 test street',
+		siteAddressPostcode: '1TT 2AA'
+	};
+	/**
+	 * @type {import("@pins/common/src/view-model-maps/rows/def").Rows} Rows
+	 */
+	let rows;
+
+	// @ts-ignore
+	beforeEach(() => (rows = bysRows(caseData, 'Test LPA', true)));
+
+	it('should display the lpa name row', () => {
+		expect(rows[0].keyText).toEqual(
+			'Which local planning authority (LPA) do you want to appeal against?'
+		);
+		expect(rows[0].valueText).toEqual('Test LPA');
+	});
+
+	it('should not display the enforcement notice row', () => {
+		expect(rows[1].keyText).toEqual('Have you received an enforcement notice?');
+		expect(rows[1].condition()).toBeFalsy();
+	});
+
+	it('should display type of application the appeal is about row', () => {
+		expect(rows[2].keyText).toEqual('What is your appeal about?');
+		expect(rows[2].valueText).toEqual('Full planning');
+	});
+
+	it('should display the date the application was submitted row', () => {
+		expect(rows[3].keyText).toEqual('What date did you submit your application?');
+		expect(rows[3].valueText).toEqual('1 Jan 2025');
+	});
+
+	it('should display whether the application was granted or refused row', () => {
+		expect(rows[4].keyText).toEqual('Was your application granted or refused?');
+		expect(rows[4].valueText).toEqual('Refused');
+	});
+
+	it('should display date on the decision letter from lpa row', () => {
+		expect(rows[5].keyText).toEqual(
+			'What is the date on the decision letter from the local planning authority?'
+		);
+		expect(rows[5].valueText).toEqual('1 Feb 2025');
+	});
+
+	it('should display when was decision due question when decision is not_receieved', () => {
+		const data = structuredClone(caseData);
+		data.applicationDecision = 'not_received';
+		// @ts-ignore
+		const rowData = bysRows(data, 'Test LPA');
+		expect(rowData[5].keyText).toEqual(
+			'What date was your decision due from the local planning authority?'
+		);
+		expect(rows[5].valueText).toEqual('1 Feb 2025');
+	});
+});
+
+describe('bys-rows - enforcement and enforcement listed, isNewBYSFlow === false', () => {
 	const enforcementCaseData = {
 		caseReference: 'test-ref',
 		LPACode: '111111',
@@ -122,6 +190,99 @@ describe('bys-rows - enforcement and enforcement listed', () => {
 		const rowData = bysRows(data, 'Test LPA');
 		expect(rowData[6].keyText).toEqual('Is your enforcement notice about a listed building?');
 		expect(rowData[6].valueText).toEqual('Yes');
+	});
+
+	it('should display issue date of enforcement notice row', () => {
+		expect(rows[7].keyText).toEqual('What is the issue date on your enforcement notice?');
+		expect(rows[7].valueText).toEqual('1 Feb 2025');
+	});
+
+	it('should display effective date of enforcement notice row', () => {
+		expect(rows[8].keyText).toEqual('What is the effective date on your enforcement notice?');
+		expect(rows[8].valueText).toEqual('1 Feb 2025');
+	});
+
+	it('should display contact PINS row if relevant', () => {
+		expect(rows[9].keyText).toEqual(
+			'Did you contact the Planning Inspectorate to tell them you will appeal the enforcement notice?'
+		);
+		expect(rows[9].valueText).toEqual('Yes');
+	});
+
+	it('should display contact PINS date row if relevant', () => {
+		expect(rows[10].keyText).toEqual('When did you contact the Planning Inspectorate?');
+		expect(rows[10].valueText).toEqual('1 Feb 2025');
+	});
+
+	it('should display enforcement reference row', () => {
+		expect(rows[11].keyText).toEqual('What is the reference number on the enforcement notice?');
+		expect(rows[11].valueText).toEqual('enf-ref');
+	});
+});
+
+describe('bys-rows - enforcement and enforcement listed, isNewBYSFlow === true', () => {
+	const enforcementCaseData = {
+		caseReference: 'test-ref',
+		LPACode: '111111',
+		appealTypeCode: CASE_TYPES.ENFORCEMENT.processCode,
+		enforcementNotice: true,
+		issueDateOfEnforcementNotice: '2025-02-01T08:00:00.000Z',
+		effectiveDateOfEnforcementNotice: '2025-02-01T08:00:00.000Z',
+		contactPlanningInspectorateDate: '2025-02-01T08:00:00.000Z',
+		enforcementReference: 'enf-ref'
+	};
+	/**
+	 * @type {import("@pins/common/src/view-model-maps/rows/def").Rows} Rows
+	 */
+	let rows;
+
+	// @ts-ignore
+	beforeEach(() => (rows = bysRows(enforcementCaseData, 'Test LPA', true)));
+
+	it('should display the lpa name row', () => {
+		expect(rows[0].keyText).toEqual(
+			'Which local planning authority (LPA) do you want to appeal against?'
+		);
+		expect(rows[0].valueText).toEqual('Test LPA');
+	});
+
+	it('should display type of application the appeal is about row - enforcement notice', () => {
+		expect(rows[2].keyText).toEqual('What is your appeal about?');
+		expect(rows[2].valueText).toEqual('Enforcement notice');
+	});
+
+	it('should display type of application the appeal is about row - elb', () => {
+		const data = structuredClone(enforcementCaseData);
+		data.appealTypeCode = CASE_TYPES.ENFORCEMENT_LISTED.processCode;
+		// @ts-ignore
+		const rowData = bysRows(data, 'Test LPA', true);
+		expect(rowData[2].keyText).toEqual('What is your appeal about?');
+		expect(rowData[2].valueText).toEqual('Enforcement listed building and conservation area');
+	});
+
+	test.each([
+		['Enforcement notice', 1],
+		['Submission date', 3],
+		['Application decision', 4],
+		['Decision date', 5]
+	])('should not display field for %s', (_, rowNumber) => {
+		expect(rows[rowNumber].condition()).toBeFalsy();
+	});
+
+	it('should not display the enforcement listed building row - enforcement notice', () => {
+		expect(rows[6].keyText).toEqual('Is your enforcement notice about a listed building?');
+		expect(rows[6].valueText).toEqual('No');
+		expect(rows[6].condition()).toBeFalsy();
+	});
+
+	it('should not display the enforcement listed building row - elb', () => {
+		const data = structuredClone(enforcementCaseData);
+		data.appealTypeCode = CASE_TYPES.ENFORCEMENT_LISTED.processCode;
+		// @ts-ignore
+		const rowData = bysRows(data, 'Test LPA', true);
+		expect(rowData[6].keyText).toEqual('Is your enforcement notice about a listed building?');
+		expect(rowData[6].valueText).toEqual('Yes');
+		expect(rowData[6].condition()).toBeFalsy();
 	});
 
 	it('should display issue date of enforcement notice row', () => {

--- a/packages/forms-web-app/src/controllers/selected-appeal/appeal-details/index.js
+++ b/packages/forms-web-app/src/controllers/selected-appeal/appeal-details/index.js
@@ -15,6 +15,8 @@ const logger = require('#lib/logger');
 const config = require('../..//../config');
 const { bysRows } = require('./appeal-before-you-start-rows');
 const { appealAdditionalDocumentsRows } = require('./appeal-additional-documents-rows');
+const { FLAG } = require('@pins/common/src/feature-flags');
+const { isLpaInFeatureFlag } = require('#lib/is-lpa-in-feature-flag');
 
 /**
  * Shared controller for /appeals/:caseRef/appeal-details, manage-appeals/:caseRef/appeal-details rule-6-appeals/:caseRef/appeal-details
@@ -64,10 +66,12 @@ exports.get = (layoutTemplate = 'layouts/no-banner-link/main.njk') => {
 
 		logger.debug({ caseData }, 'caseData');
 
+		const isNewBYSFlow = await isLpaInFeatureFlag(caseData.LPACode, FLAG.NEW_BYS_ENFORCEMENT);
+
 		const lpa = await getDepartmentFromCode(caseData.LPACode);
 		const headlineData = formatHeadlineData({ caseData, role: userType });
 
-		const beforeYouStartRows = bysRows(caseData, lpa.name);
+		const beforeYouStartRows = bysRows(caseData, lpa.name, isNewBYSFlow);
 		const beforeYouStart = formatRows(beforeYouStartRows, caseData);
 
 		const appealDetailsRows = detailsRows(caseData, userType);

--- a/packages/forms-web-app/src/controllers/selected-appeal/appeal-details/index.test.js
+++ b/packages/forms-web-app/src/controllers/selected-appeal/appeal-details/index.test.js
@@ -12,6 +12,7 @@ const { VIEW } = require('#lib/views');
 const { generatePDF } = require('#lib/pdf-api-wrapper');
 const { addCSStoHtml } = require('#lib/add-css-to-html');
 const { bysRows } = require('./appeal-before-you-start-rows');
+const { isLpaInFeatureFlag } = require('#lib/is-lpa-in-feature-flag');
 
 jest.mock('#lib/determine-user');
 jest.mock('../../../services/user.service');
@@ -22,6 +23,7 @@ jest.mock('./appeal-before-you-start-rows');
 jest.mock('@pins/common');
 jest.mock('#lib/pdf-api-wrapper');
 jest.mock('#lib/add-css-to-html');
+jest.mock('#lib/is-lpa-in-feature-flag');
 
 const date = new Date();
 const caseData = { LPACode: 'Q9999', caseValidDate: date };
@@ -87,10 +89,12 @@ describe('controllers/selected-appeal/appeal-details/index', () => {
 	describe('LPA User', () => {
 		beforeEach(() => {
 			determineUser.mockReturnValue(LPA_USER_ROLE);
+			isLpaInFeatureFlag.mockResolvedValue(false);
 		});
 
 		it('renders page if URL does not have PDF query', async () => {
 			const indexGetController = indexController.get();
+
 			await indexGetController(req, res);
 
 			expect(determineUser).toHaveBeenCalledWith('a/fake/url');
@@ -103,7 +107,7 @@ describe('controllers/selected-appeal/appeal-details/index', () => {
 			});
 			expect(getDepartmentFromCode).toHaveBeenCalledWith('Q9999');
 			expect(detailsRows).toHaveBeenCalledWith(caseData, LPA_USER_ROLE);
-			expect(bysRows).toHaveBeenCalledWith(caseData, 'Test LPA');
+			expect(bysRows).toHaveBeenCalledWith(caseData, 'Test LPA', false);
 			expect(documentsRows).toHaveBeenCalledWith(caseData);
 			expect(formatRows).toHaveBeenCalledWith('returned bys rows', caseData);
 			expect(formatRows).toHaveBeenCalledWith('returned details rows', caseData);
@@ -146,7 +150,7 @@ describe('controllers/selected-appeal/appeal-details/index', () => {
 			expect(getDepartmentFromCode).toHaveBeenCalledWith('Q9999');
 			expect(detailsRows).toHaveBeenCalledWith(caseData, LPA_USER_ROLE);
 			expect(documentsRows).toHaveBeenCalledWith(caseData);
-			expect(bysRows).toHaveBeenCalledWith(caseData, 'Test LPA');
+			expect(bysRows).toHaveBeenCalledWith(caseData, 'Test LPA', false);
 			expect(formatRows).toHaveBeenCalledWith('returned bys rows', caseData);
 			expect(formatRows).toHaveBeenCalledWith('returned details rows', caseData);
 			expect(formatHeadlineData).toHaveBeenCalledWith({ caseData, role: LPA_USER_ROLE });

--- a/packages/forms-web-app/src/views/full-appeal/can-use-service.njk
+++ b/packages/forms-web-app/src/views/full-appeal/can-use-service.njk
@@ -96,6 +96,31 @@
         {{ super() }}
     {% endif %}
 {% endblock %}
+
+{% if isNewBYSFlow %}
+	{% set enforcementNoticeRow = null %}
+{% else %}
+	{% set enforcementNoticeRow = {
+		key: {
+			text: "Have you received an enforcement notice?"
+		},
+		value: {
+			text: summaryField(enforcementNotice, { 'data-cy': "enforcement-notice" })
+		},
+		actions: {
+			items: [
+				{
+					href: "/before-you-start/enforcement-notice",
+					text: "Change",
+					visuallyHiddenText: "Have you received an enforcement notice?",
+					attributes: { "data-cy":"enforcementNotice"}
+				}
+			]
+		}
+	}
+	%}
+{% endif %}
+
 {% block canUseServiceSummaryList %}
     {{ govukSummaryList({
 		classes: "govuk-summary-list govuk-!-margin-bottom-9",
@@ -118,24 +143,7 @@
 					]
 				}
 			},
-			{
-				key: {
-					text: "Have you received an enforcement notice?"
-				},
-				value: {
-					text: summaryField(enforcementNotice, { 'data-cy': "enforcement-notice" })
-				},
-				actions: {
-					items: [
-						{
-							href: "/before-you-start/enforcement-notice",
-							text: "Change",
-							visuallyHiddenText: "Have you received an enforcement notice?",
-							attributes: { "data-cy":"enforcementNotice"}
-						}
-					]
-				}
-			},
+			enforcementNoticeRow,
 			{
               key: {
                 text: "Application number"

--- a/packages/forms-web-app/src/views/full-appeal/prior-approval/can-use-service.njk
+++ b/packages/forms-web-app/src/views/full-appeal/prior-approval/can-use-service.njk
@@ -1,6 +1,31 @@
 {% extends "../../layouts/can-use-service/main.njk" %}
 {% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
 {% from "../../macros/summary-field.njk" import summaryField %}
+
+{% if isNewBYSFlow %}
+	{% set enforcementNoticeRow = null %}
+{% else %}
+	{% set enforcementNoticeRow = {
+		key: {
+			text: "Have you received an enforcement notice?"
+		},
+		value: {
+			text: summaryField(enforcementNotice, { 'data-cy': "enforcement-notice" })
+		},
+		actions: {
+			items: [
+				{
+					href: "/before-you-start/enforcement-notice",
+					text: "Change",
+					visuallyHiddenText: "Have you received an enforcement notice?",
+					attributes: { "data-cy":"enforcementNotice"}
+				}
+			]
+		}
+	}
+	%}
+{% endif %}
+
 {% block canUseServiceSummaryList %}
     {{ govukSummaryList({
 		classes: "govuk-summary-list govuk-!-margin-bottom-9",
@@ -23,42 +48,25 @@
 					]
 				}
 			},
-			{
-				key: {
-					text: "Have you received an enforcement notice?"
-				},
-				value: {
-					text: summaryField(enforcementNotice, { 'data-cy': "enforcement-notice" })
-				},
-				actions: {
-					items: [
-						{
-							href: "/before-you-start/enforcement-notice",
-							text: "Change",
-							visuallyHiddenText: "Have you received an enforcement notice?",
-							attributes: { "data-cy":"enforcementNotice"}
-						}
-					]
-				}
-			},
-      		{
-              key: {
-                text: "Application number"
-              },
-              value: {
-                text: summaryField(planningApplicationNumber, { 'data-cy': "application-number" })
-              },
-              actions: {
-                items: [
-                  {
-                    href: "/before-you-start/application-number",
-                    text: "Change",
-                    visuallyHiddenText: "Application number",
-                    attributes: { "data-cy":"applicationNumber"}
-                  }
-                ]
-              }
-            } if planningApplicationNumber,
+			enforcementNoticeRow,
+      {
+        key: {
+          text: "Application number"
+        },
+        value: {
+          text: summaryField(planningApplicationNumber, { 'data-cy': "application-number" })
+        },
+        actions: {
+          items: [
+            {
+              href: "/before-you-start/application-number",
+              text: "Change",
+              visuallyHiddenText: "Application number",
+              attributes: { "data-cy":"applicationNumber"}
+            }
+          ]
+        }
+      } if planningApplicationNumber,
 			{
 				key: {
 					text: "Type of application"

--- a/packages/forms-web-app/src/views/full-appeal/removal-or-variation-of-conditions/can-use-service.njk
+++ b/packages/forms-web-app/src/views/full-appeal/removal-or-variation-of-conditions/can-use-service.njk
@@ -1,6 +1,31 @@
 {% extends "../../layouts/can-use-service/main.njk" %}
 {% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
 {% from "../../macros/summary-field.njk" import summaryField %}
+
+{% if isNewBYSFlow %}
+	{% set enforcementNoticeRow = null %}
+{% else %}
+	{% set enforcementNoticeRow = {
+		key: {
+			text: "Have you received an enforcement notice?"
+		},
+		value: {
+			text: summaryField(enforcementNotice, { 'data-cy': "enforcement-notice" })
+		},
+		actions: {
+			items: [
+				{
+					href: "/before-you-start/enforcement-notice",
+					text: "Change",
+					visuallyHiddenText: "Have you received an enforcement notice?",
+					attributes: { "data-cy":"enforcementNotice"}
+				}
+			]
+		}
+	}
+	%}
+{% endif %}
+
 {% block canUseServiceSummaryList %}
     {{ govukSummaryList({
 		classes: "govuk-summary-list govuk-!-margin-bottom-9",
@@ -23,24 +48,7 @@
 					]
 				}
 			},
-			{
-				key: {
-					text: "Have you received an enforcement notice?"
-				},
-				value: {
-					text: summaryField(enforcementNotice, { 'data-cy': "enforcement-notice" })
-				},
-				actions: {
-					items: [
-						{
-							href: "/before-you-start/enforcement-notice",
-							text: "Change",
-							visuallyHiddenText: "Have you received an enforcement notice?",
-							attributes: { "data-cy":"enforcementNotice"}
-						}
-					]
-				}
-			},
+			enforcementNoticeRow,
 			{
 				key: {
 					text: "Application number"

--- a/packages/forms-web-app/src/views/householder-planning/eligibility/can-use-service.njk
+++ b/packages/forms-web-app/src/views/householder-planning/eligibility/can-use-service.njk
@@ -1,6 +1,31 @@
 {% extends "../../layouts/can-use-service/main.njk" %}
 {% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
 {% from "../../macros/summary-field.njk" import summaryField %}
+
+{% if isNewBYSFlow %}
+	{% set enforcementNoticeRow = null %}
+{% else %}
+	{% set enforcementNoticeRow = {
+		key: {
+			text: "Have you received an enforcement notice?"
+		},
+		value: {
+			text: summaryField(enforcementNotice, { 'data-cy': "enforcement-notice" })
+		},
+		actions: {
+			items: [
+				{
+					href: "/before-you-start/enforcement-notice",
+					text: "Change",
+					visuallyHiddenText: "Have you received an enforcement notice?",
+					attributes: { "data-cy":"enforcementNotice"}
+				}
+			]
+		}
+	}
+	%}
+{% endif %}
+
 {% block canUseServiceSummaryList %}
     {% set summaryRows = [
 		{
@@ -21,24 +46,7 @@
 				]
 			}
 		},
-		{
-			key: {
-				text: "Have you received an enforcement notice?"
-			},
-			value: {
-				text: summaryField(enforcementNotice, { 'data-cy': "enforcement-notice" })
-			},
-			actions: {
-				items: [
-					{
-						href: "/before-you-start/enforcement-notice",
-						text: "Change",
-						visuallyHiddenText: "Have you received an enforcement notice?",
-						attributes: { "data-cy":"enforcementNotice"}
-					}
-				]
-			}
-		},
+	  enforcementNoticeRow,
 		{
 			key: {
 				text: "Application number"

--- a/packages/forms-web-app/src/views/householder-planning/eligibility/prior-approval/can-use-service.njk
+++ b/packages/forms-web-app/src/views/householder-planning/eligibility/prior-approval/can-use-service.njk
@@ -1,6 +1,31 @@
 {% extends "../../../layouts/can-use-service/main.njk" %}
 {% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
 {% from "../../../macros/summary-field.njk" import summaryField %}
+
+{% if isNewBYSFlow %}
+	{% set enforcementNoticeRow = null %}
+{% else %}
+	{% set enforcementNoticeRow = {
+		key: {
+			text: "Have you received an enforcement notice?"
+		},
+		value: {
+			text: summaryField(enforcementNotice, { 'data-cy': "enforcement-notice" })
+		},
+		actions: {
+			items: [
+				{
+					href: "/before-you-start/enforcement-notice",
+					text: "Change",
+					visuallyHiddenText: "Have you received an enforcement notice?",
+					attributes: { "data-cy":"enforcementNotice"}
+				}
+			]
+		}
+	}
+	%}
+{% endif %}
+
 {% block canUseServiceSummaryList %}
     {% set summaryRows = [
 		{
@@ -21,24 +46,7 @@
 				]
 			}
 		},
-		{
-			key: {
-				text: "Have you received an enforcement notice?"
-			},
-			value: {
-				text: summaryField(enforcementNotice, { 'data-cy': "enforcement-notice" })
-			},
-			actions: {
-				items: [
-					{
-						href: "/before-you-start/enforcement-notice",
-						text: "Change",
-						visuallyHiddenText: "Have you received an enforcement notice?",
-						attributes: { "data-cy":"enforcementNotice"}
-					}
-				]
-			}
-		},
+		enforcementNoticeRow,
 		{
 			key: {
 				text: "Application number"

--- a/packages/forms-web-app/src/views/householder-planning/eligibility/removal-or-variation-of-conditions/can-use-service.njk
+++ b/packages/forms-web-app/src/views/householder-planning/eligibility/removal-or-variation-of-conditions/can-use-service.njk
@@ -1,6 +1,31 @@
 {% extends "../../../layouts/can-use-service/main.njk" %}
 {% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
 {% from "../../../macros/summary-field.njk" import summaryField %}
+
+{% if isNewBYSFlow %}
+	{% set enforcementNoticeRow = null %}
+{% else %}
+	{% set enforcementNoticeRow = {
+		key: {
+			text: "Have you received an enforcement notice?"
+		},
+		value: {
+			text: summaryField(enforcementNotice, { 'data-cy': "enforcement-notice" })
+		},
+		actions: {
+			items: [
+				{
+					href: "/before-you-start/enforcement-notice",
+					text: "Change",
+					visuallyHiddenText: "Have you received an enforcement notice?",
+					attributes: { "data-cy":"enforcementNotice"}
+				}
+			]
+		}
+	}
+	%}
+{% endif %}
+
 {% block canUseServiceSummaryList %}
     {% set summaryRows = [
 		{
@@ -21,24 +46,7 @@
 				]
 			}
 		},
-		{
-			key: {
-				text: "Have you received an enforcement notice?"
-			},
-			value: {
-				text: summaryField(enforcementNotice, { 'data-cy': "enforcement-notice" })
-			},
-			actions: {
-				items: [
-					{
-						href: "/before-you-start/enforcement-notice",
-						text: "Change",
-						visuallyHiddenText: "Have you received an enforcement notice?",
-						attributes: { "data-cy":"enforcementNotice"}
-					}
-				]
-			}
-		},
+		enforcementNoticeRow,
 		{
 			key: {
 				text: "Application number"


### PR DESCRIPTION
### Description of change

Further new BYS flow changes (new code behind NEW_BYS_ENFORCEMENT feature flag)

- updated can use service pages for non enforcement types
- updated appeal-details bys sections

Ticket: https://pins-ds.atlassian.net/browse/A2-8049

### Checklist

- [X] Feature complete and ready for users, or behind feature-flag
- [X] Commit history is linear with no merge commits
- [ ] Requires infrastructure changes

### Important

Please do not merge from `main` (please only [rebase](https://github.com/Planning-Inspectorate/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
