### PR TITLE
fix(A2-8541): direct to HAS for granted decisions remove expedited flow for CAS planning

### DIFF
--- a/packages/forms-web-app/src/dynamic-forms/middleware/get-journey-response-for-appellant.test.js
+++ b/packages/forms-web-app/src/dynamic-forms/middleware/get-journey-response-for-appellant.test.js
@@ -131,7 +131,8 @@ describe('getJourneyResponseForAppellant', () => {
 			applicationDate: convertedResponse?.onApplicationDate,
 			eligibility: {
 				applicationDecision: convertedResponse?.applicationDecision
-			}
+			},
+			appealTypeCode: convertedResponse?.appealTypeCode
 		});
 		expect(next).toHaveBeenCalled();
 	});

--- a/packages/forms-web-app/src/lib/is-expedited-part1-eligible.js
+++ b/packages/forms-web-app/src/lib/is-expedited-part1-eligible.js
@@ -11,9 +11,7 @@ const UK_TIME_ZONE = 'Europe/London';
 const eligiblePlanningApplicationTypes = new Set([
 	TYPE_OF_PLANNING_APPLICATION.FULL_APPEAL,
 	TYPE_OF_PLANNING_APPLICATION.OUTLINE_PLANNING,
-	TYPE_OF_PLANNING_APPLICATION.RESERVED_MATTERS,
-	TYPE_OF_PLANNING_APPLICATION.HOUSEHOLDER_PLANNING,
-	TYPE_OF_PLANNING_APPLICATION.MINOR_COMMERCIAL_DEVELOPMENT
+	TYPE_OF_PLANNING_APPLICATION.RESERVED_MATTERS
 ]);
 
 /** @type {Set<string>} */
@@ -38,16 +36,29 @@ const parseApplicationDate = (value) => {
 };
 
 /**
- * @param {{ applicationDate?: string|Date|null, typeOfPlanningApplication?: string|null, eligibility?: { applicationDecision?: string|null }, appealTypeCode?: string |null } | undefined | null} appeal
+ * @param {{ applicationDate?: string|Date|null, typeOfPlanningApplication?: string|null, eligibility?: { applicationDecision?: string|null }, appealTypeCode?: string |null, typeDevelopment?: string|null, developmentType?: string|null } | undefined | null} appeal
  * @returns {boolean}
  */
 const isExpeditedPart1Eligible = (appeal) => {
-	if (
-		!eligiblePlanningApplicationTypes.has(appeal?.typeOfPlanningApplication || '') ||
-		!eligibleApplicationDecisions.has(appeal?.eligibility?.applicationDecision || '') ||
-		!eligibleAppealTypesForPart1.has(appeal?.appealTypeCode || '')
-	) {
+	if (!eligibleAppealTypesForPart1.has(appeal?.appealTypeCode || '')) {
 		return false;
+	}
+
+	if (
+		appeal?.typeOfPlanningApplication ===
+			TYPE_OF_PLANNING_APPLICATION.MINOR_COMMERCIAL_DEVELOPMENT ||
+		appeal?.typeOfPlanningApplication === TYPE_OF_PLANNING_APPLICATION.HOUSEHOLDER_PLANNING
+	) {
+		if (appeal?.eligibility?.applicationDecision !== APPLICATION_DECISION.GRANTED) {
+			return false;
+		}
+	} else {
+		if (
+			!eligiblePlanningApplicationTypes.has(appeal?.typeOfPlanningApplication || '') ||
+			!eligibleApplicationDecisions.has(appeal?.eligibility?.applicationDecision || '')
+		) {
+			return false;
+		}
 	}
 
 	const applicationDate = parseApplicationDate(appeal?.applicationDate);

--- a/packages/forms-web-app/src/lib/is-expedited-part1-eligible.test.js
+++ b/packages/forms-web-app/src/lib/is-expedited-part1-eligible.test.js
@@ -10,9 +10,7 @@ describe('isExpeditedPart1Eligible', () => {
 	it.each([
 		TYPE_OF_PLANNING_APPLICATION.FULL_APPEAL,
 		TYPE_OF_PLANNING_APPLICATION.OUTLINE_PLANNING,
-		TYPE_OF_PLANNING_APPLICATION.RESERVED_MATTERS,
-		TYPE_OF_PLANNING_APPLICATION.HOUSEHOLDER_PLANNING,
-		TYPE_OF_PLANNING_APPLICATION.MINOR_COMMERCIAL_DEVELOPMENT
+		TYPE_OF_PLANNING_APPLICATION.RESERVED_MATTERS
 	])('returns true for %s when the date is on the cutoff and the decision is granted', (type) => {
 		expect(
 			isExpeditedPart1Eligible({
@@ -75,20 +73,87 @@ describe('isExpeditedPart1Eligible', () => {
 		).toBe(false);
 	});
 
-	it.each([undefined, null, 'not-a-date'])(
-		'returns false when the application date is %p',
-		(applicationDate) => {
+	describe('minor-commercial-development', () => {
+		it('returns true when decision is GRANTED and date is on/after cutoff', () => {
 			expect(
 				isExpeditedPart1Eligible({
-					typeOfPlanningApplication: TYPE_OF_PLANNING_APPLICATION.FULL_APPEAL,
-					applicationDate,
+					typeOfPlanningApplication: TYPE_OF_PLANNING_APPLICATION.MINOR_COMMERCIAL_DEVELOPMENT,
+					applicationDate: `${EXPEDITED_PART_1_CUTOFF_DATE}T00:00:00.000Z`,
 					eligibility: {
 						applicationDecision: APPLICATION_DECISION.GRANTED
-					}
+					},
+					appealTypeCode: 'S78'
+				})
+			).toBe(true);
+		});
+
+		it('returns false when decision is REFUSED', () => {
+			expect(
+				isExpeditedPart1Eligible({
+					typeOfPlanningApplication: TYPE_OF_PLANNING_APPLICATION.MINOR_COMMERCIAL_DEVELOPMENT,
+					applicationDate: `${EXPEDITED_PART_1_CUTOFF_DATE}T00:00:00.000Z`,
+					eligibility: {
+						applicationDecision: APPLICATION_DECISION.REFUSED
+					},
+					appealTypeCode: 'S78'
 				})
 			).toBe(false);
-		}
-	);
+		});
+
+		it('returns false when decision is GRANTED but date is before cutoff', () => {
+			expect(
+				isExpeditedPart1Eligible({
+					typeOfPlanningApplication: TYPE_OF_PLANNING_APPLICATION.MINOR_COMMERCIAL_DEVELOPMENT,
+					applicationDate: '2026-03-31T22:59:59.000Z',
+					eligibility: {
+						applicationDecision: APPLICATION_DECISION.GRANTED
+					},
+					appealTypeCode: 'S78'
+				})
+			).toBe(false);
+		});
+	});
+
+	describe('householder-planning', () => {
+		it('returns true when decision is GRANTED and date is on/after cutoff', () => {
+			expect(
+				isExpeditedPart1Eligible({
+					typeOfPlanningApplication: TYPE_OF_PLANNING_APPLICATION.HOUSEHOLDER_PLANNING,
+					applicationDate: `${EXPEDITED_PART_1_CUTOFF_DATE}T00:00:00.000Z`,
+					eligibility: {
+						applicationDecision: APPLICATION_DECISION.GRANTED
+					},
+					appealTypeCode: 'S78'
+				})
+			).toBe(true);
+		});
+
+		it('returns false when decision is REFUSED', () => {
+			expect(
+				isExpeditedPart1Eligible({
+					typeOfPlanningApplication: TYPE_OF_PLANNING_APPLICATION.HOUSEHOLDER_PLANNING,
+					applicationDate: `${EXPEDITED_PART_1_CUTOFF_DATE}T00:00:00.000Z`,
+					eligibility: {
+						applicationDecision: APPLICATION_DECISION.REFUSED
+					},
+					appealTypeCode: 'S78'
+				})
+			).toBe(false);
+		});
+
+		it('returns false when decision is GRANTED but date is before cutoff', () => {
+			expect(
+				isExpeditedPart1Eligible({
+					typeOfPlanningApplication: TYPE_OF_PLANNING_APPLICATION.HOUSEHOLDER_PLANNING,
+					applicationDate: '2026-03-31T22:59:59.000Z',
+					eligibility: {
+						applicationDecision: APPLICATION_DECISION.GRANTED
+					},
+					appealTypeCode: 'S78'
+				})
+			).toBe(false);
+		});
+	});
 });
 
 describe('isExpeditedAppealDate', () => {


### PR DESCRIPTION
### Description of change

Set case type to HAS for householder appeals granted
Removed householder from the S78 expedited flow, householder now follows this logic:
- Granted with conditions = HAS
- Refused = HAS
- No decision = Old S78 form

update logic for CAS planning to follow below:

- Granted with conditions = S78 expedite
- Refused = CAS planning
- No decision = Old S78 form

Updated unit tests to cover changes
Manually tested in browser

Ticket: https://pins-ds.atlassian.net/browse/A2-8541

### Checklist

- [x] Feature complete and ready for users, or behind feature-flag
- [x] Commit history is linear with no merge commits
- [ ] Requires infrastructure changes

### Important

Please do not merge from `main` (please only [rebase](https://github.com/Planning-Inspectorate/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
