### PR TITLE
fix(forms): fixed missing fields in appeal details page (no-ticket)

### DIFF
--- a/packages/appeals-service-api/src/routes/v2/appeal-cases/appeal-cases.spec.js
+++ b/packages/appeals-service-api/src/routes/v2/appeal-cases/appeal-cases.spec.js
@@ -766,7 +766,12 @@ module.exports = ({ getSqlClient, setCurrentLpa, mockNotifyClient, appealsApi })
 						appealUnderActSection: data.appealUnderActSection ?? null,
 						lpaConsiderAppealInvalid: data.lpaConsiderAppealInvalid ?? null,
 						lpaAppealInvalidReasons: data.lpaAppealInvalidReasons ?? null,
-						listOfDocumentsBeforeDecision: data.listOfDocumentsBeforeDecision ?? null
+						listOfDocumentsBeforeDecision: data.listOfDocumentsBeforeDecision ?? null,
+						anySignificantChangesLpa: null,
+						anySignificantChangesLpa_courtJudgementSignificantChanges: null,
+						anySignificantChangesLpa_localPlanSignificantChanges: null,
+						anySignificantChangesLpa_nationalPolicySignificantChanges: null,
+						anySignificantChangesLpa_otherSignificantChanges: null
 					});
 					expectEmails(email, testCaseRef);
 				});
@@ -1023,7 +1028,12 @@ module.exports = ({ getSqlClient, setCurrentLpa, mockNotifyClient, appealsApi })
 					appealUnderActSection: data.appealUnderActSection ?? null,
 					lpaConsiderAppealInvalid: data.lpaConsiderAppealInvalid ?? null,
 					lpaAppealInvalidReasons: data.lpaAppealInvalidReasons ?? null,
-					listOfDocumentsBeforeDecision: data.listOfDocumentsBeforeDecision ?? null
+					listOfDocumentsBeforeDecision: data.listOfDocumentsBeforeDecision ?? null,
+					anySignificantChangesLpa: null,
+					anySignificantChangesLpa_courtJudgementSignificantChanges: null,
+					anySignificantChangesLpa_localPlanSignificantChanges: null,
+					anySignificantChangesLpa_nationalPolicySignificantChanges: null,
+					anySignificantChangesLpa_otherSignificantChanges: null
 				});
 			});
 

--- a/packages/appeals-service-api/src/routes/v2/appeal-cases/service.js
+++ b/packages/appeals-service-api/src/routes/v2/appeal-cases/service.js
@@ -587,6 +587,26 @@ const mapS78DataModelToAppealCase = (caseProcessCode, dataModel) => ({
 		dataModel.significantChangesAffectingApplicationAppellant?.find(
 			(/** @type {any} */ c) => c.value === 'court-judgement'
 		)?.comment || null,
+	anySignificantChangesLpa:
+		dataModel.significantChangesAffectingApplicationLpa
+			?.map((/** @type {any} */ c) => c.value)
+			.join(',') || null,
+	anySignificantChangesLpa_otherSignificantChanges:
+		dataModel.significantChangesAffectingApplicationLpa?.find(
+			(/** @type {any} */ c) => c.value === 'other'
+		)?.comment || null,
+	anySignificantChangesLpa_localPlanSignificantChanges:
+		dataModel.significantChangesAffectingApplicationLpa?.find(
+			(/** @type {any} */ c) => c.value === 'adopted-a-new-local-plan'
+		)?.comment || null,
+	anySignificantChangesLpa_nationalPolicySignificantChanges:
+		dataModel.significantChangesAffectingApplicationLpa?.find(
+			(/** @type {any} */ c) => c.value === 'national-policy-change'
+		)?.comment || null,
+	anySignificantChangesLpa_courtJudgementSignificantChanges:
+		dataModel.significantChangesAffectingApplicationLpa?.find(
+			(/** @type {any} */ c) => c.value === 'court-judgement'
+		)?.comment || null,
 	// s20 specific fields
 	preserveGrantLoan: dataModel.preserveGrantLoan,
 	consultHistoricEngland: dataModel.consultHistoricEngland

--- a/packages/common/src/lib/format-questionnaire-details.js
+++ b/packages/common/src/lib/format-questionnaire-details.js
@@ -136,3 +136,13 @@ exports.formatProcedurePreference = (caseData) => {
  */
 exports.formatConditions = (caseData) =>
 	(caseData.newConditionDetails && `Yes\n${caseData.newConditionDetails ?? ''}`) || 'No';
+
+/**
+ * @param {AppealCaseDetailed} caseData
+ */
+exports.formatListOfDocumentsBeforeDecision = (caseData) => {
+	if (caseData.listOfDocumentsBeforeDecision && caseData.listOfDocumentsBeforeDecision.length > 0) {
+		return caseData.listOfDocumentsBeforeDecision.join('\n');
+	}
+	return 'No';
+};

--- a/packages/database/src/migrations/20260605142247_add_any_significant_changes_lpa_to_appeal/migration.sql
+++ b/packages/database/src/migrations/20260605142247_add_any_significant_changes_lpa_to_appeal/migration.sql
@@ -1,0 +1,23 @@
+BEGIN TRY
+
+BEGIN TRAN;
+
+-- AlterTable
+ALTER TABLE [dbo].[AppealCase] ADD [anySignificantChangesLpa] NVARCHAR(1000),
+[anySignificantChangesLpa_courtJudgementSignificantChanges] NVARCHAR(max),
+[anySignificantChangesLpa_localPlanSignificantChanges] NVARCHAR(max),
+[anySignificantChangesLpa_nationalPolicySignificantChanges] NVARCHAR(max),
+[anySignificantChangesLpa_otherSignificantChanges] NVARCHAR(max);
+
+COMMIT TRAN;
+
+END TRY
+BEGIN CATCH
+
+IF @@TRANCOUNT > 0
+BEGIN
+    ROLLBACK TRAN;
+END;
+THROW
+
+END CATCH

--- a/packages/database/src/schema.prisma
+++ b/packages/database/src/schema.prisma
@@ -425,27 +425,31 @@ model AppealCase {
   contactPlanningInspectorateDate   DateTime?
 
   // LPAQ fields
-  noticeRelatesToBuildingEngineeringMiningOther Boolean?
-  areaOfAllegedBreachInSquareMetres             Decimal?
-  floorSpaceCreatedByBreachInSquareMetres       Decimal?
-  changeOfUseRefuseOrWaste                      Boolean?
-  changeOfUseMineralExtraction                  Boolean?
-  changeOfUseMineralStorage                     Boolean?
-  relatesToErectionOfBuildingOrBuildings        Boolean?
-  relatesToBuildingWithAgriculturalPurpose      Boolean?
-  relatesToBuildingSingleDwellingHouse          Boolean?
-  affectedTrunkRoadName                         String?
-  isSiteOnCrownLand                             Boolean?
-  article4AffectedDevelopmentRights             String?
-
+  noticeRelatesToBuildingEngineeringMiningOther             Boolean?
+  areaOfAllegedBreachInSquareMetres                         Decimal?
+  floorSpaceCreatedByBreachInSquareMetres                   Decimal?
+  changeOfUseRefuseOrWaste                                  Boolean?
+  changeOfUseMineralExtraction                              Boolean?
+  changeOfUseMineralStorage                                 Boolean?
+  relatesToErectionOfBuildingOrBuildings                    Boolean?
+  relatesToBuildingWithAgriculturalPurpose                  Boolean?
+  relatesToBuildingSingleDwellingHouse                      Boolean?
+  affectedTrunkRoadName                                     String?
+  isSiteOnCrownLand                                         Boolean?
+  article4AffectedDevelopmentRights                         String?
+  anySignificantChangesLpa                                  String?
+  anySignificantChangesLpa_otherSignificantChanges          String?  @db.NVarChar(MAX)
+  anySignificantChangesLpa_localPlanSignificantChanges      String?  @db.NVarChar(MAX)
+  anySignificantChangesLpa_nationalPolicySignificantChanges String?  @db.NVarChar(MAX)
+  anySignificantChangesLpa_courtJudgementSignificantChanges String?  @db.NVarChar(MAX)
   //***************************************************************************
   // LDC fields
   //***************************************************************************
-  applicationMadeUnderActSection String? /// appellant - lawful development certificate type
-  siteUseAtTimeOfApplication     String? /// Site use at time of application
-  appealUnderActSection          String? /// lpa - lawful development certificate type
-  lpaConsiderAppealInvalid       Boolean? /// Does LPA consider the appeal invalid
-  lpaAppealInvalidReasons        String?  @db.NVarChar(MAX) /// Reason(s) why LPA consider the appeal invalid
+  applicationMadeUnderActSection                            String? /// appellant - lawful development certificate type
+  siteUseAtTimeOfApplication                                String? /// Site use at time of application
+  appealUnderActSection                                     String? /// lpa - lawful development certificate type
+  lpaConsiderAppealInvalid                                  Boolean? /// Does LPA consider the appeal invalid
+  lpaAppealInvalidReasons                                   String?  @db.NVarChar(MAX) /// Reason(s) why LPA consider the appeal invalid
 
   //***************************************************************************
   // Relations

--- a/packages/forms-web-app/src/controllers/selected-appeal/questionnaire-details/appeal-process-details-rows.js
+++ b/packages/forms-web-app/src/controllers/selected-appeal/questionnaire-details/appeal-process-details-rows.js
@@ -6,6 +6,8 @@ const {
 } = require('@pins/common');
 const { fieldNames } = require('@pins/common/src/dynamic-forms/field-names');
 const { isNotUndefinedOrNull } = require('#lib/is-not-undefined-or-null');
+const { isExpeditedPart1Eligible } = require('#lib/is-expedited-part1-eligible');
+const { nl2br } = require('@pins/common/src/utils');
 
 /**
  * @param {import('appeals-service-api').Api.AppealCaseDetailed } caseData
@@ -18,7 +20,59 @@ exports.appealProcessRows = (caseData) => {
 	);
 	const showNearby = !!formattedNearby;
 
-	return [
+	const formatSignificantChanges = (caseData) => {
+		const changes = caseData.anySignificantChangesLpa?.split(',').map((s) => s.trim()) || [];
+		if (changes.length === 0) return '';
+		const mapping = [
+			{
+				key: 'adopted-a-new-local-plan',
+				label: 'Adopted a new local plan',
+				details: caseData.anySignificantChangesLpa_localPlanSignificantChanges
+			},
+			{
+				key: 'national-policy-change',
+				label: 'National policy changes',
+				details: caseData.anySignificantChangesLpa_nationalPolicySignificantChanges
+			},
+			{
+				key: 'court-judgement',
+				label: 'Court judgment',
+				details: caseData.anySignificantChangesLpa_courtJudgementSignificantChanges
+			},
+			{
+				key: 'other',
+				label: 'Other',
+				details: caseData.anySignificantChangesLpa_otherSignificantChanges
+			}
+		];
+
+		return nl2br(
+			mapping
+				.filter((m) => changes.includes(m.key))
+				.map((m) => {
+					const details = m.details ? `\n${m.details}` : '';
+					return `${m.label}:${details}`;
+				})
+				.join('\n\n')
+		);
+	};
+
+	/**
+	 * @param {AppealCaseDetailed} caseData
+	 * @param {DetailsContext} context
+	 * @returns {Rows}
+	 */
+	const getExpeditedDetailsRows = (caseData) => {
+		return [
+			{
+				keyText: 'Significant changes since application',
+				valueText: formatSignificantChanges(caseData),
+				condition: (caseData) => isNotUndefinedOrNull(caseData.anySignificantChangesLpa),
+				isEscaped: true
+			}
+		];
+	};
+	const rows = [
 		{
 			keyText: 'Appeal procedure',
 			valueText: formatProcedurePreference(caseData),
@@ -41,4 +95,14 @@ exports.appealProcessRows = (caseData) => {
 			condition: () => isNotUndefinedOrNull(caseData.newConditionDetails)
 		}
 	];
+
+	if (
+		isExpeditedPart1Eligible({
+			...caseData,
+			eligibility: { applicationDecision: caseData.applicationDecision }
+		})
+	) {
+		rows.push(...getExpeditedDetailsRows(caseData));
+	}
+	return rows;
 };

--- a/packages/forms-web-app/src/controllers/selected-appeal/questionnaire-details/appeal-process-details.test.js
+++ b/packages/forms-web-app/src/controllers/selected-appeal/questionnaire-details/appeal-process-details.test.js
@@ -8,6 +8,14 @@ const casPlanningLPAQData = caseTypeLPAQFactory(
 	'appealProcess'
 );
 const s78LPAQData = caseTypeLPAQFactory(CASE_TYPES.S78.processCode, 'appealProcess');
+const s78ExpeditedLPAQData = {
+	...caseTypeLPAQFactory(CASE_TYPES.S78.processCode, 'appealProcess'),
+	typeOfPlanningApplication: 'full-appeal',
+	applicationDate: '2026-04-01',
+	eligibility: { applicationDecision: 'granted' },
+	anySignificantChangesLpa: 'no',
+	anySignificantChangesLpa_otherSignificantChanges: ''
+};
 const s20LPAQData = caseTypeLPAQFactory(CASE_TYPES.S20.processCode, 'appealProcess');
 const advertLPAQData = caseTypeLPAQFactory(CASE_TYPES.ADVERTS.processCode, 'appealProcess');
 const casAdvertLPAQData = caseTypeLPAQFactory(CASE_TYPES.CAS_ADVERTS.processCode, 'appealProcess');
@@ -28,7 +36,10 @@ const expectedRowsS78 = [
 	{ title: 'Appeal references', value: '00000001' },
 	{ title: 'Are there any proposed conditions?', value: 'Yes\nexample new conditions' }
 ];
-
+const expectedRowsS78Expedited = [
+	...expectedRowsS78,
+	{ title: 'Significant changes since application', value: '' }
+];
 const expectedRowsLDC = [{ title: 'Appeals near the site', value: 'No' }];
 
 describe('appealProcessRows', () => {
@@ -36,6 +47,7 @@ describe('appealProcessRows', () => {
 		['HAS', hasLPAQData, expectedRowsHas],
 		['CAS Planning', casPlanningLPAQData, expectedRowsHas],
 		['S78', s78LPAQData, expectedRowsS78],
+		['S78Expedited', s78ExpeditedLPAQData, expectedRowsS78Expedited],
 		['S20', s20LPAQData, expectedRowsS78],
 		['ADVERTS', advertLPAQData, expectedRowsS78],
 		['CAS_ADVERTS', casAdvertLPAQData, expectedRowsHas],

--- a/packages/forms-web-app/src/controllers/selected-appeal/questionnaire-details/index.js
+++ b/packages/forms-web-app/src/controllers/selected-appeal/questionnaire-details/index.js
@@ -16,11 +16,13 @@ const { notifiedRows } = require('./notified-details-rows');
 const { planningOfficerReportRows } = require('./planning-officer-details-rows');
 const { siteAccessRows } = require('./site-access-details-rows');
 const { additionalDocumentsRows } = require('./additional-documents-details-rows');
+const { originalEvidenceRows } = require('./original-evidence-details-rows');
 const { getUserFromSession } = require('../../../services/user.service');
 const { getDepartmentFromCode } = require('../../../services/department.service');
 const { addCSStoHtml } = require('#lib/add-css-to-html');
 const { generatePDF } = require('#lib/pdf-api-wrapper');
 const { APPEAL_CASE_STAGE } = require('@planning-inspectorate/data-model');
+const { isExpeditedPart1Eligible } = require('#lib/is-expedited-part1-eligible');
 
 /**
  * Shared controller for /appeals/:caseRef/appeal-details, manage-appeals/:caseRef/appeal-details rule-6-appeals/:caseRef/appeal-details
@@ -95,6 +97,19 @@ exports.get = (layoutTemplate = 'layouts/no-banner-link/main.njk') => {
 		// appeal process rows
 		const appealProcessDetailsRows = appealProcessRows(caseData);
 		const appealProcessDetails = formatQuestionnaireRows(appealProcessDetailsRows, caseData);
+		// original evidence rows
+		const originalEvidenceDetailsRows = isExpeditedPart1Eligible({
+			...caseData,
+			eligibility: { applicationDecision: caseData.applicationDecision }
+		})
+			? originalEvidenceRows({ caseData, userType })
+			: [];
+		const originalEvidenceDetails = isExpeditedPart1Eligible({
+			...caseData,
+			eligibility: { applicationDecision: caseData.applicationDecision }
+		})
+			? formatQuestionnaireRows(originalEvidenceDetailsRows, caseData)
+			: [];
 		// additional documents row
 		const additionalDocumentsDetailsRows = additionalDocumentsRows({
 			caseData,
@@ -126,6 +141,13 @@ exports.get = (layoutTemplate = 'layouts/no-banner-link/main.njk') => {
 			zipDownloadUrl
 		};
 
+		isExpeditedPart1Eligible({
+			...caseData,
+			eligibility: { applicationDecision: caseData.applicationDecision }
+		})
+			? // @ts-ignore
+				(viewContext.appeal.originalEvidenceDetails = originalEvidenceDetails)
+			: null;
 		await res.render(VIEW.SELECTED_APPEAL.APPEAL_QUESTIONNAIRE, viewContext, async (_, html) => {
 			if (!isPagePdfDownload) return res.send(html);
 			const pdfHtml = await addCSStoHtml(html);

--- a/packages/forms-web-app/src/controllers/selected-appeal/questionnaire-details/original-evidence-details-rows.js
+++ b/packages/forms-web-app/src/controllers/selected-appeal/questionnaire-details/original-evidence-details-rows.js
@@ -1,0 +1,35 @@
+const { APPEAL_DOCUMENT_TYPE } = require('@planning-inspectorate/data-model');
+const { documentExists, formatDocumentDetails } = require('@pins/common');
+
+/**
+ * @param {{ caseData: import('appeals-service-api').Api.AppealCaseDetailed, userType: string }} params
+ * @returns {import("@pins/common/src/view-model-maps/rows/def").Rows}
+ */
+exports.originalEvidenceRows = ({ caseData }) => {
+	const documents = caseData.Documents || [];
+	return [
+		{
+			keyText: 'Design and access statement',
+			valueText: formatDocumentDetails(documents, APPEAL_DOCUMENT_TYPE.DESIGN_ACCESS_STATEMENT_LPA),
+			condition: () => documentExists(documents, APPEAL_DOCUMENT_TYPE.DESIGN_ACCESS_STATEMENT_LPA),
+			isEscaped: true
+		},
+		{
+			keyText: 'Plans and drawings',
+			valueText: formatDocumentDetails(documents, APPEAL_DOCUMENT_TYPE.PLANS_DRAWINGS_LPA),
+			condition: () => documentExists(documents, APPEAL_DOCUMENT_TYPE.PLANS_DRAWINGS_LPA),
+			isEscaped: true
+		},
+		{
+			keyText: 'Any other documents submitted with the application',
+			valueText: formatDocumentDetails(documents, APPEAL_DOCUMENT_TYPE.ADDITIONAL_DOCUMENTS_LPA),
+			condition: () => documentExists(documents, APPEAL_DOCUMENT_TYPE.ADDITIONAL_DOCUMENTS_LPA),
+			isEscaped: true
+		},
+		{
+			keyText: 'What documents and plans did you use to make your decision?',
+			valueText: caseData.listOfDocumentsBeforeDecision,
+			condition: () => !!caseData.listOfDocumentsBeforeDecision
+		}
+	];
+};

--- a/packages/forms-web-app/src/controllers/selected-appeal/questionnaire-details/original-evidence-details-rows.test.js
+++ b/packages/forms-web-app/src/controllers/selected-appeal/questionnaire-details/original-evidence-details-rows.test.js
@@ -1,0 +1,52 @@
+const { originalEvidenceRows } = require('./original-evidence-details-rows');
+const {
+	APPEAL_DOCUMENT_TYPE,
+	APPEAL_LPA_QUESTIONNAIRE_VALIDATION_OUTCOME
+} = require('@planning-inspectorate/data-model');
+const { makeDocument } = require('./test-factory');
+
+describe('Original Evidence', () => {
+	it('should return all rows when documents exist', () => {
+		const docDesignAccessStatement = makeDocument(APPEAL_DOCUMENT_TYPE.DESIGN_ACCESS_STATEMENT_LPA);
+		const docPlansAndDrawings = makeDocument(APPEAL_DOCUMENT_TYPE.PLANS_DRAWINGS_LPA);
+		const docAdditionalDocuments = makeDocument(APPEAL_DOCUMENT_TYPE.ADDITIONAL_DOCUMENTS_LPA);
+		const caseData = {
+			Documents: [docDesignAccessStatement, docPlansAndDrawings, docAdditionalDocuments],
+			lpaQuestionnaireValidationOutcome: APPEAL_LPA_QUESTIONNAIRE_VALIDATION_OUTCOME.COMPLETE,
+			eligibility: { applicationDecision: 'granted' },
+			typeOfPlanningApplication: 'full-appeal',
+			applicationDate: '2026-04-01',
+			listOfDocumentsBeforeDecision: 'Document 1, Document 2, Document 3'
+		};
+		const rows = originalEvidenceRows({ caseData });
+		expect(rows).toHaveLength(4);
+		expect(rows[0].keyText).toBe('Design and access statement');
+		expect(rows[0].valueText).toContain('name.pdf');
+		expect(rows[1].keyText).toBe('Plans and drawings');
+		expect(rows[1].valueText).toContain('name.pdf');
+		expect(rows[2].keyText).toBe('Any other documents submitted with the application');
+		expect(rows[2].valueText).toContain('name.pdf');
+		expect(rows[3].keyText).toBe('What documents and plans did you use to make your decision?');
+		expect(rows[3].valueText).toBe('Document 1, Document 2, Document 3');
+	});
+
+	it('should handle missing Documents array gracefully', () => {
+		const caseData = {
+			listOfDocumentsBeforeDecision: 'Document 1, Document 2, Document 3'
+		};
+		const visibleRows = originalEvidenceRows({
+			caseData
+		}).map((visibleRow) => {
+			return { title: visibleRow.keyText, value: visibleRow.valueText };
+		});
+		expect(visibleRows).toEqual([
+			{ title: 'Design and access statement', value: 'No' },
+			{ title: 'Plans and drawings', value: 'No' },
+			{ title: 'Any other documents submitted with the application', value: 'No' },
+			{
+				title: 'What documents and plans did you use to make your decision?',
+				value: 'Document 1, Document 2, Document 3'
+			}
+		]);
+	});
+});

--- a/packages/forms-web-app/src/views/selected-appeal/questionnaire-details.njk
+++ b/packages/forms-web-app/src/views/selected-appeal/questionnaire-details.njk
@@ -63,7 +63,8 @@
                 { title: "Planning officer’s report and supplementary documents", details: appeal.planningOfficerDetails },
                 { title: "Site access", details: appeal.siteAccessDetails },
                 { title: "Appeal process", details: appeal.appealProcessDetails },
-                { title: "Additional documents", details: appeal.additionalDocumentsDetails}
+                { title: "Additional documents", details: appeal.additionalDocumentsDetails},
+								{ title: "Original evidence", details: appeal.originalEvidenceDetails}
             ] %}
 
             {% for section in sections %}


### PR DESCRIPTION
### Description of change

- Added missing fields back into mapping
- Added missing fields into appeal details page
- added missing fields and section into questionnaire page
- updated unit tests
- Updated prisma 

Ticket: https://pins-ds.atlassian.net/browse/A2-

### Checklist

- [ ] Feature complete and ready for users, or behind feature-flag
- [ ] Commit history is linear with no merge commits
- [ ] Requires infrastructure changes

### Important

Please do not merge from `main` (please only [rebase](https://github.com/Planning-Inspectorate/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
