### PR TITLE
fix: incorrect service name for cost files on lpa dashboard (A2-8495)

### DIFF
--- a/packages/forms-web-app/src/routes/lpa-dashboard/selected-appeal.js
+++ b/packages/forms-web-app/src/routes/lpa-dashboard/selected-appeal.js
@@ -139,19 +139,31 @@ router.get(
 // costs
 router.get(
 	'/:appealNumber/appellant-cost-application',
-	costsController.get({ userType, costsType: APPEAL_DOCUMENT_TYPE.APPELLANT_COSTS_APPLICATION })
+	costsController.get(
+		{ userType, costsType: APPEAL_DOCUMENT_TYPE.APPELLANT_COSTS_APPLICATION },
+		'layouts/lpa-dashboard/main.njk'
+	)
 );
 router.get(
 	'/:appealNumber/lpa-cost-application',
-	costsController.get({ userType, costsType: APPEAL_DOCUMENT_TYPE.LPA_COSTS_APPLICATION })
+	costsController.get(
+		{ userType, costsType: APPEAL_DOCUMENT_TYPE.LPA_COSTS_APPLICATION },
+		'layouts/lpa-dashboard/main.njk'
+	)
 );
 router.get(
 	'/:appealNumber/appellant-cost-comments',
-	costsController.get({ userType, costsType: APPEAL_DOCUMENT_TYPE.APPELLANT_COSTS_CORRESPONDENCE })
+	costsController.get(
+		{ userType, costsType: APPEAL_DOCUMENT_TYPE.APPELLANT_COSTS_CORRESPONDENCE },
+		'layouts/lpa-dashboard/main.njk'
+	)
 );
 router.get(
 	'/:appealNumber/lpa-cost-comments',
-	costsController.get({ userType, costsType: APPEAL_DOCUMENT_TYPE.LPA_COSTS_CORRESPONDENCE })
+	costsController.get(
+		{ userType, costsType: APPEAL_DOCUMENT_TYPE.LPA_COSTS_CORRESPONDENCE },
+		'layouts/lpa-dashboard/main.njk'
+	)
 );
 
 module.exports = router;


### PR DESCRIPTION
### Description of change

Correct service linked on cost files LPA dashboard, so 'Manage appelas' shows in place on 'Appeal a planning decision'

Ticket: https://pins-ds.atlassian.net/browse/A2-8495

### Checklist

- [x] Feature complete and ready for users, or behind feature-flag
- [x] Commit history is linear with no merge commits
- [ ] Requires infrastructure changes

### Important

Please do not merge from `main` (please only [rebase](https://github.com/Planning-Inspectorate/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
