### PR TITLE
fix(forms): added expedite check to determine banner (A2-8087)

### DIFF
--- a/packages/business-rules/src/rules/appeal-case/case-due-dates.js
+++ b/packages/business-rules/src/rules/appeal-case/case-due-dates.js
@@ -1,6 +1,7 @@
 const {
 	APPEAL_CASE_STATUS,
-	APPEAL_REPRESENTATION_TYPE
+	APPEAL_REPRESENTATION_TYPE,
+	APPEAL_CASE_PROCEDURE
 } = require('@planning-inspectorate/data-model');
 const { deadlineHasPassed } = require('@pins/common/src/lib/deadline-has-passed');
 const {
@@ -47,6 +48,7 @@ exports.isLPAQuestionnaireDue = (appealCaseData) =>
  * the deadline has not passed
  * we are in statement stage | the lpaq due date has already gone | the lpaq has been published
  * more than APPEAL_CASE_STATUS.STATEMENTS as there are internal stages in-between lpaq and statements
+ * written part 1 procedure relates to expedited appeals, who do no submit statements
  * @param {AppealCaseDetailed} appealCaseData
  * @returns {boolean}
  */
@@ -55,6 +57,7 @@ const statementsAreOpen = (appealCaseData) =>
 	!!appealCaseData.statementDueDate &&
 	!deadlineHasPassed(appealCaseData.statementDueDate) &&
 	appealCaseData.caseStatus !== APPEAL_CASE_STATUS.INVALID &&
+	appealCaseData.caseProcedure !== APPEAL_CASE_PROCEDURE.WRITTEN_PART_1 &&
 	(appealCaseData.caseStatus === APPEAL_CASE_STATUS.STATEMENTS ||
 		deadlineHasPassed(appealCaseData.lpaQuestionnaireDueDate) ||
 		!!appealCaseData.lpaQuestionnaireValidationOutcomeDate);

--- a/packages/business-rules/src/rules/appeal-case/case-due-dates.test.js
+++ b/packages/business-rules/src/rules/appeal-case/case-due-dates.test.js
@@ -11,7 +11,7 @@ const {
 	isAppellantFinalCommentOpen,
 	isLPAFinalCommentOpen
 } = require('./case-due-dates');
-const { APPEAL_CASE_STATUS } = require('@planning-inspectorate/data-model');
+const { APPEAL_CASE_STATUS, APPEAL_CASE_PROCEDURE } = require('@planning-inspectorate/data-model');
 const { deadlineHasPassed } = require('@pins/common/src/lib/deadline-has-passed');
 const { representationExists } = require('@pins/common/src/lib/representations');
 const { CASE_TYPES } = require('@pins/common/src/database/data-static');
@@ -37,7 +37,8 @@ describe('case-due-dates', () => {
 			LPACommentsSubmittedDate: null,
 			finalCommentsDueDate: null,
 			appellantCommentsSubmittedDate: null,
-			Representations: []
+			Representations: [],
+			caseProcedure: APPEAL_CASE_PROCEDURE.WRITTEN
 		};
 	});
 
@@ -195,6 +196,16 @@ describe('case-due-dates', () => {
 				];
 				expect(isLPAStatementOpen(appealCaseData)).toBe(false);
 			});
+
+			it('should return false if case is written part 1 aka expedited', () => {
+				// as seen in test above the first three attributes would lead to return of true
+				appealCaseData.statementDueDate = '2025-03-01';
+				deadlineHasPassed.mockReturnValueOnce(false);
+				appealCaseData.lpaQuestionnaireValidationOutcomeDate = '2025-03-01';
+				// case procedure to written part 1
+				appealCaseData.caseProcedure = APPEAL_CASE_PROCEDURE.WRITTEN_PART_1;
+				expect(isLPAStatementOpen(appealCaseData)).toBe(false);
+			});
 		});
 
 		describe('isAppellantStatementOpen', () => {
@@ -287,6 +298,17 @@ describe('case-due-dates', () => {
 						leadCaseReference: 'testLeadReference'
 					}
 				];
+				expect(isAppellantStatementOpen(appealCaseData)).toBe(false);
+			});
+
+			it('should return false if case is written part 1 aka expedited', () => {
+				// as seen in test above the first four attributes would lead to return of true
+				appealCaseData.appealTypeCode = CASE_TYPES.LDC.processCode;
+				appealCaseData.statementDueDate = '2025-03-01';
+				deadlineHasPassed.mockReturnValueOnce(false);
+				appealCaseData.lpaQuestionnaireValidationOutcomeDate = '2025-03-01';
+				// case procedure to written part 1
+				appealCaseData.caseProcedure = APPEAL_CASE_PROCEDURE.WRITTEN_PART_1;
 				expect(isAppellantStatementOpen(appealCaseData)).toBe(false);
 			});
 		});


### PR DESCRIPTION
### Description of change

Adds a case procedure check to areStatementsOpen function in order to ensure statements are not open for written part 1 (expedited) appeals.

No such check is needed for other due date checks as expedited appeals will not be in the relevant status (statements open check does not include an outright appeal status check)

Ticket: https://pins-ds.atlassian.net/browse/A2-8087

### Checklist

- [X] Feature complete and ready for users, or behind feature-flag
- [X] Commit history is linear with no merge commits
- [ ] Requires infrastructure changes

### Important

Please do not merge from `main` (please only [rebase](https://github.com/Planning-Inspectorate/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
