### PR TITLE
feat(A2-8601): move enf notice upload questions on enf lpaq

### DIFF
--- a/packages/forms-web-app/src/dynamic-forms/docs/enforcement-lpaq-journey.md
+++ b/packages/forms-web-app/src/dynamic-forms/docs/enforcement-lpaq-journey.md
@@ -133,6 +133,8 @@ condition: () => questionHasAnswer(response, questions.screeningOpinion, 'yes');
 
 ## Notifying relevant parties
 
+- multi-file-upload `/upload-enforcement-notice/` Upload the enforcement notice
+- multi-file-upload `/upload-enforcement-notice-plan/` Upload the enforcement notice plan
 - multi-file-upload `/upload-enforcement-list/` Upload the list of people and the addresses where you served the notices.
 - multi-file-upload `/appeal-notification-letter/` Upload the appeal notification letter and the list of people that you notified
 
@@ -211,19 +213,6 @@ condition: () => questionHasAnswer(response, questions.localDevelopmentOrder, 'y
 
 ```js
 condition: () => questionHasAnswer(response, questions.previousPlanningPermission, 'yes');
-```
-
-- radio `/enforcement-notice-date-application/` Existing enforcement notice
-- multi-file-upload `/upload-enforcement-notice/` Upload the enforcement notice
-
-```js
-condition: () => questionHasAnswer(response, questions.enforcementNoticeDateApplication, 'yes');
-```
-
-- multi-file-upload `/upload-enforcement-notice-plan/` Upload the enforcement notice plan
-
-```js
-condition: () => questionHasAnswer(response, questions.enforcementNoticeDateApplication, 'yes');
 ```
 
 - boolean `/planning-contravention-notice/` Did you serve a planning contravention notice?

--- a/packages/forms-web-app/src/dynamic-forms/enforcement-questionnaire/journey.js
+++ b/packages/forms-web-app/src/dynamic-forms/enforcement-questionnaire/journey.js
@@ -117,6 +117,8 @@ const makeSections = (response) => {
 		// new section with enforcement specific questions
 		// new Section('Notifying relevant parties', 'notified'),
 		new Section('Notifying relevant parties', 'notified')
+			.addQuestion(questions.enforcementNoticeDateApplicationUpload)
+			.addQuestion(questions.enforcementNoticePlanUpload)
 			.addQuestion(questions.listOfPeopleSentEnforcementNotice)
 			.addQuestion(questions.appealNotification),
 
@@ -163,15 +165,6 @@ const makeSections = (response) => {
 			.addQuestion(questions.previousPlanningPermission)
 			.addQuestion(questions.previousPlanningPermissionUpload)
 			.withCondition(() => questionHasAnswer(response, questions.previousPlanningPermission, 'yes'))
-			.addQuestion(questions.enforcementNoticeDateApplication)
-			.addQuestion(questions.enforcementNoticeDateApplicationUpload)
-			.withCondition(() =>
-				questionHasAnswer(response, questions.enforcementNoticeDateApplication, 'yes')
-			)
-			.addQuestion(questions.enforcementNoticePlanUpload)
-			.withCondition(() =>
-				questionHasAnswer(response, questions.enforcementNoticeDateApplication, 'yes')
-			)
 			.addQuestion(questions.planningContraventionNotice)
 			.addQuestion(questions.planningContraventionNoticeUpload)
 			.withCondition(() =>

--- a/packages/forms-web-app/src/dynamic-forms/enforcement-questionnaire/journey.test.js
+++ b/packages/forms-web-app/src/dynamic-forms/enforcement-questionnaire/journey.test.js
@@ -274,22 +274,41 @@ describe('Enforcement Journey', () => {
 		if (notifiedSection) {
 			const questions = notifiedSection.questions || [];
 
+			const expectedQuestions = [
+				{
+					fieldName: 'noticeDateApplicationUpload',
+					question: 'Upload the enforcement notice',
+					urlSegment: 'upload-enforcement-notice'
+				},
+				{
+					fieldName: 'noticePlanUpload',
+					question: 'Upload the enforcement notice plan',
+					urlSegment: 'upload-enforcement-notice-plan'
+				},
+				{
+					fieldName: 'listOfPeopleSentEnforcementNotice',
+					question: 'Upload the list of people and the addresses where you served the notices.',
+					urlSegment: 'upload-enforcement-list'
+				},
+				{
+					fieldName: 'appealNotification',
+					question:
+						'Upload the appeal notification letter and the list of people that you notified',
+					urlSegment: 'appeal-notification-letter'
+				}
+			];
+
 			expect(notifiedSection.name).toBe(sectionTitle);
-			expect(questions.length).toBe(2);
+			expect(questions.length).toBe(4);
 
-			const question1 = questions[0];
-			expect(question1.title).toBe(
-				'Upload the list of people you served the enforcement notice to'
-			);
-			expect(question1.fieldName).toBe('listOfPeopleSentEnforcementNotice');
-			expect(question1.url).toContain('upload-enforcement-list');
+			expectedQuestions.forEach((expected, index) => {
+				const actual = questions[index];
 
-			const question2 = questions[1];
-			expect(question2.title).toBe(
-				'Upload the appeal notification letter and the list of people that you notified'
-			);
-			expect(question2.fieldName).toBe('appealNotification');
-			expect(question2.url).toContain('appeal-notification-letter');
+				expect(actual).toBeDefined();
+				expect(actual.fieldName).toBe(expected.fieldName);
+				expect(actual.url).toBe(expected.urlSegment);
+				expect(actual.question).toBe(expected.question);
+			});
 		}
 	});
 
@@ -389,21 +408,6 @@ describe('Enforcement Journey', () => {
 				fieldName: 'previousPlanningPermissionUpload',
 				question: 'Upload the planning permission and any other relevant documents',
 				urlSegment: 'upload-planning-permission'
-			},
-			{
-				fieldName: 'noticeDateApplication',
-				question: 'Existing enforcement notice',
-				urlSegment: 'enforcement-notice-date-application'
-			},
-			{
-				fieldName: 'noticeDateApplicationUpload',
-				question: 'Upload the enforcement notice',
-				urlSegment: 'upload-enforcement-notice'
-			},
-			{
-				fieldName: 'noticePlanUpload',
-				question: 'Upload the enforcement notice plan',
-				urlSegment: 'upload-enforcement-notice-plan'
 			},
 			{
 				fieldName: 'planningContraventionNotice',

--- a/packages/forms-web-app/src/dynamic-forms/questions.js
+++ b/packages/forms-web-app/src/dynamic-forms/questions.js
@@ -4084,7 +4084,7 @@ exports.getQuestionProps = (response) => ({
 	},
 	enforcementNoticePlanUpload: {
 		type: 'multi-file-upload',
-		title: 'The enforcement notice plan',
+		title: 'Upload the enforcement notice plan',
 		question: 'Upload the enforcement notice plan',
 		fieldName: 'noticePlanUpload',
 		url: 'upload-enforcement-notice-plan',

--- a/packages/forms-web-app/src/journeys/__snapshots__/index.test.js.snap
+++ b/packages/forms-web-app/src/journeys/__snapshots__/index.test.js.snap
@@ -32986,54 +32986,6 @@ exports[`Dynamic forms journey tests lpa Enforcement notice Enforcement notice s
 </main>"
 `;
 
-exports[`Dynamic forms journey tests lpa Enforcement notice Enforcement notice should render the enforcement-notice-date-application question 1`] = `
-"<main id="main-content" role="main" class="govuk-main-wrapper govuk-main-wrapper--auto-spacing">
-    <div class="govuk-grid-row">
-        <div class="govuk-grid-column-two-thirds"></div>
-    </div>
-    <div class="govuk-grid-row">
-        <div class="govuk-grid-column-two-thirds"><span class="govuk-caption-l"> Planning officer’s report and supporting documents</span>
-        </div>
-    </div>
-    <div class="govuk-grid-row">
-        <div class="govuk-grid-column-two-thirds">
-            <form action="/manage-appeals/questionnaire/appeal-ref/planning-officer-report/enforcement-notice-date-application"
-            method="post" novalidate=null>
-                <h1 class="govuk-heading-l">Existing enforcement notice</h1>
-                <p class="govuk-body">Applicants may apply for planning permission retrospectively, after the
-                    LPA has issued an enforcement notice, or on Ground (a).</p>
-                <div class="govuk-form-group">
-                    <fieldset class="govuk-fieldset">
-                        <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">Was there an enforcement notice in place at the date of the application?</legend>
-                        <div
-                        class="govuk-radios govuk-radios" data-module="govuk-radios">
-                            <div class="govuk-radios__item">
-                                <input class="govuk-radios__input" id="noticeDateApplication" name="noticeDateApplication"
-                                type="radio" value="yes" data-cy="answer-yes">
-                                <label class="govuk-label govuk-radios__label" for="noticeDateApplication">Yes</label>
-                            </div>
-                            <div class="govuk-radios__item">
-                                <input class="govuk-radios__input" id="noticeDateApplication-2" name="noticeDateApplication"
-                                type="radio" value="no" data-cy="answer-no">
-                                <label class="govuk-label govuk-radios__label" for="noticeDateApplication-2">No</label>
-                            </div>
-                </div>
-                </fieldset>
-        </div>
-        <button type="submit" class="govuk-button" data-module="govuk-button"
-        data-cy="button-save-and-continue">Continue</button>
-        </form>
-    </div>
-    </div>
-    <div class="govuk-grid-row">
-        <div class="govuk-grid-column-two-thirds">
-            <p class="govuk-body"><a href="/manage-appeals/questionnaire/appeal-ref" class="govuk-link">Return to questionnaire homepage</a>
-            </p>
-        </div>
-    </div>
-</main>"
-`;
-
 exports[`Dynamic forms journey tests lpa Enforcement notice Enforcement notice should render the environmental-statement question 1`] = `
 "<main id="main-content" role="main" class="govuk-main-wrapper govuk-main-wrapper--auto-spacing">
     <div class="govuk-grid-row">
@@ -35252,37 +35204,36 @@ exports[`Dynamic forms journey tests lpa Enforcement notice Enforcement notice s
 exports[`Dynamic forms journey tests lpa Enforcement notice Enforcement notice should render the upload-enforcement-notice question 1`] = `
 "<main id="main-content" role="main" class="govuk-main-wrapper govuk-main-wrapper--auto-spacing">
     <div class="govuk-grid-row">
-        <div class="govuk-grid-column-two-thirds"><span class="govuk-caption-l">Planning officer’s report and supporting documents</span>
-            <h1
-            class="govuk-heading-l">Upload the enforcement notice</h1>
-                <form action="/manage-appeals/questionnaire/appeal-ref/planning-officer-report/upload-enforcement-notice"
-                method="post" novalidate=null enctype="multipart/form-data">
-                    <div class="moj-multi-file-upload">
-                        <div class="moj-multi-file__uploaded-files" aria-live="polite">
-                            <div class="moj-multi-file__uploaded-files-container moj-hidden">
-                                <h2 class="govuk-heading-m" id="-uploaded-files-heading">Files added</h2>
-                                <ul class="govuk-summary-list moj-multi-file-upload__list"></ul>
-                            </div>
-                        </div>
-                        <div class="moj-multi-file-upload__upload">
-                            <div class="govuk-form-group">
-                                <label class="govuk-label govuk-label--m" for="noticeDateApplicationUpload">Upload files</label>
-                                <div id="noticeDateApplicationUpload-hint" class="govuk-hint">The files must be a DOC, DOCX, PDF, TIF, JPG, PNG or XLSX and be smaller
-                                    than 1GB</div>
-                                <input class="govuk-file-upload moj-multi-file-upload__input"
-                                id="noticeDateApplicationUpload" name="noticeDateApplicationUpload" type="file"
-                                aria-describedby="noticeDateApplicationUpload-hint" multiple="">
-                            </div>
-                            <button value="upload-and-remain-on-page" type="submit" name="upload-and-remain-on-page"
-                            class="govuk-button govuk-button--secondary moj-multi-file-upload__button"
-                            data-module="govuk-button" data-cy="button-upload-file">Upload file</button>
+        <div class="govuk-grid-column-two-thirds"><span class="govuk-caption-l">Notifying relevant parties</span>
+            <h1 class="govuk-heading-l">Upload the enforcement notice</h1>
+            <form action="/manage-appeals/questionnaire/appeal-ref/notified/upload-enforcement-notice"
+            method="post" novalidate=null enctype="multipart/form-data">
+                <div class="moj-multi-file-upload">
+                    <div class="moj-multi-file__uploaded-files" aria-live="polite">
+                        <div class="moj-multi-file__uploaded-files-container moj-hidden">
+                            <h2 class="govuk-heading-m" id="-uploaded-files-heading">Files added</h2>
+                            <ul class="govuk-summary-list moj-multi-file-upload__list"></ul>
                         </div>
                     </div>
-                    <div class="govuk-button-group">
-                        <button type="submit" class="govuk-button" data-module="govuk-button"
-                        data-cy="button-save-and-continue">Continue</button>
+                    <div class="moj-multi-file-upload__upload">
+                        <div class="govuk-form-group">
+                            <label class="govuk-label govuk-label--m" for="noticeDateApplicationUpload">Upload files</label>
+                            <div id="noticeDateApplicationUpload-hint" class="govuk-hint">The files must be a DOC, DOCX, PDF, TIF, JPG, PNG or XLSX and be smaller
+                                than 1GB</div>
+                            <input class="govuk-file-upload moj-multi-file-upload__input"
+                            id="noticeDateApplicationUpload" name="noticeDateApplicationUpload" type="file"
+                            aria-describedby="noticeDateApplicationUpload-hint" multiple="">
+                        </div>
+                        <button value="upload-and-remain-on-page" type="submit" name="upload-and-remain-on-page"
+                        class="govuk-button govuk-button--secondary moj-multi-file-upload__button"
+                        data-module="govuk-button" data-cy="button-upload-file">Upload file</button>
                     </div>
-                </form>
+                </div>
+                <div class="govuk-button-group">
+                    <button type="submit" class="govuk-button" data-module="govuk-button"
+                    data-cy="button-save-and-continue">Continue</button>
+                </div>
+            </form>
         </div>
     </div>
     <div class="govuk-grid-row">
@@ -35297,37 +35248,36 @@ exports[`Dynamic forms journey tests lpa Enforcement notice Enforcement notice s
 exports[`Dynamic forms journey tests lpa Enforcement notice Enforcement notice should render the upload-enforcement-notice-plan question 1`] = `
 "<main id="main-content" role="main" class="govuk-main-wrapper govuk-main-wrapper--auto-spacing">
     <div class="govuk-grid-row">
-        <div class="govuk-grid-column-two-thirds"><span class="govuk-caption-l">Planning officer’s report and supporting documents</span>
-            <h1
-            class="govuk-heading-l">Upload the enforcement notice plan</h1>
-                <form action="/manage-appeals/questionnaire/appeal-ref/planning-officer-report/upload-enforcement-notice-plan"
-                method="post" novalidate=null enctype="multipart/form-data">
-                    <div class="moj-multi-file-upload">
-                        <div class="moj-multi-file__uploaded-files" aria-live="polite">
-                            <div class="moj-multi-file__uploaded-files-container moj-hidden">
-                                <h2 class="govuk-heading-m" id="-uploaded-files-heading">Files added</h2>
-                                <ul class="govuk-summary-list moj-multi-file-upload__list"></ul>
-                            </div>
-                        </div>
-                        <div class="moj-multi-file-upload__upload">
-                            <div class="govuk-form-group">
-                                <label class="govuk-label govuk-label--m" for="noticePlanUpload">Upload files</label>
-                                <div id="noticePlanUpload-hint" class="govuk-hint">The files must be a DOC, DOCX, PDF, TIF, JPG, PNG or XLSX and be smaller
-                                    than 1GB</div>
-                                <input class="govuk-file-upload moj-multi-file-upload__input"
-                                id="noticePlanUpload" name="noticePlanUpload" type="file" aria-describedby="noticePlanUpload-hint"
-                                multiple="">
-                            </div>
-                            <button value="upload-and-remain-on-page" type="submit" name="upload-and-remain-on-page"
-                            class="govuk-button govuk-button--secondary moj-multi-file-upload__button"
-                            data-module="govuk-button" data-cy="button-upload-file">Upload file</button>
+        <div class="govuk-grid-column-two-thirds"><span class="govuk-caption-l">Notifying relevant parties</span>
+            <h1 class="govuk-heading-l">Upload the enforcement notice plan</h1>
+            <form action="/manage-appeals/questionnaire/appeal-ref/notified/upload-enforcement-notice-plan"
+            method="post" novalidate=null enctype="multipart/form-data">
+                <div class="moj-multi-file-upload">
+                    <div class="moj-multi-file__uploaded-files" aria-live="polite">
+                        <div class="moj-multi-file__uploaded-files-container moj-hidden">
+                            <h2 class="govuk-heading-m" id="-uploaded-files-heading">Files added</h2>
+                            <ul class="govuk-summary-list moj-multi-file-upload__list"></ul>
                         </div>
                     </div>
-                    <div class="govuk-button-group">
-                        <button type="submit" class="govuk-button" data-module="govuk-button"
-                        data-cy="button-save-and-continue">Continue</button>
+                    <div class="moj-multi-file-upload__upload">
+                        <div class="govuk-form-group">
+                            <label class="govuk-label govuk-label--m" for="noticePlanUpload">Upload files</label>
+                            <div id="noticePlanUpload-hint" class="govuk-hint">The files must be a DOC, DOCX, PDF, TIF, JPG, PNG or XLSX and be smaller
+                                than 1GB</div>
+                            <input class="govuk-file-upload moj-multi-file-upload__input"
+                            id="noticePlanUpload" name="noticePlanUpload" type="file" aria-describedby="noticePlanUpload-hint"
+                            multiple="">
+                        </div>
+                        <button value="upload-and-remain-on-page" type="submit" name="upload-and-remain-on-page"
+                        class="govuk-button govuk-button--secondary moj-multi-file-upload__button"
+                        data-module="govuk-button" data-cy="button-upload-file">Upload file</button>
                     </div>
-                </form>
+                </div>
+                <div class="govuk-button-group">
+                    <button type="submit" class="govuk-button" data-module="govuk-button"
+                    data-cy="button-save-and-continue">Continue</button>
+                </div>
+            </form>
         </div>
     </div>
     <div class="govuk-grid-row">
@@ -36095,6 +36045,18 @@ exports[`Dynamic forms journey tests lpa Enforcement notice renders listing page
                         <h2 class="govuk-heading-m"><span class="app-task-list__section-number">3. </span> Notifying relevant parties<strong class="govuk-tag govuk-tag--grey moj-task-list__task-completed"> Not started</strong></h2>
                     </div>
                     <dl class="govuk-summary-list">
+                        <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Upload the enforcement notice</dt>
+                            <dd
+                            class="govuk-summary-list__value">Not started</dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/manage-appeals/questionnaire/appeal-ref/notified/upload-enforcement-notice">Upload<span class="govuk-visually-hidden"> enforcement notice</span></a>
+                                </dd>
+                        </div>
+                        <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Upload the enforcement notice plan</dt>
+                            <dd
+                            class="govuk-summary-list__value">Not started</dd>
+                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/manage-appeals/questionnaire/appeal-ref/notified/upload-enforcement-notice-plan">Upload<span class="govuk-visually-hidden"> enforcement notice plan</span></a>
+                                </dd>
+                        </div>
                         <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Upload the list of people you served the enforcement notice to</dt>
                             <dd
                             class="govuk-summary-list__value">Not started</dd>
@@ -36154,12 +36116,6 @@ exports[`Dynamic forms journey tests lpa Enforcement notice renders listing page
                             <dd
                             class="govuk-summary-list__value">Not started</dd>
                                 <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/manage-appeals/questionnaire/appeal-ref/planning-officer-report/previous-planning-permission">Answer<span class="govuk-visually-hidden"> Did you previously grant any planning permission for this development?</span></a>
-                                </dd>
-                        </div>
-                        <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Was there any enforcement notice in place at the date of the application?</dt>
-                            <dd
-                            class="govuk-summary-list__value">Not started</dd>
-                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/manage-appeals/questionnaire/appeal-ref/planning-officer-report/enforcement-notice-date-application">Answer<span class="govuk-visually-hidden"> Existing enforcement notice</span></a>
                                 </dd>
                         </div>
                         <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Did you serve a planning contravention notice?</dt>


### PR DESCRIPTION
### Description of change

Ticket: https://pins-ds.atlassian.net/browse/A2-8601

Updates enforcement notice lpaq but moving enforcement notice and enforcement notice plan upload questions and removing 'was an enforcement notice in place' question

### Checklist

- [X] Feature complete and ready for users, or behind feature-flag
- [X] Commit history is linear with no merge commits
- [ ] Requires infrastructure changes

### Important

Please do not merge from `main` (please only [rebase](https://github.com/Planning-Inspectorate/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
