### PR TITLE
feat(A2-8447): remove statement of common ground from expedited appeals

### DIFF
--- a/packages/forms-web-app/src/dynamic-forms/s78-appeal-form-part-1/journey.js
+++ b/packages/forms-web-app/src/dynamic-forms/s78-appeal-form-part-1/journey.js
@@ -174,17 +174,6 @@ const makeSections = (response) => {
 			.addQuestion(questions.separateOwnershipCert)
 			.addQuestion(questions.uploadSeparateOwnershipCert)
 			.withCondition(() => questionHasAnswer(response, questions.separateOwnershipCert, 'yes'))
-			.addQuestion(questions.uploadStatementCommonGround)
-			.withCondition(() =>
-				questionsHaveAnswers(
-					response,
-					[
-						[questions.appellantProcedurePreference, APPEAL_CASE_PROCEDURE.HEARING],
-						[questions.appellantProcedurePreference, APPEAL_CASE_PROCEDURE.INQUIRY]
-					],
-					{ logicalCombinator: 'or' }
-				)
-			)
 			.addQuestion(questions.costApplication)
 			.addQuestion(questions.uploadCostApplication)
 			.withCondition(() => questionHasAnswer(response, questions.costApplication, 'yes'))

--- a/packages/forms-web-app/src/dynamic-forms/s78-appeal-form-part-1/journey.test.js
+++ b/packages/forms-web-app/src/dynamic-forms/s78-appeal-form-part-1/journey.test.js
@@ -49,4 +49,17 @@ describe('S78 Appeal Form Part 1 Journey', () => {
 		expect(whyAreYouAppealing).toBeDefined();
 		expect(anySignificantChanges).toBeDefined();
 	});
+	it('should not display uploadStatementCommonGround question', () => {
+		const journey = new Journey({ ...params, response: mockResponse });
+		const uploadSection = journey.sections.find((s) => s.segment === 'upload-documents');
+		if (!uploadSection) {
+			throw new Error('upload-documents section not found');
+		}
+
+		const uploadStatementCommonGround = uploadSection.questions.find(
+			(q) => q.fieldName === 'uploadStatementCommonGround'
+		);
+
+		expect(uploadStatementCommonGround).toBeUndefined();
+	});
 });


### PR DESCRIPTION
### Description of change

This ticket removes the statement of common ground file upload from the expedited form

Ticket: https://pins-ds.atlassian.net/browse/A2-8447

### Checklist

- [x] Feature complete and ready for users, or behind feature-flag
- [x] Commit history is linear with no merge commits
- [ ] Requires infrastructure changes

### Important

Please do not merge from `main` (please only [rebase](https://github.com/Planning-Inspectorate/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
