### PR TITLE
feat(A2-8668): add expedited questions to HAS LPAQ

### DIFF
--- a/packages/dynamic-forms/src/section.js
+++ b/packages/dynamic-forms/src/section.js
@@ -193,8 +193,8 @@ class Section {
 		}
 
 		// all required questions complete
-		// if no required sections this will never be hit
-		if (requiredQuestionCount !== 0 && requiredAnswerCount >= requiredQuestionCount) {
+		// if no required sections (or if requiredQuestionCount is 0), this is marked complete
+		if (requiredQuestionCount === 0 || requiredAnswerCount >= requiredQuestionCount) {
 			result = SECTION_STATUS.COMPLETE;
 		}
 

--- a/packages/dynamic-forms/src/section.test.js
+++ b/packages/dynamic-forms/src/section.test.js
@@ -125,6 +125,47 @@ describe('./src/dynamic-forms/section.js', () => {
 			const isComplete = section.isComplete(mockJourneyResponse);
 			expect(isComplete).toBe(true);
 		});
+
+		it('should return COMPLETE when there are only optional questions', () => {
+			const mockJourneyResponse = {
+				answers: {}
+			};
+
+			const notARequiredQuestion = {
+				fieldName: 'someQuestion',
+				isRequired: () => false,
+				shouldDisplay: () => true,
+				isAnswered: () => false
+			};
+
+			const section = new Section();
+			section.addQuestion(notARequiredQuestion);
+
+			const result = section.getStatus(mockJourneyResponse);
+			expect(result).toBe(SECTION_STATUS.COMPLETE);
+			const isComplete = section.isComplete(mockJourneyResponse);
+			expect(isComplete).toBe(true);
+		});
+
+		it('should return COMPLETE when there are no displayable questions', () => {
+			const mockJourneyResponse = {
+				answers: {}
+			};
+
+			const requiredQuestionHidden = {
+				fieldName: 'someQuestion',
+				isRequired: () => true,
+				isAnswered: () => false
+			};
+
+			const section = new Section();
+			section.addQuestion(requiredQuestionHidden).withCondition(() => false);
+
+			const result = section.getStatus(mockJourneyResponse);
+			expect(result).toBe(SECTION_STATUS.COMPLETE);
+			const isComplete = section.isComplete(mockJourneyResponse);
+			expect(isComplete).toBe(true);
+		});
 	});
 	it('should return COMPLETE when a file upload question has files associated with it', () => {
 		const mockJourneyResponse = {

--- a/packages/forms-web-app/src/controllers/selected-appeal/questionnaire-details/appeal-process-details-rows.js
+++ b/packages/forms-web-app/src/controllers/selected-appeal/questionnaire-details/appeal-process-details-rows.js
@@ -6,7 +6,11 @@ const {
 } = require('@pins/common');
 const { fieldNames } = require('@pins/common/src/dynamic-forms/field-names');
 const { isNotUndefinedOrNull } = require('#lib/is-not-undefined-or-null');
-const { isExpeditedPart1Eligible } = require('#lib/is-expedited-part1-eligible');
+const {
+	isExpeditedPart1Eligible,
+	isExpeditedAppealDate
+} = require('#lib/is-expedited-part1-eligible');
+const { CASE_TYPES } = require('@pins/common/src/database/data-static');
 const { nl2br } = require('@pins/common/src/utils');
 
 /**
@@ -58,9 +62,9 @@ exports.appealProcessRows = (caseData) => {
 	};
 
 	/**
-	 * @param {AppealCaseDetailed} caseData
-	 * @param {DetailsContext} context
-	 * @returns {Rows}
+	 * @param {import('#lib/dashboard-functions').AppealCaseDetailed} caseData
+	 * @param {import('../appeal-details/appeal-details-rows').DetailsContext} context
+	 * @returns {import('../appeal-details/appeal-details-rows').Rows}
 	 */
 	const getExpeditedDetailsRows = (caseData) => {
 		return [
@@ -96,12 +100,15 @@ exports.appealProcessRows = (caseData) => {
 		}
 	];
 
-	if (
-		isExpeditedPart1Eligible({
-			...caseData,
-			eligibility: { applicationDecision: caseData.applicationDecision }
-		})
-	) {
+	const isExpeditedS78 = isExpeditedPart1Eligible({
+		...caseData,
+		eligibility: { applicationDecision: caseData.applicationDecision }
+	});
+	const isExpeditedHAS =
+		caseData.appealTypeCode === CASE_TYPES.HAS.processCode &&
+		isExpeditedAppealDate(caseData.applicationDate);
+
+	if (isExpeditedS78 || isExpeditedHAS) {
 		rows.push(...getExpeditedDetailsRows(caseData));
 	}
 	return rows;

--- a/packages/forms-web-app/src/controllers/selected-appeal/questionnaire-details/appeal-process-details.test.js
+++ b/packages/forms-web-app/src/controllers/selected-appeal/questionnaire-details/appeal-process-details.test.js
@@ -25,10 +25,21 @@ const enforcementLPAQData = caseTypeLPAQFactory(
 	'appealProcess'
 );
 
+const hasExpeditedLPAQData = {
+	...caseTypeLPAQFactory(CASE_TYPES.HAS.processCode, 'appealProcess'),
+	applicationDate: '2026-04-01',
+	anySignificantChangesLpa: 'no',
+	anySignificantChangesLpa_otherSignificantChanges: ''
+};
+
 const expectedRowsHas = [
 	{ title: 'Appeals near the site', value: 'Yes' },
 	{ title: 'Appeal references', value: '00000001' },
 	{ title: 'Are there any proposed conditions?', value: 'Yes\nexample new conditions' }
+];
+const expectedRowsHasExpedited = [
+	...expectedRowsHas,
+	{ title: 'Significant changes since application', value: '' }
 ];
 const expectedRowsS78 = [
 	{ title: 'Appeal procedure', value: 'Inquiry\ninquiry preference\nExpected duration: 6 days' },
@@ -45,6 +56,7 @@ const expectedRowsLDC = [{ title: 'Appeals near the site', value: 'No' }];
 describe('appealProcessRows', () => {
 	it.each([
 		['HAS', hasLPAQData, expectedRowsHas],
+		['HASExpedited', hasExpeditedLPAQData, expectedRowsHasExpedited],
 		['CAS Planning', casPlanningLPAQData, expectedRowsHas],
 		['S78', s78LPAQData, expectedRowsS78],
 		['S78Expedited', s78ExpeditedLPAQData, expectedRowsS78Expedited],

--- a/packages/forms-web-app/src/controllers/selected-appeal/questionnaire-details/index.js
+++ b/packages/forms-web-app/src/controllers/selected-appeal/questionnaire-details/index.js
@@ -22,7 +22,11 @@ const { getDepartmentFromCode } = require('../../../services/department.service'
 const { addCSStoHtml } = require('#lib/add-css-to-html');
 const { generatePDF } = require('#lib/pdf-api-wrapper');
 const { APPEAL_CASE_STAGE } = require('@planning-inspectorate/data-model');
-const { isExpeditedPart1Eligible } = require('#lib/is-expedited-part1-eligible');
+const {
+	isExpeditedPart1Eligible,
+	isExpeditedAppealDate
+} = require('#lib/is-expedited-part1-eligible');
+const { CASE_TYPES } = require('@pins/common/src/database/data-static');
 
 /**
  * Shared controller for /appeals/:caseRef/appeal-details, manage-appeals/:caseRef/appeal-details rule-6-appeals/:caseRef/appeal-details
@@ -102,10 +106,15 @@ exports.get = (layoutTemplate = 'layouts/no-banner-link/main.njk') => {
 			...caseData,
 			eligibility: { applicationDecision: caseData.applicationDecision }
 		});
-		const originalEvidenceDetailsRows = isExpeditedPart1
+		const isExpeditedHAS =
+			caseData.appealTypeCode === CASE_TYPES.HAS.processCode &&
+			isExpeditedAppealDate(caseData.applicationDate);
+		const showOriginalEvidence = isExpeditedPart1 || isExpeditedHAS;
+
+		const originalEvidenceDetailsRows = showOriginalEvidence
 			? originalEvidenceRows({ caseData, userType })
 			: [];
-		const originalEvidenceDetails = isExpeditedPart1
+		const originalEvidenceDetails = showOriginalEvidence
 			? formatQuestionnaireRows(originalEvidenceDetailsRows, caseData)
 			: [];
 

--- a/packages/forms-web-app/src/dynamic-forms/controller.js
+++ b/packages/forms-web-app/src/dynamic-forms/controller.js
@@ -224,11 +224,6 @@ exports.list = async (req, res, pageCaption, viewData) => {
 		const status = section.getStatus(journeyResponse);
 		const sectionView = buildSectionViewModel(section.name, status);
 
-		// update completed count
-		if (status === SECTION_STATUS.COMPLETE) {
-			summaryListData.completedSectionCount++;
-		}
-
 		// add questions
 		for (const question of section.questions) {
 			// don't show question on tasklist if set to false
@@ -256,7 +251,12 @@ exports.list = async (req, res, pageCaption, viewData) => {
 			});
 		}
 
-		summaryListData.sections.push(sectionView);
+		if (sectionView.list.rows.length > 0) {
+			if (status === SECTION_STATUS.COMPLETE) {
+				summaryListData.completedSectionCount++;
+			}
+			summaryListData.sections.push(sectionView);
+		}
 	}
 
 	return res.render(journey.listingPageViewPath, {

--- a/packages/forms-web-app/src/dynamic-forms/display-questions.js
+++ b/packages/forms-web-app/src/dynamic-forms/display-questions.js
@@ -114,6 +114,16 @@ exports.isBeforeExpeditedCutoff = (response) => {
 
 /**
  * @param {JourneyResponse} response
+ * @returns {boolean}
+ */
+exports.isBeforeExpeditedCutoffLPAQ = (response) => {
+	const answers = /** @type {any} */ (response.answers);
+	const applicationDate = answers.AppealCase?.applicationDate;
+	return !isExpeditedAppealDate(applicationDate);
+};
+
+/**
+ * @param {JourneyResponse} response
  * @param {import('../config')|undefined} config
  * @returns {boolean}
  */

--- a/packages/forms-web-app/src/dynamic-forms/has-questionnaire/journey.js
+++ b/packages/forms-web-app/src/dynamic-forms/has-questionnaire/journey.js
@@ -12,6 +12,7 @@ const {
 	mapAppealTypeToDisplayText,
 	mapAppealTypeToDisplayTextWithAnOrA
 } = require('@pins/common/src/appeal-type-to-display-text');
+const { isBeforeExpeditedCutoffLPAQ } = require('../display-questions');
 
 /**
  * @typedef {import('@pins/dynamic-forms/src/journey-response').JourneyResponse} JourneyResponse
@@ -91,6 +92,15 @@ const makeSections = (response) => {
 				() => response.answers && response.answers[questions.appealsNearSite.fieldName] == 'yes'
 			)
 			.addQuestion(questions.addNewConditions)
+			.addQuestion(questions.anySignificantChangesLPA)
+			.withCondition(() => !isBeforeExpeditedCutoffLPAQ(response)),
+		new Section('Original Evidence', 'original-evidence')
+			.startMultiQuestionCondition('expedited', () => !isBeforeExpeditedCutoffLPAQ(response))
+			.addQuestion(questions.designAccessStatementPart1)
+			.addQuestion(questions.uploadDesignAccessStatementPart1)
+			.withCondition(() => questionHasAnswer(response, questions.designAccessStatementPart1, 'yes'))
+			.addQuestion(questions.listOfDocumentsBeforeDecision)
+			.endMultiQuestionCondition('expedited')
 	];
 };
 

--- a/packages/forms-web-app/src/dynamic-forms/has-questionnaire/journey.test.js
+++ b/packages/forms-web-app/src/dynamic-forms/has-questionnaire/journey.test.js
@@ -8,6 +8,11 @@ const mockResponse = {
 	answers: {}
 };
 
+const getVisibleQuestionUrls = (journey, response) =>
+	journey.sections.flatMap((s) =>
+		s.questions.filter((q) => q.shouldDisplay(response)).map((q) => q.url)
+	);
+
 describe('HAS Journey', () => {
 	it('should error if no response', () => {
 		expect(() => {
@@ -52,5 +57,76 @@ describe('HAS Journey', () => {
 		expect(journey.sections.length > 0).toBe(true);
 		expect(Array.isArray(journey.sections[0].questions)).toBe(true);
 		expect(journey.sections[0].questions.length > 0).toBe(true);
+	});
+
+	describe('expedited questions (on or after 1 April 2026)', () => {
+		const ALWAYS_VISIBLE_EXPEDITED_URLS = [
+			'significant-changes',
+			'design-and-access-statement',
+			'list-of-documents'
+		];
+
+		const UPLOAD_DESIGN_ACCESS_URL = 'design-access-statement-upload';
+
+		const makeExpeditedResponse = (applicationDate, designAccessStatement) => ({
+			...mockResponse,
+			answers: {
+				designAccessStatement,
+				AppealCase: {
+					applicationDate
+				}
+			}
+		});
+
+		it('should include expedited questions when applicationDate is on the cutoff date', () => {
+			const response = makeExpeditedResponse(new Date('2026-04-01'));
+			const journey = new Journey({ ...params, response });
+			const urls = getVisibleQuestionUrls(journey, response);
+			ALWAYS_VISIBLE_EXPEDITED_URLS.forEach((url) => expect(urls).toContain(url));
+		});
+
+		it('should include expedited questions when applicationDate is after the cutoff date', () => {
+			const response = makeExpeditedResponse(new Date('2026-06-15'));
+			const journey = new Journey({ ...params, response });
+			const urls = getVisibleQuestionUrls(journey, response);
+			ALWAYS_VISIBLE_EXPEDITED_URLS.forEach((url) => expect(urls).toContain(url));
+		});
+
+		it('should show upload design access statement when designAccessStatement is "yes"', () => {
+			const response = makeExpeditedResponse(new Date('2026-04-01'), 'yes');
+			const journey = new Journey({ ...params, response });
+			const urls = getVisibleQuestionUrls(journey, response);
+			expect(urls).toContain(UPLOAD_DESIGN_ACCESS_URL);
+		});
+
+		it('should NOT show upload design access statement when designAccessStatement is "no"', () => {
+			const response = makeExpeditedResponse(new Date('2026-04-01'), 'no');
+			const journey = new Journey({ ...params, response });
+			const urls = getVisibleQuestionUrls(journey, response);
+			expect(urls).not.toContain(UPLOAD_DESIGN_ACCESS_URL);
+		});
+
+		it('should NOT include expedited questions when applicationDate is before the cutoff date', () => {
+			const response = makeExpeditedResponse(new Date('2026-03-31'));
+			const journey = new Journey({ ...params, response });
+			const urls = getVisibleQuestionUrls(journey, response);
+			ALWAYS_VISIBLE_EXPEDITED_URLS.forEach((url) => expect(urls).not.toContain(url));
+			expect(urls).not.toContain(UPLOAD_DESIGN_ACCESS_URL);
+		});
+
+		it('should NOT include expedited questions when applicationDate is null', () => {
+			const response = makeExpeditedResponse(null);
+			const journey = new Journey({ ...params, response });
+			const urls = getVisibleQuestionUrls(journey, response);
+			ALWAYS_VISIBLE_EXPEDITED_URLS.forEach((url) => expect(urls).not.toContain(url));
+			expect(urls).not.toContain(UPLOAD_DESIGN_ACCESS_URL);
+		});
+
+		it('should NOT include expedited questions when applicationDate is absent', () => {
+			const journey = new Journey({ ...params, response: mockResponse });
+			const urls = getVisibleQuestionUrls(journey, mockResponse);
+			ALWAYS_VISIBLE_EXPEDITED_URLS.forEach((url) => expect(urls).not.toContain(url));
+			expect(urls).not.toContain(UPLOAD_DESIGN_ACCESS_URL);
+		});
 	});
 });

--- a/packages/forms-web-app/src/dynamic-forms/middleware/get-journey-response-for-lpa.js
+++ b/packages/forms-web-app/src/dynamic-forms/middleware/get-journey-response-for-lpa.js
@@ -93,6 +93,11 @@ module.exports =
 			result = getDefaultResponse(journeyType, referenceId, user.lpaCode);
 		}
 
+		/** @type {any} */ (result.answers).AppealCase = {
+			...(result.answers.AppealCase || {}),
+			applicationDate: appeal?.applicationDate ?? null
+		};
+
 		if (result.LPACode !== user.lpaCode) {
 			return res.status(404).render('error/not-found');
 		}

--- a/packages/forms-web-app/src/journeys/__snapshots__/index.test.js.snap
+++ b/packages/forms-web-app/src/journeys/__snapshots__/index.test.js.snap
@@ -36462,6 +36462,102 @@ exports[`Dynamic forms journey tests lpa Householder Householder should render t
 </main>"
 `;
 
+exports[`Dynamic forms journey tests lpa Householder Householder should render the design-access-statement-upload question 1`] = `
+"<main id="main-content" role="main" class="govuk-main-wrapper govuk-main-wrapper--auto-spacing">
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds"><span class="govuk-caption-l">Original Evidence</span>
+            <h1 class="govuk-heading-l">Upload the design and access statement submitted for the application</h1>
+            <p class="govuk-body">Upload the planning officer’s report to committee or delegated report
+                on the application. You can also upload any other relevant documents or
+                minutes.</p>
+            <p class="govuk-body">If you did not make a decision for the application, upload a copy of what
+                your decision notice would have said.</p>
+            <form action="/manage-appeals/questionnaire/appeal-ref/original-evidence/design-access-statement-upload"
+            method="post" novalidate=null enctype="multipart/form-data">
+                <div class="moj-multi-file-upload">
+                    <div class="moj-multi-file__uploaded-files" aria-live="polite">
+                        <div class="moj-multi-file__uploaded-files-container moj-hidden">
+                            <h2 class="govuk-heading-m" id="-uploaded-files-heading">Files added</h2>
+                            <ul class="govuk-summary-list moj-multi-file-upload__list"></ul>
+                        </div>
+                    </div>
+                    <div class="moj-multi-file-upload__upload">
+                        <div class="govuk-form-group">
+                            <label class="govuk-label govuk-label--m" for="uploadDesignAccessStatement">Upload files</label>
+                            <div id="uploadDesignAccessStatement-hint" class="govuk-hint">The files must be a DOC, DOCX, PDF, TIF, JPG, PNG or XLSX and be smaller
+                                than 1GB</div>
+                            <input class="govuk-file-upload moj-multi-file-upload__input"
+                            id="uploadDesignAccessStatement" name="uploadDesignAccessStatement" type="file"
+                            aria-describedby="uploadDesignAccessStatement-hint" multiple="">
+                        </div>
+                        <button value="upload-and-remain-on-page" type="submit" name="upload-and-remain-on-page"
+                        class="govuk-button govuk-button--secondary moj-multi-file-upload__button"
+                        data-module="govuk-button" data-cy="button-upload-file">Upload file</button>
+                    </div>
+                </div>
+                <div class="govuk-button-group">
+                    <button type="submit" class="govuk-button" data-module="govuk-button"
+                    data-cy="button-save-and-continue">Continue</button>
+                </div>
+            </form>
+        </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+            <p class="govuk-body"><a href="/manage-appeals/questionnaire/appeal-ref" class="govuk-link">Return to questionnaire homepage</a>
+            </p>
+        </div>
+    </div>
+</main>"
+`;
+
+exports[`Dynamic forms journey tests lpa Householder Householder should render the design-and-access-statement question 1`] = `
+"<main id="main-content" role="main" class="govuk-main-wrapper govuk-main-wrapper--auto-spacing">
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds"></div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds"><span class="govuk-caption-l"> Original Evidence</span>
+        </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+            <form action="/manage-appeals/questionnaire/appeal-ref/original-evidence/design-and-access-statement"
+            method="post" novalidate=null>
+                <div class="govuk-form-group">
+                    <fieldset class="govuk-fieldset" aria-describedby="designAccessStatement-hint">
+                        <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+                            <h1 class="govuk-fieldset__heading"> Did the applicant submit a design and access statement with the application?</h1>
+                        </legend>
+                        <div id="designAccessStatement-hint" class="govuk-hint"></div>
+                        <div class="govuk-radios govuk-radios" data-module="govuk-radios">
+                            <div class="govuk-radios__item">
+                                <input class="govuk-radios__input" id="designAccessStatement" name="designAccessStatement"
+                                type="radio" value="yes" data-cy="answer-yes">
+                                <label class="govuk-label govuk-radios__label" for="designAccessStatement">Yes</label>
+                            </div>
+                            <div class="govuk-radios__item">
+                                <input class="govuk-radios__input" id="designAccessStatement-2" name="designAccessStatement"
+                                type="radio" value="no" data-cy="answer-no">
+                                <label class="govuk-label govuk-radios__label" for="designAccessStatement-2">No</label>
+                            </div>
+                        </div>
+                    </fieldset>
+                </div>
+                <button type="submit" class="govuk-button" data-module="govuk-button"
+                data-cy="button-save-and-continue">Continue</button>
+            </form>
+        </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+            <p class="govuk-body"><a href="/manage-appeals/questionnaire/appeal-ref" class="govuk-link">Return to questionnaire homepage</a>
+            </p>
+        </div>
+    </div>
+</main>"
+`;
+
 exports[`Dynamic forms journey tests lpa Householder Householder should render the emerging-plan question 1`] = `
 "<main id="main-content" role="main" class="govuk-main-wrapper govuk-main-wrapper--auto-spacing">
     <div class="govuk-grid-row">
@@ -36710,6 +36806,40 @@ exports[`Dynamic forms journey tests lpa Householder Householder should render t
                     <button type="submit" class="govuk-button" data-module="govuk-button"
                     data-cy="button-save-and-continue">Continue</button>
                 </div>
+            </form>
+        </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+            <p class="govuk-body"><a href="/manage-appeals/questionnaire/appeal-ref" class="govuk-link">Return to questionnaire homepage</a>
+            </p>
+        </div>
+    </div>
+</main>"
+`;
+
+exports[`Dynamic forms journey tests lpa Householder Householder should render the list-of-documents question 1`] = `
+"<main id="main-content" role="main" class="govuk-main-wrapper govuk-main-wrapper--auto-spacing">
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds"></div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds"><span class="govuk-caption-l"> Original Evidence</span>
+        </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+            <form action="/manage-appeals/questionnaire/appeal-ref/original-evidence/list-of-documents"
+            method="post" novalidate=null>
+                <h1 class="govuk-label-wrapper"><label class="govuk-label govuk-label--l" for="listOfDocumentsBeforeDecision"> What documents and plans did you use to make your decision?</label></h1>
+                <div class="govuk-form-group">
+                    <div id="listOfDocumentsBeforeDecision-hint" class="govuk-hint">Only include the most up-to-date versions of the documents you received</div>
+                    <textarea
+                    class="govuk-textarea" id="listOfDocumentsBeforeDecision" name="listOfDocumentsBeforeDecision"
+                    rows="5" aria-describedby="listOfDocumentsBeforeDecision-hint"></textarea>
+                </div>
+                <button type="submit" class="govuk-button" data-module="govuk-button"
+                data-cy="button-save-and-continue">Continue</button>
             </form>
         </div>
     </div>
@@ -37110,6 +37240,120 @@ exports[`Dynamic forms journey tests lpa Householder Householder should render t
                 data-cy="button-save-and-continue">Continue</button>
             </form>
         </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+            <p class="govuk-body"><a href="/manage-appeals/questionnaire/appeal-ref" class="govuk-link">Return to questionnaire homepage</a>
+            </p>
+        </div>
+    </div>
+</main>"
+`;
+
+exports[`Dynamic forms journey tests lpa Householder Householder should render the significant-changes question 1`] = `
+"<main id="main-content" role="main" class="govuk-main-wrapper govuk-main-wrapper--auto-spacing">
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds"></div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds"><span class="govuk-caption-l"> Appeal process</span>
+        </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+            <form action="/manage-appeals/questionnaire/appeal-ref/appeal-process/significant-changes"
+            method="post" novalidate=null>
+                <fieldset class="govuk-fieldset" aria-describedby="anySignificantChanges-hint">
+                    <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+                        <h1 class="govuk-fieldset__heading"> Have there been any significant changes that would affect the application?</h1>
+                    </legend>
+                    <p class="govuk-body">Only tell us about changes that are relevant or material to the application.</p>
+                    <h2
+                    class="govuk-heading-m">Significant changes</h2>
+                        <div class="govuk-form-group">
+                            <div id="anySignificantChanges-hint" class="govuk-hint">Select all that apply</div>
+                            <div class="govuk-checkboxes govuk-checkboxes"
+                            data-module="govuk-checkboxes">
+                                <div class="govuk-checkboxes__item">
+                                    <input class="govuk-checkboxes__input" id="anySignificantChanges" name="anySignificantChanges"
+                                    type="checkbox" value="local-plan" data-aria-controls="conditional-anySignificantChanges"
+                                    aria-describedby="anySignificantChanges-hint" data-cy="answer-local-plan">
+                                    <label class="govuk-label govuk-checkboxes__label" for="anySignificantChanges">Adopted a new local plan</label>
+                                </div>
+                                <div class="govuk-checkboxes__conditional govuk-checkboxes__conditional--hidden"
+                                id="conditional-anySignificantChanges">
+                                    <div class="govuk-form-group">
+                                        <label class="govuk-label" for="anySignificantChanges_localPlanSignificantChanges">Enter the local plan changes and why they’re relevant</label>
+                                        <div id="anySignificantChanges_localPlanSignificantChanges-hint"
+                                        class="govuk-hint"></div>
+                                        <textarea class="govuk-textarea" id="anySignificantChanges_localPlanSignificantChanges"
+                                        name="anySignificantChanges_localPlanSignificantChanges" rows="5" aria-describedby="anySignificantChanges_localPlanSignificantChanges-hint"></textarea>
+                                    </div>
+                                </div>
+                                <div class="govuk-checkboxes__item">
+                                    <input class="govuk-checkboxes__input" id="anySignificantChanges-2" name="anySignificantChanges"
+                                    type="checkbox" value="national-policy" data-aria-controls="conditional-anySignificantChanges-2"
+                                    aria-describedby="anySignificantChanges-hint" data-cy="answer-national-policy">
+                                    <label class="govuk-label govuk-checkboxes__label" for="anySignificantChanges-2">National policy change</label>
+                                </div>
+                                <div class="govuk-checkboxes__conditional govuk-checkboxes__conditional--hidden"
+                                id="conditional-anySignificantChanges-2">
+                                    <div class="govuk-form-group">
+                                        <label class="govuk-label" for="anySignificantChanges_nationalPolicySignificantChanges">Enter the national policy changes and why they’re relevant</label>
+                                        <div
+                                        id="anySignificantChanges_nationalPolicySignificantChanges-hint" class="govuk-hint"></div>
+                                    <textarea class="govuk-textarea" id="anySignificantChanges_nationalPolicySignificantChanges"
+                                    name="anySignificantChanges_nationalPolicySignificantChanges" rows="5"
+                                    aria-describedby="anySignificantChanges_nationalPolicySignificantChanges-hint"></textarea>
+                                </div>
+                            </div>
+                            <div class="govuk-checkboxes__item">
+                                <input class="govuk-checkboxes__input" id="anySignificantChanges-3" name="anySignificantChanges"
+                                type="checkbox" value="court-judgment" data-aria-controls="conditional-anySignificantChanges-3"
+                                aria-describedby="anySignificantChanges-hint" data-cy="answer-court-judgment">
+                                <label class="govuk-label govuk-checkboxes__label" for="anySignificantChanges-3">Court judgment</label>
+                            </div>
+                            <div class="govuk-checkboxes__conditional govuk-checkboxes__conditional--hidden"
+                            id="conditional-anySignificantChanges-3">
+                                <div class="govuk-form-group">
+                                    <label class="govuk-label" for="anySignificantChanges_courtJudgementSignificantChanges">Enter the court judgment</label>
+                                    <div id="anySignificantChanges_courtJudgementSignificantChanges-hint"
+                                    class="govuk-hint"></div>
+                                    <textarea class="govuk-textarea" id="anySignificantChanges_courtJudgementSignificantChanges"
+                                    name="anySignificantChanges_courtJudgementSignificantChanges" rows="5"
+                                    aria-describedby="anySignificantChanges_courtJudgementSignificantChanges-hint"></textarea>
+                                </div>
+                            </div>
+                            <div class="govuk-checkboxes__item">
+                                <input class="govuk-checkboxes__input" id="anySignificantChanges-4" name="anySignificantChanges"
+                                type="checkbox" value="other" data-aria-controls="conditional-anySignificantChanges-4"
+                                aria-describedby="anySignificantChanges-hint" data-cy="answer-other">
+                                <label class="govuk-label govuk-checkboxes__label" for="anySignificantChanges-4">Other</label>
+                            </div>
+                            <div class="govuk-checkboxes__conditional govuk-checkboxes__conditional--hidden"
+                            id="conditional-anySignificantChanges-4">
+                                <div class="govuk-form-group">
+                                    <label class="govuk-label" for="anySignificantChanges_otherSignificantChanges">Enter the other significant changes and why they&#39;re relevant</label>
+                                    <div
+                                    id="anySignificantChanges_otherSignificantChanges-hint" class="govuk-hint"></div>
+                                <textarea class="govuk-textarea" id="anySignificantChanges_otherSignificantChanges"
+                                name="anySignificantChanges_otherSignificantChanges" rows="5" aria-describedby="anySignificantChanges_otherSignificantChanges-hint"></textarea>
+                            </div>
+                        </div>
+                        <div class="govuk-checkboxes__divider">or</div>
+                        <div class="govuk-checkboxes__item">
+                            <input class="govuk-checkboxes__input" id="anySignificantChanges-6" name="anySignificantChanges"
+                            type="checkbox" value="none" data-behaviour="exclusive" aria-describedby="anySignificantChanges-hint"
+                            data-cy="answer-none">
+                            <label class="govuk-label govuk-checkboxes__label" for="anySignificantChanges-6">There have been no significant changes</label>
+                        </div>
+        </div>
+    </div>
+    <button type="submit" class="govuk-button" data-module="govuk-button"
+    data-cy="button-save-and-continue">Continue</button>
+    </fieldset>
+    </form>
+    </div>
     </div>
     <div class="govuk-grid-row">
         <div class="govuk-grid-column-two-thirds">


### PR DESCRIPTION
### Description of change

### Updates
This PR implements the display of the new expedited questions for the HAS LPAQ.
This include adding the application date to the journey so that checks can be made for if the questions should be displayed
Adding the new questions to the journey
Updating the controller to hid sections that are empty
Adding the questions to the appeal details LPAQ display

### Testing:
Added new unit tests for the expected logic on HAS expedited questions
updating snapshots for existing appeal displays
Manually testing scenarios in browser:
HAS LPAQ form and display with application date on 1st april 2026
HAS LPAQ form and display with application date after 1st april 2026
HAS LPAQ form and display with application date before 1st april 2026
HAS LPAQ form and display with application date set to null

Ticket: https://pins-ds.atlassian.net/browse/A2-8668

### Checklist

- [x] Feature complete and ready for users, or behind feature-flag
- [x] Commit history is linear with no merge commits
- [ ] Requires infrastructure changes

### Important

Please do not merge from `main` (please only [rebase](https://github.com/Planning-Inspectorate/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
