### PR TITLE
feat(A2-8466): remove statement of common ground for expedited appeal summary

### DIFF
--- a/packages/forms-web-app/src/controllers/selected-appeal/appeal-details/appeal-documents-rows.js
+++ b/packages/forms-web-app/src/controllers/selected-appeal/appeal-details/appeal-documents-rows.js
@@ -123,7 +123,8 @@ exports.documentsRows = (caseData) => {
 			valueText: formatDocumentDetails(documents, APPEAL_DOCUMENT_TYPE.STATEMENT_COMMON_GROUND),
 			condition: () =>
 				(isS20orS78 || isLDC) &&
-				caseData.appellantProcedurePreference !== APPEAL_APPELLANT_PROCEDURE_PREFERENCE.WRITTEN,
+				caseData.appellantProcedurePreference !== APPEAL_APPELLANT_PROCEDURE_PREFERENCE.WRITTEN &&
+				!isExpeditedPart1Eligible(caseData),
 			isEscaped: true
 		},
 		{

--- a/packages/forms-web-app/src/controllers/selected-appeal/appeal-details/appeal-documents-rows.test.js
+++ b/packages/forms-web-app/src/controllers/selected-appeal/appeal-details/appeal-documents-rows.test.js
@@ -153,6 +153,19 @@ describe('appeal-documents-rows', () => {
 			expect(rows[draftRow].condition()).toEqual(false);
 			expect(rows[draftRow].isEscaped).toEqual(true);
 		});
+
+		it('should not display field if expedited part 1 eligible', () => {
+			const rows = documentsRows({
+				appealTypeCode: CASE_TYPES.S78.processCode,
+				typeOfPlanningApplication: 'full-appeal',
+				eligibility: { applicationDecision: 'refused' },
+				applicationDate: '2026-04-10'
+			});
+			expect(rows[draftRow].keyText).toEqual('Draft statement of common ground');
+			expect(rows[draftRow].valueText).toEqual('No');
+			expect(rows[draftRow].condition()).toEqual(false);
+			expect(rows[draftRow].isEscaped).toEqual(true);
+		});
 	});
 
 	// text varies based on appeal type


### PR DESCRIPTION
### Description of change

Removes statement of common ground for expedited appeals 
Added unit tests and manually tested in browser

Ticket: https://pins-ds.atlassian.net/browse/A2-8466

### Checklist

- [x] Feature complete and ready for users, or behind feature-flag
- [x] Commit history is linear with no merge commits
- [ ] Requires infrastructure changes

### Important

Please do not merge from `main` (please only [rebase](https://github.com/Planning-Inspectorate/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
