### PR TITLE
fix(A2-8049): vary application about label depending on isNewBYS

### DIFF
--- a/packages/forms-web-app/src/views/full-appeal/can-use-service.njk
+++ b/packages/forms-web-app/src/views/full-appeal/can-use-service.njk
@@ -99,6 +99,7 @@
 
 {% if isNewBYSFlow %}
 	{% set enforcementNoticeRow = null %}
+	{% set appealAboutText = "What is your appeal about?" %}
 {% else %}
 	{% set enforcementNoticeRow = {
 		key: {
@@ -119,6 +120,7 @@
 		}
 	}
 	%}
+	{% set appealAboutText = "Type of application" %}
 {% endif %}
 
 {% block canUseServiceSummaryList %}
@@ -164,7 +166,7 @@
             } if planningApplicationNumber,
 			{
 				key: {
-				text: "Type of application"
+				text: appealAboutText
 			},
 				value: {
 				text: summaryField(applicationType, { 'data-cy': "application-type" })
@@ -174,7 +176,7 @@
 						{
 							href: "/before-you-start/type-of-planning-application",
 							text: "Change",
-							visuallyHiddenText: "Type of application",
+							visuallyHiddenText: appealAboutText,
 							attributes: { "data-cy":"applicationType"}
 						}
 					]

--- a/packages/forms-web-app/src/views/full-appeal/prior-approval/can-use-service.njk
+++ b/packages/forms-web-app/src/views/full-appeal/prior-approval/can-use-service.njk
@@ -4,6 +4,7 @@
 
 {% if isNewBYSFlow %}
 	{% set enforcementNoticeRow = null %}
+	{% set appealAboutText = "What is your appeal about?" %}
 {% else %}
 	{% set enforcementNoticeRow = {
 		key: {
@@ -24,6 +25,7 @@
 		}
 	}
 	%}
+	{% set appealAboutText = "Type of application" %}
 {% endif %}
 
 {% block canUseServiceSummaryList %}
@@ -69,7 +71,7 @@
       } if planningApplicationNumber,
 			{
 				key: {
-					text: "Type of application"
+					text: appealAboutText
 				},
 				value: {
 					text: summaryField(applicationType, { 'data-cy': "application-type" })
@@ -79,7 +81,7 @@
 						{
 							href: "/before-you-start/type-of-planning-application",
 							text: "Change",
-							visuallyHiddenText: "Type of application",
+							visuallyHiddenText: appealAboutText,
 							attributes: { "data-cy":"applicationType"}
 						}
 					]

--- a/packages/forms-web-app/src/views/full-appeal/removal-or-variation-of-conditions/can-use-service.njk
+++ b/packages/forms-web-app/src/views/full-appeal/removal-or-variation-of-conditions/can-use-service.njk
@@ -4,6 +4,7 @@
 
 {% if isNewBYSFlow %}
 	{% set enforcementNoticeRow = null %}
+	{% set appealAboutText = "What is your appeal about?" %}
 {% else %}
 	{% set enforcementNoticeRow = {
 		key: {
@@ -24,6 +25,7 @@
 		}
 	}
 	%}
+	{% set appealAboutText = "Type of application" %}
 {% endif %}
 
 {% block canUseServiceSummaryList %}
@@ -69,7 +71,7 @@
 			} if planningApplicationNumber,
 			{
 				key: {
-					text: "Type of application"
+					text: appealAboutText
 				},
 				value: {
 					text: summaryField(applicationType, { 'data-cy': "application-type" })
@@ -79,7 +81,7 @@
 						{
 							href: "/before-you-start/type-of-planning-application",
 							text: "Change",
-							visuallyHiddenText: "Type of application",
+							visuallyHiddenText: appealAboutText,
 							attributes: { "data-cy":"applicationType"}
 						}
 					]

--- a/packages/forms-web-app/src/views/householder-planning/eligibility/can-use-service.njk
+++ b/packages/forms-web-app/src/views/householder-planning/eligibility/can-use-service.njk
@@ -4,6 +4,7 @@
 
 {% if isNewBYSFlow %}
 	{% set enforcementNoticeRow = null %}
+	{% set appealAboutText = "What is your appeal about?" %}
 {% else %}
 	{% set enforcementNoticeRow = {
 		key: {
@@ -24,6 +25,7 @@
 		}
 	}
 	%}
+	{% set appealAboutText = "Type of application" %}
 {% endif %}
 
 {% block canUseServiceSummaryList %}
@@ -67,7 +69,7 @@
 		} if planningApplicationNumber,
 		{
 			key: {
-				text: "Type of application"
+				text: appealAboutText
 			},
 			value: {
 				text: summaryField(applicationType, { 'data-cy': "application-type" })
@@ -77,7 +79,7 @@
 					{
 						href: "/before-you-start/type-of-planning-application",
 						text: "Change",
-						visuallyHiddenText: "Type of application",
+						visuallyHiddenText: appealAboutText,
 						attributes: { "data-cy":"applicationType"}
 					}
 				]

--- a/packages/forms-web-app/src/views/householder-planning/eligibility/prior-approval/can-use-service.njk
+++ b/packages/forms-web-app/src/views/householder-planning/eligibility/prior-approval/can-use-service.njk
@@ -4,6 +4,7 @@
 
 {% if isNewBYSFlow %}
 	{% set enforcementNoticeRow = null %}
+	{% set appealAboutText = "What is your appeal about?" %}
 {% else %}
 	{% set enforcementNoticeRow = {
 		key: {
@@ -24,6 +25,7 @@
 		}
 	}
 	%}
+	{% set appealAboutText = "Type of application" %}
 {% endif %}
 
 {% block canUseServiceSummaryList %}
@@ -67,7 +69,7 @@
 		} if planningApplicationNumber,
 		{
 			key: {
-				text: "Type of application"
+				text: appealAboutText
 			},
 			value: {
 				text: summaryField(applicationType, { 'data-cy': "application-type" })
@@ -77,7 +79,7 @@
 					{
 						href: "/before-you-start/type-of-planning-application",
 						text: "Change",
-						visuallyHiddenText: "Type of application",
+						visuallyHiddenText: appealAboutText,
 						attributes: { "data-cy":"applicationType"}
 					}
 				]

--- a/packages/forms-web-app/src/views/householder-planning/eligibility/removal-or-variation-of-conditions/can-use-service.njk
+++ b/packages/forms-web-app/src/views/householder-planning/eligibility/removal-or-variation-of-conditions/can-use-service.njk
@@ -4,6 +4,7 @@
 
 {% if isNewBYSFlow %}
 	{% set enforcementNoticeRow = null %}
+	{% set appealAboutText = "What is your appeal about?" %}
 {% else %}
 	{% set enforcementNoticeRow = {
 		key: {
@@ -24,6 +25,7 @@
 		}
 	}
 	%}
+	{% set appealAboutText = "Type of application" %}
 {% endif %}
 
 {% block canUseServiceSummaryList %}
@@ -67,7 +69,7 @@
 		} if planningApplicationNumber,
 		{
 			key: {
-				text: "Type of application"
+				text: appealAboutText
 			},
 			value: {
 				text: summaryField(applicationType, { 'data-cy': "application-type" })
@@ -77,7 +79,7 @@
 					{
 						href: "/before-you-start/type-of-planning-application",
 						text: "Change",
-						visuallyHiddenText: "Type of application",
+						visuallyHiddenText: appealAboutText,
 						attributes: { "data-cy":"applicationType"}
 					}
 				]


### PR DESCRIPTION
### Description of change

Varies text on the application about row of 'can use service' pages based on isNewBYS flag.

Ticket: https://pins-ds.atlassian.net/browse/A2-8049

### Checklist

- [X] Feature complete and ready for users, or behind feature-flag
- [X] Commit history is linear with no merge commits
- [ ] Requires infrastructure changes

### Important

Please do not merge from `main` (please only [rebase](https://github.com/Planning-Inspectorate/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
