### PR TITLE
fix(a2-8551): stop unredacted docs from appearing in zip downloads re…

### DIFF
--- a/packages/document-service-api/src/routes/v2/back-office/_caseReference/case_stage/_caseStage/controller.js
+++ b/packages/document-service-api/src/routes/v2/back-office/_caseReference/case_stage/_caseStage/controller.js
@@ -44,6 +44,7 @@ async function getBlobCollection(
 	const representationMap = new Map(representations.map((rep) => [rep.documentId, rep]));
 
 	return allDocuments
+		.filter((document) => document.redacted)
 		.filter((document) => checkDocumentAccessByRepresentationOwner(document, representationMap))
 		.filter((document) =>
 			checkDocAccess({

--- a/packages/document-service-api/src/routes/v2/back-office/_caseReference/case_stage/_caseStage/controller.test.js
+++ b/packages/document-service-api/src/routes/v2/back-office/_caseReference/case_stage/_caseStage/controller.test.js
@@ -168,7 +168,7 @@ describe('/v2/back-office/{caseReference}/case_stage/{caseStage}', () => {
 		expect(res.status).toHaveBeenCalledWith(200);
 	});
 
-	it('should expect 2 blob streams to be appended, 4 not included due to access rules', async () => {
+	it('should expect 1 blob stream to be appended, 5 not included due to access rules', async () => {
 		checkDocAccess.mockImplementation(
 			(params) => params.documentWithAppeal.documentType === testDocumentTypes[0]
 		);
@@ -176,7 +176,7 @@ describe('/v2/back-office/{caseReference}/case_stage/{caseStage}', () => {
 		await getDocumentsByCaseReferenceAndCaseStage(req, res);
 
 		// only adds
-		expect(mockAppend).toHaveBeenCalledTimes(2);
+		expect(mockAppend).toHaveBeenCalledTimes(1);
 
 		testDocumentTypes
 			.filter((x) => x === testDocumentTypes[0])

--- a/packages/document-service-api/src/routes/v2/back-office/_caseReference/document-type/controller.js
+++ b/packages/document-service-api/src/routes/v2/back-office/_caseReference/document-type/controller.js
@@ -54,6 +54,7 @@ async function getBlobCollection(
 	});
 
 	return allDocuments
+		.filter((document) => document.redacted)
 		.filter((document) =>
 			checkDocAccess({
 				logger,

--- a/packages/document-service-api/src/routes/v2/back-office/_caseReference/document-type/controller.test.js
+++ b/packages/document-service-api/src/routes/v2/back-office/_caseReference/document-type/controller.test.js
@@ -136,7 +136,7 @@ describe('/v2/back-office/{caseReference}/document-type', () => {
 	it('should return status of 200', async () => {
 		checkDocAccess.mockImplementation(() => true);
 		await getDocumentsByCaseReference(req, res);
-		expect(mockAppend).toHaveBeenCalledTimes(4);
+		expect(mockAppend).toHaveBeenCalledTimes(3);
 		expect(res.status).toHaveBeenCalledWith(200);
 	});
 


### PR DESCRIPTION
…gardless of owner

### Description of change

Low level access rules allow owner of doc to access unredacted docs as they supplied it
But we are marking as 'awaiting review' in UI so for consistency will also keep out of zip download

Ticket: https://pins-ds.atlassian.net/browse/A2-8551

### Checklist

- [x] Feature complete and ready for users, or behind feature-flag
- [x] Commit history is linear with no merge commits
- [ ] Requires infrastructure changes

### Important

Please do not merge from `main` (please only [rebase](https://github.com/Planning-Inspectorate/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
