### PR TITLE
fix(forms): Removed appeal statements for CAS adverts expedite

### DIFF
--- a/packages/forms-web-app/src/controllers/selected-appeal/appeal-details/appeal-documents-rows.js
+++ b/packages/forms-web-app/src/controllers/selected-appeal/appeal-details/appeal-documents-rows.js
@@ -97,9 +97,10 @@ exports.documentsRows = (caseData) => {
 			valueText: formatDocumentDetails(documents, APPEAL_DOCUMENT_TYPE.APPELLANT_STATEMENT),
 			condition: () => {
 				if (
-					caseData &&
-					(caseData.appealTypeCode === CASE_TYPES.HAS.processCode ||
-						caseData.appealTypeCode === CASE_TYPES.CAS_PLANNING.processCode)
+					(caseData &&
+						(caseData.appealTypeCode === CASE_TYPES.HAS.processCode ||
+							caseData.appealTypeCode === CASE_TYPES.CAS_PLANNING.processCode)) ||
+					caseData.appealTypeCode === CASE_TYPES.CAS_ADVERTS.processCode
 				) {
 					return !isExpeditedAppealDate(caseData.applicationDate);
 				}

--- a/packages/forms-web-app/src/controllers/selected-appeal/appeal-details/appeal-documents-rows.test.js
+++ b/packages/forms-web-app/src/controllers/selected-appeal/appeal-details/appeal-documents-rows.test.js
@@ -411,6 +411,12 @@ describe('appeal-documents-rows - HAS and CAS conditional appeal statement', () 
 		});
 		const casRow = casRows.find((row) => row.keyText === 'Appeal statement');
 		expect(casRow.condition()).toBe(true);
+
+		const casAdvertsRows = documentsRows({
+			appealTypeCode: CASE_TYPES.CAS_ADVERTS.processCode
+		});
+		const casAdvertsRow = casAdvertsRows.find((row) => row.keyText === 'Appeal statement');
+		expect(casAdvertsRow.condition()).toBe(true);
 	});
 });
 


### PR DESCRIPTION

### Description of change

- Added CAS Adverts to expedite check

Ticket: https://pins-ds.atlassian.net/browse/A2-8659
### Checklist

- [ ] Feature complete and ready for users, or behind feature-flag
- [ ] Commit history is linear with no merge commits
- [ ] Requires infrastructure changes

### Important

Please do not merge from `main` (please only [rebase](https://github.com/Planning-Inspectorate/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
