### PR TITLE
feat(A2-8601): remove appeal statement from appeal details for expedited appeals

### DIFF
--- a/packages/forms-web-app/src/controllers/selected-appeal/appeal-details/appeal-documents-rows.js
+++ b/packages/forms-web-app/src/controllers/selected-appeal/appeal-details/appeal-documents-rows.js
@@ -279,12 +279,6 @@ const getExpeditedDocumentsRows = (caseData) => {
 			isEscaped: true
 		},
 		{
-			keyText: 'Appeal statement',
-			valueText: formatDocumentDetails(documents, APPEAL_DOCUMENT_TYPE.APPELLANT_STATEMENT),
-			condition: () => true,
-			isEscaped: true
-		},
-		{
 			keyText: 'Environmental statement',
 			valueText: formatDocumentDetails(
 				documents,

--- a/packages/forms-web-app/src/controllers/selected-appeal/appeal-details/appeal-documents-rows.test.js
+++ b/packages/forms-web-app/src/controllers/selected-appeal/appeal-details/appeal-documents-rows.test.js
@@ -330,7 +330,7 @@ describe('appeal-documents-rows - expedited part 1', () => {
 
 	it('should create rows for an expedited part 1 appeal', () => {
 		const rows = documentsRows(expeditedCaseData);
-		expect(rows.length).toEqual(7);
+		expect(rows.length).toEqual(6);
 	});
 
 	it('should have the correct rows in the correct order', () => {
@@ -340,7 +340,6 @@ describe('appeal-documents-rows - expedited part 1', () => {
 			'Decision letter',
 			'Separate ownership certificate in application',
 			'Evidence of agreement to change description of development',
-			'Appeal statement',
 			'Environmental statement',
 			'Costs application'
 		];
@@ -363,7 +362,7 @@ describe('appeal-documents-rows - expedited part 1', () => {
 		// Evidence of agreement to change description
 		expect(rows[3].condition(minimalCaseData)).toEqual(false);
 		// Costs application
-		expect(rows[6].condition(minimalCaseData)).toEqual(false);
+		expect(rows[5].condition(minimalCaseData)).toEqual(false);
 	});
 });
 


### PR DESCRIPTION
### Description of change

Remove appeal statement from S78 expedited appeals 

Updated tests to cover changes 
Manually tested in browser

Ticket: https://pins-ds.atlassian.net/browse/A2-8601

### Checklist

- [x] Feature complete and ready for users, or behind feature-flag
- [x] Commit history is linear with no merge commits
- [ ] Requires infrastructure changes

### Important

Please do not merge from `main` (please only [rebase](https://github.com/Planning-Inspectorate/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
