### PR TITLE
fix(forms): added missing inquiry parts (A2-3613)

### DIFF
--- a/packages/forms-web-app/src/controllers/selected-appeal/appeal-details/appeal-details-rows.js
+++ b/packages/forms-web-app/src/controllers/selected-appeal/appeal-details/appeal-details-rows.js
@@ -348,7 +348,8 @@ const getStandardDetailsRows = (caseData, context) => {
 				? caseData.appellantProcedurePreferenceDuration.toString()
 				: '',
 			condition: (caseData) =>
-				!isExpeditedAppealType && caseData.appellantProcedurePreferenceDuration != null
+				!isExpeditedAppealType &&
+				isNotUndefinedOrNull(caseData.appellantProcedurePreferenceDuration)
 		},
 		{
 			keyText: 'Expected witness count',
@@ -356,7 +357,8 @@ const getStandardDetailsRows = (caseData, context) => {
 				? caseData.appellantProcedurePreferenceWitnessCount.toString()
 				: '',
 			condition: (caseData) =>
-				!isExpeditedAppealType && caseData.appellantProcedurePreferenceWitnessCount != null
+				!isExpeditedAppealType &&
+				isNotUndefinedOrNull(caseData.appellantProcedurePreferenceWitnessCount)
 		},
 		{
 			keyText: 'Are there other appeals linked to your development?',
@@ -728,7 +730,8 @@ const getExpeditedDetailsRows = (caseData, context) => {
 		isS20orS78,
 		showRelatedAppeals,
 		relatedAppeals,
-		costApplicationKeyText
+		costApplicationKeyText,
+		isExpeditedAppealType
 	} = context;
 
 	return [
@@ -880,6 +883,24 @@ const getExpeditedDetailsRows = (caseData, context) => {
 			keyText: 'Preferred procedure',
 			valueText: formatProcedure(caseData),
 			condition: (caseData) => caseData.appellantProcedurePreference
+		},
+		{
+			keyText: 'Expected procedure duration',
+			valueText: caseData.appellantProcedurePreferenceDuration
+				? caseData.appellantProcedurePreferenceDuration.toString()
+				: '',
+			condition: (caseData) =>
+				!isExpeditedAppealType &&
+				isNotUndefinedOrNull(caseData.appellantProcedurePreferenceDuration)
+		},
+		{
+			keyText: 'Expected witness count',
+			valueText: caseData.appellantProcedurePreferenceWitnessCount
+				? caseData.appellantProcedurePreferenceWitnessCount.toString()
+				: '',
+			condition: (caseData) =>
+				!isExpeditedAppealType &&
+				isNotUndefinedOrNull(caseData.appellantProcedurePreferenceWitnessCount)
 		},
 		{
 			keyText: 'Are there other appeals linked to your development?',

--- a/packages/forms-web-app/src/controllers/selected-appeal/appeal-details/appeal-details-rows.test.js
+++ b/packages/forms-web-app/src/controllers/selected-appeal/appeal-details/appeal-details-rows.test.js
@@ -1573,7 +1573,38 @@ describe('appeal-details-rows - enforcement and enforcement listed', () => {
 			anySignificantChanges_localPlanSignificantChanges: 'Local plan details',
 			anySignificantChanges_otherSignificantChanges: 'Other details',
 			appellantProcedurePreference: 'Inquiry',
+			appellantProcedurePreferenceDetails: 'For reasons',
 			appellantCostsAppliedFor: true
+		};
+		const nonExpeditedCaseData = {
+			appealTypeCode: CASE_TYPES.S78.processCode,
+			typeOfPlanningApplication: 'full-appeal',
+			applicationDecision: 'refused',
+			applicationDate: '2026-03-10',
+			applicationReference: 'APP/Q9999/W/22/1234567',
+			users: [appellant],
+			siteAddressLine1: '123 Test Road',
+			siteAddressTown: 'Test Town',
+			siteAddressPostcode: 'TE1 1ST',
+			siteAreaSquareMetres: 100,
+			isGreenBelt: true,
+			ownsAllLand: true,
+			agriculturalHolding: false,
+			siteAccessDetails: ['Is accessible'],
+			siteHealthAndSafetyDetails: ['Safe'],
+			developmentType: 'major-dwellings',
+			originalDevelopmentDescription: 'Large development',
+			changedDevelopmentDescription: true,
+			reasonForAppealAppellant: 'The reason for appeal',
+			anySignificantChanges: 'adopted-a-new-local-plan, other',
+			anySignificantChanges_localPlanSignificantChanges: 'Local plan details',
+			anySignificantChanges_otherSignificantChanges: 'Other details',
+			appellantProcedurePreference: 'Inquiry',
+			appellantProcedurePreferenceDetails: 'For reasons',
+			appellantCostsAppliedFor: true,
+			expedited: false,
+			appellantProcedurePreferenceDuration: 1,
+			appellantProcedurePreferenceWitnessCount: 1
 		};
 
 		it('should create expedited rows in the correct order', () => {
@@ -1610,6 +1641,23 @@ describe('appeal-details-rows - enforcement and enforcement listed', () => {
 			const rows = detailsRows(caseData, APPEAL_USER_ROLES.APPELLANT);
 			const row = rows.find((r) => r.keyText === 'Significant changes since application');
 			expect(row.condition(caseData)).toBe(false);
+		});
+
+		it('should not display the appellant Expected procedure duration if not expedited', () => {
+			const caseData = {
+				...nonExpeditedCaseData
+			};
+			const rows = detailsRows(caseData, APPEAL_USER_ROLES.APPELLANT);
+			const row = rows.find((r) => r.keyText === 'Expected procedure duration');
+			expect(row.condition(caseData)).toBe(true);
+		});
+		it('should not display the appellant Expected witness count if not expedited', () => {
+			const caseData = {
+				...nonExpeditedCaseData
+			};
+			const rows = detailsRows(caseData, APPEAL_USER_ROLES.APPELLANT);
+			const row = rows.find((r) => r.keyText === 'Expected witness count');
+			expect(row.condition(caseData)).toBe(true);
 		});
 	});
 });


### PR DESCRIPTION
### Description of change

- Added appellantProcedurePreferenceWitnessCount to expedite inquiry appeal
- Added appellantProcedurePreferenceDuration to expedite inquiry appeal

Ticket: https://pins-ds.atlassian.net/browse/A2-3613

### Checklist

- [ ] Feature complete and ready for users, or behind feature-flag
- [ ] Commit history is linear with no merge commits
- [ ] Requires infrastructure changes

### Important

Please do not merge from `main` (please only [rebase](https://github.com/Planning-Inspectorate/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
