### PR TITLE
fix(a2-7992): display invalid appeals correctly on dashboards

### DIFF
--- a/packages/appeals-service-api/src/routes/v2/appeal-cases/repo.js
+++ b/packages/appeals-service-api/src/routes/v2/appeal-cases/repo.js
@@ -56,6 +56,7 @@ const dashboardSelect = {
 
 	// outcome
 	caseDecisionOutcome: true,
+	caseValidationOutcome: true,
 
 	// case dates
 	caseSubmittedDate: true,

--- a/packages/appeals-service-api/src/routes/v2/appeals/repo.js
+++ b/packages/appeals-service-api/src/routes/v2/appeals/repo.js
@@ -64,6 +64,7 @@ class UserAppealsRepository {
 											caseDecisionOutcomeDate: true,
 											caseDecisionOutcome: true,
 											caseValidationDate: true,
+											caseValidationOutcome: true,
 											caseReference: true,
 											appellantCommentsSubmittedDate: true,
 											appellantProofsSubmittedDate: true,

--- a/packages/business-rules/src/lib/filter-invalid-validation-one-month.js
+++ b/packages/business-rules/src/lib/filter-invalid-validation-one-month.js
@@ -1,0 +1,60 @@
+const {
+	APPEAL_CASE_STATUS,
+	APPEAL_CASE_VALIDATION_OUTCOME
+} = require('@planning-inspectorate/data-model');
+const { differenceInCalendarDays } = require('date-fns');
+const INVALID_APPEAL_TIME_LIMIT = 28;
+
+/**
+ * filters out invalid appeals that have not been invalidated within the last 28 days from appellant case validation
+ * @param {import('appeals-service-api').Api.AppealCaseDetailed} appeal
+ * @returns {boolean}
+ */
+const ifInvalidOnlyRecentValidation = (appeal) => {
+	// don't impact non invalid appeals
+	if (appeal.caseStatus !== APPEAL_CASE_STATUS.INVALID) return true;
+
+	// remove appeals given invalid decision
+	if (appeal.caseValidationOutcome !== APPEAL_CASE_VALIDATION_OUTCOME.INVALID) return false;
+
+	// if we don't know when the appeal was invalidated, we can't show it
+	if (!appeal.caseValidationDate) return false;
+
+	const daysSinceInvalidated = differenceInCalendarDays(
+		new Date(),
+		new Date(appeal.caseValidationDate)
+	);
+
+	// only show the validation invalid appeals if they were marked as invalid within the last 28 days
+	return daysSinceInvalidated < INVALID_APPEAL_TIME_LIMIT;
+};
+
+/**
+ * filters out invalid appeals that have not been invalidated within the last 28 days from appellant case validation
+ * @param {import('appeals-service-api').Api.AppealCaseDetailed} appeal
+ * @returns {boolean}
+ */
+const ifInvalidOnlyOldValidation = (appeal) => {
+	// don't impact non invalid appeals
+	if (appeal.caseStatus !== APPEAL_CASE_STATUS.INVALID) return true;
+
+	// remove appeals given invalid decision
+	if (appeal.caseValidationOutcome !== APPEAL_CASE_VALIDATION_OUTCOME.INVALID) return false;
+
+	// if we don't know when the appeal was invalidated, we can't show it
+	if (!appeal.caseValidationDate) return false;
+
+	const daysSinceInvalidated = differenceInCalendarDays(
+		new Date(),
+		new Date(appeal.caseValidationDate)
+	);
+
+	// only show the validation invalid appeals if they were marked as invalid within the last 28 days
+	return daysSinceInvalidated >= INVALID_APPEAL_TIME_LIMIT;
+};
+
+module.exports = {
+	ifInvalidOnlyOldValidation,
+	ifInvalidOnlyRecentValidation,
+	INVALID_APPEAL_TIME_LIMIT
+};

--- a/packages/business-rules/src/lib/filter-invalid-validation-one-month.test.js
+++ b/packages/business-rules/src/lib/filter-invalid-validation-one-month.test.js
@@ -1,0 +1,117 @@
+const {
+	ifInvalidOnlyRecentValidation,
+	ifInvalidOnlyOldValidation
+} = require('./filter-invalid-validation-one-month');
+const { getCaseFixture } = require('@pins/common/__tests__/fixtures/appeal-cases.fixture.js');
+const {
+	APPEAL_CASE_STATUS,
+	APPEAL_CASE_VALIDATION_OUTCOME,
+	APPEAL_CASE_PROCEDURE
+} = require('@planning-inspectorate/data-model');
+const { CASE_TYPES } = require('@pins/common/src/database/data-static');
+
+describe('filter-invalid-validation-one-month', () => {
+	describe('ifInvalidOnlyRecentValidation', () => {
+		it('ignores non invalid appeals', () => {
+			const appeals = [
+				getCaseFixture(
+					CASE_TYPES.HAS.processCode,
+					APPEAL_CASE_STATUS.LPA_QUESTIONNAIRE,
+					APPEAL_CASE_PROCEDURE.WRITTEN
+				)
+			];
+			const result = appeals.filter(ifInvalidOnlyRecentValidation);
+			expect(result).toEqual(appeals);
+		});
+
+		it('hides invalid appeals from case decision', () => {
+			const appeals = [
+				getCaseFixture(
+					CASE_TYPES.HAS.processCode,
+					APPEAL_CASE_STATUS.INVALID,
+					APPEAL_CASE_PROCEDURE.WRITTEN
+				)
+					.setValidationOutcome(APPEAL_CASE_VALIDATION_OUTCOME.VALID)
+					.setDecisionOutcome(APPEAL_CASE_VALIDATION_OUTCOME.INVALID, true)
+			];
+			const result = appeals.filter(ifInvalidOnlyRecentValidation);
+			expect(result).toEqual([]);
+		});
+
+		it('hides invalid appeals from a long time ago', () => {
+			const appeals = [
+				getCaseFixture(
+					CASE_TYPES.HAS.processCode,
+					APPEAL_CASE_STATUS.INVALID,
+					APPEAL_CASE_PROCEDURE.WRITTEN
+				).setValidationOutcome(APPEAL_CASE_VALIDATION_OUTCOME.INVALID, new Date('2025-12-01'))
+			];
+			const result = appeals.filter(ifInvalidOnlyRecentValidation);
+			expect(result).toEqual([]);
+		});
+
+		it('shows invalid appeals from a recent date', () => {
+			const appeals = [
+				getCaseFixture(
+					CASE_TYPES.HAS.processCode,
+					APPEAL_CASE_STATUS.INVALID,
+					APPEAL_CASE_PROCEDURE.WRITTEN
+				).setValidationOutcome(APPEAL_CASE_VALIDATION_OUTCOME.INVALID)
+			];
+			const result = appeals.filter(ifInvalidOnlyRecentValidation);
+			expect(result).toEqual(appeals);
+		});
+	});
+
+	describe('ifInvalidOnlyOldValidation', () => {
+		it('ignores non invalid appeals', () => {
+			const appeals = [
+				getCaseFixture(
+					CASE_TYPES.HAS.processCode,
+					APPEAL_CASE_STATUS.LPA_QUESTIONNAIRE,
+					APPEAL_CASE_PROCEDURE.WRITTEN
+				)
+			];
+			const result = appeals.filter(ifInvalidOnlyOldValidation);
+			expect(result).toEqual(appeals);
+		});
+
+		it('hides invalid appeals from case decision', () => {
+			const appeals = [
+				getCaseFixture(
+					CASE_TYPES.HAS.processCode,
+					APPEAL_CASE_STATUS.INVALID,
+					APPEAL_CASE_PROCEDURE.WRITTEN
+				)
+					.setValidationOutcome(APPEAL_CASE_VALIDATION_OUTCOME.VALID)
+					.setDecisionOutcome(APPEAL_CASE_VALIDATION_OUTCOME.INVALID, true)
+			];
+			const result = appeals.filter(ifInvalidOnlyOldValidation);
+			expect(result).toEqual([]);
+		});
+
+		it('shows invalid appeals from a long time ago', () => {
+			const appeals = [
+				getCaseFixture(
+					CASE_TYPES.HAS.processCode,
+					APPEAL_CASE_STATUS.INVALID,
+					APPEAL_CASE_PROCEDURE.WRITTEN
+				).setValidationOutcome(APPEAL_CASE_VALIDATION_OUTCOME.INVALID, new Date('2025-12-01'))
+			];
+			const result = appeals.filter(ifInvalidOnlyOldValidation);
+			expect(result).toEqual(appeals);
+		});
+
+		it('hides invalid appeals from a recent date', () => {
+			const appeals = [
+				getCaseFixture(
+					CASE_TYPES.HAS.processCode,
+					APPEAL_CASE_STATUS.INVALID,
+					APPEAL_CASE_PROCEDURE.WRITTEN
+				).setValidationOutcome(APPEAL_CASE_VALIDATION_OUTCOME.INVALID)
+			];
+			const result = appeals.filter(ifInvalidOnlyOldValidation);
+			expect(result).toEqual([]);
+		});
+	});
+});

--- a/packages/common/__tests__/fixtures/appeal-cases.fixture.js
+++ b/packages/common/__tests__/fixtures/appeal-cases.fixture.js
@@ -1,0 +1,337 @@
+const { randomUUID } = require('node:crypto');
+const {
+	APPEAL_CASE_STATUS,
+	APPEAL_CASE_VALIDATION_OUTCOME,
+	APPEAL_CASE_DECISION_OUTCOME
+} = require('@planning-inspectorate/data-model');
+
+const generateRandomCaseReference = () => {
+	return `6${Math.floor(Math.random() * 1000000)
+		.toString()
+		.padStart(6, '0')}`;
+};
+
+/**
+ * @param {string} appealTypeCode
+ * @param {string} caseStatus
+ * @param {string} caseProcedure
+ */
+exports.getCaseFixture = (appealTypeCode, caseStatus, caseProcedure) => {
+	const caseFixture = new CaseFixture(appealTypeCode, caseStatus, caseProcedure);
+	return caseFixture;
+};
+
+class CaseFixture {
+	/**
+	 * @param {string} appealTypeCode
+	 * @param {string} caseStatus
+	 * @param {string} caseProcedure
+	 */
+	constructor(appealTypeCode, caseStatus, caseProcedure) {
+		const caseRef = generateRandomCaseReference();
+		this.id = randomUUID();
+		this.appealId = randomUUID();
+		this.caseReference = caseRef;
+		this.caseId = Number(caseRef) - 6000000;
+		this.appealTypeCode = appealTypeCode;
+		this.caseStatus = caseStatus;
+		this.caseProcedure = caseProcedure;
+	}
+
+	/** @param {string} outcome @param {Date} [date] */
+	setValidationOutcome(outcome, date) {
+		this.caseValidationOutcome = outcome;
+		this.caseValidationOutcomeDate = date || new Date();
+		this.caseValidationDate = date || new Date();
+		this.caseStatus =
+			outcome === APPEAL_CASE_VALIDATION_OUTCOME.INVALID
+				? APPEAL_CASE_STATUS.INVALID
+				: this.caseStatus;
+		return this;
+	}
+
+	/** @param {string} outcome @param {boolean} [published] */
+	setDecisionOutcome(outcome, published) {
+		this.caseDecisionOutcome = outcome;
+		this.caseDecisionOutcomeDate = new Date();
+
+		if (published) {
+			this.caseDecisionOutcomePublishedDate = new Date();
+		}
+
+		if (this.caseDecisionOutcome === APPEAL_CASE_DECISION_OUTCOME.INVALID) {
+			this.caseStatus = APPEAL_CASE_STATUS.INVALID;
+		}
+
+		return this;
+	}
+
+	markAsWithdrawn() {
+		this.caseWithdrawnDate = new Date();
+		this.caseStatus = APPEAL_CASE_STATUS.WITHDRAWN;
+		return this;
+	}
+
+	//***************************************************************************
+	// general case fields
+	//***************************************************************************
+
+	LPACode = 'Q9999';
+	appealTypeCode = null;
+	caseStatus = null;
+	caseProcedure = null;
+
+	applicationReference = null;
+	applicationDecision = null;
+	applicationDate = null;
+	applicationDecisionDate = null;
+	caseSubmissionDueDate = null;
+	enforcementNotice = null;
+	developmentType = null;
+	typeOfPlanningApplication = null;
+
+	isGreenBelt = null;
+	inConservationArea = null;
+	scheduledMonument = null;
+	protectedSpecies = null;
+	areaOutstandingBeauty = null;
+	gypsyTraveller = null;
+	publicRightOfWay = null;
+
+	//***************************************************************************
+	// site details
+	//***************************************************************************
+
+	siteAddressLine1 = null;
+	siteAddressLine2 = null;
+	siteAddressTown = null;
+	siteAddressCounty = null;
+	siteAddressPostcode = null;
+	siteAddressPostcodeSanitized = null;
+	siteAccessDetails = null;
+	siteSafetyDetails = null;
+	siteAreaSquareMetres = null;
+	floorSpaceSquareMetres = null;
+	siteGridReferenceEasting = null;
+	siteGridReferenceNorthing = null;
+
+	//***************************************************************************
+	// Appellant fields
+	//***************************************************************************
+
+	appellantCostsAppliedFor = null;
+	originalDevelopmentDescription = null;
+	statusPlanningObligation = null;
+
+	ownsAllLand = null;
+	ownsSomeLand = null;
+	knowsOtherOwners = null;
+	knowsAllOwners = null;
+	advertisedAppeal = null;
+	ownersInformed = null;
+
+	agriculturalHolding = null;
+	tenantAgriculturalHolding = null;
+	otherTenantsAgriculturalHolding = null;
+	informedTenantsAgriculturalHolding = null;
+
+	appellantProcedurePreference = null;
+	appellantProcedurePreferenceDetails = null;
+	appellantProcedurePreferenceDuration = null;
+	appellantProcedurePreferenceWitnessCount = null;
+
+	//***************************************************************************
+	// LPA fields
+	//***************************************************************************
+
+	isCorrectAppealType = null;
+	lpaCostsAppliedFor = null;
+	changedDevelopmentDescription = null;
+	newConditionDetails = null;
+
+	lpaStatement = null;
+	lpaProcedurePreference = null;
+	lpaProcedurePreferenceDetails = null;
+	lpaProcedurePreferenceDuration = null;
+
+	statutoryConsultees = null;
+	consultedBodiesDetails = null;
+
+	reasonForNeighbourVisits = null;
+
+	designatedSitesNames = null;
+	listOfDocumentsBeforeDecision = null;
+
+	//***************************************************************************
+	// Environmental Impact Assesement fields
+	//***************************************************************************
+
+	environmentalImpactSchedule = null;
+	developmentDescription = null;
+	sensitiveAreaDetails = null;
+	columnTwoThreshold = null;
+	screeningOpinion = null;
+	requiresEnvironmentalStatement = null;
+	completedEnvironmentalStatement = null;
+
+	//***************************************************************************
+	// Infrastructure levy fields
+	//***************************************************************************
+
+	infrastructureLevy = null;
+	infrastructureLevyAdopted = null;
+	infrastructureLevyAdoptedDate = null;
+	infrastructureLevyExpectedDate = null;
+
+	//***************************************************************************
+	// PINS provided details
+	//***************************************************************************
+
+	caseDecisionOutcome = null;
+	caseValidationOutcome = null;
+	lpaQuestionnaireValidationOutcome = null;
+
+	// JSON arrays
+	caseValidationInvalidDetails = null;
+	caseValidationIncompleteDetails = null;
+	lpaQuestionnaireValidationDetails = null;
+
+	// (unexpected FO will need to use the following PINs info)
+	caseSpecialisms = null;
+	caseOfficerId = null;
+	inspectorId = null;
+	allocationLevel = null;
+	allocationBand = null;
+
+	//***************************************************************************
+	// system dates
+	//***************************************************************************
+
+	// case dates
+	caseSubmittedDate = new Date();
+	caseCreatedDate = new Date();
+	caseUpdatedDate = null;
+	caseValidDate = null;
+	caseValidationDate = null;
+	caseExtensionDate = null;
+	caseStartedDate = null;
+	casePublishedDate = null;
+	caseWithdrawnDate = null;
+	caseTransferredDate = null;
+	transferredCaseClosedDate = null;
+	caseDecisionOutcomeDate = null;
+	caseDecisionPublishedDate = null;
+	caseCompletedDate = null;
+
+	// lpaq dates
+	lpaQuestionnaireDueDate = null;
+	lpaQuestionnaireSubmittedDate = null;
+	lpaQuestionnaireCreatedDate = null;
+	lpaQuestionnairePublishedDate = null;
+	lpaQuestionnaireValidationOutcomeDate = null;
+
+	// statements
+	statementDueDate = null;
+	appellantStatementSubmittedDate = null;
+	LPAStatementSubmittedDate = null;
+
+	// final comments
+	finalCommentsDueDate = null;
+	appellantCommentsSubmittedDate = null;
+	LPACommentsSubmittedDate = null;
+
+	// IP dates
+	interestedPartyRepsDueDate = null;
+
+	// proofs of evidence
+	proofsOfEvidenceDueDate = null;
+	LPAProofsSubmittedDate = null;
+	appellantProofsSubmittedDate = null;
+
+	//***************************************************************************
+	// s78 fields
+	//***************************************************************************
+
+	siteWithinSSSI = null; // SSSI is an option for designatedSites
+	siteViewableFromRoad = null;
+	caseworkReason = null;
+	importantInformation = null;
+	jurisdiction = null;
+	redeterminedIndicator = null;
+	numberOfResidencesNetChange = null;
+	// consistent naming for date fields?
+	dateNotRecoveredOrDerecovered = null;
+	dateRecovered = null;
+	originalCaseDecisionDate = null;
+	targetDate = null;
+	siteNoticesSentDate = null;
+	dateCostsReportDespatched = null;
+	reasonForAppealAppellant = null;
+	screeningOpinionIndicatesEiaRequired = null;
+	anySignificantChanges = null;
+	anySignificantChanges_otherSignificantChanges = null;
+	anySignificantChanges_localPlanSignificantChanges = null;
+	anySignificantChanges_nationalPolicySignificantChanges = null;
+	anySignificantChanges_courtJudgementSignificantChanges = null;
+
+	//***************************************************************************
+	// s20 fields
+	//***************************************************************************
+	preserveGrantLoan = null;
+	consultHistoricEngland = null;
+
+	//***************************************************************************
+	// Adverts fields
+	//***************************************************************************
+	hasLandownersPermission = null;
+
+	wasApplicationRefusedDueToHighwayOrTraffic = null;
+	isSiteInAreaOfSpecialControlAdverts = null;
+	didAppellantSubmitCompletePhotosAndPlans = null;
+
+	//***************************************************************************
+	// enforcement fields
+	//***************************************************************************
+	ownerOccupancyStatus = null;
+	occupancyConditionsMet = null;
+	applicationMadeAndFeePaid = null;
+	retrospectiveApplication = null;
+	groundAFeePaid = null;
+	previousPlanningPermissionGranted = null;
+	issueDateOfEnforcementNotice = null;
+	effectiveDateOfEnforcementNotice = null;
+	didAppellantAppealLpaDecision = null;
+	dateLpaDecisionDue = null;
+	dateLpaDecisionReceived = null;
+	enforcementReference = null;
+	descriptionOfAllegedBreach = null;
+	applicationPartOrWholeDevelopment = null;
+	contactPlanningInspectorateDate = null;
+
+	// LPAQ fields
+	noticeRelatesToBuildingEngineeringMiningOther = null;
+	areaOfAllegedBreachInSquareMetres = null;
+	floorSpaceCreatedByBreachInSquareMetres = null;
+	changeOfUseRefuseOrWaste = null;
+	changeOfUseMineralExtraction = null;
+	changeOfUseMineralStorage = null;
+	relatesToErectionOfBuildingOrBuildings = null;
+	relatesToBuildingWithAgriculturalPurpose = null;
+	relatesToBuildingSingleDwellingHouse = null;
+	affectedTrunkRoadName = null;
+	isSiteOnCrownLand = null;
+	article4AffectedDevelopmentRights = null;
+	anySignificantChangesLpa = null;
+	anySignificantChangesLpa_otherSignificantChanges = null;
+	anySignificantChangesLpa_localPlanSignificantChanges = null;
+	anySignificantChangesLpa_nationalPolicySignificantChanges = null;
+	anySignificantChangesLpa_courtJudgementSignificantChanges = null;
+	//***************************************************************************
+	// LDC fields
+	//***************************************************************************
+	applicationMadeUnderActSection = null;
+	siteUseAtTimeOfApplication = null;
+	appealUnderActSection = null;
+	lpaConsiderAppealInvalid = null;
+	lpaAppealInvalidReasons = null;
+}

--- a/packages/common/__tests__/fixtures/appeal-cases.fixture.test.js
+++ b/packages/common/__tests__/fixtures/appeal-cases.fixture.test.js
@@ -1,0 +1,46 @@
+const { getCaseFixture } = require('./appeal-cases.fixture');
+const {
+	APPEAL_CASE_DECISION_OUTCOME,
+	APPEAL_CASE_STATUS,
+	APPEAL_CASE_VALIDATION_OUTCOME,
+	APPEAL_CASE_PROCEDURE
+} = require('@planning-inspectorate/data-model');
+
+const { CASE_TYPES } = require('@pins/common/src/database/data-static');
+
+describe('appeal-cases.fixtures', () => {
+	it('should return a valid appeal case fixture', () => {
+		const appealTypeCode = CASE_TYPES.HAS.processCode;
+		const caseStatus = APPEAL_CASE_STATUS.COMPLETE;
+		const caseProcedure = APPEAL_CASE_PROCEDURE.WRITTEN;
+
+		const appealCaseFixture = getCaseFixture(appealTypeCode, caseStatus, caseProcedure);
+
+		expect(appealCaseFixture).toHaveProperty('appealTypeCode', appealTypeCode);
+		expect(appealCaseFixture).toHaveProperty('caseStatus', caseStatus);
+		expect(appealCaseFixture).toHaveProperty('caseProcedure', caseProcedure);
+
+		const result = appealCaseFixture.setValidationOutcome(APPEAL_CASE_VALIDATION_OUTCOME.VALID);
+		expect(result).toHaveProperty('caseValidationOutcome', APPEAL_CASE_VALIDATION_OUTCOME.VALID);
+		expect(result).toHaveProperty('caseValidationOutcomeDate');
+		expect(appealCaseFixture).toHaveProperty(
+			'caseValidationOutcome',
+			APPEAL_CASE_VALIDATION_OUTCOME.VALID
+		);
+		expect(appealCaseFixture).toHaveProperty('caseValidationOutcomeDate');
+
+		const result2 = appealCaseFixture.setDecisionOutcome(
+			APPEAL_CASE_DECISION_OUTCOME.ALLOWED,
+			true
+		);
+		expect(result2).toHaveProperty('caseDecisionOutcome', APPEAL_CASE_DECISION_OUTCOME.ALLOWED);
+		expect(result2).toHaveProperty('caseDecisionOutcomeDate');
+		expect(result2).toHaveProperty('caseDecisionOutcomePublishedDate');
+		expect(appealCaseFixture).toHaveProperty(
+			'caseDecisionOutcome',
+			APPEAL_CASE_DECISION_OUTCOME.ALLOWED
+		);
+		expect(appealCaseFixture).toHaveProperty('caseDecisionOutcomeDate');
+		expect(appealCaseFixture).toHaveProperty('caseDecisionOutcomePublishedDate');
+	});
+});

--- a/packages/common/src/lib/appeal-sorting.js
+++ b/packages/common/src/lib/appeal-sorting.js
@@ -17,6 +17,9 @@ const sortByCaseReference = (a, b) => {
 /** @type {AppealSorter} */
 const sortByCaseDecisionDate = sortByDateFieldDesc('caseDecisionOutcomeDate');
 
+/** @type {AppealSorter} */
+const sortByWithdrawnDate = sortByDateFieldDesc('caseWithdrawnDate');
+
 /**
  * @param {string} field
  * @returns {function(any, any): number}
@@ -41,5 +44,6 @@ function sortByDateFieldDesc(field) {
 module.exports = {
 	sortByCaseReference,
 	sortByCaseDecisionDate,
+	sortByWithdrawnDate,
 	sortByDateFieldDesc
 };

--- a/packages/database/src/seed/lpa-appeal-case-data-dev.js
+++ b/packages/database/src/seed/lpa-appeal-case-data-dev.js
@@ -2,7 +2,8 @@ const { pickRandom, datesNMonthsAgo, datesNMonthsAhead } = require('./util');
 const {
 	APPEAL_CASE_STATUS,
 	APPEAL_CASE_DECISION_OUTCOME,
-	APPEAL_CASE_PROCEDURE
+	APPEAL_CASE_PROCEDURE,
+	APPEAL_CASE_VALIDATION_OUTCOME
 } = require('@planning-inspectorate/data-model');
 
 const lpaAppealIds = {
@@ -37,6 +38,7 @@ const lpaAppealIds = {
 	appeal75: '7b8312e0-c724-4969-b7d4-441c60c6741b',
 	appealTP1: '7c8412e0-c734-4969-b7d4-441c60c6840b',
 	appealTP2: '7c8412e0-c734-4969-b7d4-441c60c6841b',
+	appealTP3: '7c8412e0-c734-4969-b7d4-441c60c6841c',
 	appealKN1: '7c8412e0-c676-4969-b7d4-231c60c6845b',
 	appealTestPOE: '7c8412e0-c676-4969-b7d4-231c60c6845c'
 };
@@ -76,6 +78,7 @@ const lpaAppeals = [
 	{ id: lpaAppealIds.appeal75 },
 	{ id: lpaAppealIds.appealTP1 },
 	{ id: lpaAppealIds.appealTP2 },
+	{ id: lpaAppealIds.appealTP3 },
 	{ id: lpaAppealIds.appealKN1 },
 	{ id: lpaAppealIds.appealTestPOE }
 ];
@@ -590,17 +593,15 @@ const lpaAppealCaseData = [
 		},
 		...commonAppealCaseDataProperties,
 		caseReference: '8087801',
-		siteAddressLine1: 'Invalid',
+		siteAddressLine1: 'Invalid validation',
 		siteAddressLine2: null,
 		siteAddressTown: 'within 28 days',
 		siteAddressCounty: 'Countyshire',
 		siteAddressPostcode: 'BS1 6PN',
 		developmentDescription: 'test description',
-		CaseDecisionOutcome: {
-			connect: { key: APPEAL_CASE_DECISION_OUTCOME.INVALID }
+		CaseValidationOutcome: {
+			connect: { key: APPEAL_CASE_VALIDATION_OUTCOME.INVALID }
 		},
-		caseDecisionPublishedDate: new Date(),
-		caseDecisionOutcomeDate: new Date(),
 		CaseType: { connect: { processCode: 'S78' } },
 		CaseStatus: {
 			connect: { key: APPEAL_CASE_STATUS.INVALID }
@@ -614,9 +615,31 @@ const lpaAppealCaseData = [
 		},
 		...commonAppealCaseDataProperties,
 		caseReference: '8087802',
-		siteAddressLine1: 'Invalid',
+		siteAddressLine1: 'Invalid validation',
 		siteAddressLine2: null,
 		siteAddressTown: 'more than 28 days',
+		siteAddressCounty: 'Countyshire',
+		siteAddressPostcode: 'BS1 6PN',
+		developmentDescription: 'test description',
+		CaseType: { connect: { processCode: 'S78' } },
+		CaseStatus: {
+			connect: { key: APPEAL_CASE_STATUS.INVALID }
+		},
+		caseValidationDate: pickRandom(datesNMonthsAgo(2)),
+		CaseValidationOutcome: {
+			connect: { key: APPEAL_CASE_VALIDATION_OUTCOME.INVALID }
+		},
+		caseSubmittedDate: pickRandom(datesNMonthsAgo(3))
+	},
+	{
+		Appeal: {
+			connect: { id: lpaAppealIds.appealTP3 }
+		},
+		...commonAppealCaseDataProperties,
+		caseReference: '8087803',
+		siteAddressLine1: 'Invalid',
+		siteAddressLine2: null,
+		siteAddressTown: 'decision issued',
 		siteAddressCounty: 'Countyshire',
 		siteAddressPostcode: 'BS1 6PN',
 		developmentDescription: 'test description',

--- a/packages/forms-web-app/__tests__/unit/controllers/appeals/your-appeals.test.js
+++ b/packages/forms-web-app/__tests__/unit/controllers/appeals/your-appeals.test.js
@@ -1,71 +1,121 @@
+const { getCaseFixture } = require('@pins/common/__tests__/fixtures/appeal-cases.fixture.js');
+const { CASE_TYPES } = require('@pins/common/src/database/data-static');
+const {
+	APPEAL_CASE_STATUS,
+	APPEAL_CASE_PROCEDURE,
+	APPEAL_CASE_DECISION_OUTCOME,
+	APPEAL_CASE_VALIDATION_OUTCOME
+} = require('@planning-inspectorate/data-model');
+
 const { get } = require('../../../../src/controllers/appeals/your-appeals');
 
 const { VIEW } = require('../../../../src/lib/views');
 const { mockReq, mockRes } = require('../../mocks');
-const {
-	mapToAppellantDashboardDisplayData,
-	isToDoAppellantDashboard,
-	updateChildAppealDisplayData
-} = require('../../../../src/lib/dashboard-functions');
 
-jest.mock('../../../../src/lib/dashboard-functions');
+jest.mock('../../../../src/featureFlag');
+const { isFeatureActive } = require('../../../../src/featureFlag');
+
+const now = new Date();
+const monthAgo = new Date(now.setMonth(now.getMonth() - 1));
+
+const mockAppealData = [
+	// final comments submitted, show in waiting for review appeals
+	{
+		...getCaseFixture(
+			CASE_TYPES.HAS.processCode,
+			APPEAL_CASE_STATUS.FINAL_COMMENTS,
+			APPEAL_CASE_PROCEDURE.WRITTEN
+		),
+		finalCommentsDueDate: new Date(),
+		appellantCommentsSubmittedDate: new Date()
+	},
+	// final comments due show in todo appeals
+	{
+		...getCaseFixture(
+			CASE_TYPES.HAS.processCode,
+			APPEAL_CASE_STATUS.FINAL_COMMENTS,
+			APPEAL_CASE_PROCEDURE.WRITTEN
+		),
+		finalCommentsDueDate: new Date()
+	},
+	// validated invalid, show in todo appeals as invalid
+	{
+		...getCaseFixture(
+			CASE_TYPES.HAS.processCode,
+			APPEAL_CASE_STATUS.INVALID,
+			APPEAL_CASE_PROCEDURE.WRITTEN
+		).setValidationOutcome(APPEAL_CASE_VALIDATION_OUTCOME.INVALID),
+		finalCommentsDueDate: new Date()
+	},
+	// old invalid - counted with withdrawn
+	{
+		...getCaseFixture(
+			CASE_TYPES.HAS.processCode,
+			APPEAL_CASE_STATUS.INVALID,
+			APPEAL_CASE_PROCEDURE.WRITTEN
+		).setValidationOutcome(APPEAL_CASE_VALIDATION_OUTCOME.INVALID, monthAgo),
+		finalCommentsDueDate: monthAgo
+	},
+	// decided allowed
+	{
+		...getCaseFixture(
+			CASE_TYPES.HAS.processCode,
+			APPEAL_CASE_STATUS.COMPLETE,
+			APPEAL_CASE_PROCEDURE.WRITTEN
+		).setDecisionOutcome(APPEAL_CASE_DECISION_OUTCOME.ALLOWED, true)
+	},
+	// decided invalid
+	{
+		...getCaseFixture(
+			CASE_TYPES.HAS.processCode,
+			APPEAL_CASE_STATUS.INVALID,
+			APPEAL_CASE_PROCEDURE.WRITTEN
+		).setDecisionOutcome(APPEAL_CASE_DECISION_OUTCOME.INVALID, true),
+		caseValidationOutcome: APPEAL_CASE_VALIDATION_OUTCOME.VALID
+	},
+	// withdrawn
+	{
+		...getCaseFixture(
+			CASE_TYPES.HAS.processCode,
+			APPEAL_CASE_STATUS.WITHDRAWN,
+			APPEAL_CASE_PROCEDURE.WRITTEN
+		).markAsWithdrawn()
+	},
+	// v2 draft
+	{
+		id: 'abc',
+		AppellantSubmission: {
+			submitted: false,
+			appealTypeCode: 'HAS',
+			applicationDecisionDate: new Date(),
+			applicationDecision: 'refused',
+			siteAddress: null,
+			SubmissionAddress: null,
+			enforcementEffectiveDate: null,
+			hasContactedPlanningInspectorate: null,
+			isListedBuilding: false
+		}
+	},
+	// v2 submitted draft
+	{
+		id: 'abc123',
+		AppellantSubmission: {
+			submitted: true,
+			appealTypeCode: 'HAS',
+			applicationDecisionDate: new Date(),
+			applicationDecision: 'refused',
+			siteAddress: null,
+			SubmissionAddress: null,
+			enforcementEffectiveDate: null,
+			hasContactedPlanningInspectorate: null,
+			isListedBuilding: false
+		}
+	}
+];
 
 describe('controllers/appeals/your-appeals', () => {
-	let appeal;
 	let req;
 	let res;
-
-	const toDoData = {
-		appealNumber: '0000001',
-		address: 'toDoAddress',
-		appealType: 'an appeal',
-		nextJourneyDue: {
-			deadline: 'a future date',
-			dueInDays: 1,
-			journeyDue: 'Final comments'
-		},
-		isDraft: false,
-		appealDecision: null
-	};
-
-	const waitingForReviewData = {
-		appealNumber: '0000002',
-		address: 'wfrAddress',
-		appealType: 'an overdue appeal',
-		nextJourneyDue: {
-			deadline: 'a past date',
-			dueInDays: -1,
-			journeyDue: 'testDocument'
-		},
-		isDraft: false,
-		appealDecision: null
-	};
-
-	const completedData = {
-		appealNumber: '0000003',
-		address: 'completedAddress',
-		appealType: 'an appeal',
-		nextJourneyDue: {
-			deadline: null,
-			dueInDays: 100000,
-			journeyDue: null
-		},
-		isDraft: false,
-		appealDecision: null
-	};
-
-	const decidedData = {
-		appealNumber: '0000004',
-		address: 'decidedAddress',
-		appealType: 'an appeal',
-		nextJourneyDue: {
-			deadline: null,
-			dueInDays: 100000,
-			journeyDue: null
-		},
-		isDraft: false,
-		appealDecision: 'allowed'
-	};
 
 	beforeEach(() => {
 		req = mockReq();
@@ -73,109 +123,86 @@ describe('controllers/appeals/your-appeals', () => {
 
 		jest.resetAllMocks();
 
-		appeal = { id: 'appeal123' };
 		req.appealsApiClient = {
 			getUserAppeals: jest.fn()
 		};
-		req.appealsApiClient.getUserAppeals.mockImplementation(() => Promise.resolve([appeal]));
 	});
 
-	describe('Get - To Do appeals', () => {
-		it('Displays appeal in to do list if it passes all criteria', async () => {
-			mapToAppellantDashboardDisplayData.mockReturnValue(toDoData);
-			updateChildAppealDisplayData.mockReturnValue([toDoData]);
-			isToDoAppellantDashboard.mockReturnValue(true);
+	describe('Get - Your appeals', () => {
+		it('should render the view with correct counts and appeals', async () => {
+			req.appealsApiClient.getUserAppeals.mockResolvedValue(mockAppealData);
+			isFeatureActive.mockResolvedValueOnce(true);
+
 			await get(req, res);
 
 			expect(res.render).toHaveBeenCalledWith(VIEW.APPEALS.YOUR_APPEALS, {
-				toDoAppeals: [toDoData],
-				waitingForReviewAppeals: [],
+				toDoAppeals: [
+					expect.objectContaining({
+						appealId: expect.any(String),
+						appealNumber: expect.any(String),
+						appealType: expect.any(String),
+						nextJourneyDue: {
+							deadline: null,
+							dueInDays: -100000,
+							journeyDue: 'Invalid'
+						},
+						isDraft: false,
+						displayInvalid: true,
+						displayNextJourneyLink: true
+					}),
+					expect.objectContaining({
+						appealId: expect.any(String),
+						appealNumber: expect.any(String),
+						appealType: expect.any(String),
+						nextJourneyDue: {
+							baseUrl: expect.stringContaining('/appeals/final-comments/'),
+							deadline: expect.any(Date),
+							dueInDays: 0,
+							journeyDue: 'Final comments'
+						},
+						isDraft: false,
+						displayInvalid: false,
+						displayNextJourneyLink: true
+					}),
+					expect.objectContaining({
+						nextJourneyDue: {
+							deadline: expect.any(Date),
+							dueInDays: expect.any(Number),
+							journeyDue: 'Continue'
+						},
+						isDraft: true,
+						displayInvalid: false,
+						displayNextJourneyLink: true
+					})
+				],
+				waitingForReviewAppeals: [
+					expect.objectContaining({
+						appealNumber: mockAppealData[0].caseReference,
+						displayInvalid: false,
+						displayNextJourneyLink: true,
+						nextJourneyDue: {
+							baseUrl: null,
+							deadline: null,
+							dueInDays: 100000,
+							journeyDue: null
+						}
+					})
+				],
 				noToDoAppeals: false,
 				decidedAppealsLink: `/${VIEW.YOUR_APPEALS.DECIDED_APPEALS}`,
-				decidedAppealsCount: 0,
-				withdrawnAppealsCount: 0,
+				decidedAppealsCount: 2,
+				withdrawnAppealsCount: 2,
 				withdrawnAppealsLink: `/${VIEW.YOUR_APPEALS.WITHDRAWN_APPEALS}`
 			});
 		});
 
-		it('Does not display appeal in to do list if all documents have been submitted', async () => {
-			mapToAppellantDashboardDisplayData.mockReturnValue(completedData);
-			updateChildAppealDisplayData.mockReturnValue([completedData]);
+		it('should render the view when no appeals', async () => {
+			req.appealsApiClient.getUserAppeals.mockResolvedValue([]);
+			isFeatureActive.mockResolvedValueOnce(true);
 
 			await get(req, res);
 
-			expect(res.render).toHaveBeenCalledWith(VIEW.APPEALS.YOUR_APPEALS, {
-				toDoAppeals: [],
-				waitingForReviewAppeals: [completedData],
-				noToDoAppeals: true,
-				decidedAppealsLink: `/${VIEW.YOUR_APPEALS.DECIDED_APPEALS}`,
-				decidedAppealsCount: 0,
-				withdrawnAppealsCount: 0,
-				withdrawnAppealsLink: `/${VIEW.YOUR_APPEALS.WITHDRAWN_APPEALS}`
-			});
-		});
-
-		it('Does not display appeal in to do list or WFR list if it has been decided', async () => {
-			mapToAppellantDashboardDisplayData.mockReturnValue(decidedData);
-			updateChildAppealDisplayData.mockReturnValue([]);
-
-			await get(req, res);
-			expect(updateChildAppealDisplayData).toHaveBeenCalledWith([]);
-			expect(res.render).toHaveBeenCalledWith(VIEW.APPEALS.YOUR_APPEALS, {
-				toDoAppeals: [],
-				waitingForReviewAppeals: [],
-				noToDoAppeals: true,
-				decidedAppealsLink: `/${VIEW.YOUR_APPEALS.DECIDED_APPEALS}`,
-				decidedAppealsCount: 0,
-				withdrawnAppealsCount: 0,
-				withdrawnAppealsLink: `/${VIEW.YOUR_APPEALS.WITHDRAWN_APPEALS}`
-			});
-		});
-
-		it('Does not display appeal in to do list if the next document due is overdue', async () => {
-			mapToAppellantDashboardDisplayData.mockReturnValue(waitingForReviewData);
-			updateChildAppealDisplayData.mockReturnValue([waitingForReviewData]);
-
-			await get(req, res);
-
-			expect(res.render).toHaveBeenCalledWith(VIEW.APPEALS.YOUR_APPEALS, {
-				toDoAppeals: [],
-				waitingForReviewAppeals: [waitingForReviewData],
-				noToDoAppeals: true,
-				decidedAppealsLink: `/${VIEW.YOUR_APPEALS.DECIDED_APPEALS}`,
-				decidedAppealsCount: 0,
-				withdrawnAppealsCount: 0,
-				withdrawnAppealsLink: `/${VIEW.YOUR_APPEALS.WITHDRAWN_APPEALS}`
-			});
-		});
-
-		it('hides appeals where hideFromDashboard is true', async () => {
-			req.appealsApiClient.getUserAppeals.mockResolvedValue([
-				{ appeal: { hideFromDashboard: true, status: 'confirmed' } },
-				{ appeal: { hideFromDashboard: false, status: 'confirmed' } },
-				{ appeal: { hideFromDashboard: false, status: 'confirmed' } }
-			]);
-
-			mapToAppellantDashboardDisplayData.mockImplementation((data) => {
-				if (data.appeal?.hideFromDashboard === true)
-					throw new Error('Should not map hidden appeal');
-				return toDoData;
-			});
-			updateChildAppealDisplayData.mockImplementation((arr) => arr);
-			isToDoAppellantDashboard.mockReturnValue(true);
-
-			await get(req, res);
-
-			expect(mapToAppellantDashboardDisplayData).toHaveBeenCalledTimes(2);
-			expect(res.render).toHaveBeenCalledWith(VIEW.APPEALS.YOUR_APPEALS, {
-				toDoAppeals: [toDoData, toDoData],
-				waitingForReviewAppeals: [],
-				noToDoAppeals: false,
-				decidedAppealsLink: `/${VIEW.YOUR_APPEALS.DECIDED_APPEALS}`,
-				decidedAppealsCount: 0,
-				withdrawnAppealsCount: 0,
-				withdrawnAppealsLink: `/${VIEW.YOUR_APPEALS.WITHDRAWN_APPEALS}`
-			});
+			expect(res.redirect).toHaveBeenCalledWith(`/${VIEW.APPEALS.NO_APPEALS}`);
 		});
 	});
 });

--- a/packages/forms-web-app/__tests__/unit/controllers/appeals/your-appeals/decided-appeals.test.js
+++ b/packages/forms-web-app/__tests__/unit/controllers/appeals/your-appeals/decided-appeals.test.js
@@ -1,33 +1,40 @@
+const { getCaseFixture } = require('@pins/common/__tests__/fixtures/appeal-cases.fixture.js');
+const { CASE_TYPES } = require('@pins/common/src/database/data-static');
+const {
+	APPEAL_CASE_STATUS,
+	APPEAL_CASE_PROCEDURE,
+	APPEAL_CASE_DECISION_OUTCOME
+} = require('@planning-inspectorate/data-model');
+
 const { get } = require('../../../../../src/controllers/appeals/your-appeals/decided-appeals');
 
 const { VIEW } = require('../../../../../src/lib/views');
 const { mockReq, mockRes } = require('../../../mocks');
-const {
-	mapToAppellantDashboardDisplayData
-} = require('../../../../../src/lib/dashboard-functions');
-const { filterAppealsWithinGivenDate } = require('../../../../../src/lib/filter-decided-appeals');
 
-jest.mock('../../../../../src/lib/dashboard-functions');
-jest.mock('../../../../../src/lib/filter-decided-appeals');
-
+const now = new Date();
+const hourAgo = new Date(now.setHours(now.getHours() - 1));
 describe('controllers/appeals/your-appeals/decided-appeals', () => {
-	let appeal;
 	let req;
 	let res;
 
-	const decidedData = {
-		appealNumber: '0000004',
-		address: 'decidedAddress',
-		appealType: 'an appeal',
-		nextJourneyDue: {
-			deadline: null,
-			dueInDays: 100000,
-			journeyDue: null
+	const mockAppealData = [
+		{
+			...getCaseFixture(
+				CASE_TYPES.HAS.processCode,
+				APPEAL_CASE_STATUS.COMPLETE,
+				APPEAL_CASE_PROCEDURE.WRITTEN
+			).setDecisionOutcome(APPEAL_CASE_DECISION_OUTCOME.ALLOWED, true),
+			caseDecisionOutcomeDate: now
 		},
-		isDraft: false,
-		appealDecision: 'allowed',
-		caseDecisionOutcomeDate: 'a date'
-	};
+		{
+			...getCaseFixture(
+				CASE_TYPES.HAS.processCode,
+				APPEAL_CASE_STATUS.INVALID,
+				APPEAL_CASE_PROCEDURE.WRITTEN
+			).setDecisionOutcome(APPEAL_CASE_DECISION_OUTCOME.INVALID, false),
+			caseDecisionOutcomeDate: hourAgo
+		}
+	];
 
 	beforeEach(() => {
 		req = mockReq();
@@ -35,21 +42,35 @@ describe('controllers/appeals/your-appeals/decided-appeals', () => {
 
 		jest.resetAllMocks();
 
-		appeal = [{ id: 'appeal123', decisionOutcome: 'allowed' }];
 		req.appealsApiClient = {
 			getUserAppeals: jest.fn()
 		};
-		req.appealsApiClient.getUserAppeals.mockImplementation(() => Promise.resolve([appeal]));
 	});
 
-	it('Test get method calls the correct template and view context', async () => {
-		mapToAppellantDashboardDisplayData.mockReturnValue(decidedData);
-		filterAppealsWithinGivenDate.mockReturnValue(true);
-		const decidedAppeals = [decidedData];
+	it('should render the decided appeals view with correctly mapped and filtered data', async () => {
+		req.appealsApiClient.getUserAppeals.mockImplementation(() => Promise.resolve(mockAppealData));
+
 		await get(req, res);
 
 		expect(res.render).toHaveBeenCalledWith(VIEW.YOUR_APPEALS.DECIDED_APPEALS, {
-			decidedAppeals
+			decidedAppeals: [
+				expect.objectContaining({
+					caseDecisionOutcomeDate: expect.any(Date),
+					appealDecision: 'Allowed'
+				}),
+				expect.objectContaining({
+					caseDecisionOutcomeDate: expect.any(Date),
+					appealDecision: 'Invalid'
+				})
+			]
 		});
+	});
+
+	it('should render the decided appeals view with no data', async () => {
+		req.appealsApiClient.getUserAppeals.mockImplementation(() => Promise.resolve([]));
+
+		await get(req, res);
+
+		expect(res.render).toHaveBeenCalledWith(VIEW.YOUR_APPEALS.DECIDED_APPEALS, {});
 	});
 });

--- a/packages/forms-web-app/__tests__/unit/controllers/appeals/your-appeals/withdrawn-appeals.test.js
+++ b/packages/forms-web-app/__tests__/unit/controllers/appeals/your-appeals/withdrawn-appeals.test.js
@@ -1,0 +1,75 @@
+const { getCaseFixture } = require('@pins/common/__tests__/fixtures/appeal-cases.fixture.js');
+const { CASE_TYPES } = require('@pins/common/src/database/data-static');
+const {
+	APPEAL_CASE_STATUS,
+	APPEAL_CASE_PROCEDURE,
+	APPEAL_CASE_VALIDATION_OUTCOME
+} = require('@planning-inspectorate/data-model');
+
+const { get } = require('../../../../../src/controllers/appeals/your-appeals/withdrawn-appeals');
+
+const { VIEW } = require('../../../../../src/lib/views');
+const { mockReq, mockRes } = require('../../../mocks');
+
+describe('controllers/appeals/your-appeals/withdrawn-appeals', () => {
+	let req;
+	let res;
+
+	const mockWithdrawnData = [
+		{
+			...getCaseFixture(
+				CASE_TYPES.HAS.processCode,
+				APPEAL_CASE_STATUS.WITHDRAWN,
+				APPEAL_CASE_PROCEDURE.WRITTEN
+			).markAsWithdrawn()
+		},
+		{
+			...getCaseFixture(
+				CASE_TYPES.HAS.processCode,
+				APPEAL_CASE_STATUS.LPA_QUESTIONNAIRE,
+				APPEAL_CASE_PROCEDURE.WRITTEN
+			).setValidationOutcome(APPEAL_CASE_VALIDATION_OUTCOME.INVALID, new Date('2025-12-01')),
+			lpaQuestionnaireDueDate: new Date('2025-12-01')
+		}
+	];
+
+	beforeEach(() => {
+		req = mockReq();
+		res = mockRes();
+
+		jest.resetAllMocks();
+
+		req.appealsApiClient = {
+			getUserAppeals: jest.fn()
+		};
+	});
+
+	it('should render the withdrawn appeals view with correctly mapped and filtered data', async () => {
+		req.appealsApiClient.getUserAppeals.mockImplementation(() =>
+			Promise.resolve(mockWithdrawnData)
+		);
+
+		await get(req, res);
+
+		expect(res.render).toHaveBeenCalledWith(VIEW.YOUR_APPEALS.WITHDRAWN_APPEALS, {
+			withdrawnAppeals: [
+				expect.objectContaining({
+					caseWithdrawnDate: expect.any(Date)
+				}),
+				expect.objectContaining({
+					caseWithdrawnDate: expect.any(Date)
+				})
+			]
+		});
+	});
+
+	it('should render the withdrawn appeals view with no data', async () => {
+		req.appealsApiClient.getUserAppeals.mockImplementation(() => Promise.resolve([]));
+
+		await get(req, res);
+
+		expect(res.render).toHaveBeenCalledWith(VIEW.YOUR_APPEALS.WITHDRAWN_APPEALS, {
+			withdrawnAppeals: []
+		});
+	});
+});

--- a/packages/forms-web-app/__tests__/unit/controllers/lpa-dashboard/decided-appeals.test.js
+++ b/packages/forms-web-app/__tests__/unit/controllers/lpa-dashboard/decided-appeals.test.js
@@ -1,0 +1,88 @@
+const { getCaseFixture } = require('@pins/common/__tests__/fixtures/appeal-cases.fixture.js');
+const { CASE_TYPES } = require('@pins/common/src/database/data-static');
+const {
+	APPEAL_CASE_STATUS,
+	APPEAL_CASE_PROCEDURE,
+	APPEAL_CASE_DECISION_OUTCOME
+} = require('@planning-inspectorate/data-model');
+
+const { getDecidedAppeals } = require('../../../../src/controllers/lpa-dashboard/decided-appeals');
+const { getUserFromSession } = require('../../../../src/services/user.service');
+const { VIEW } = require('../../../../src/lib/views');
+
+const { mockReq, mockRes } = require('../../mocks');
+
+jest.mock('../../../../src/services/user.service');
+
+const req = {
+	...mockReq(null)
+};
+const res = mockRes();
+
+const mockUser = {
+	lpaCode: 'test',
+	email: 'test@example.com',
+	lpaName: 'test-lpa'
+};
+
+const mockAppealData = [
+	{
+		...getCaseFixture(
+			CASE_TYPES.HAS.processCode,
+			APPEAL_CASE_STATUS.COMPLETE,
+			APPEAL_CASE_PROCEDURE.WRITTEN
+		).setDecisionOutcome(APPEAL_CASE_DECISION_OUTCOME.ALLOWED, true)
+	},
+	{
+		...getCaseFixture(
+			CASE_TYPES.HAS.processCode,
+			APPEAL_CASE_STATUS.INVALID,
+			APPEAL_CASE_PROCEDURE.WRITTEN
+		).setDecisionOutcome(APPEAL_CASE_DECISION_OUTCOME.INVALID, false)
+	}
+];
+
+describe('controllers/lpa-dashboard/your-appeals', () => {
+	beforeEach(() => {
+		req.appealsApiClient = {
+			getDecidedAppealsCaseDataV2: jest.fn()
+		};
+
+		jest.resetAllMocks();
+	});
+
+	describe('getDecidedAppeals', () => {
+		it('should render the decided appeals view with correctly mapped and filtered data', async () => {
+			getUserFromSession.mockReturnValue(mockUser);
+			req.appealsApiClient.getDecidedAppealsCaseDataV2.mockResolvedValue(mockAppealData);
+
+			await getDecidedAppeals(req, res);
+
+			expect(res.render).toHaveBeenCalledWith(VIEW.LPA_DASHBOARD.DECIDED_APPEALS, {
+				lpaName: mockUser.lpaName,
+				decidedAppeals: [
+					expect.objectContaining({
+						caseDecisionOutcomeDate: expect.any(String)
+					}),
+					expect.objectContaining({
+						caseDecisionOutcomeDate: expect.any(String)
+					})
+				],
+				yourAppealsLink: `/${VIEW.LPA_DASHBOARD.DASHBOARD}`
+			});
+		});
+
+		it('should render the decided appeals view with no data', async () => {
+			getUserFromSession.mockReturnValue(mockUser);
+			req.appealsApiClient.getDecidedAppealsCaseDataV2.mockResolvedValue([]);
+
+			await getDecidedAppeals(req, res);
+
+			expect(res.render).toHaveBeenCalledWith(VIEW.LPA_DASHBOARD.DECIDED_APPEALS, {
+				lpaName: mockUser.lpaName,
+				decidedAppeals: [],
+				yourAppealsLink: `/${VIEW.LPA_DASHBOARD.DASHBOARD}`
+			});
+		});
+	});
+});

--- a/packages/forms-web-app/__tests__/unit/controllers/lpa-dashboard/withdrawn-appeals.test.js
+++ b/packages/forms-web-app/__tests__/unit/controllers/lpa-dashboard/withdrawn-appeals.test.js
@@ -1,15 +1,19 @@
+const { getCaseFixture } = require('@pins/common/__tests__/fixtures/appeal-cases.fixture.js');
+const { CASE_TYPES } = require('@pins/common/src/database/data-static');
+const {
+	APPEAL_CASE_STATUS,
+	APPEAL_CASE_PROCEDURE,
+	APPEAL_CASE_VALIDATION_OUTCOME
+} = require('@planning-inspectorate/data-model');
+
 const {
 	getWithdrawnAppeals
 } = require('../../../../src/controllers/lpa-dashboard/withdrawn-appeals');
 const { getUserFromSession } = require('../../../../src/services/user.service');
 const { VIEW } = require('../../../../src/lib/views');
 const { mockReq, mockRes } = require('../../mocks');
-const { mapToLPADashboardDisplayData } = require('../../../../src/lib/dashboard-functions');
-const { sortByDateFieldDesc } = require('@pins/common/src/lib/appeal-sorting');
 
 jest.mock('../../../../src/services/user.service');
-jest.mock('../../../../src/lib/dashboard-functions');
-jest.mock('@pins/common/src/lib/appeal-sorting');
 
 describe('controllers/lpa-dashboard/withdrawn-appeals', () => {
 	let req;
@@ -20,12 +24,23 @@ describe('controllers/lpa-dashboard/withdrawn-appeals', () => {
 		lpaName: 'Test LPA'
 	};
 
-	const mockWithdrawnData = {
-		appealNumber: '1234567',
-		address: '123 Test Lane',
-		caseWithdrawnDate: '2025-12-01',
-		appealType: 'Planning'
-	};
+	const mockWithdrawnData = [
+		{
+			...getCaseFixture(
+				CASE_TYPES.HAS.processCode,
+				APPEAL_CASE_STATUS.WITHDRAWN,
+				APPEAL_CASE_PROCEDURE.WRITTEN
+			).markAsWithdrawn()
+		},
+		{
+			...getCaseFixture(
+				CASE_TYPES.HAS.processCode,
+				APPEAL_CASE_STATUS.LPA_QUESTIONNAIRE,
+				APPEAL_CASE_PROCEDURE.WRITTEN
+			).setValidationOutcome(APPEAL_CASE_VALIDATION_OUTCOME.INVALID, new Date('2025-12-01')),
+			lpaQuestionnaireDueDate: new Date('2025-12-01')
+		}
+	];
 
 	beforeEach(() => {
 		jest.resetAllMocks();
@@ -41,21 +56,34 @@ describe('controllers/lpa-dashboard/withdrawn-appeals', () => {
 	});
 
 	it('should render the withdrawn appeals view with correctly mapped and filtered data', async () => {
-		const rawApiData = [
-			{ caseReference: '1234567', caseWithdrawnDate: '2025-12-01' },
-			{ caseReference: '7654321' }
-		];
-
-		req.appealsApiClient.getAppealsCaseDataV2.mockResolvedValue(rawApiData);
-		mapToLPADashboardDisplayData.mockReturnValue(mockWithdrawnData);
-		sortByDateFieldDesc.mockReturnValue(() => 0);
+		req.appealsApiClient.getAppealsCaseDataV2.mockResolvedValue(mockWithdrawnData);
 
 		await getWithdrawnAppeals(req, res);
 
 		expect(req.appealsApiClient.getAppealsCaseDataV2).toHaveBeenCalledWith(mockUser.lpaCode);
 		expect(res.render).toHaveBeenCalledWith(VIEW.LPA_DASHBOARD.WITHDRAWN_APPEALS, {
 			lpaName: mockUser.lpaName,
-			withdrawnAppeals: [mockWithdrawnData],
+			withdrawnAppeals: [
+				expect.objectContaining({
+					caseWithdrawnDate: expect.any(Date)
+				}),
+				expect.objectContaining({
+					caseWithdrawnDate: expect.any(Date)
+				})
+			],
+			yourAppealsLink: `/${VIEW.LPA_DASHBOARD.DASHBOARD}`
+		});
+	});
+
+	it('should render the withdrawn appeals view with no data', async () => {
+		req.appealsApiClient.getAppealsCaseDataV2.mockResolvedValue([]);
+
+		await getWithdrawnAppeals(req, res);
+
+		expect(req.appealsApiClient.getAppealsCaseDataV2).toHaveBeenCalledWith(mockUser.lpaCode);
+		expect(res.render).toHaveBeenCalledWith(VIEW.LPA_DASHBOARD.WITHDRAWN_APPEALS, {
+			lpaName: mockUser.lpaName,
+			withdrawnAppeals: [],
 			yourAppealsLink: `/${VIEW.LPA_DASHBOARD.DASHBOARD}`
 		});
 	});

--- a/packages/forms-web-app/__tests__/unit/controllers/lpa-dashboard/your-appeals.test.js
+++ b/packages/forms-web-app/__tests__/unit/controllers/lpa-dashboard/your-appeals.test.js
@@ -1,3 +1,11 @@
+const { getCaseFixture } = require('@pins/common/__tests__/fixtures/appeal-cases.fixture.js');
+const { CASE_TYPES } = require('@pins/common/src/database/data-static');
+const {
+	APPEAL_CASE_STATUS,
+	APPEAL_CASE_PROCEDURE,
+	APPEAL_CASE_VALIDATION_OUTCOME
+} = require('@planning-inspectorate/data-model');
+
 const { getYourAppeals } = require('../../../../src/controllers/lpa-dashboard/your-appeals');
 const { getUserFromSession } = require('../../../../src/services/user.service');
 
@@ -5,15 +13,9 @@ const { VIEW } = require('../../../../src/lib/views');
 const { baseHASUrl } = require('../../../../src/dynamic-forms/has-questionnaire/journey');
 
 const { mockReq, mockRes } = require('../../mocks');
-const {
-	mapToLPADashboardDisplayData,
-	isToDoLPADashboard,
-	updateChildAppealDisplayData
-} = require('../../../../src/lib/dashboard-functions');
 const { isFeatureActive } = require('../../../../src/featureFlag');
 
 jest.mock('../../../../src/services/user.service');
-jest.mock('../../../../src/lib/dashboard-functions');
 jest.mock('../../../../src/featureFlag');
 
 const req = {
@@ -27,17 +29,50 @@ const mockUser = {
 	lpaName: 'test-lpa'
 };
 
-const mockAppealData = {
-	_id: '89aa8504-773c-42be-bb68-029716ad9756',
-	LPAApplicationReference: '12/3456789/PLA',
-	caseReference: 'APP/Q9999/W/22/3221288',
-	questionnaireDueDate: '2023-07-07T13:53:31.6003126+00:00',
-	appealType: 'Full Planning (S78) Appeal',
-	siteAddressLine1: 'Test Address 1',
-	siteAddressLine2: 'Test Address 2',
-	siteAddressTown: 'Test Town',
-	siteAddressPostcode: 'TS1 1TT'
-};
+const now = new Date();
+const monthAgo = new Date(now.setMonth(now.getMonth() - 1));
+const mockAppealData = [
+	{
+		...getCaseFixture(
+			CASE_TYPES.HAS.processCode,
+			APPEAL_CASE_STATUS.LPA_QUESTIONNAIRE,
+			APPEAL_CASE_PROCEDURE.WRITTEN
+		),
+		lpaQuestionnaireDueDate: new Date(),
+		lpaQuestionnaireSubmittedDate: new Date()
+	},
+	{
+		...getCaseFixture(
+			CASE_TYPES.HAS.processCode,
+			APPEAL_CASE_STATUS.LPA_QUESTIONNAIRE,
+			APPEAL_CASE_PROCEDURE.WRITTEN
+		),
+		lpaQuestionnaireDueDate: new Date()
+	},
+	{
+		...getCaseFixture(
+			CASE_TYPES.HAS.processCode,
+			APPEAL_CASE_STATUS.INVALID,
+			APPEAL_CASE_PROCEDURE.WRITTEN
+		).setValidationOutcome(APPEAL_CASE_VALIDATION_OUTCOME.INVALID),
+		lpaQuestionnaireDueDate: new Date()
+	},
+	{
+		...getCaseFixture(
+			CASE_TYPES.HAS.processCode,
+			APPEAL_CASE_STATUS.INVALID,
+			APPEAL_CASE_PROCEDURE.WRITTEN
+		).setValidationOutcome(APPEAL_CASE_VALIDATION_OUTCOME.INVALID, monthAgo),
+		lpaQuestionnaireDueDate: monthAgo
+	},
+	{
+		...getCaseFixture(
+			CASE_TYPES.HAS.processCode,
+			APPEAL_CASE_STATUS.WITHDRAWN,
+			APPEAL_CASE_PROCEDURE.WRITTEN
+		).markAsWithdrawn()
+	}
+];
 
 const mockDecidedCount = {
 	count: 1
@@ -55,42 +90,10 @@ describe('controllers/lpa-dashboard/your-appeals', () => {
 	});
 
 	describe('getYourAppeals', () => {
-		it('should render the view with a link to add-remove', async () => {
+		it('should render the view with correct counts and appeals', async () => {
 			getUserFromSession.mockReturnValue(mockUser);
-			req.appealsApiClient.getAppealsCaseDataV2.mockResolvedValue([mockAppealData]);
-			req.appealsApiClient.getAppealsCasesByLpaAndStatus.mockResolvedValue([]);
+			req.appealsApiClient.getAppealsCaseDataV2.mockResolvedValue(mockAppealData);
 			req.appealsApiClient.getDecidedAppealsCountV2.mockResolvedValue(mockDecidedCount);
-			mapToLPADashboardDisplayData.mockReturnValue(mockAppealData);
-			updateChildAppealDisplayData.mockReturnValue([mockAppealData]);
-			isToDoLPADashboard.mockReturnValue(true);
-			isFeatureActive.mockResolvedValueOnce(false);
-
-			await getYourAppeals(req, res);
-
-			expect(getUserFromSession).toHaveBeenCalledWith(req);
-			expect(res.render).toHaveBeenCalledWith(VIEW.LPA_DASHBOARD.DASHBOARD, {
-				lpaName: mockUser.lpaName,
-				addOrRemoveLink: `/${VIEW.LPA_DASHBOARD.ADD_REMOVE_USERS}`,
-				toDoAppeals: [mockAppealData],
-				waitingForReviewAppeals: [],
-				appealDetailsLink: `/${VIEW.LPA_DASHBOARD.APPEAL_DETAILS}`,
-				appealQuestionnaireLink: baseHASUrl,
-				decidedAppealsLink: `/${VIEW.LPA_DASHBOARD.DECIDED_APPEALS}`,
-				decidedAppealsCount: 1,
-				noToDoAppeals: false,
-				withdrawnAppealsCount: 0,
-				withdrawnAppealsLink: `/${VIEW.LPA_DASHBOARD.WITHDRAWN_APPEALS}`
-			});
-		});
-
-		it('should show questionnaire ', async () => {
-			getUserFromSession.mockReturnValue(mockUser);
-			req.appealsApiClient.getAppealsCaseDataV2.mockResolvedValue([mockAppealData]);
-			req.appealsApiClient.getAppealsCasesByLpaAndStatus.mockResolvedValue([]);
-			req.appealsApiClient.getDecidedAppealsCountV2.mockResolvedValue(mockDecidedCount);
-			mapToLPADashboardDisplayData.mockReturnValue(mockAppealData);
-			updateChildAppealDisplayData.mockReturnValue([mockAppealData]);
-			isToDoLPADashboard.mockReturnValue(true);
 			isFeatureActive.mockResolvedValueOnce(true);
 
 			await getYourAppeals(req, res);
@@ -99,30 +102,74 @@ describe('controllers/lpa-dashboard/your-appeals', () => {
 			expect(res.render).toHaveBeenCalledWith(VIEW.LPA_DASHBOARD.DASHBOARD, {
 				lpaName: mockUser.lpaName,
 				addOrRemoveLink: `/${VIEW.LPA_DASHBOARD.ADD_REMOVE_USERS}`,
-				toDoAppeals: [mockAppealData],
-				waitingForReviewAppeals: [],
-				appealDetailsLink: `/${VIEW.LPA_DASHBOARD.APPEAL_DETAILS}`,
+				toDoAppeals: [
+					expect.objectContaining({
+						isNewAppeal: false,
+						displayInvalid: true,
+						displayNextJourneyLink: true,
+						nextJourneyDue: {
+							deadline: null,
+							dueInDays: -100000,
+							journeyDue: null
+						}
+					}),
+					expect.objectContaining({
+						isNewAppeal: false,
+						displayInvalid: false,
+						displayNextJourneyLink: true,
+						nextJourneyDue: {
+							baseUrl: expect.stringContaining('/manage-appeals/questionnaire/'),
+							deadline: expect.any(Date),
+							dueInDays: 0,
+							journeyDue: 'Questionnaire'
+						}
+					})
+				],
+				waitingForReviewAppeals: [
+					expect.objectContaining({
+						displayInvalid: false,
+						displayNextJourneyLink: true,
+						isNewAppeal: false,
+						nextJourneyDue: {
+							baseUrl: null,
+							deadline: null,
+							dueInDays: 100000,
+							journeyDue: null
+						}
+					})
+				],
 				appealQuestionnaireLink: baseHASUrl,
 				decidedAppealsLink: `/${VIEW.LPA_DASHBOARD.DECIDED_APPEALS}`,
-				withdrawnAppealsLink: `/${VIEW.LPA_DASHBOARD.WITHDRAWN_APPEALS}`,
 				decidedAppealsCount: 1,
-				withdrawnAppealsCount: 0,
-				noToDoAppeals: false
+				noToDoAppeals: false,
+				withdrawnAppealsCount: 2,
+				withdrawnAppealsLink: `/${VIEW.LPA_DASHBOARD.WITHDRAWN_APPEALS}`
 			});
 		});
 
-		it('should call API to fetch appeals case data', async () => {
+		it('should render the view when no appeals', async () => {
 			getUserFromSession.mockReturnValue(mockUser);
-			req.appealsApiClient.getAppealsCaseDataV2.mockResolvedValue([mockAppealData]);
-			req.appealsApiClient.getAppealsCasesByLpaAndStatus.mockResolvedValue([]);
-			req.appealsApiClient.getDecidedAppealsCountV2.mockResolvedValue(mockDecidedCount);
-			mapToLPADashboardDisplayData.mockReturnValue(mockAppealData);
-			updateChildAppealDisplayData.mockReturnValue([mockAppealData]);
-			isToDoLPADashboard.mockReturnValue(true);
+			req.appealsApiClient.getAppealsCaseDataV2.mockResolvedValue([]);
+			req.appealsApiClient.getDecidedAppealsCountV2.mockResolvedValue({
+				count: 0
+			});
+			isFeatureActive.mockResolvedValueOnce(true);
 
 			await getYourAppeals(req, res);
 
-			expect(req.appealsApiClient.getAppealsCaseDataV2).toHaveBeenCalledWith(mockUser.lpaCode);
+			expect(getUserFromSession).toHaveBeenCalledWith(req);
+			expect(res.render).toHaveBeenCalledWith(VIEW.LPA_DASHBOARD.DASHBOARD, {
+				lpaName: mockUser.lpaName,
+				addOrRemoveLink: `/${VIEW.LPA_DASHBOARD.ADD_REMOVE_USERS}`,
+				toDoAppeals: [],
+				waitingForReviewAppeals: [],
+				appealQuestionnaireLink: baseHASUrl,
+				decidedAppealsLink: `/${VIEW.LPA_DASHBOARD.DECIDED_APPEALS}`,
+				decidedAppealsCount: 0,
+				noToDoAppeals: true,
+				withdrawnAppealsCount: 0,
+				withdrawnAppealsLink: `/${VIEW.LPA_DASHBOARD.WITHDRAWN_APPEALS}`
+			});
 		});
 	});
 });

--- a/packages/forms-web-app/src/controllers/appeals/your-appeals.js
+++ b/packages/forms-web-app/src/controllers/appeals/your-appeals.js
@@ -1,7 +1,10 @@
 const {
 	mapToAppellantDashboardDisplayData,
 	isToDoAppellantDashboard,
-	updateChildAppealDisplayData
+	updateChildAppealDisplayData,
+	withdrawnAppeals,
+	decidedAppeals,
+	oldInvalidAppeals
 } = require('../../lib/dashboard-functions');
 const { VIEW } = require('../../lib/views');
 const logger = require('../../lib/logger');
@@ -15,10 +18,11 @@ const {
 	}
 } = require('../../lib/views');
 
-const { filterAppealsWithinGivenDate } = require('../../lib/filter-decided-appeals');
-const { filterTime } = require('../../config');
 const { FLAG } = require('@pins/common/src/feature-flags');
 const { isFeatureActive } = require('../../featureFlag');
+const {
+	ifInvalidOnlyRecentValidation
+} = require('@pins/business-rules/src/lib/filter-invalid-validation-one-month');
 
 exports.get = async (req, res) => {
 	let viewContext = {};
@@ -36,44 +40,23 @@ exports.get = async (req, res) => {
 			)
 		};
 
-		logger.debug({ appeals }, 'appeals');
-
-		const withdrawnAppealsCount = appeals
-			.filter((appeal) => appeal.caseWithdrawnDate)
-			.map((a) => mapToAppellantDashboardDisplayData(a, flags))
-			.filter(Boolean)
-			.filter((appeal) =>
-				filterAppealsWithinGivenDate(
-					appeal,
-					'caseWithdrawnDate',
-					filterTime.FIVE_YEARS_IN_MILISECONDS
-				)
-			).length;
+		const decidedAppealsCount = decidedAppeals(appeals).length;
+		const withdrawnAppealsCount = withdrawnAppeals(appeals).length;
+		const oldInvalidAppealCount = oldInvalidAppeals(appeals).length;
 
 		const validAppeals = appeals
 			.filter((data) => data.appeal?.hideFromDashboard !== true)
 			.filter(isNotWithdrawn)
-			.filter(isNotTransferred);
+			.filter(isNotTransferred)
+			.filter((appeal) => ifInvalidOnlyRecentValidation(appeal));
 
 		const mappedAppeals = validAppeals
 			.map((a) => mapToAppellantDashboardDisplayData(a, flags))
 			.filter(Boolean);
 
-		const decidedAppealsCount = mappedAppeals
-			.filter((appeal) => appeal.appealDecision)
-			.filter((appeal) =>
-				filterAppealsWithinGivenDate(
-					appeal,
-					'caseDecisionOutcomeDate',
-					filterTime.FIVE_YEARS_IN_MILISECONDS
-				)
-			).length;
-
 		const undecidedAppeals = mappedAppeals.filter(
 			(appeal) => !appeal.appealDecision || appeal.displayInvalid
 		);
-
-		logger.debug({ undecidedAppeals }, 'undecided appeals');
 
 		// aligns child's nextJourneyDue information with lead linked case
 		const undecidedWithUpdatedChildAppealDisplayData =
@@ -93,9 +76,6 @@ exports.get = async (req, res) => {
 				{ toDoAppeals: [], waitingForReviewAppeals: [] }
 			);
 
-		logger.debug({ toDoAppeals }, 'toDoAppeals');
-		logger.debug({ waitingForReviewAppeals }, 'waitingForReviewAppeals');
-
 		toDoAppeals.sort((a, b) => a.nextJourneyDue.dueInDays - b.nextJourneyDue.dueInDays);
 		waitingForReviewAppeals.sort((a, b) => a.appealNumber - b.appealNumber);
 		const noToDoAppeals = !arrayHasItems(toDoAppeals);
@@ -105,7 +85,7 @@ exports.get = async (req, res) => {
 			waitingForReviewAppeals,
 			noToDoAppeals,
 			decidedAppealsCount,
-			withdrawnAppealsCount,
+			withdrawnAppealsCount: withdrawnAppealsCount + oldInvalidAppealCount,
 			decidedAppealsLink: `/${DECIDED_APPEALS}`,
 			withdrawnAppealsLink: `/${WITHDRAWN_APPEALS}`
 		};

--- a/packages/forms-web-app/src/controllers/appeals/your-appeals/decided-appeals.js
+++ b/packages/forms-web-app/src/controllers/appeals/your-appeals/decided-appeals.js
@@ -1,13 +1,17 @@
-const { mapToAppellantDashboardDisplayData } = require('../../../lib/dashboard-functions');
+const {
+	mapToAppellantDashboardDisplayData,
+	decidedAppeals
+} = require('../../../lib/dashboard-functions');
 const { VIEW } = require('../../../lib/views');
 const logger = require('../../../lib/logger');
-const { sortByDateFieldDesc } = require('@pins/common/src/lib/appeal-sorting');
-const { filterAppealsWithinGivenDate } = require('#lib/filter-decided-appeals');
-const { filterTime } = require('../../../config');
+const { sortByCaseDecisionDate } = require('@pins/common/src/lib/appeal-sorting');
 const { APPEAL_USER_ROLES } = require('@pins/common/src/constants');
 const { FLAG } = require('@pins/common/src/feature-flags');
 const { isFeatureActive } = require('../../../featureFlag');
 
+/**
+ * @type {import('express').RequestHandler}
+ */
 exports.get = async (req, res) => {
 	let viewContext = {};
 	const flags = {
@@ -19,19 +23,14 @@ exports.get = async (req, res) => {
 	try {
 		const appeals = await req.appealsApiClient.getUserAppeals(APPEAL_USER_ROLES.APPELLANT);
 		if (appeals?.length > 0) {
-			const decidedAppeals = appeals
+			const decidedCases = decidedAppeals(appeals);
+
+			const mappedCases = decidedCases
 				.map((a) => mapToAppellantDashboardDisplayData(a, flags))
-				.filter(Boolean)
-				.filter((appeal) => appeal.appealDecision)
-				.filter((appeal) =>
-					filterAppealsWithinGivenDate(
-						appeal,
-						'caseDecisionOutcomeDate',
-						filterTime.FIVE_YEARS_IN_MILISECONDS
-					)
-				);
-			decidedAppeals.sort(sortByDateFieldDesc('caseDecisionOutcomeDate'));
-			viewContext = { decidedAppeals };
+				.filter(Boolean);
+
+			mappedCases.sort(sortByCaseDecisionDate);
+			viewContext = { decidedAppeals: mappedCases };
 		}
 	} catch (error) {
 		logger.error(`Failed to get user decided appeals: ${error}`);

--- a/packages/forms-web-app/src/controllers/appeals/your-appeals/withdrawn-appeals.js
+++ b/packages/forms-web-app/src/controllers/appeals/your-appeals/withdrawn-appeals.js
@@ -1,9 +1,11 @@
-const { mapToAppellantDashboardDisplayData } = require('../../../lib/dashboard-functions');
+const {
+	mapToAppellantDashboardDisplayData,
+	withdrawnAppeals,
+	oldInvalidAppeals
+} = require('../../../lib/dashboard-functions');
 const { VIEW } = require('../../../lib/views');
 const logger = require('../../../lib/logger');
-const { filterAppealsWithinGivenDate } = require('../../../lib/filter-decided-appeals');
-const { filterTime } = require('../../../config');
-const { sortByDateFieldDesc } = require('@pins/common/src/lib/appeal-sorting');
+const { sortByWithdrawnDate } = require('@pins/common/src/lib/appeal-sorting');
 const { APPEAL_USER_ROLES } = require('@pins/common/src/constants');
 const { FLAG } = require('@pins/common/src/feature-flags');
 const { isFeatureActive } = require('../../../featureFlag');
@@ -19,23 +21,19 @@ exports.get = async (req, res) => {
 			)
 		};
 
-		logger.debug('Total appeals from API:', appeals?.length);
-
 		if (appeals?.length > 0) {
-			const withdrawnAppeals = appeals
-				.filter((appeal) => appeal.caseWithdrawnDate)
-				.map((a) => mapToAppellantDashboardDisplayData(a, flags))
-				.filter(Boolean)
-				.filter((appeal) =>
-					filterAppealsWithinGivenDate(
-						appeal,
-						'caseWithdrawnDate',
-						filterTime.FIVE_YEARS_IN_MILISECONDS
-					)
-				);
+			const withdrawnCases = withdrawnAppeals(appeals);
+			const oldInvalidatedCases = oldInvalidAppeals(appeals).map((appeal) => ({
+				...appeal,
+				caseWithdrawnDate: appeal.caseValidationDate
+			}));
 
-			withdrawnAppeals.sort(sortByDateFieldDesc('caseWithdrawnDate'));
-			viewContext = { withdrawnAppeals };
+			const appealsToDisplay = [...withdrawnCases, ...oldInvalidatedCases]
+				.sort(sortByWithdrawnDate)
+				.map((a) => mapToAppellantDashboardDisplayData(a, flags))
+				.filter(Boolean);
+
+			viewContext = { withdrawnAppeals: appealsToDisplay };
 		}
 	} catch (error) {
 		logger.error(`Failed to get user withdrawn appeals: ${error}`);

--- a/packages/forms-web-app/src/controllers/lpa-dashboard/decided-appeals.js
+++ b/packages/forms-web-app/src/controllers/lpa-dashboard/decided-appeals.js
@@ -3,6 +3,9 @@ const { mapToLPADashboardDisplayData } = require('../../lib/dashboard-functions'
 const { sortByCaseDecisionDate } = require('@pins/common/src/lib/appeal-sorting');
 const { filterAppealsWithinGivenDate } = require('../../lib/filter-decided-appeals');
 const { filterTime } = require('../../config');
+const { APPEAL_CASE_VALIDATION_OUTCOME } = require('@planning-inspectorate/data-model');
+const { isNotWithdrawn } = require('@pins/business-rules/src/lib/filter-withdrawn-appeal');
+const { isNotTransferred } = require('@pins/business-rules/src/lib/filter-transferred-appeal');
 
 const {
 	VIEW: {
@@ -15,9 +18,15 @@ const getDecidedAppeals = async (req, res) => {
 
 	const appealsCaseData = await req.appealsApiClient.getDecidedAppealsCaseDataV2(user.lpaCode);
 
-	appealsCaseData.sort(sortByCaseDecisionDate);
+	const appealsForDisplay = appealsCaseData
+		.filter((appeal) => isNotWithdrawn(appeal))
+		.filter((appeal) => isNotTransferred(appeal))
+		// invalid appeals from appellant case validation are not displayed on decided dashboard
+		.filter((appeal) => appeal.caseValidationOutcome !== APPEAL_CASE_VALIDATION_OUTCOME.INVALID);
 
-	const decidedAppeals = appealsCaseData
+	appealsForDisplay.sort(sortByCaseDecisionDate);
+
+	const decidedAppeals = appealsForDisplay
 		.map(mapToLPADashboardDisplayData)
 		.filter((appeal) =>
 			filterAppealsWithinGivenDate(

--- a/packages/forms-web-app/src/controllers/lpa-dashboard/withdrawn-appeals.js
+++ b/packages/forms-web-app/src/controllers/lpa-dashboard/withdrawn-appeals.js
@@ -1,9 +1,11 @@
 const { getUserFromSession } = require('../../services/user.service');
-const { mapToLPADashboardDisplayData } = require('../../lib/dashboard-functions');
-const { sortByDateFieldDesc } = require('@pins/common/src/lib/appeal-sorting');
+const {
+	mapToLPADashboardDisplayData,
+	withdrawnAppeals,
+	oldInvalidAppeals
+} = require('../../lib/dashboard-functions');
+const { sortByWithdrawnDate } = require('@pins/common/src/lib/appeal-sorting');
 const logger = require('../../lib/logger');
-const { filterAppealsWithinGivenDate } = require('../../lib/filter-decided-appeals');
-const { filterTime } = require('../../config');
 
 const {
 	VIEW: {
@@ -23,21 +25,19 @@ const getWithdrawnAppeals = async (req, res) => {
 
 		const appealsCaseData = await req.appealsApiClient.getAppealsCaseDataV2(user.lpaCode);
 
-		const withdrawnAppeals = appealsCaseData
-			.filter((appeal) => appeal.caseWithdrawnDate)
+		const withdrawnCases = withdrawnAppeals(appealsCaseData);
+		const oldInvalidatedCases = oldInvalidAppeals(appealsCaseData).map((appeal) => ({
+			...appeal,
+			caseWithdrawnDate: appeal.caseValidationDate
+		}));
+
+		const appealsToDisplay = [...withdrawnCases, ...oldInvalidatedCases]
 			.map(mapToLPADashboardDisplayData)
-			.filter(Boolean)
-			.filter((appeal) =>
-				filterAppealsWithinGivenDate(
-					appeal,
-					'caseWithdrawnDate',
-					filterTime.FIVE_YEARS_IN_MILISECONDS
-				)
-			);
+			.filter(Boolean);
 
-		withdrawnAppeals.sort(sortByDateFieldDesc('caseWithdrawnDate'));
+		appealsToDisplay.sort(sortByWithdrawnDate);
 
-		viewContext.withdrawnAppeals = withdrawnAppeals;
+		viewContext.withdrawnAppeals = appealsToDisplay;
 
 		return res.render(WITHDRAWN_APPEALS, viewContext);
 	} catch (error) {

--- a/packages/forms-web-app/src/controllers/lpa-dashboard/your-appeals.js
+++ b/packages/forms-web-app/src/controllers/lpa-dashboard/your-appeals.js
@@ -2,27 +2,23 @@ const { getUserFromSession } = require('../../services/user.service');
 const {
 	mapToLPADashboardDisplayData,
 	isToDoLPADashboard,
-	updateChildAppealDisplayData
+	updateChildAppealDisplayData,
+	withdrawnAppeals,
+	oldInvalidAppeals
 } = require('../../lib/dashboard-functions');
 const { arrayHasItems } = require('@pins/common/src/lib/array-has-items');
-const { filterAppealsWithinGivenDate } = require('../../lib/filter-decided-appeals');
-const { filterTime } = require('../../config');
-
 const { isNotWithdrawn } = require('@pins/business-rules/src/lib/filter-withdrawn-appeal');
 const { isNotTransferred } = require('@pins/business-rules/src/lib/filter-transferred-appeal');
 const {
+	ifInvalidOnlyRecentValidation
+} = require('@pins/business-rules/src/lib/filter-invalid-validation-one-month');
+
+const {
 	VIEW: {
-		LPA_DASHBOARD: {
-			DASHBOARD,
-			ADD_REMOVE_USERS,
-			APPEAL_DETAILS,
-			DECIDED_APPEALS,
-			WITHDRAWN_APPEALS
-		}
+		LPA_DASHBOARD: { DASHBOARD, ADD_REMOVE_USERS, DECIDED_APPEALS, WITHDRAWN_APPEALS }
 	}
 } = require('../../lib/views');
 const { baseHASUrl } = require('../../dynamic-forms/has-questionnaire/journey');
-const { APPEAL_CASE_STATUS } = require('@planning-inspectorate/data-model');
 
 const getYourAppeals = async (req, res) => {
 	const user = getUserFromSession(req);
@@ -31,29 +27,14 @@ const getYourAppeals = async (req, res) => {
 
 	const appealsCaseData = await req.appealsApiClient.getAppealsCaseDataV2(lpaCode);
 
-	const withdrawnAppealsCount = appealsCaseData
-		.filter((appeal) => appeal.caseWithdrawnDate)
-		.map(mapToLPADashboardDisplayData)
-		.filter(Boolean)
-		.filter((appeal) =>
-			filterAppealsWithinGivenDate(
-				appeal,
-				'caseWithdrawnDate',
-				filterTime.FIVE_YEARS_IN_MILISECONDS
-			)
-		).length;
-
-	const invalidAppeals = await req.appealsApiClient.getAppealsCasesByLpaAndStatus({
-		lpaCode,
-		caseStatus: APPEAL_CASE_STATUS.INVALID,
-		decidedOnly: true
-	});
-
 	const decidedAppealsCount = await req.appealsApiClient.getDecidedAppealsCountV2(lpaCode);
+	const withdrawnAppealsCount = withdrawnAppeals(appealsCaseData).length;
+	const oldInvalidAppealCount = oldInvalidAppeals(appealsCaseData).length;
 
-	const appealsForDisplay = [...appealsCaseData, ...invalidAppeals]
-		.filter(isNotWithdrawn)
-		.filter(isNotTransferred)
+	const appealsForDisplay = appealsCaseData
+		.filter((appeal) => isNotWithdrawn(appeal))
+		.filter((appeal) => isNotTransferred(appeal))
+		.filter((appeal) => ifInvalidOnlyRecentValidation(appeal))
 		.map(mapToLPADashboardDisplayData);
 
 	const appealsWithUpdatedChildAppealDisplayData = updateChildAppealDisplayData(appealsForDisplay);
@@ -81,12 +62,11 @@ const getYourAppeals = async (req, res) => {
 		addOrRemoveLink: `/${ADD_REMOVE_USERS}`,
 		toDoAppeals: toDoAppeals,
 		waitingForReviewAppeals: waitingForReviewAppeals,
-		appealDetailsLink: `/${APPEAL_DETAILS}`,
 		appealQuestionnaireLink: baseHASUrl,
 		decidedAppealsLink: `/${DECIDED_APPEALS}`,
 		withdrawnAppealsLink: `/${WITHDRAWN_APPEALS}`,
 		decidedAppealsCount: decidedAppealsCount.count,
-		withdrawnAppealsCount,
+		withdrawnAppealsCount: withdrawnAppealsCount + oldInvalidAppealCount,
 		noToDoAppeals
 	});
 };

--- a/packages/forms-web-app/src/lib/dashboard-functions.js
+++ b/packages/forms-web-app/src/lib/dashboard-functions.js
@@ -91,6 +91,13 @@ const { calculateDaysSinceInvalidated } = require('./calculate-days-since-invali
 const { APPEAL_USER_ROLES, LPA_USER_ROLE } = require('@pins/common/src/constants');
 const { formatGridReference } = require('@pins/common/src/lib/format-grid-reference');
 const { CASE_TYPES } = require('@pins/common/src/database/data-static');
+const {
+	ifInvalidOnlyOldValidation,
+	INVALID_APPEAL_TIME_LIMIT
+} = require('@pins/business-rules/src/lib/filter-invalid-validation-one-month');
+
+const { filterAppealsWithinGivenDate } = require('#lib/filter-decided-appeals');
+const { filterTime } = require('../config');
 
 const questionnaireBaseUrl = '/manage-appeals/questionnaire';
 const statementBaseUrl = '/manage-appeals/appeal-statement';
@@ -103,8 +110,6 @@ const appellantStatementBaseUrl = '/appeals/statement';
 
 const rule6StatementBaseUrl = '/rule-6/appeal-statement';
 const rule6ProofsBaseUrl = '/rule-6/proof-evidence';
-
-const INVALID_APPEAL_TIME_LIMIT = 28;
 
 // MAP DATABASE RETURN OBJECTS TO DASHBOARD DISPLAY DATA
 
@@ -529,6 +534,55 @@ const getAppealType = (appealCaseData) => {
 	return caseTypeNameWithDefault(appealCaseData?.appealTypeCode);
 };
 
+/**
+ * Used by LPA and appellant dashboards
+ * @param {AppealCaseDetailed[]} appealsCaseData
+ * @returns {AppealCaseDetailed[]}
+ */
+const withdrawnAppeals = (appealsCaseData) =>
+	appealsCaseData
+		.filter((appeal) => appeal.caseWithdrawnDate)
+		.filter(Boolean)
+		.filter((appeal) =>
+			filterAppealsWithinGivenDate(
+				appeal,
+				'caseWithdrawnDate',
+				filterTime.FIVE_YEARS_IN_MILISECONDS
+			)
+		);
+
+/**
+ * Used by LPA and appellant dashboards
+ * @param {AppealCaseDetailed[]} appealsCaseData
+ * @returns {AppealCaseDetailed[]}
+ */
+const oldInvalidAppeals = (appealsCaseData) =>
+	appealsCaseData
+		.filter((appeal) => appeal.caseValidationOutcome === APPEAL_CASE_STATUS.INVALID)
+		.filter((appeal) => ifInvalidOnlyOldValidation(appeal))
+		.filter((appeal) =>
+			filterAppealsWithinGivenDate(
+				appeal,
+				'caseValidationDate',
+				filterTime.FIVE_YEARS_IN_MILISECONDS
+			)
+		);
+
+/**
+ * @param {AppealCaseDetailed[]} appealsCaseData
+ * @returns {AppealCaseDetailed[]}
+ */
+const decidedAppeals = (appealsCaseData) =>
+	appealsCaseData
+		.filter((appeal) => appeal.caseDecisionOutcomeDate)
+		.filter((appeal) =>
+			filterAppealsWithinGivenDate(
+				appeal,
+				'caseDecisionOutcomeDate',
+				filterTime.FIVE_YEARS_IN_MILISECONDS
+			)
+		);
+
 module.exports = {
 	formatAddress,
 	determineJourneyToDisplayLPADashboard,
@@ -539,5 +593,8 @@ module.exports = {
 	mapToAppellantDashboardDisplayData,
 	mapToRule6DashboardDisplayData,
 	isToDoRule6Dashboard,
-	updateChildAppealDisplayData
+	updateChildAppealDisplayData,
+	withdrawnAppeals,
+	oldInvalidAppeals,
+	decidedAppeals
 };

--- a/packages/forms-web-app/src/lib/filter-decided-appeals.js
+++ b/packages/forms-web-app/src/lib/filter-decided-appeals.js
@@ -1,7 +1,12 @@
 const { subYears } = require('date-fns');
 
 /**
- * @param {import('./dashboard-functions').DashboardDisplayData} appeal
+ * @typedef {import('appeals-service-api').Api.AppealCaseDetailed} AppealCaseDetailed
+ * @typedef {import('./dashboard-functions').DashboardDisplayData} DashboardDisplayData
+ */
+
+/**
+ * @param {DashboardDisplayData|AppealCaseDetailed} appeal
  * @param {string} dateToFilterBy
  * @param {number} timeInMiliseconds
  * @returns {boolean}


### PR DESCRIPTION
### Description of change

Fixes display of invalid appeals
Improves tests by reducing mocking

Ticket: https://pins-ds.atlassian.net/browse/a2-7992

### Checklist

- [x] Feature complete and ready for users, or behind feature-flag
- [x] Commit history is linear with no merge commits
- [ ] Requires infrastructure changes

### Important

Please do not merge from `main` (please only [rebase](https://github.com/Planning-Inspectorate/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
