### PR TITLE
fix: typo in cost urls on lpa dashbaord (A2-8606)

### DIFF
--- a/packages/forms-web-app/src/controllers/selected-appeal/lpa-user-sections.js
+++ b/packages/forms-web-app/src/controllers/selected-appeal/lpa-user-sections.js
@@ -218,7 +218,7 @@ exports.sections = [
 					)
 			},
 			{
-				url: '/appellant-cost-application',
+				url: '/appellant-costs-applications',
 				text: 'View the appellant costs applications',
 				condition: (appealCase) =>
 					appealCase.Documents.some(
@@ -237,7 +237,7 @@ exports.sections = [
 					)
 			},
 			{
-				url: '/appellant-cost-comments',
+				url: '/appellant-costs-comments',
 				text: 'View the appellant costs comments',
 				condition: (appealCase) =>
 					appealCase.Documents.some(


### PR DESCRIPTION
### Description of change

Corrected typos in urls of lpa dashboard

Ticket: https://pins-ds.atlassian.net/browse/A2-8606

### Checklist

- [x] Feature complete and ready for users, or behind feature-flag
- [x] Commit history is linear with no merge commits
- [ ] Requires infrastructure changes

### Important

Please do not merge from `main` (please only [rebase](https://github.com/Planning-Inspectorate/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
