### PR TITLE
test: enforcement notice boolean screen removed test

### DIFF
--- a/test-packages/platform-feature-tests/cypress/support/flows/sections/appellantAAPD/initialiseApplicationTypeAppeal.js
+++ b/test-packages/platform-feature-tests/cypress/support/flows/sections/appellantAAPD/initialiseApplicationTypeAppeal.js
@@ -21,8 +21,8 @@ module.exports = (statusOfOriginalApplication, planning, expeditedAppeal, contex
 	cy.get(basePage?._selectors?.localPlanningDepartmentOptionZero).click();
 	cy.advanceToNextPage();
 	// Select the enforcement notice as 'No'
-	cy.getByData(basePage?._selectors.answerNo).click();
-	cy.advanceToNextPage();
+	//cy.getByData(basePage?._selectors.answerNo).click();
+	//cy.advanceToNextPage();
 	// Select the application type
 	cy.get(`[data-cy="${planning}"]`).click();
 	cy.advanceToNextPage();

--- a/test-packages/platform-feature-tests/cypress/support/flows/sections/appellantAAPD/initialiseApplicationTypeAppeal.js
+++ b/test-packages/platform-feature-tests/cypress/support/flows/sections/appellantAAPD/initialiseApplicationTypeAppeal.js
@@ -19,10 +19,7 @@ module.exports = (statusOfOriginalApplication, planning, expeditedAppeal, contex
 	// Select the local planning authority
 	cy.get(basePage?._selectors?.localPlanningDepartment).type(prepareAppealSelector?._selectors?.systemTest2BoroughCouncil);
 	cy.get(basePage?._selectors?.localPlanningDepartmentOptionZero).click();
-	cy.advanceToNextPage();
-	// Select the enforcement notice as 'No'
-	//cy.getByData(basePage?._selectors.answerNo).click();
-	//cy.advanceToNextPage();
+	cy.advanceToNextPage();	
 	// Select the application type
 	cy.get(`[data-cy="${planning}"]`).click();
 	cy.advanceToNextPage();


### PR DESCRIPTION
### Description of change

Enforcement Notice Boolean screen removed in BYS and added an option in in type of application screen which is causing issue for automation tests.
It has been fixed

Ticket: https://pins-ds.atlassian.net/browse/A2-8511

### Checklist

- [ ] Feature complete and ready for users, or behind feature-flag
- [ ] Commit history is linear with no merge commits
- [ ] Requires infrastructure changes

### Important

Please do not merge from `main` (please only [rebase](https://github.com/Planning-Inspectorate/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
