### PR TITLE
feat(forms): update cas planning lpaq for expedite (A2-8670)

### DIFF
--- a/packages/appeals-service-api/src/routes/v2/appeal-cases/_caseReference/lpa-questionnaire-submission/submit/index.test.js
+++ b/packages/appeals-service-api/src/routes/v2/appeal-cases/_caseReference/lpa-questionnaire-submission/submit/index.test.js
@@ -581,7 +581,9 @@ const formattedCASPlanning = [
 			caseReference: '004',
 			consultedBodiesDetails: null,
 			hasConsultationResponses: undefined,
-			hasStatutoryConsultees: false
+			hasStatutoryConsultees: false,
+			significantChangesAffectingApplicationLpa: null,
+			listOfDocumentsBeforeDecision: undefined
 		},
 		documents: [...expectedHAS.documents]
 	})

--- a/packages/appeals-service-api/src/services/back-office-v2/formatters/cas-planning/questionnaire.test.js
+++ b/packages/appeals-service-api/src/services/back-office-v2/formatters/cas-planning/questionnaire.test.js
@@ -41,6 +41,36 @@ describe('formatter', () => {
 		consultationResponses: true
 	};
 
+	const expectedCASPlanningAnswers = {
+		correctAppealType: true,
+		SubmissionListedBuilding: [{ reference: 'LB123', fieldName: 'affectedListedBuildingNumber' }],
+		conservationArea: true,
+		greenBelt: false,
+		notificationMethod: 'site-notice,letters-or-emails,advert',
+		lpaSiteAccess_lpaSiteAccessDetails: 'Access details',
+		lpaSiteSafetyRisks_lpaSiteSafetyRiskDetails: 'Safety details',
+		SubmissionAddress: [
+			{
+				fieldName: 'neighbourSiteAddress',
+				addressLine1: 'Line 1',
+				addressLine2: 'Line 2',
+				townCity: 'Town',
+				county: 'County',
+				postcode: 'Postcode'
+			}
+		],
+		neighbourSiteAccess_neighbourSiteAccessDetails: 'check the impact',
+		SubmissionLinkedCase: [{ caseReference: 'CASE123' }],
+		newConditions_newConditionDetails: 'New condition details',
+		statutoryConsultees: true,
+		statutoryConsultees_consultedBodiesDetails: 'body 1, body 2',
+		consultationResponses: true,
+		anySignificantChanges: 'local-plan,national-policy',
+		anySignificantChanges_localPlanSignificantChanges: 'local plan changes',
+		anySignificantChanges_nationalPolicySignificantChanges: 'national policy changes',
+		listOfDocumentsBeforeDecision: 'list of documents'
+	};
+
 	beforeEach(() => {
 		jest.clearAllMocks();
 	});
@@ -78,7 +108,59 @@ describe('formatter', () => {
 				lpaCostsAppliedFor: null,
 				consultedBodiesDetails: 'body 1, body 2',
 				hasConsultationResponses: true,
-				hasStatutoryConsultees: false
+				hasStatutoryConsultees: false,
+				significantChangesAffectingApplicationLpa: null,
+				listOfDocumentsBeforeDecision: undefined
+			},
+			documents: [1]
+		});
+	});
+
+	it('should format the expedite data correctly', async () => {
+		const result = await formatter(caseReference, expectedCASPlanningAnswers);
+
+		expect(result).toEqual({
+			casedata: {
+				caseType: CAS_PLANNING,
+				caseReference: '12345',
+				lpaQuestionnaireSubmittedDate: expect.any(String),
+				isCorrectAppealType: true,
+				affectedListedBuildingNumbers: ['LB123'],
+				inConservationArea: true,
+				isGreenBelt: false,
+				notificationMethod: ['notice', 'letter', 'advert'],
+				siteAccessDetails: ['Access details'],
+				siteSafetyDetails: ['Safety details'],
+				neighbouringSiteAddresses: [
+					{
+						neighbouringSiteAddressLine1: 'Line 1',
+						neighbouringSiteAddressLine2: 'Line 2',
+						neighbouringSiteAddressTown: 'Town',
+						neighbouringSiteAddressCounty: 'County',
+						neighbouringSiteAddressPostcode: 'Postcode',
+						neighbouringSiteAccessDetails: null,
+						neighbouringSiteSafetyDetails: null
+					}
+				],
+				reasonForNeighbourVisits: 'check the impact',
+				nearbyCaseReferences: ['CASE123'],
+				newConditionDetails: 'New condition details',
+				lpaStatement: '',
+				lpaCostsAppliedFor: null,
+				consultedBodiesDetails: 'body 1, body 2',
+				hasConsultationResponses: true,
+				hasStatutoryConsultees: false,
+				significantChangesAffectingApplicationLpa: [
+					{
+						value: 'adopted-a-new-local-plan',
+						comment: 'local plan changes'
+					},
+					{
+						value: 'national-policy-change',
+						comment: 'national policy changes'
+					}
+				],
+				listOfDocumentsBeforeDecision: 'list of documents'
 			},
 			documents: [1]
 		});
@@ -110,7 +192,9 @@ describe('formatter', () => {
 				lpaCostsAppliedFor: null,
 				consultedBodiesDetails: null,
 				hasConsultationResponses: undefined,
-				hasStatutoryConsultees: false
+				hasStatutoryConsultees: false,
+				significantChangesAffectingApplicationLpa: null,
+				listOfDocumentsBeforeDecision: undefined
 			},
 			documents: [1]
 		});

--- a/packages/appeals-service-api/src/services/back-office-v2/formatters/utils.js
+++ b/packages/appeals-service-api/src/services/back-office-v2/formatters/utils.js
@@ -1176,7 +1176,11 @@ exports.getCASPlanningLPAQSubmissionFields = (answers) => {
 		// Consultation responses and representations
 		hasStatutoryConsultees: exports.toBool(answers.statutoryConsultees),
 		consultedBodiesDetails: answers.statutoryConsultees_consultedBodiesDetails || null,
-		hasConsultationResponses: answers.consultationResponses
+		hasConsultationResponses: answers.consultationResponses,
+		// Appeal process
+		significantChangesAffectingApplicationLpa: exports.formatSignificantChanges(answers),
+		// Original Evidence
+		listOfDocumentsBeforeDecision: answers.listOfDocumentsBeforeDecision
 	};
 };
 

--- a/packages/common/src/dynamic-forms/journey-types.js
+++ b/packages/common/src/dynamic-forms/journey-types.js
@@ -88,6 +88,12 @@ exports.JOURNEY_TYPES = Object.freeze({
 		userType: LPA_USER_ROLE,
 		caseType: CASE_TYPES.CAS_PLANNING.processCode
 	},
+	CAS_PLANNING_QUESTIONNAIRE_PART_1: {
+		id: 'cas-planning-questionnaire-part-1',
+		type: exports.JOURNEY_TYPE.questionnaire,
+		userType: LPA_USER_ROLE,
+		caseType: CASE_TYPES.CAS_PLANNING.processCode
+	},
 	CAS_ADVERTS_QUESTIONNAIRE: {
 		id: 'cas-adverts-questionnaire',
 		type: exports.JOURNEY_TYPE.questionnaire,

--- a/packages/forms-web-app/src/dynamic-forms/cas-planning-questionnaire-part-1/journey.js
+++ b/packages/forms-web-app/src/dynamic-forms/cas-planning-questionnaire-part-1/journey.js
@@ -1,0 +1,129 @@
+const { getQuestions } = require('../questions');
+const { Section } = require('@pins/dynamic-forms/src/section');
+const { JOURNEY_TYPES } = require('@pins/common/src/dynamic-forms/journey-types');
+const { QUESTION_VARIABLES } = require('@pins/common/src/dynamic-forms/question-variables');
+const {
+	CASE_TYPES: { CAS_PLANNING }
+} = require('@pins/common/src/database/data-static');
+const {
+	questionHasAnswer
+} = require('@pins/dynamic-forms/src/dynamic-components/utils/question-has-answer');
+const {
+	mapAppealTypeToDisplayText,
+	mapAppealTypeToDisplayTextWithAnOrA
+} = require('@pins/common/src/appeal-type-to-display-text');
+
+/**
+ * @typedef {import('@pins/dynamic-forms/src/journey-response').JourneyResponse} JourneyResponse
+ * @typedef {Omit<ConstructorParameters<typeof import('@pins/dynamic-forms/src/journey').Journey>[0], 'response'>} JourneyParameters
+ */
+
+/**
+ * @param {JourneyResponse} response
+ * @returns {Section[]}
+ */
+const makeSections = (response) => {
+	const questions = getQuestions(response);
+	return [
+		new Section('Constraints, designations and other issues', 'constraints')
+			.addQuestion(questions.appealTypeAppropriate)
+			.withVariables({
+				[QUESTION_VARIABLES.APPEAL_TYPE_WITH_AN_OR_A]:
+					mapAppealTypeToDisplayTextWithAnOrA(CAS_PLANNING),
+				[QUESTION_VARIABLES.APPEAL_TYPE]: mapAppealTypeToDisplayText(CAS_PLANNING)
+			})
+			.addQuestion(questions.listedBuildingCheck)
+			.addQuestion(questions.affectedListedBuildings)
+			.withCondition(
+				() => response.answers && response.answers[questions.listedBuildingCheck.fieldName] == 'yes'
+			)
+			.addQuestion(questions.conservationArea)
+			.addQuestion(questions.conservationAreaUpload)
+			.withCondition(
+				() => response.answers && response.answers[questions.conservationArea.fieldName] == 'yes'
+			)
+			.addQuestion(questions.greenBelt),
+		new Section('Notifying relevant parties', 'notified')
+			.addQuestion(questions.whoWasNotified)
+			.addQuestion(questions.howYouNotifiedPeople)
+			.addQuestion(questions.uploadSiteNotice)
+			.withCondition(() =>
+				questionHasAnswer(response, questions.howYouNotifiedPeople, 'site-notice')
+			)
+			.addQuestion(questions.uploadNeighbourLetterAddresses)
+			.withCondition(() =>
+				questionHasAnswer(response, questions.howYouNotifiedPeople, 'letters-or-emails')
+			)
+			.addQuestion(questions.pressAdvertUpload)
+			.withCondition(() => questionHasAnswer(response, questions.howYouNotifiedPeople, 'advert'))
+			.addQuestion(questions.appealNotification),
+		new Section('Consultation responses and representations', 'consultation')
+			.addQuestion(questions.representationsFromOthers)
+			.addQuestion(questions.representationUpload)
+			.withCondition(
+				() =>
+					response.answers &&
+					response.answers[questions.representationsFromOthers.fieldName] == 'yes'
+			),
+		new Section("Planning officer's report and supporting documents", 'planning-officer-report')
+			.addQuestion(questions.planningOfficersReportUpload)
+			.addQuestion(questions.developmentPlanPolicies)
+			.addQuestion(questions.uploadDevelopmentPlanPolicies)
+			.withCondition(() => questionHasAnswer(response, questions.developmentPlanPolicies, 'yes'))
+			.addQuestion(questions.emergingPlan)
+			.addQuestion(questions.emergingPlanUpload)
+			.withCondition(() => questionHasAnswer(response, questions.emergingPlan, 'yes'))
+			.addQuestion(questions.supplementaryPlanning)
+			.addQuestion(questions.supplementaryPlanningUpload)
+			.withCondition(() => questionHasAnswer(response, questions.supplementaryPlanning, 'yes')),
+		new Section('Site access', 'site-access')
+			.addQuestion(questions.accessForInspection)
+			.addQuestion(questions.neighbouringSite)
+			.addQuestion(questions.neighbouringSitesToBeVisited)
+			.withCondition(
+				() => response.answers && response.answers[questions.neighbouringSite.fieldName] == 'yes'
+			)
+			.addQuestion(questions.potentialSafetyRisks),
+		new Section('Appeal process', 'appeal-process')
+			.addQuestion(questions.appealsNearSite)
+			.addQuestion(questions.nearbyAppeals)
+			.withCondition(
+				() => response.answers && response.answers[questions.appealsNearSite.fieldName] == 'yes'
+			)
+			.addQuestion(questions.anySignificantChanges)
+			.addQuestion(questions.addNewConditions),
+		new Section('Original Evidence', 'original-evidence')
+			.addQuestion(questions.designAccessStatementPart1)
+			.addQuestion(questions.uploadDesignAccessStatementPart1)
+			.withCondition(() => questionHasAnswer(response, questions.designAccessStatementPart1, 'yes'))
+			.addQuestion(questions.plansAndDrawingsPart1)
+			.addQuestion(questions.plansAndDrawingsUploadPart1)
+			.withCondition(() => questionHasAnswer(response, questions.plansAndDrawingsPart1, 'yes'))
+			.addQuestion(questions.additionalDocumentsPart1)
+			.addQuestion(questions.uploadAdditionalDocumentsPart1)
+			.withCondition(() => questionHasAnswer(response, questions.additionalDocumentsPart1, 'yes'))
+			.addQuestion(questions.listOfDocumentsBeforeDecision)
+	];
+};
+
+const baseCASPlanningUrl = '/manage-appeals/questionnaire';
+
+/**
+ * @param {JourneyResponse} response
+ * @returns {string}
+ */
+const makeBaseUrl = (response) =>
+	`${baseCASPlanningUrl}/${encodeURIComponent(response.referenceId)}`;
+
+/** @type {JourneyParameters} */
+const params = {
+	journeyId: JOURNEY_TYPES.CAS_PLANNING_QUESTIONNAIRE_PART_1.id,
+	makeSections,
+	journeyTemplate: 'questionnaire-template.njk',
+	listingPageViewPath: 'dynamic-components/task-list/questionnaire',
+	informationPageViewPath: 'dynamic-components/submission-information/index',
+	journeyTitle: 'Manage your appeals',
+	makeBaseUrl
+};
+
+module.exports = { ...params, baseCASPlanningUrl };

--- a/packages/forms-web-app/src/dynamic-forms/cas-planning-questionnaire-part-1/journey.test.js
+++ b/packages/forms-web-app/src/dynamic-forms/cas-planning-questionnaire-part-1/journey.test.js
@@ -1,0 +1,84 @@
+const { Journey } = require('@pins/dynamic-forms/src/journey');
+const { baseCASPlanningUrl, ...params } = require('./journey');
+
+const mockResponse = {
+	journeyId: 'CAS_PLANNING',
+	LPACode: 'Q9999',
+	referenceId: '123',
+	answers: {}
+};
+
+describe('CAS Planning LPAQ Journey', () => {
+	it('should error if no response', () => {
+		expect(() => {
+			new Journey(params);
+		}).toThrow("Cannot read properties of undefined (reading 'referenceId')");
+	});
+
+	it('should set baseUrl', () => {
+		const journey = new Journey({ ...params, response: mockResponse });
+		expect(journey.baseUrl).toEqual(expect.stringContaining(baseCASPlanningUrl));
+		expect(journey.baseUrl).toEqual(expect.stringContaining(mockResponse.referenceId));
+	});
+
+	it('should set taskListUrl', () => {
+		const journey = new Journey({ ...params, response: mockResponse });
+		expect(journey.taskListUrl).toEqual('/manage-appeals/questionnaire/123');
+	});
+
+	it('should set template', () => {
+		const journey = new Journey({ ...params, response: mockResponse });
+		expect(journey.journeyTemplate).toBe('questionnaire-template.njk');
+	});
+
+	it('should set listingPageViewPath', () => {
+		const journey = new Journey({ ...params, response: mockResponse });
+		expect(journey.listingPageViewPath).toBe('dynamic-components/task-list/questionnaire');
+	});
+
+	it('should set informationPageViewPath', () => {
+		const journey = new Journey({ ...params, response: mockResponse });
+		expect(journey.informationPageViewPath).toBe('dynamic-components/submission-information/index');
+	});
+
+	it('should set journeyTitle', () => {
+		const journey = new Journey({ ...params, response: mockResponse });
+		expect(journey.journeyTitle).toBe('Manage your appeals');
+	});
+
+	it('should define sections and questions', () => {
+		const journey = new Journey({ ...params, response: mockResponse });
+		expect(Array.isArray(journey.sections)).toBe(true);
+		expect(journey.sections.length > 0).toBe(true);
+		expect(Array.isArray(journey.sections[0].questions)).toBe(true);
+		expect(journey.sections[0].questions.length > 0).toBe(true);
+	});
+
+	it('should include expedite specific questions', () => {
+		const answers = { onApplicationDate: '2026-04-01T00:00:00.000Z' };
+		const journey = new Journey({
+			...params,
+			response: {
+				...mockResponse,
+				answers
+			}
+		});
+		const appealProcessSection = journey.getSection('appeal-process');
+		const anySignificantQuestion = appealProcessSection?.questions?.find(
+			(q) => q.fieldName === 'anySignificantChanges'
+		);
+		expect(anySignificantQuestion?.shouldDisplay(journey.response)).toBe(true);
+
+		const originalEvidenceSection = journey.getSection('original-evidence');
+		const originalEvidenceQuestions = [
+			'designAccessStatement',
+			'plansAndDrawings',
+			'additionalDocuments',
+			'listOfDocumentsBeforeDecision'
+		];
+		originalEvidenceQuestions.forEach((fieldName) => {
+			const question = originalEvidenceSection?.questions?.find((q) => q.fieldName === fieldName);
+			expect(question?.shouldDisplay(journey.response)).toBe(true);
+		});
+	});
+});

--- a/packages/forms-web-app/src/dynamic-forms/middleware/get-journey-response-for-lpa.js
+++ b/packages/forms-web-app/src/dynamic-forms/middleware/get-journey-response-for-lpa.js
@@ -72,6 +72,13 @@ module.exports =
 			journeyType = JOURNEY_TYPES.S78_QUESTIONNAIRE_PART_1.id;
 		}
 
+		if (
+			appeal.appealTypeCode === CASE_TYPES.CAS_PLANNING.processCode &&
+			isExpeditedAppealDate(appeal?.applicationDate)
+		) {
+			journeyType = JOURNEY_TYPES.CAS_PLANNING_QUESTIONNAIRE_PART_1.id;
+		}
+
 		if (typeof journeyType === 'undefined') {
 			throw new Error('appealType is undefined');
 		}

--- a/packages/forms-web-app/src/dynamic-forms/middleware/get-journey-response-for-lpa.test.js
+++ b/packages/forms-web-app/src/dynamic-forms/middleware/get-journey-response-for-lpa.test.js
@@ -1,4 +1,7 @@
-const { isExpeditedPart1Eligible } = require('#lib/is-expedited-part1-eligible');
+const {
+	isExpeditedPart1Eligible,
+	isExpeditedAppealDate
+} = require('#lib/is-expedited-part1-eligible');
 jest.mock('#lib/is-expedited-part1-eligible');
 
 const getJourneyResponse = require('./get-journey-response-for-lpa');
@@ -216,6 +219,30 @@ describe('getJourneyResponse', () => {
 			},
 			appealTypeCode: s78Appeal.appealTypeCode
 		});
+		expect(next).toHaveBeenCalled();
+	});
+
+	it('should route to JOURNEY_TYPES.CAS_PLANNING_QUESTIONNAIRE_PART_1.id when eligible for expedited ', async () => {
+		getUserFromSession.mockReturnValue(mockValidTestLpaUser);
+		const casAppeal = {
+			...mockSubmission,
+			appealTypeCode: CASE_TYPES.CAS_PLANNING.processCode,
+			lpaQuestionnaireDueDate: new Date(),
+			typeOfPlanningApplication: 'full',
+			applicationDate: '2026-04-02',
+			applicationDecision: 'granted',
+			caseProcedure: undefined
+		};
+		req.appealsApiClient.getUsersAppealCase.mockResolvedValue(casAppeal);
+		require('../../lib/is-lpa-in-feature-flag').isLpaInFeatureFlag.mockImplementation(async () => {
+			return true;
+		});
+		isExpeditedAppealDate.mockReturnValue(true);
+		await getJourneyResponse()(req, res, next);
+
+		expect(res.locals.journeyResponse.journeyId).toBe(
+			JOURNEY_TYPES.CAS_PLANNING_QUESTIONNAIRE_PART_1.id
+		);
 		expect(next).toHaveBeenCalled();
 	});
 });

--- a/packages/forms-web-app/src/journeys/index.js
+++ b/packages/forms-web-app/src/journeys/index.js
@@ -19,6 +19,7 @@ const s20AppealParams = require('../dynamic-forms/s20-appeal-form/journey');
 const s20QuestionnaireParams = require('../dynamic-forms/s20-lpa-questionnaire/journey');
 const casPlanningAppealForm = require('../dynamic-forms/cas-planning-appeal-form/journey');
 const casPlanningQuestionnaireParams = require('../dynamic-forms/cas-planning-questionnaire/journey');
+const casPlanningQuestionnairePart1Params = require('../dynamic-forms/cas-planning-questionnaire-part-1/journey');
 const advertsAppealForm = require('../dynamic-forms/adverts-appeal-form/journey');
 const {
 	casAdverts: casAdvertsQuestionnaireParams,
@@ -68,5 +69,6 @@ journeys.registerJourney({ ...commonParams, ...enforcementListedQuestionnairePar
 journeys.registerJourney({ ...commonParams, ...ldcAppealParams });
 journeys.registerJourney({ ...commonParams, ...ldcQuestionnaireParams });
 journeys.registerJourney({ ...commonParams, ...s78AppellantStatementParams });
+journeys.registerJourney({ ...commonParams, ...casPlanningQuestionnairePart1Params });
 
 module.exports = { journeys };


### PR DESCRIPTION
### Description of change

- Added new questionnaire for CAS planning expedite with expedite specific questions and sections
- Updated Unit tests

Ticket: https://pins-ds.atlassian.net/browse/A2-8670

### Checklist

- [ ] Feature complete and ready for users, or behind feature-flag
- [ ] Commit history is linear with no merge commits
- [ ] Requires infrastructure changes

### Important

Please do not merge from `main` (please only [rebase](https://github.com/Planning-Inspectorate/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
