### PR TITLE
fix(a2-8547): appellant case costs docs

### DIFF
--- a/packages/database/src/migrations/20260626120958_publish_costs_appellant_case/migration.sql
+++ b/packages/database/src/migrations/20260626120958_publish_costs_appellant_case/migration.sql
@@ -1,0 +1,27 @@
+BEGIN TRY
+
+BEGIN TRAN;
+
+-- publish appellantCostsApplication that came from the appellant case
+BEGIN TRANSACTION
+UPDATE [dbo].[Document]
+SET
+    [published]            = 1,
+    [publishedDocumentURI] = [documentUri],
+    [datePublished]        = [dateCreated]
+WHERE [documentType] = 'appellantCostsApplication'
+AND [stage] = 'appellant-case'
+COMMIT TRANSACTION
+
+COMMIT TRAN;
+
+END TRY
+BEGIN CATCH
+
+IF @@TRANCOUNT > 0
+BEGIN
+    ROLLBACK TRAN;
+END;
+THROW
+
+END CATCH

--- a/packages/forms-web-app/src/controllers/selected-appeal/lpa-user-sections.js
+++ b/packages/forms-web-app/src/controllers/selected-appeal/lpa-user-sections.js
@@ -17,6 +17,12 @@ const { APPEAL_DOCUMENT_TYPE } = require('@planning-inspectorate/data-model');
 /** @typedef {function({documentType: string, published: boolean}): boolean} CostsCondition */
 
 /**
+ * @param {import ('appeals-service-api').Api.AppealCase} appealCase
+ * @returns {boolean}
+ */
+const caseValid = (appealCase) => !!appealCase.caseValidDate;
+
+/**
  * @type {import("@pins/common/src/view-model-maps/sections/def").Sections}
  */
 exports.sections = [
@@ -26,7 +32,7 @@ exports.sections = [
 			{
 				url: '/appeal-details',
 				text: 'View appeal details',
-				condition: (appealCase) => !!appealCase.caseValidDate
+				condition: caseValid
 			}
 		]
 	},
@@ -221,6 +227,7 @@ exports.sections = [
 				url: '/appellant-costs-applications',
 				text: 'View the appellant costs applications',
 				condition: (appealCase) =>
+					caseValid(appealCase) &&
 					appealCase.Documents.some(
 						/** @type {CostsCondition} */
 						(doc) =>
@@ -240,6 +247,7 @@ exports.sections = [
 				url: '/appellant-costs-comments',
 				text: 'View the appellant costs comments',
 				condition: (appealCase) =>
+					caseValid(appealCase) &&
 					appealCase.Documents.some(
 						/** @type {CostsCondition} */
 						(doc) =>

--- a/packages/forms-web-app/src/controllers/selected-appeal/user-sections.test.js
+++ b/packages/forms-web-app/src/controllers/selected-appeal/user-sections.test.js
@@ -7,7 +7,10 @@ const {
 	LPA_USER_ROLE
 } = require('@pins/common/src/constants');
 const { CASE_TYPES } = require('@pins/common/src/database/data-static');
-const { APPEAL_REPRESENTATION_STATUS } = require('@planning-inspectorate/data-model');
+const {
+	APPEAL_DOCUMENT_TYPE,
+	APPEAL_REPRESENTATION_STATUS
+} = require('@planning-inspectorate/data-model');
 
 const { addDays } = require('date-fns');
 
@@ -372,6 +375,81 @@ describe('LPA and Appellant Sections', () => {
 			it("should not show 'View proof of evidence and witnesses from other parties' when no rule proofs are published", () => {
 				const section = findSectionByHeading(lpaSections, 'Proof of evidence and witnesses');
 				const link = findLinkByUrl(section, '/other-party-proof-evidence');
+				expect(link?.condition(appealCase)).toBe(false);
+			});
+		});
+
+		describe('Costs', () => {
+			it('should show own costs applications when docs are present', () => {
+				appealCase.Documents = [
+					{
+						documentType: APPEAL_DOCUMENT_TYPE.LPA_COSTS_APPLICATION,
+						published: true
+					}
+				];
+				const section = findSectionByHeading(lpaSections, 'Costs');
+				const link = findLinkByUrl(section, '/your-cost-application');
+				expect(link?.condition(appealCase)).toBe(true);
+				expect(link?.text).toBe('View your costs applications');
+			});
+			it('should show own costs correspondence when docs are present', () => {
+				appealCase.Documents = [
+					{
+						documentType: APPEAL_DOCUMENT_TYPE.LPA_COSTS_CORRESPONDENCE,
+						published: true
+					}
+				];
+				const section = findSectionByHeading(lpaSections, 'Costs');
+				const link = findLinkByUrl(section, '/your-cost-comments');
+				expect(link?.condition(appealCase)).toBe(true);
+				expect(link?.text).toBe('View your costs comments');
+			});
+			it('should show appellant costs applications when docs are present', () => {
+				appealCase.Documents = [
+					{
+						documentType: APPEAL_DOCUMENT_TYPE.APPELLANT_COSTS_APPLICATION,
+						published: true
+					}
+				];
+				const section = findSectionByHeading(lpaSections, 'Costs');
+				const link = findLinkByUrl(section, '/appellant-costs-applications');
+				expect(link?.condition(appealCase)).toBe(true);
+				expect(link?.text).toBe('View the appellant costs applications');
+			});
+			it('should show appellant costs comments when docs are present', () => {
+				appealCase.Documents = [
+					{
+						documentType: APPEAL_DOCUMENT_TYPE.APPELLANT_COSTS_CORRESPONDENCE,
+						published: true
+					}
+				];
+				const section = findSectionByHeading(lpaSections, 'Costs');
+				const link = findLinkByUrl(section, '/appellant-costs-comments');
+				expect(link?.condition(appealCase)).toBe(true);
+				expect(link?.text).toBe('View the appellant costs comments');
+			});
+			it('should not show appellant costs applications when docs are present', () => {
+				appealCase.caseValidDate = null;
+				appealCase.Documents = [
+					{
+						documentType: APPEAL_DOCUMENT_TYPE.APPELLANT_COSTS_APPLICATION,
+						published: true
+					}
+				];
+				const section = findSectionByHeading(lpaSections, 'Costs');
+				const link = findLinkByUrl(section, '/appellant-costs-applications');
+				expect(link?.condition(appealCase)).toBe(false);
+			});
+			it('should not show appellant costs comments when docs are present', () => {
+				appealCase.caseValidDate = null;
+				appealCase.Documents = [
+					{
+						documentType: APPEAL_DOCUMENT_TYPE.APPELLANT_COSTS_CORRESPONDENCE,
+						published: true
+					}
+				];
+				const section = findSectionByHeading(lpaSections, 'Costs');
+				const link = findLinkByUrl(section, '/appellant-costs-comments');
 				expect(link?.condition(appealCase)).toBe(false);
 			});
 		});


### PR DESCRIPTION
### Description of change

**Migration**
Last manual migration unpublished all costs documents so that they could be managed with a share button in Back Office

This republishes the costs docs that come in from appellant case so they can still be seen on the appeal details pages before they are shared

**LPA sections**
The appellant costs sections are now hidden from LPA until the case is visible to the LPA as well (case marked as valid)

Ticket: https://pins-ds.atlassian.net/browse/A2-8637

### Checklist

- [x] Feature complete and ready for users, or behind feature-flag
- [x] Commit history is linear with no merge commits
- [ ] Requires infrastructure changes

### Important

Please do not merge from `main` (please only [rebase](https://github.com/Planning-Inspectorate/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
