### PR TITLE
feat(web): updating lpa and appellant final comments copy (A2-8172)

### DIFF
--- a/packages/forms-web-app/src/dynamic-forms/questions.js
+++ b/packages/forms-web-app/src/dynamic-forms/questions.js
@@ -2887,7 +2887,6 @@ exports.getQuestionProps = (response) => ({
 		html: 'resources/appellant-final-comments/content.html',
 		fieldName: 'appellantFinalCommentDetails',
 		textEntryCheckbox: {
-			header: 'Your comments',
 			name: 'sensitiveInformationCheckbox',
 			text: 'I confirm that I have not included any sensitive information in my final comments'
 		},
@@ -2949,7 +2948,6 @@ exports.getQuestionProps = (response) => ({
 		html: 'resources/lpa-final-comments/comment-details.html',
 		fieldName: 'lpaFinalCommentDetails',
 		textEntryCheckbox: {
-			header: 'Your comments',
 			name: 'sensitiveInformationCheckbox',
 			text: 'I confirm that I have not included any sensitive information in my final comments'
 		},

--- a/packages/forms-web-app/src/public/resources/appellant-final-comments/content.html
+++ b/packages/forms-web-app/src/public/resources/appellant-final-comments/content.html
@@ -1,9 +1,4 @@
 <p class="govuk-body">
-	Only respond to any comments from interested parties. Do not include any new evidence.
-</p>
-<p class="govuk-body">You can upload documents to support your final comments later.</p>
-<h2 class="govuk-heading">Sensitive information</h2>
-<p class="govuk-body">
 	Do not include any sensitive information in your final comments. It will delay your appeal.
 </p>
 <details class="govuk-details">
@@ -34,3 +29,4 @@
 		</ul>
 	</div>
 </details>
+<h2 class="govuk-heading-m">Final comments</h2>

--- a/packages/forms-web-app/src/public/resources/lpa-final-comments/comment-details.html
+++ b/packages/forms-web-app/src/public/resources/lpa-final-comments/comment-details.html
@@ -1,10 +1,5 @@
 <p class="govuk-body">
-	Only respond to any comments from interested parties. Do not include any new evidence.
-</p>
-<p class="govuk-body">You can upload documents to support your final comments later.</p>
-<h2 class="govuk-heading">Sensitive information</h2>
-<p class="govuk-body">
-	Do not include any sensitive information in your final comments. It will delay your appeal.
+	Do not include any sensitive information in your final comments. It will delay the appeal process.
 </p>
 <details class="govuk-details">
 	<summary class="govuk-details__summary">
@@ -34,3 +29,4 @@
 		</ul>
 	</div>
 </details>
+<h2 class="govuk-heading-m">Final comments</h2>


### PR DESCRIPTION
### Description of change

- Copy update for lpa and appellant final comments pages

Tested locally:
- LPA
<img width="708" height="1170" alt="image" src="https://github.com/user-attachments/assets/48c08ddf-7509-4444-887d-49dda4dd6004" />


- Appellant
<img width="791" height="1163" alt="image" src="https://github.com/user-attachments/assets/bfa3a042-01fb-4ae7-8dbd-08c288752f64" />


Ticket: https://pins-ds.atlassian.net/browse/A2-8172

### Checklist

- [x] Feature complete and ready for users, or behind feature-flag
- [x] Commit history is linear with no merge commits
- [ ] Requires infrastructure changes

### Important

Please do not merge from `main` (please only [rebase](https://github.com/Planning-Inspectorate/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
