### PR TITLE
feat(forms): update cas adverts lpaq for expedite (A2-8674)

### DIFF
--- a/packages/appeals-service-api/src/routes/v2/appeal-cases/_caseReference/lpa-questionnaire-submission/submit/index.test.js
+++ b/packages/appeals-service-api/src/routes/v2/appeal-cases/_caseReference/lpa-questionnaire-submission/submit/index.test.js
@@ -605,7 +605,9 @@ const formattedCASAdverts = [
 			lpaQuestionnaireSubmittedDate: expect.any(String),
 			isSiteInAreaOfSpecialControlAdverts: true,
 			wasApplicationRefusedDueToHighwayOrTraffic: false,
-			didAppellantSubmitCompletePhotosAndPlans: true
+			didAppellantSubmitCompletePhotosAndPlans: true,
+			significantChangesAffectingApplicationLpa: null,
+			listOfDocumentsBeforeDecision: undefined
 		},
 		documents: [...expectedHAS.documents]
 	})

--- a/packages/appeals-service-api/src/services/back-office-v2/formatters/cas-adverts/questionnaire.js
+++ b/packages/appeals-service-api/src/services/back-office-v2/formatters/cas-adverts/questionnaire.js
@@ -8,7 +8,8 @@ const {
 	getCommonLPAQSubmissionFields,
 	getHASLPAQSubmissionFields,
 	getCASAdvertsLPAQSubmissionFields,
-	getLPAProcedurePreference
+	getLPAProcedurePreference,
+	formatSignificantChanges
 } = require('../utils');
 const { documentTypes } = require('@pins/common/src/document-types');
 const { CASE_TYPES } = require('@pins/common/src/database/data-static');
@@ -30,7 +31,11 @@ exports.formatter = async (caseReference, { ...answers }) => {
 			...getHASLPAQSubmissionFields(answers),
 			...getLPAProcedurePreference(answers),
 			// CAS Adverts specific fields
-			...getCASAdvertsLPAQSubmissionFields(answers)
+			...getCASAdvertsLPAQSubmissionFields(answers),
+			// Appeal process
+			significantChangesAffectingApplicationLpa: formatSignificantChanges(answers),
+			// Original Evidence
+			listOfDocumentsBeforeDecision: answers?.listOfDocumentsBeforeDecision
 		},
 		documents: await getDocuments(answers, documentTypes.planningOfficersReportUpload.dataModelName)
 	};

--- a/packages/appeals-service-api/src/services/back-office-v2/formatters/cas-adverts/questionnaire.test.js
+++ b/packages/appeals-service-api/src/services/back-office-v2/formatters/cas-adverts/questionnaire.test.js
@@ -107,7 +107,9 @@ describe('formatter', () => {
 				),
 				isSiteInAreaOfSpecialControlAdverts: true,
 				wasApplicationRefusedDueToHighwayOrTraffic: false,
-				didAppellantSubmitCompletePhotosAndPlans: true
+				didAppellantSubmitCompletePhotosAndPlans: true,
+				significantChangesAffectingApplicationLpa: null,
+				listOfDocumentsBeforeDecision: undefined
 			},
 			documents: [1]
 		});
@@ -151,7 +153,9 @@ describe('formatter', () => {
 				lpaProcedurePreferenceDuration: null,
 				isSiteInAreaOfSpecialControlAdverts: undefined,
 				wasApplicationRefusedDueToHighwayOrTraffic: undefined,
-				didAppellantSubmitCompletePhotosAndPlans: undefined
+				didAppellantSubmitCompletePhotosAndPlans: undefined,
+				significantChangesAffectingApplicationLpa: null,
+				listOfDocumentsBeforeDecision: undefined
 			},
 			documents: [1]
 		});

--- a/packages/common/src/dynamic-forms/journey-types.js
+++ b/packages/common/src/dynamic-forms/journey-types.js
@@ -94,6 +94,12 @@ exports.JOURNEY_TYPES = Object.freeze({
 		userType: LPA_USER_ROLE,
 		caseType: CASE_TYPES.CAS_ADVERTS.processCode
 	},
+	CAS_ADVERTS_QUESTIONNAIRE_PART_1: {
+		id: 'cas-adverts-questionnaire-part-1',
+		type: exports.JOURNEY_TYPE.questionnaire,
+		userType: LPA_USER_ROLE,
+		caseType: CASE_TYPES.CAS_ADVERTS.processCode
+	},
 	ADVERTS_APPEAL_FORM: {
 		id: 'adverts-appeal-form',
 		type: exports.JOURNEY_TYPE.appealForm,

--- a/packages/forms-web-app/src/dynamic-forms/cas-adverts-questionnaire-part-1/journey.js
+++ b/packages/forms-web-app/src/dynamic-forms/cas-adverts-questionnaire-part-1/journey.js
@@ -1,0 +1,141 @@
+const { getQuestions } = require('../questions');
+const { Section } = require('@pins/dynamic-forms/src/section');
+const { JOURNEY_TYPES } = require('@pins/common/src/dynamic-forms/journey-types');
+const { QUESTION_VARIABLES } = require('@pins/common/src/dynamic-forms/question-variables');
+const {
+	CASE_TYPES: { CAS_ADVERTS }
+} = require('@pins/common/src/database/data-static');
+const {
+	questionHasAnswer
+} = require('@pins/dynamic-forms/src/dynamic-components/utils/question-has-answer');
+const {
+	mapAppealTypeToDisplayText,
+	mapAppealTypeToDisplayTextWithAnOrA
+} = require('@pins/common/src/appeal-type-to-display-text');
+const { APPEAL_CASE_PROCEDURE } = require('@planning-inspectorate/data-model');
+
+/**
+ * @typedef {import('@pins/dynamic-forms/src/journey-response').JourneyResponse} JourneyResponse
+ * @typedef {Omit<ConstructorParameters<typeof import('@pins/dynamic-forms/src/journey').Journey>[0], 'response'>} JourneyParameters
+ */
+
+/**
+ * @param {JourneyResponse} response
+ * @returns {Section[]}
+ */
+const makeSections = (response) => {
+	const questions = getQuestions(response);
+	return [
+		new Section('Constraints, designations and other issues', 'constraints')
+			.addQuestion(questions.appealTypeAppropriate)
+			.withVariables({
+				[QUESTION_VARIABLES.APPEAL_TYPE_WITH_AN_OR_A]:
+					mapAppealTypeToDisplayTextWithAnOrA(CAS_ADVERTS),
+				[QUESTION_VARIABLES.APPEAL_TYPE]: mapAppealTypeToDisplayText(CAS_ADVERTS)
+			})
+			.addQuestion(questions.listedBuildingCheck)
+			.addQuestion(questions.affectedListedBuildings)
+			.withCondition(() => questionHasAnswer(response, questions.listedBuildingCheck, 'yes'))
+			.addQuestion(questions.scheduledMonument)
+			.addQuestion(questions.conservationArea)
+			.addQuestion(questions.conservationAreaUpload)
+			.withCondition(() => questionHasAnswer(response, questions.conservationArea, 'yes'))
+			.addQuestion(questions.protectedSpecies)
+			.addQuestion(questions.isSiteInAreaOfSpecialControlAdverts)
+			.addQuestion(questions.greenBelt)
+			.addQuestion(questions.areaOfOutstandingNaturalBeauty)
+			.addQuestion(questions.designatedSitesCheck),
+		new Section('Notifying relevant parties', 'notified')
+			.addQuestion(questions.whoWasNotified)
+			.addQuestion(questions.howYouNotifiedPeople)
+			.addQuestion(questions.uploadSiteNotice)
+			.withCondition(() =>
+				questionHasAnswer(response, questions.howYouNotifiedPeople, 'site-notice')
+			)
+			.addQuestion(questions.uploadNeighbourLetterAddresses)
+			.withCondition(() =>
+				questionHasAnswer(response, questions.howYouNotifiedPeople, 'letters-or-emails')
+			)
+			.addQuestion(questions.pressAdvertUpload)
+			.withCondition(() => questionHasAnswer(response, questions.howYouNotifiedPeople, 'advert'))
+			.addQuestion(questions.appealNotification),
+		new Section('Consultation responses and representations', 'consultation')
+			.addQuestion(questions.statutoryConsultees)
+			.addQuestion(questions.representationsFromOthers)
+			.addQuestion(questions.representationUpload)
+			.withCondition(() => questionHasAnswer(response, questions.representationsFromOthers, 'yes')),
+		new Section('Planning officer’s report and supporting documents', 'planning-officer-report')
+			.addQuestion(questions.planningOfficersReportUpload)
+			.addQuestion(questions.wasApplicationRefusedDueToHighwayOrTraffic)
+			.addQuestion(questions.didAppellantSubmitCompletePhotosAndPlans)
+			.addQuestion(questions.developmentPlanPolicies)
+			.addQuestion(questions.uploadDevelopmentPlanPolicies)
+			.withCondition(() => questionHasAnswer(response, questions.developmentPlanPolicies, 'yes'))
+			.addQuestion(questions.emergingPlan)
+			.addQuestion(questions.emergingPlanUpload)
+			.withCondition(() => questionHasAnswer(response, questions.emergingPlan, 'yes'))
+			.addQuestion(questions.otherRelevantPolicies)
+			.addQuestion(questions.uploadOtherRelevantPolicies)
+			.withCondition(() => questionHasAnswer(response, questions.otherRelevantPolicies, 'yes'))
+			.addQuestion(questions.supplementaryPlanning)
+			.addQuestion(questions.supplementaryPlanningUpload)
+			.withCondition(() => questionHasAnswer(response, questions.supplementaryPlanning, 'yes')),
+		new Section('Site access', 'site-access')
+			.addQuestion(questions.accessForInspection)
+			.addQuestion(questions.neighbouringSite)
+			.addQuestion(questions.neighbouringSitesToBeVisited)
+			.withCondition(() => questionHasAnswer(response, questions.neighbouringSite, 'yes'))
+			.addQuestion(questions.potentialSafetyRisks),
+		new Section('Appeal process', 'appeal-process')
+			.addQuestion(questions.procedureType)
+			.addQuestion(questions.whyInquiry)
+			.withCondition(() =>
+				questionHasAnswer(response, questions.procedureType, APPEAL_CASE_PROCEDURE.INQUIRY)
+			)
+			.addQuestion(questions.whyHearing)
+			.withCondition(() =>
+				questionHasAnswer(response, questions.procedureType, APPEAL_CASE_PROCEDURE.HEARING)
+			)
+			.addQuestion(questions.appealsNearSite)
+			.addQuestion(questions.nearbyAppeals)
+			.withCondition(() => questionHasAnswer(response, questions.appealsNearSite, 'yes'))
+			.addQuestion(questions.anySignificantChanges)
+			.addQuestion(questions.addNewConditions),
+		new Section('Original Evidence', 'original-evidence')
+			.addQuestion(questions.designAccessStatementPart1)
+			.addQuestion(questions.uploadDesignAccessStatementPart1)
+			.withCondition(() => questionHasAnswer(response, questions.designAccessStatementPart1, 'yes'))
+			.addQuestion(questions.plansAndDrawingsPart1)
+			.addQuestion(questions.plansAndDrawingsUploadPart1)
+			.withCondition(() => questionHasAnswer(response, questions.plansAndDrawingsPart1, 'yes'))
+			.addQuestion(questions.additionalDocumentsPart1)
+			.addQuestion(questions.uploadAdditionalDocumentsPart1)
+			.withCondition(() => questionHasAnswer(response, questions.additionalDocumentsPart1, 'yes'))
+			.addQuestion(questions.listOfDocumentsBeforeDecision)
+	];
+};
+
+const baseCASAdvertsMinorUrl = '/manage-appeals/questionnaire';
+
+/**
+ * @param {JourneyResponse} response
+ * @returns {string}
+ */
+const makeBaseUrl = (response) =>
+	`${baseCASAdvertsMinorUrl}/${encodeURIComponent(response.referenceId)}`;
+
+/** @type {JourneyParameters} */
+const params = {
+	journeyId: JOURNEY_TYPES.CAS_ADVERTS_QUESTIONNAIRE_PART_1.id,
+	makeSections,
+	journeyTemplate: 'questionnaire-template.njk',
+	listingPageViewPath: 'dynamic-components/task-list/questionnaire',
+	informationPageViewPath: 'dynamic-components/submission-information/index',
+	journeyTitle: 'Manage your appeals',
+	makeBaseUrl
+};
+
+module.exports = {
+	...params,
+	baseCASAdvertsMinorUrl
+};

--- a/packages/forms-web-app/src/dynamic-forms/cas-adverts-questionnaire-part-1/journey.test.js
+++ b/packages/forms-web-app/src/dynamic-forms/cas-adverts-questionnaire-part-1/journey.test.js
@@ -1,0 +1,83 @@
+const { Journey } = require('@pins/dynamic-forms/src/journey');
+const { baseCASAdvertsMinorUrl, ...params } = require('./journey');
+
+const mockResponse = {
+	journeyId: 'cas-adverts-questionnaire',
+	LPACode: 'Q9999',
+	referenceId: '123',
+	answers: {}
+};
+describe('CAS Adverts LPAQ Journey', () => {
+	it('should error if no response', () => {
+		expect(() => {
+			new Journey(params);
+		}).toThrow("Cannot read properties of undefined (reading 'referenceId')");
+	});
+
+	it('should set baseUrl', () => {
+		const journey = new Journey({ ...params, response: mockResponse });
+		expect(journey.baseUrl).toEqual(expect.stringContaining(baseCASAdvertsMinorUrl));
+		expect(journey.baseUrl).toEqual(expect.stringContaining(mockResponse.referenceId));
+	});
+
+	it('should set taskListUrl', () => {
+		const journey = new Journey({ ...params, response: mockResponse });
+		expect(journey.taskListUrl).toEqual('/manage-appeals/questionnaire/123');
+	});
+
+	it('should set template', () => {
+		const journey = new Journey({ ...params, response: mockResponse });
+		expect(journey.journeyTemplate).toBe('questionnaire-template.njk');
+	});
+
+	it('should set listingPageViewPath', () => {
+		const journey = new Journey({ ...params, response: mockResponse });
+		expect(journey.listingPageViewPath).toBe('dynamic-components/task-list/questionnaire');
+	});
+
+	it('should set informationPageViewPath', () => {
+		const journey = new Journey({ ...params, response: mockResponse });
+		expect(journey.informationPageViewPath).toBe('dynamic-components/submission-information/index');
+	});
+
+	it('should set journeyTitle', () => {
+		const journey = new Journey({ ...params, response: mockResponse });
+		expect(journey.journeyTitle).toBe('Manage your appeals');
+	});
+
+	it('should define sections and questions', () => {
+		const journey = new Journey({ ...params, response: mockResponse });
+		expect(Array.isArray(journey.sections)).toBe(true);
+		expect(journey.sections.length > 0).toBe(true);
+		expect(Array.isArray(journey.sections[0].questions)).toBe(true);
+		expect(journey.sections[0].questions.length > 0).toBe(true);
+	});
+
+	it('should include expedite specific questions', () => {
+		const answers = { onApplicationDate: '2026-04-01T00:00:00.000Z' };
+		const journey = new Journey({
+			...params,
+			response: {
+				...mockResponse,
+				answers
+			}
+		});
+		const appealProcessSection = journey.getSection('appeal-process');
+		const anySignificantQuestion = appealProcessSection?.questions?.find(
+			(q) => q.fieldName === 'anySignificantChanges'
+		);
+		expect(anySignificantQuestion?.shouldDisplay(journey.response)).toBe(true);
+
+		const originalEvidenceSection = journey.getSection('original-evidence');
+		const originalEvidenceQuestions = [
+			'designAccessStatement',
+			'plansAndDrawings',
+			'additionalDocuments',
+			'listOfDocumentsBeforeDecision'
+		];
+		originalEvidenceQuestions.forEach((fieldName) => {
+			const question = originalEvidenceSection?.questions?.find((q) => q.fieldName === fieldName);
+			expect(question?.shouldDisplay(journey.response)).toBe(true);
+		});
+	});
+});

--- a/packages/forms-web-app/src/dynamic-forms/middleware/get-journey-response-for-lpa.js
+++ b/packages/forms-web-app/src/dynamic-forms/middleware/get-journey-response-for-lpa.js
@@ -13,7 +13,10 @@ const {
 		LPA_DASHBOARD: { DASHBOARD }
 	}
 } = require('../../lib/views');
-const { isExpeditedPart1Eligible } = require('#lib/is-expedited-part1-eligible');
+const {
+	isExpeditedPart1Eligible,
+	isExpeditedAppealDate
+} = require('#lib/is-expedited-part1-eligible');
 const { FLAG } = require('@pins/common/src/feature-flags');
 const { CASE_TYPES } = require('@pins/common/src/database/data-static');
 const { isLpaInFeatureFlag } = require('#lib/is-lpa-in-feature-flag');
@@ -71,6 +74,13 @@ module.exports =
 
 		if (typeof journeyType === 'undefined') {
 			throw new Error('appealType is undefined');
+		}
+
+		if (
+			appeal.appealTypeCode === CASE_TYPES.CAS_ADVERTS.processCode &&
+			isExpeditedAppealDate(appeal?.applicationDate)
+		) {
+			journeyType = JOURNEY_TYPES.CAS_ADVERTS_QUESTIONNAIRE_PART_1.id;
 		}
 
 		try {

--- a/packages/forms-web-app/src/journeys/index.js
+++ b/packages/forms-web-app/src/journeys/index.js
@@ -24,6 +24,7 @@ const {
 	casAdverts: casAdvertsQuestionnaireParams,
 	adverts: advertsQuestionnaireParams
 } = require('../dynamic-forms/adverts-questionnaire/journey');
+const casAdvertsQuestionnairePart1Params = require('../dynamic-forms/cas-adverts-questionnaire-part-1/journey');
 const enforcementAppealParams = require('../dynamic-forms/enforcement-appeal-form/journey');
 const enforcementQuestionnaireParams = require('../dynamic-forms/enforcement-questionnaire/journey');
 const enforcementListedAppealParams = require('../dynamic-forms/enforcement-listed-appeal-form/journey');
@@ -57,6 +58,7 @@ journeys.registerJourney({ ...commonParams, ...s20QuestionnaireParams });
 journeys.registerJourney({ ...commonParams, ...casPlanningAppealForm });
 journeys.registerJourney({ ...commonParams, ...casPlanningQuestionnaireParams });
 journeys.registerJourney({ ...commonParams, ...casAdvertsQuestionnaireParams });
+journeys.registerJourney({ ...commonParams, ...casAdvertsQuestionnairePart1Params });
 journeys.registerJourney({ ...commonParams, ...advertsAppealForm });
 journeys.registerJourney({ ...commonParams, ...advertsQuestionnaireParams });
 journeys.registerJourney({ ...commonParams, ...enforcementAppealParams });


### PR DESCRIPTION
### Description of change

<!-- Please describe the change -->
- Added new questionnaire for CAS adverts expedite with expedite specific questions and sections
- Updated Unit tests
Ticket: https://pins-ds.atlassian.net/browse/A2-8674

### Checklist

- [ ] Feature complete and ready for users, or behind feature-flag
- [ ] Commit history is linear with no merge commits
- [ ] Requires infrastructure changes

### Important

Please do not merge from `main` (please only [rebase](https://github.com/Planning-Inspectorate/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
