### PR TITLE
feat(A2-8453): remove design access statement for CAS planning after expedited cutoff

### DIFF
--- a/packages/forms-web-app/src/controllers/selected-appeal/appeal-details/appeal-documents-rows.js
+++ b/packages/forms-web-app/src/controllers/selected-appeal/appeal-details/appeal-documents-rows.js
@@ -69,8 +69,12 @@ exports.documentsRows = (caseData) => {
 		{
 			keyText: 'Design and access statement in application',
 			valueText: formatDocumentDetails(documents, APPEAL_DOCUMENT_TYPE.DESIGN_ACCESS_STATEMENT),
-			condition: () =>
-				isS20orS78 || caseData.appealTypeCode === CASE_TYPES.CAS_PLANNING.processCode,
+			condition: () => {
+				if (caseData.appealTypeCode === CASE_TYPES.CAS_PLANNING.processCode) {
+					return !isExpeditedAppealDate(caseData.applicationDate);
+				}
+				return isS20orS78;
+			},
 			isEscaped: true
 		},
 		{

--- a/packages/forms-web-app/src/controllers/selected-appeal/appeal-details/appeal-documents-rows.test.js
+++ b/packages/forms-web-app/src/controllers/selected-appeal/appeal-details/appeal-documents-rows.test.js
@@ -405,3 +405,37 @@ describe('appeal-documents-rows - HAS and CAS conditional appeal statement', () 
 		expect(casRow.condition()).toBe(true);
 	});
 });
+
+describe('appeal-documents-rows - CAS Planning conditional design and access statement', () => {
+	it('should display design and access statement for CAS Planning if applicationDate is before April 1st 2026', () => {
+		const caseData = {
+			appealTypeCode: CASE_TYPES.CAS_PLANNING.processCode,
+			applicationDate: '2026-03-30T12:00:00.000Z'
+		};
+		const casRows = documentsRows(caseData);
+		const row = casRows.find((r) => r.keyText === 'Design and access statement in application');
+		expect(row).toBeDefined();
+		expect(row?.condition(caseData)).toBe(true);
+	});
+
+	it('should not display design and access statement for CAS Planning if applicationDate is on or after April 1st 2026', () => {
+		const caseData = {
+			appealTypeCode: CASE_TYPES.CAS_PLANNING.processCode,
+			applicationDate: '2026-04-01T00:00:00.000Z'
+		};
+		const casRows = documentsRows(caseData);
+		const row = casRows.find((r) => r.keyText === 'Design and access statement in application');
+		expect(row).toBeDefined();
+		expect(row?.condition(caseData)).toBe(false);
+	});
+
+	it('should display design and access statement for CAS Planning if applicationDate is not set', () => {
+		const caseData = {
+			appealTypeCode: CASE_TYPES.CAS_PLANNING.processCode
+		};
+		const casRows = documentsRows(caseData);
+		const row = casRows.find((r) => r.keyText === 'Design and access statement in application');
+		expect(row).toBeDefined();
+		expect(row?.condition(caseData)).toBe(true);
+	});
+});

--- a/packages/forms-web-app/src/dynamic-forms/adverts-appeal-form/journey.js
+++ b/packages/forms-web-app/src/dynamic-forms/adverts-appeal-form/journey.js
@@ -18,7 +18,7 @@ const {
 	shouldDisplayUploadDecisionLetter,
 	shouldDisplayGridReference,
 	shouldDisplayAdvertsQuestions,
-	shouldDisplayAppellantStatement: displayAppellantStatement
+	isBeforeExpeditedCutoff
 } = require('../display-questions');
 
 /**
@@ -34,7 +34,7 @@ const shouldDisplayAppellantStatement = (response) => {
 	if (shouldDisplayAdvertsQuestions(response)) {
 		return true;
 	}
-	return displayAppellantStatement(response);
+	return isBeforeExpeditedCutoff(response);
 };
 
 /**

--- a/packages/forms-web-app/src/dynamic-forms/cas-planning-appeal-form/journey.js
+++ b/packages/forms-web-app/src/dynamic-forms/cas-planning-appeal-form/journey.js
@@ -13,7 +13,7 @@ const {
 const {
 	shouldDisplayIdentifyingLandowners,
 	shouldDisplayTellingLandowners,
-	shouldDisplayAppellantStatement
+	isBeforeExpeditedCutoff
 } = require('../display-questions');
 
 /**
@@ -78,9 +78,9 @@ const makeSections = (response) => {
 			.addQuestion(questions.enterDevelopmentDescription)
 			.addQuestion(questions.updateDevelopmentDescription)
 			.addQuestion(questions.whyAreYouAppealingPart1)
-			.withCondition(() => !shouldDisplayAppellantStatement(response))
+			.withCondition(() => !isBeforeExpeditedCutoff(response))
 			.addQuestion(questions.anySignificantChanges)
-			.withCondition(() => !shouldDisplayAppellantStatement(response))
+			.withCondition(() => !isBeforeExpeditedCutoff(response))
 			.addQuestion(questions.anyOtherAppeals)
 			.addQuestion(questions.linkAppeals)
 			.withCondition(() => questionHasAnswer(response, questions.anyOtherAppeals, 'yes')),
@@ -92,13 +92,18 @@ const makeSections = (response) => {
 			)
 			.addQuestion(questions.uploadApplicationDecisionLetter)
 			.addQuestion(questions.uploadAppellantStatement)
-			.withCondition(() => shouldDisplayAppellantStatement(response))
+			.withCondition(() => isBeforeExpeditedCutoff(response))
 			.addQuestion(questions.costApplication)
 			.addQuestion(questions.uploadCostApplication)
 			.withCondition(() => questionHasAnswer(response, questions.costApplication, 'yes'))
 			.addQuestion(questions.designAccessStatement)
+			.withCondition(() => isBeforeExpeditedCutoff(response))
 			.addQuestion(questions.uploadDesignAccessStatement)
-			.withCondition(() => questionHasAnswer(response, questions.designAccessStatement, 'yes'))
+			.withCondition(
+				() =>
+					isBeforeExpeditedCutoff(response) &&
+					questionHasAnswer(response, questions.designAccessStatement, 'yes')
+			)
 			.addQuestion(questions.uploadPlansDrawingsDocuments)
 	];
 };

--- a/packages/forms-web-app/src/dynamic-forms/cas-planning-appeal-form/journey.test.js
+++ b/packages/forms-web-app/src/dynamic-forms/cas-planning-appeal-form/journey.test.js
@@ -1,5 +1,6 @@
 const { Journey } = require('@pins/dynamic-forms/src/journey');
-const { baseCASPlanningSubmissionUrl, ...params } = require('./journey');
+const journeyModule = require('./journey');
+const { baseCASPlanningSubmissionUrl, ...params } = journeyModule;
 
 const mockResponse = {
 	journeyId: 'CAS',
@@ -119,6 +120,113 @@ describe('CAS Appeal Form Journey', () => {
 						}
 					})
 			).toBe(true);
+		});
+	});
+
+	describe('designAccessStatement condition', () => {
+		it('should include designAccessStatement if application date is before April 1st 2026', () => {
+			const answers = { onApplicationDate: '2026-03-30T12:00:00.000Z' };
+			const journey = new Journey({
+				...params,
+				response: {
+					...mockResponse,
+					answers
+				}
+			});
+			const uploadSection = journey.getSection('upload-documents');
+			const designAccessQuestion = uploadSection?.questions?.find(
+				(q) => q.fieldName === 'designAccessStatement'
+			);
+			expect(designAccessQuestion?.shouldDisplay(journey.response)).toBe(true);
+		});
+
+		it('should not include designAccessStatement if application date is on or after April 1st 2026', () => {
+			const answers = { onApplicationDate: '2026-04-01T00:00:00.000Z' };
+			const journey = new Journey({
+				...params,
+				response: {
+					...mockResponse,
+					answers
+				}
+			});
+			const uploadSection = journey.getSection('upload-documents');
+			const designAccessQuestion = uploadSection?.questions?.find(
+				(q) => q.fieldName === 'designAccessStatement'
+			);
+			expect(designAccessQuestion?.shouldDisplay(journey.response)).toBe(false);
+		});
+
+		it('should include designAccessStatement if application date is not set', () => {
+			const answers = {};
+			const journey = new Journey({
+				...params,
+				response: {
+					...mockResponse,
+					answers
+				}
+			});
+			const uploadSection = journey.getSection('upload-documents');
+			const designAccessQuestion = uploadSection?.questions?.find(
+				(q) => q.fieldName === 'designAccessStatement'
+			);
+			expect(designAccessQuestion?.shouldDisplay(journey.response)).toBe(true);
+		});
+
+		it('should include uploadDesignAccessStatement if designAccessStatement is yes and application date is before April 1st 2026', () => {
+			const answers = {
+				onApplicationDate: '2026-03-30T12:00:00.000Z',
+				designAccessStatement: 'yes'
+			};
+			const journey = new Journey({
+				...params,
+				response: {
+					...mockResponse,
+					answers
+				}
+			});
+			const uploadSection = journey.getSection('upload-documents');
+			const uploadDesignAccessQuestion = uploadSection?.questions?.find(
+				(q) => q.fieldName === 'uploadDesignAccessStatement'
+			);
+			expect(uploadDesignAccessQuestion?.shouldDisplay(journey.response)).toBe(true);
+		});
+
+		it('should not include uploadDesignAccessStatement if designAccessStatement is no and application date is before April 1st 2026', () => {
+			const answers = {
+				onApplicationDate: '2026-03-30T12:00:00.000Z',
+				designAccessStatement: 'no'
+			};
+			const journey = new Journey({
+				...params,
+				response: {
+					...mockResponse,
+					answers
+				}
+			});
+			const uploadSection = journey.getSection('upload-documents');
+			const uploadDesignAccessQuestion = uploadSection?.questions?.find(
+				(q) => q.fieldName === 'uploadDesignAccessStatement'
+			);
+			expect(uploadDesignAccessQuestion?.shouldDisplay(journey.response)).toBe(false);
+		});
+
+		it('should not include uploadDesignAccessStatement if application date is on or after April 1st 2026 even if designAccessStatement is yes', () => {
+			const answers = {
+				onApplicationDate: '2026-04-01T00:00:00.000Z',
+				designAccessStatement: 'yes'
+			};
+			const journey = new Journey({
+				...params,
+				response: {
+					...mockResponse,
+					answers
+				}
+			});
+			const uploadSection = journey.getSection('upload-documents');
+			const uploadDesignAccessQuestion = uploadSection?.questions?.find(
+				(q) => q.fieldName === 'uploadDesignAccessStatement'
+			);
+			expect(uploadDesignAccessQuestion?.shouldDisplay(journey.response)).toBe(false);
 		});
 	});
 });

--- a/packages/forms-web-app/src/dynamic-forms/controller.test.js
+++ b/packages/forms-web-app/src/dynamic-forms/controller.test.js
@@ -1056,6 +1056,25 @@ describe('dynamic-form/controller', () => {
 					'If you have any of the following documents, you’ll also need to upload your:'
 			});
 		});
+		it('renders correct page for CAS Planning after expedited date (on/after 2026-04-01)', () => {
+			req.session.appeal = {
+				appealType: APPEAL_ID.MINOR_COMMERCIAL,
+				applicationDate: '2026-04-01T09:00:00.000Z'
+			};
+			appellantBYSListOfDocuments(req, res);
+			expect(res.render).toHaveBeenCalledWith('full-appeal/submit-appeal/list-of-documents-v2', {
+				bannerHtmlOverride:
+					config.betaBannerText +
+					config.generateBetaBannerFeedbackLink(
+						config.getAppealTypeFeedbackUrl(CASE_TYPES.CAS_PLANNING.processCode)
+					),
+				optionalDocuments: ['decision letter from the local planning authority'],
+				requiredDocuments: [],
+				requiredDocumentsSubheading: 'You’ll need your planning application form.',
+				optionalDocumentsSubheading:
+					'If you have any of the following documents, you’ll also need to upload your:'
+			});
+		});
 		it('renders correct page for CAS Adverts', () => {
 			req.session.appeal = { appealType: APPEAL_ID.MINOR_COMMERCIAL_ADVERTISEMENT };
 			appellantBYSListOfDocuments(req, res);

--- a/packages/forms-web-app/src/dynamic-forms/display-questions.js
+++ b/packages/forms-web-app/src/dynamic-forms/display-questions.js
@@ -107,8 +107,8 @@ exports.shouldDisplayAdvertsQuestions = (response) => {
  * @param {JourneyResponse} response
  * @returns {boolean}
  */
-exports.shouldDisplayAppellantStatement = (response) => {
-	const applicationDate = response.answers.onApplicationDate;
+exports.isBeforeExpeditedCutoff = (response) => {
+	const applicationDate = /** @type {any} */ (response.answers.onApplicationDate);
 	return !isExpeditedAppealDate(applicationDate);
 };
 

--- a/packages/forms-web-app/src/dynamic-forms/docs/cas-planning-appeal-form-journey.md
+++ b/packages/forms-web-app/src/dynamic-forms/docs/cas-planning-appeal-form-journey.md
@@ -77,13 +77,13 @@ condition: () => shouldDisplayTellingLandowners(response, questions);
 - text-entry `/why-are-you-appealing/` Why are you appealing?
 
 ```js
-condition: () => !shouldDisplayAppellantStatement(response);
+condition: () => !isBeforeExpeditedCutoff(response);
 ```
 
 - checkbox `/any-significant-changes/` Have there been any significant changes that would affect the application?
 
 ```js
-condition: () => !shouldDisplayAppellantStatement(response);
+condition: () => !isBeforeExpeditedCutoff(response);
 ```
 
 - boolean `/other-appeals/` Are there other appeals linked to your development?
@@ -106,7 +106,7 @@ condition: () => questionHasAnswer(response, questions.updateDevelopmentDescript
 - multi-file-upload `/upload-appeal-statement/` Upload your appeal statement
 
 ```js
-condition: () => shouldDisplayAppellantStatement(response);
+condition: () => isBeforeExpeditedCutoff(response);
 ```
 
 - boolean `/apply-appeal-costs/` Do you want to apply for an award of appeal costs?
@@ -117,10 +117,17 @@ condition: () => questionHasAnswer(response, questions.costApplication, 'yes');
 ```
 
 - boolean `/submit-design-access-statement/` Did you submit a design and access statement with your application?
+
+```js
+condition: () => isBeforeExpeditedCutoff(response);
+```
+
 - multi-file-upload `/upload-design-access-statement/` Upload your design and access statement
 
 ```js
-condition: () => questionHasAnswer(response, questions.designAccessStatement, 'yes');
+condition: () =>
+	isBeforeExpeditedCutoff(response) &&
+	questionHasAnswer(response, questions.designAccessStatement, 'yes');
 ```
 
 - multi-file-upload `/upload-plans-drawings-documents/` Upload your plans, drawings and supporting documents you submitted with your application

--- a/packages/forms-web-app/src/dynamic-forms/docs/has-appeal-form-journey.md
+++ b/packages/forms-web-app/src/dynamic-forms/docs/has-appeal-form-journey.md
@@ -77,13 +77,13 @@ condition: () => shouldDisplayTellingLandowners(response, questions);
 - text-entry `/why-are-you-appealing/` Why are you appealing?
 
 ```js
-condition: () => !shouldDisplayAppellantStatement(response);
+condition: () => !isBeforeExpeditedCutoff(response);
 ```
 
 - checkbox `/any-significant-changes/` Have there been any significant changes that would affect the application?
 
 ```js
-condition: () => !shouldDisplayAppellantStatement(response);
+condition: () => !isBeforeExpeditedCutoff(response);
 ```
 
 - boolean `/other-appeals/` Are there other appeals linked to your development?
@@ -106,7 +106,7 @@ condition: () => questionHasAnswer(response, questions.updateDevelopmentDescript
 - multi-file-upload `/upload-appeal-statement/` Upload your appeal statement
 
 ```js
-condition: () => shouldDisplayAppellantStatement(response);
+condition: () => isBeforeExpeditedCutoff(response);
 ```
 
 - boolean `/apply-appeal-costs/` Do you want to apply for an award of appeal costs?

--- a/packages/forms-web-app/src/dynamic-forms/has-appeal-form/journey.js
+++ b/packages/forms-web-app/src/dynamic-forms/has-appeal-form/journey.js
@@ -12,7 +12,7 @@ const config = require('../../config');
 const {
 	shouldDisplayTellingLandowners,
 	shouldDisplayIdentifyingLandowners,
-	shouldDisplayAppellantStatement
+	isBeforeExpeditedCutoff
 } = require('../display-questions');
 
 /**
@@ -77,9 +77,9 @@ const makeSections = (response) => {
 			.addQuestion(questions.enterDevelopmentDescription)
 			.addQuestion(questions.updateDevelopmentDescription)
 			.addQuestion(questions.whyAreYouAppealingPart1)
-			.withCondition(() => !shouldDisplayAppellantStatement(response))
+			.withCondition(() => !isBeforeExpeditedCutoff(response))
 			.addQuestion(questions.anySignificantChanges)
-			.withCondition(() => !shouldDisplayAppellantStatement(response))
+			.withCondition(() => !isBeforeExpeditedCutoff(response))
 			.addQuestion(questions.anyOtherAppeals)
 			.addQuestion(questions.linkAppeals)
 			.withCondition(() => questionHasAnswer(response, questions.anyOtherAppeals, 'yes')),
@@ -91,7 +91,7 @@ const makeSections = (response) => {
 			)
 			.addQuestion(questions.uploadApplicationDecisionLetter)
 			.addQuestion(questions.uploadAppellantStatement)
-			.withCondition(() => shouldDisplayAppellantStatement(response))
+			.withCondition(() => isBeforeExpeditedCutoff(response))
 			.addQuestion(questions.costApplication)
 			.addQuestion(questions.uploadCostApplication)
 			.withCondition(() => questionHasAnswer(response, questions.costApplication, 'yes'))


### PR DESCRIPTION
### Description of change
Covers the dev work on 2 tickets:
Removes the design access statement from the CAS planning appellant form when the application date is after the 1st of April
Removes the design access statement from the appeal details when CAS planning and the application date is after the 1st of April
Updates naming of function to isBeforeExpeditedCutoff rather than should showAppellantStatement for better naming standards

Added new unit tests to cover changes 
Manually tested in browser

Tickets:
 https://pins-ds.atlassian.net/browse/A2-8447
https://pins-ds.atlassian.net/browse/A2-8471

### Checklist

- [x] Feature complete and ready for users, or behind feature-flag
- [x] Commit history is linear with no merge commits
- [ ] Requires infrastructure changes

### Important

Please do not merge from `main` (please only [rebase](https://github.com/Planning-Inspectorate/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
