### PR TITLE
fix: correct urls to cost docs from appellant & lpa dashboards (A2-8496)

### DIFF
--- a/packages/forms-web-app/src/controllers/selected-appeal/appellant-sections.js
+++ b/packages/forms-web-app/src/controllers/selected-appeal/appellant-sections.js
@@ -191,7 +191,7 @@ exports.sections = [
 		heading: 'Costs',
 		links: [
 			{
-				url: '/appellant-cost-application',
+				url: '/your-cost-application',
 				text: 'View your costs applications',
 				condition: (appealCase) =>
 					appealCase.Documents.some(
@@ -200,7 +200,7 @@ exports.sections = [
 					)
 			},
 			{
-				url: '/lpa-cost-application',
+				url: '/local-planning-authority-costs-applications',
 				text: 'View local planning authority cost applications',
 				condition: (appealCase) =>
 					appealCase.Documents.some(
@@ -210,7 +210,7 @@ exports.sections = [
 					)
 			},
 			{
-				url: '/appellant-cost-comments',
+				url: '/your-cost-comments',
 				text: 'View your costs comments',
 				condition: (appealCase) =>
 					appealCase.Documents.some(
@@ -219,7 +219,7 @@ exports.sections = [
 					)
 			},
 			{
-				url: '/lpa-cost-comments',
+				url: '/local-planning-authority-costs-comments',
 				text: 'View local planning authority costs comments',
 				condition: (appealCase) =>
 					appealCase.Documents.some(

--- a/packages/forms-web-app/src/controllers/selected-appeal/lpa-user-sections.js
+++ b/packages/forms-web-app/src/controllers/selected-appeal/lpa-user-sections.js
@@ -209,7 +209,7 @@ exports.sections = [
 		heading: 'Costs',
 		links: [
 			{
-				url: '/lpa-cost-application',
+				url: '/your-cost-application',
 				text: 'View your costs applications',
 				condition: (appealCase) =>
 					appealCase.Documents.some(
@@ -228,7 +228,7 @@ exports.sections = [
 					)
 			},
 			{
-				url: '/lpa-cost-comments',
+				url: '/your-cost-comments',
 				text: 'View your costs comments',
 				condition: (appealCase) =>
 					appealCase.Documents.some(

--- a/packages/forms-web-app/src/routes/appeals/selected-appeal/selected-appeal.js
+++ b/packages/forms-web-app/src/routes/appeals/selected-appeal/selected-appeal.js
@@ -110,19 +110,19 @@ router.get('/:appealNumber/planning-obligation', planningObligationDetailsContro
 
 // costs
 router.get(
-	'/:appealNumber/appellant-cost-application',
+	'/:appealNumber/your-cost-application',
 	costsController.get({ userType, costsType: APPEAL_DOCUMENT_TYPE.APPELLANT_COSTS_APPLICATION })
 );
 router.get(
-	'/:appealNumber/lpa-cost-application',
+	'/:appealNumber/local-planning-authority-costs-applications',
 	costsController.get({ userType, costsType: APPEAL_DOCUMENT_TYPE.LPA_COSTS_APPLICATION })
 );
 router.get(
-	'/:appealNumber/appellant-cost-comments',
+	'/:appealNumber/your-cost-comments',
 	costsController.get({ userType, costsType: APPEAL_DOCUMENT_TYPE.APPELLANT_COSTS_CORRESPONDENCE })
 );
 router.get(
-	'/:appealNumber/lpa-cost-comments',
+	'/:appealNumber/local-planning-authority-costs-comments',
 	costsController.get({ userType, costsType: APPEAL_DOCUMENT_TYPE.LPA_COSTS_CORRESPONDENCE })
 );
 

--- a/packages/forms-web-app/src/routes/lpa-dashboard/selected-appeal.js
+++ b/packages/forms-web-app/src/routes/lpa-dashboard/selected-appeal.js
@@ -138,28 +138,28 @@ router.get(
 
 // costs
 router.get(
-	'/:appealNumber/appellant-cost-application',
+	'/:appealNumber/appellant-costs-applications',
 	costsController.get(
 		{ userType, costsType: APPEAL_DOCUMENT_TYPE.APPELLANT_COSTS_APPLICATION },
 		'layouts/lpa-dashboard/main.njk'
 	)
 );
 router.get(
-	'/:appealNumber/lpa-cost-application',
+	'/:appealNumber/your-cost-application',
 	costsController.get(
 		{ userType, costsType: APPEAL_DOCUMENT_TYPE.LPA_COSTS_APPLICATION },
 		'layouts/lpa-dashboard/main.njk'
 	)
 );
 router.get(
-	'/:appealNumber/appellant-cost-comments',
+	'/:appealNumber/appellant-costs-comments',
 	costsController.get(
 		{ userType, costsType: APPEAL_DOCUMENT_TYPE.APPELLANT_COSTS_CORRESPONDENCE },
 		'layouts/lpa-dashboard/main.njk'
 	)
 );
 router.get(
-	'/:appealNumber/lpa-cost-comments',
+	'/:appealNumber/your-cost-comments',
 	costsController.get(
 		{ userType, costsType: APPEAL_DOCUMENT_TYPE.LPA_COSTS_CORRESPONDENCE },
 		'layouts/lpa-dashboard/main.njk'


### PR DESCRIPTION
### Description of change
 
Corrects urls for appellant and lpa dashboards to be as follows:

LPA DASHBOARD:

- Your costs applications (LPA): </manage-appeals/[appeal number]/your-costs-applications>
- Your costs comments (LPA): </manage-appeals/[appeal number]/your-costs-comments>
- View appellant costs applications on LPA dashboard: </manage-appeals/[appeal number]/appellant-costs-applications>
- View appellant costs comments on LPA dashboard: </manage-appeals/[appeal number]/appellant-costs comments>

APPELLANT DASHBOARD-

- Your costs applications (Appellant): </appeals/[appeal number]/your-costs-applications>
- Your costs comments (Appellant): </appeals/[appeal number]/your-costs-comments
- View LPA costs applications on Appellant dashboard: </appeals/[appeal number]/local-planning-authority-costs-applications>
- View LPA costs comments on Appellant dashboard: </appeals/[appeal number]/Local-planning-authority-costs-comments>


Ticket: https://pins-ds.atlassian.net/browse/A2-8496

### Checklist

- [x] Feature complete and ready for users, or behind feature-flag
- [x] Commit history is linear with no merge commits
- [ ] Requires infrastructure changes

### Important

Please do not merge from `main` (please only [rebase](https://github.com/Planning-Inspectorate/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
