### PR TITLE
feat(a2-7783): allow unpublished docs into db

### DIFF
--- a/packages/integration-functions/__tests__/functions/appeal-document.test.js
+++ b/packages/integration-functions/__tests__/functions/appeal-document.test.js
@@ -90,18 +90,6 @@ describe('appeal-document', () => {
 		expect(mockClient.putAppealDocument).not.toHaveBeenCalled();
 	});
 
-	it('should ignore unpublished documents', async () => {
-		const invalidMessage = {
-			...testData,
-			datePublished: null
-		};
-
-		await handler(invalidMessage, ctx);
-
-		expect(ctx.log).toHaveBeenCalledWith('Invalid message status, skipping');
-		expect(mockClient.putAppealDocument).not.toHaveBeenCalled();
-	});
-
 	const invalidVirusStatuses = ['not_scanned', 'affected', 'unknown'];
 
 	it.each(invalidVirusStatuses)(
@@ -153,7 +141,7 @@ describe('appeal-document', () => {
 
 	it('Should ignore invalid delete documents requests as they wont exist in the database', async () => {
 		const result = await handler(
-			{ ...testData, datePublished: null },
+			{ ...testData, virusCheckStatus: 'not_scanned' },
 			{
 				...ctx,
 				triggerMetadata: { applicationProperties: { type: 'Delete' } }

--- a/packages/integration-functions/src/functions/appeal-document.js
+++ b/packages/integration-functions/src/functions/appeal-document.js
@@ -3,7 +3,7 @@
  * service bus topic trigger
  * consumes document metadata messages from BO
  * document metadata represent files attached to appeal cases
- * ignore messages if not published/scanned/redacted
+ * ignore messages if not scanned
  * currently this is assuming that all docs meeting this criteria will be publicly available and so FO can just link users to the storage account uri directly
  */
 
@@ -67,10 +67,7 @@ function checkMessageIsValid(documentMessage, context) {
 		throw new Error('Invalid message schema');
 	}
 
-	return (
-		!!documentMessage.datePublished &&
-		VALID_SCAN_STATUSES.includes(documentMessage.virusCheckStatus)
-	);
+	return VALID_SCAN_STATUSES.includes(documentMessage.virusCheckStatus);
 }
 
 /**


### PR DESCRIPTION
### Description of change

Allow unpublished docs into db

Ticket: https://pins-ds.atlassian.net/browse/A2-7783

### Checklist

- [x] Feature complete and ready for users, or behind feature-flag
- [x] Commit history is linear with no merge commits
- [ ] Requires infrastructure changes

### Important

Please do not merge from `main` (please only [rebase](https://github.com/Planning-Inspectorate/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.