### PR TITLE
fix(a2-7783): unpublish costs docs and ignore internal documents

### DIFF
--- a/packages/database/src/migrations/20260611111644_unpublish_existing_cost_docs/migration.sql
+++ b/packages/database/src/migrations/20260611111644_unpublish_existing_cost_docs/migration.sql
@@ -1,0 +1,31 @@
+BEGIN TRY
+
+BEGIN TRAN;
+
+-- Unpublish costs docs
+UPDATE [dbo].[Document]
+SET
+    [published]            = 0,
+    [publishedDocumentURI] = NULL,
+    [datePublished]        = NULL
+WHERE [documentType] IN (
+    'appellantCostsApplication',
+    'appellantCostsCorrespondence',
+    'appellantCostsWithdrawal',
+    'lpaCostsApplication',
+    'lpaCostsCorrespondence',
+    'lpaCostsWithdrawal'
+)
+
+COMMIT TRAN;
+
+END TRY
+BEGIN CATCH
+
+IF @@TRANCOUNT > 0
+BEGIN
+    ROLLBACK TRAN;
+END;
+THROW
+
+END CATCH

--- a/packages/database/src/schema.prisma
+++ b/packages/database/src/schema.prisma
@@ -721,7 +721,7 @@ model Document {
   // indexes
   // additional covering/filtered indexes added manually, as include not supported by Prisma https://www.prisma.io/docs/orm/prisma-schema/data-model/indexes
   // NONCLUSTERED INDEX (caseReference) INCLUDE (id, publishedDocumentURI, filename, documentType, datePublished, redacted, virusCheckStatus, published) WHERE published = 1
-  // NONCLUSTERED INDEX ([caseReference], [documentType]) INCLUDE (id, publishedDocumentURI, filename, datePublished, redacted, virusCheckStatus, published)
+  @@index([caseReference, documentType], map: "Document_caseRef_type_idx")
   @@index([caseReference, published])
   @@index([documentURI]) // for documentsApi lookups
   @@index([caseReference, stage, published]) // for documentsApi zip generation

--- a/packages/integration-functions/__tests__/functions/appeal-document.test.js
+++ b/packages/integration-functions/__tests__/functions/appeal-document.test.js
@@ -2,7 +2,7 @@ const { InvocationContext } = require('@azure/functions');
 const handler = require('../../src/functions/appeal-document');
 const createApiClient = require('../../src/common/api-client');
 const config = require('../../src/common/config');
-const { APPEAL_REDACTED_STATUS } = require('@planning-inspectorate/data-model');
+const { APPEAL_CASE_STAGE, APPEAL_REDACTED_STATUS } = require('@planning-inspectorate/data-model');
 
 jest.mock('../../src/common/api-client');
 
@@ -147,6 +147,15 @@ describe('appeal-document', () => {
 				triggerMetadata: { applicationProperties: { type: 'Delete' } }
 			}
 		);
+
+		expect(mockClient.deleteAppealDocument).not.toHaveBeenCalled();
+		expect(mockClient.putAppealDocument).not.toHaveBeenCalled();
+		expect(ctx.log).toHaveBeenCalledWith(`Invalid message status, skipping`);
+		expect(result).toEqual({});
+	});
+
+	it('Should ignore internal documents', async () => {
+		const result = await handler({ ...testData, stage: APPEAL_CASE_STAGE.INTERNAL }, ctx);
 
 		expect(mockClient.deleteAppealDocument).not.toHaveBeenCalled();
 		expect(mockClient.putAppealDocument).not.toHaveBeenCalled();

--- a/packages/integration-functions/src/functions/appeal-document.js
+++ b/packages/integration-functions/src/functions/appeal-document.js
@@ -10,6 +10,7 @@
 const { app } = require('@azure/functions');
 const config = require('../common/config');
 const {
+	APPEAL_CASE_STAGE,
 	APPEAL_VIRUS_CHECK_STATUS,
 	MESSAGE_EVENT_TYPE
 } = require('@planning-inspectorate/data-model');
@@ -67,7 +68,10 @@ function checkMessageIsValid(documentMessage, context) {
 		throw new Error('Invalid message schema');
 	}
 
-	return VALID_SCAN_STATUSES.includes(documentMessage.virusCheckStatus);
+	return (
+		VALID_SCAN_STATUSES.includes(documentMessage.virusCheckStatus) &&
+		documentMessage.stage !== APPEAL_CASE_STAGE.INTERNAL
+	);
 }
 
 /**


### PR DESCRIPTION
### Description of change

- Ignore internal documents
- Unpublish costs docs to allow that to be managed from back office
- map manually added index to avoid it being removed by future migrations

Ticket: https://pins-ds.atlassian.net/browse/A2-7783

### Checklist

- [x] Feature complete and ready for users, or behind feature-flag
- [x] Commit history is linear with no merge commits
- [ ] Requires infrastructure changes

### Important

Please do not merge from `main` (please only [rebase](https://github.com/Planning-Inspectorate/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
