### PR TITLE
feat(A2-8758): implement batching on multi file upload

### DIFF
--- a/packages/appeals-service-api/src/app.js
+++ b/packages/appeals-service-api/src/app.js
@@ -17,9 +17,6 @@ const http = require('http');
 https.globalAgent = new https.Agent({ keepAlive: false });
 http.globalAgent = new http.Agent({ keepAlive: false });
 
-app.use('/api/v2/appellant-submissions', bodyParser.json({ limit: '1mb' }));
-app.use('/api/v2/appeal-cases', bodyParser.json({ limit: '1mb' }));
-
 app.use(bodyParser.json());
 app.use(bodyParser.urlencoded({ extended: true }));
 

--- a/packages/appeals-service-api/src/app.js
+++ b/packages/appeals-service-api/src/app.js
@@ -17,6 +17,9 @@ const http = require('http');
 https.globalAgent = new https.Agent({ keepAlive: false });
 http.globalAgent = new http.Agent({ keepAlive: false });
 
+app.use('/api/v2/appellant-submissions', bodyParser.json({ limit: '1mb' }));
+app.use('/api/v2/appeal-cases', bodyParser.json({ limit: '1mb' }));
+
 app.use(bodyParser.json());
 app.use(bodyParser.urlencoded({ extended: true }));
 

--- a/packages/forms-web-app/src/journeys/question-overrides/multi-file-upload.js
+++ b/packages/forms-web-app/src/journeys/question-overrides/multi-file-upload.js
@@ -1,4 +1,5 @@
 const { createDocument } = require('#lib/documents-api-wrapper');
+const logger = require('#lib/logger');
 const {
 	isObjectWithUploadedFiles,
 	removeFilesV2,
@@ -206,7 +207,16 @@ async function saveAction(req, res, saveFunction, journey, section, journeyRespo
 		.filter(Boolean);
 
 	if (filesToAttach.length) {
-		await uploadDocuments(journeyResponse.referenceId, filesToAttach);
+		const chunkSize = 50;
+		for (let i = 0; i < filesToAttach.length; i += chunkSize) {
+			const chunk = filesToAttach.slice(i, i + chunkSize);
+			try {
+				await uploadDocuments(journeyResponse.referenceId, chunk);
+			} catch (error) {
+				logger.error(error, `Error uploading document batch starting at index ${i}`);
+				throw new Error('Failed to save uploaded files. Please try again.');
+			}
+		}
 	}
 
 	const allUploadedFiles = [...updatedUploadedFiles, ...uploadedFiles].filter(Boolean);


### PR DESCRIPTION
### Description of change

### Summary
Multi file upload pages were generating metadata larger than 100kb which the api rejects. This PR implement batching on mutlifile uploads to keep batch size below 100KB.
 
Ticket: https://pins-ds.atlassian.net/browse/A2-8758

### Checklist

- [x] Feature complete and ready for users, or behind feature-flag
- [x] Commit history is linear with no merge commits
- [ ] Requires infrastructure changes

### Important

Please do not merge from `main` (please only [rebase](https://github.com/Planning-Inspectorate/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
