### PR TITLE
fix(A2-8764): selectedAppeal - add lead appeal decision docs lookup i…

### DIFF
--- a/packages/appeals-service-api/src/routes/v2/appeal-cases/_caseReference/documents/controller.js
+++ b/packages/appeals-service-api/src/routes/v2/appeal-cases/_caseReference/documents/controller.js
@@ -1,0 +1,17 @@
+const { AppealDocumentRepository } = require('./repo');
+const repo = new AppealDocumentRepository();
+
+/**
+ * @type {import('express').RequestHandler}
+ */
+async function getAppealDocuments(req, res) {
+	const { documentTypes } = req.query;
+
+	const documentTypesArray = documentTypes ? documentTypes.split(',') : [];
+	const content = await repo.getDocumentsByAppealRef(req.params.caseReference, documentTypesArray);
+	res.status(200).send(content);
+}
+
+module.exports = {
+	getAppealDocuments
+};

--- a/packages/appeals-service-api/src/routes/v2/appeal-cases/_caseReference/documents/document.spec.js
+++ b/packages/appeals-service-api/src/routes/v2/appeal-cases/_caseReference/documents/document.spec.js
@@ -1,0 +1,104 @@
+const { APPEAL_USER_ROLES } = require('@pins/common/src/constants');
+const { APPEAL_DOCUMENT_TYPE } = require('@planning-inspectorate/data-model');
+const crypto = require('crypto');
+const {
+	createTestAppealCase
+} = require('../../../../../../__tests__/developer/fixtures/appeals-case-data');
+const {
+	createTestDocData
+} = require('../../../../../../__tests__/developer/fixtures/appeals-document-data');
+
+let validUserId = '';
+const validLpa = 'Q9999';
+
+/**
+ * @param {Object} dependencies
+ * @param {function(): import('@pins/database/src/client/client').PrismaClient} dependencies.getSqlClient
+ * @param {function(string): void} dependencies.setCurrentSub
+ * @param {import('supertest').Agent} dependencies.appealsApi
+ */
+module.exports = ({ getSqlClient, setCurrentSub, appealsApi }) => {
+	const sqlClient = getSqlClient();
+
+	beforeAll(async () => {
+		const user = await sqlClient.appealUser.create({
+			data: {
+				email: crypto.randomUUID() + '@example.com'
+			}
+		});
+
+		validUserId = user.id;
+	});
+
+	beforeEach(() => {
+		setCurrentSub(validUserId);
+	});
+
+	/**
+	 * @param {string} caseRef
+	 * @returns {Promise<string>}
+	 */
+	const createAppeal = async (caseRef) => {
+		const appeal = await sqlClient.appeal.create({
+			include: {
+				AppealCase: true
+			},
+			data: {
+				Users: {
+					create: {
+						userId: validUserId,
+						role: APPEAL_USER_ROLES.APPELLANT
+					}
+				},
+				AppealCase: {
+					create: createTestAppealCase(caseRef, 'S78', validLpa)
+				}
+			}
+		});
+		return appeal.AppealCase?.caseReference;
+	};
+
+	const decisionDocumentTypes = [
+		APPEAL_DOCUMENT_TYPE.APPELLANT_COSTS_DECISION_LETTER,
+		APPEAL_DOCUMENT_TYPE.LPA_COSTS_DECISION_LETTER,
+		APPEAL_DOCUMENT_TYPE.CASE_DECISION_LETTER
+	];
+
+	describe('/appeal-cases/_caseReference/documents/', () => {
+		it('get should retrieve the documents - no documentTypes query param', async () => {
+			const testCaseRef = '3636563';
+			await createAppeal(testCaseRef);
+
+			await sqlClient.document.createMany({
+				data: decisionDocumentTypes.map((type) => ({
+					...createTestDocData(testCaseRef, type)
+				}))
+			});
+
+			const documentResponse = await appealsApi.get(
+				`/api/v2/appeal-cases/${testCaseRef}/documents`
+			);
+
+			expect(documentResponse.status).toEqual(200);
+			expect(documentResponse.body.length).toBe(3);
+		});
+
+		it('get should retrieve specified document types if document types query param included', async () => {
+			const testCaseRef = '3636564';
+			await createAppeal(testCaseRef);
+
+			await sqlClient.document.createMany({
+				data: decisionDocumentTypes.map((type) => ({
+					...createTestDocData(testCaseRef, type)
+				}))
+			});
+
+			const eventResponse = await appealsApi.get(
+				`/api/v2/appeal-cases/${testCaseRef}/documents?documentTypes=${APPEAL_DOCUMENT_TYPE.CASE_DECISION_LETTER}`
+			);
+
+			expect(eventResponse.status).toEqual(200);
+			expect(eventResponse.body.length).toBe(1);
+		});
+	});
+};

--- a/packages/appeals-service-api/src/routes/v2/appeal-cases/_caseReference/documents/index.js
+++ b/packages/appeals-service-api/src/routes/v2/appeal-cases/_caseReference/documents/index.js
@@ -1,0 +1,19 @@
+const express = require('express');
+const { getAppealDocuments } = require('./controller');
+const { AUTH } = require('@pins/common/src/constants');
+const config = require('../../../../../configuration/config');
+const { auth } = require('express-oauth2-jwt-bearer');
+const { openApiValidatorMiddleware } = require('../../../../../validators/validate-open-api');
+const asyncHandler = require('@pins/common/src/middleware/async-handler');
+
+const router = express.Router({ mergeParams: true });
+router.use(
+	auth({
+		issuerBaseURL: `${config.auth.authServerUrl}${AUTH.OIDC_ENDPOINT}`,
+		audience: AUTH.RESOURCE
+	})
+);
+
+router.get('/', openApiValidatorMiddleware(), asyncHandler(getAppealDocuments));
+
+module.exports = { router };

--- a/packages/appeals-service-api/src/routes/v2/appeal-cases/_caseReference/documents/repo.js
+++ b/packages/appeals-service-api/src/routes/v2/appeal-cases/_caseReference/documents/repo.js
@@ -1,0 +1,42 @@
+const { createPrismaClient } = require('#db-client');
+
+const { DocumentsArgs } = require('../../repo');
+
+/**
+ * @typedef {import('@pins/database/src/client/client').Document} Document
+ */
+class AppealDocumentRepository {
+	dbClient;
+
+	constructor() {
+		this.dbClient = createPrismaClient();
+	}
+
+	/**
+	 * Get event for given appeal
+	 *
+	 * @param {string} caseReference
+	 * @param {Array<string> | undefined} [documentTypes]
+	 * @returns {Promise<Array<Document>>}
+	 */
+	getDocumentsByAppealRef(caseReference, documentTypes) {
+		/** @type {import('@pins/database/src/client/client').Prisma.DocumentWhereInput} */
+		const where = {
+			caseReference: caseReference,
+			published: true
+		};
+
+		if (documentTypes && documentTypes?.length > 0) {
+			where.documentType = {
+				in: documentTypes
+			};
+		}
+
+		return this.dbClient.document.findMany({
+			...DocumentsArgs,
+			where: where
+		});
+	}
+}
+
+module.exports = { AppealDocumentRepository };

--- a/packages/appeals-service-api/src/routes/v2/appeal-cases/_caseReference/documents/spec.yaml
+++ b/packages/appeals-service-api/src/routes/v2/appeal-cases/_caseReference/documents/spec.yaml
@@ -1,0 +1,31 @@
+paths:
+  /api/v2/appeal-cases/{caseReference}/documents/:
+    get:
+      tags:
+        - documents
+      description: Gets documents associated with an appeal case
+      parameters:
+        - in: path
+          name: caseReference
+          required: true
+          schema:
+            type: string
+          description: appeal case reference
+        - in: query
+          name: documentTypes
+          schema:
+            type: string
+          description: types of documents to retrieve in comma separated string, leave blank to get all documents.
+      responses:
+        200:
+          description: Returns the documents for a case
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Document'
+        404:
+          description: Unable to find case
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorBody'

--- a/packages/common/src/client/appeals-api-client.js
+++ b/packages/common/src/client/appeals-api-client.js
@@ -220,6 +220,22 @@ class AppealsApiClient {
 	}
 
 	/**
+	 * Gets documents for a case.
+	 * @param {string} caseReference
+	 * @param {Array<string>} [documentTypes]
+	 * @returns {Promise<Array<Document>>}
+	 */
+	async getDocumentsByCaseRef(caseReference, documentTypes) {
+		const urlParams = new URLSearchParams();
+
+		if (documentTypes) urlParams.append('documentTypes', documentTypes.join(','));
+
+		const endpoint = `${v2}/appeal-cases/${caseReference}/documents?${urlParams.toString()}`;
+		const response = await this.#makeGetRequest(endpoint);
+		return response.json();
+	}
+
+	/**
 	 * Gets events for a case.
 	 * @param {string} caseReference
 	 * @param {object} [options]

--- a/packages/common/src/lib/linked-appeals.js
+++ b/packages/common/src/lib/linked-appeals.js
@@ -52,8 +52,11 @@ const mapLinkedCaseStatusLabel = (status) => {
  * @param {AppealCaseDetailed} appealCaseData
  * @returns {boolean}
  */
-const isChildLinkedAppeal = (appealCaseData) =>
-	appealCaseData.linkedCases?.[0].childCaseReference === appealCaseData.caseReference;
+const isChildLinkedAppeal = (appealCaseData) => {
+	if (!appealCaseData.linkedCases || !appealCaseData.caseReference) return false;
+
+	return appealCaseData.linkedCases?.[0].childCaseReference === appealCaseData.caseReference;
+};
 
 /**
  * check whether case is an enforcement child linked case

--- a/packages/forms-web-app/__tests__/unit/controllers/appeals/your-appeals/decided-appeals.test.js
+++ b/packages/forms-web-app/__tests__/unit/controllers/appeals/your-appeals/decided-appeals.test.js
@@ -55,11 +55,11 @@ describe('controllers/appeals/your-appeals/decided-appeals', () => {
 		expect(res.render).toHaveBeenCalledWith(VIEW.YOUR_APPEALS.DECIDED_APPEALS, {
 			decidedAppeals: [
 				expect.objectContaining({
-					caseDecisionOutcomeDate: expect.any(Date),
+					caseDecisionOutcomeDate: expect.any(String),
 					appealDecision: 'Allowed'
 				}),
 				expect.objectContaining({
-					caseDecisionOutcomeDate: expect.any(Date),
+					caseDecisionOutcomeDate: expect.any(String),
 					appealDecision: 'Invalid'
 				})
 			]

--- a/packages/forms-web-app/__tests__/unit/controllers/appeals/your-appeals/withdrawn-appeals.test.js
+++ b/packages/forms-web-app/__tests__/unit/controllers/appeals/your-appeals/withdrawn-appeals.test.js
@@ -54,10 +54,10 @@ describe('controllers/appeals/your-appeals/withdrawn-appeals', () => {
 		expect(res.render).toHaveBeenCalledWith(VIEW.YOUR_APPEALS.WITHDRAWN_APPEALS, {
 			withdrawnAppeals: [
 				expect.objectContaining({
-					caseWithdrawnDate: expect.any(Date)
+					caseWithdrawnDate: expect.any(String)
 				}),
 				expect.objectContaining({
-					caseWithdrawnDate: expect.any(Date)
+					caseWithdrawnDate: expect.any(String)
 				})
 			]
 		});

--- a/packages/forms-web-app/__tests__/unit/controllers/lpa-dashboard/withdrawn-appeals.test.js
+++ b/packages/forms-web-app/__tests__/unit/controllers/lpa-dashboard/withdrawn-appeals.test.js
@@ -65,10 +65,10 @@ describe('controllers/lpa-dashboard/withdrawn-appeals', () => {
 			lpaName: mockUser.lpaName,
 			withdrawnAppeals: [
 				expect.objectContaining({
-					caseWithdrawnDate: expect.any(Date)
+					caseWithdrawnDate: expect.any(String)
 				}),
 				expect.objectContaining({
-					caseWithdrawnDate: expect.any(Date)
+					caseWithdrawnDate: expect.any(String)
 				})
 			],
 			yourAppealsLink: `/${VIEW.LPA_DASHBOARD.DASHBOARD}`

--- a/packages/forms-web-app/src/controllers/selected-appeal/index.js
+++ b/packages/forms-web-app/src/controllers/selected-appeal/index.js
@@ -50,6 +50,12 @@ const userSectionsDict = {
 	[APPEAL_USER_ROLES.RULE_6_PARTY]: rule6Sections
 };
 
+const decisionDocumentTypes = [
+	APPEAL_DOCUMENT_TYPE.APPELLANT_COSTS_DECISION_LETTER,
+	APPEAL_DOCUMENT_TYPE.LPA_COSTS_DECISION_LETTER,
+	APPEAL_DOCUMENT_TYPE.CASE_DECISION_LETTER
+];
+
 /**
  * Shared controller for /appeals/:caseRef, manage-appeals/:caseRef rule-6-appeals/:caseRef
  * @param {string} layoutTemplate - njk template to extend
@@ -85,6 +91,13 @@ exports.get = (layoutTemplate = 'layouts/no-banner-link/main.njk') => {
 
 		const lpa = await getDepartmentFromCode(caseData.LPACode);
 		const headlineData = displayHeadlinesByUser(caseData, lpa.name, userType);
+
+		const unfilteredDecisionDocuments = isChildLinkedAppeal(caseData)
+			? await req.appealsApiClient.getDocumentsByCaseRef(
+					caseData.linkedCases[0]?.leadCaseReference,
+					decisionDocumentTypes
+				)
+			: caseData.Documents;
 
 		const isEnforcement = caseData.appealTypeCode === CASE_TYPES.ENFORCEMENT.processCode;
 
@@ -142,7 +155,7 @@ exports.get = (layoutTemplate = 'layouts/no-banner-link/main.njk') => {
 				decisionDate: formatDateForDisplay(caseData.caseDecisionOutcomeDate, {
 					format: 'd MMMM yyyy'
 				}),
-				decisionDocuments: filterDecisionDocuments(caseData.Documents ?? []),
+				decisionDocuments: filterDecisionDocuments(unfilteredDecisionDocuments ?? []),
 				lpaQuestionnaireDueDate: formatDateForNotification(caseData.lpaQuestionnaireDueDate),
 				statementDueDate: formatDateForNotification(caseData.statementDueDate),
 				rule6StatementDueDate: formatDateForNotification(caseData.statementDueDate),
@@ -185,11 +198,8 @@ const filterDecisionDocuments = (documents) => {
 			return false;
 		}
 
-		if (
-			document.documentType === APPEAL_DOCUMENT_TYPE.CASE_DECISION_LETTER ||
-			document.documentType === APPEAL_DOCUMENT_TYPE.LPA_COSTS_DECISION_LETTER ||
-			document.documentType === APPEAL_DOCUMENT_TYPE.APPELLANT_COSTS_DECISION_LETTER
-		) {
+		// @ts-ignore
+		if (decisionDocumentTypes.includes(document.documentType)) {
 			return true;
 		}
 		return false;

--- a/packages/forms-web-app/src/controllers/selected-appeal/index.test.js
+++ b/packages/forms-web-app/src/controllers/selected-appeal/index.test.js
@@ -2,11 +2,13 @@ const { get } = require('./index');
 const { determineUser } = require('../../lib/determine-user');
 const { getUserFromSession } = require('../../services/user.service');
 const { getDepartmentFromCode } = require('../../services/department.service');
+const { isChildLinkedAppeal } = require('@pins/common/src/lib/linked-appeals');
 const { VIEW } = require('../../lib/views');
 
 jest.mock('../../lib/determine-user');
 jest.mock('../../services/user.service');
 jest.mock('../../services/department.service');
+jest.mock('@pins/common/src/lib/linked-appeals');
 jest.mock('#lib/logger');
 
 describe('get', () => {
@@ -19,12 +21,17 @@ describe('get', () => {
 			appealsApiClient: {
 				getUserByEmailV2: jest.fn(),
 				getEventsByCaseRef: jest.fn(),
-				getAppealCaseWithRepresentations: jest.fn()
+				getAppealCaseWithRepresentations: jest.fn(),
+				getDocumentsByCaseRef: jest.fn()
 			}
 		};
 		res = {
 			render: jest.fn()
 		};
+	});
+
+	afterEach(() => {
+		jest.resetAllMocks();
 	});
 
 	it('should throw an error if user type is unknown', async () => {
@@ -38,6 +45,7 @@ describe('get', () => {
 	it('should render the view with the correct context', async () => {
 		determineUser.mockReturnValue('Appellant');
 		getUserFromSession.mockReturnValue({ email: 'test@example.com' });
+		isChildLinkedAppeal.mockReturnValue(false);
 		req.appealsApiClient.getUserByEmailV2.mockResolvedValue({ id: 'user-id' });
 		req.appealsApiClient.getAppealCaseWithRepresentations.mockResolvedValue({
 			LPACode: 'LPA123',
@@ -57,6 +65,59 @@ describe('get', () => {
 				appeal: expect.objectContaining({
 					appealNumber: '123',
 					baseUrl: '/appeals/123'
+				})
+			})
+		);
+	});
+
+	it('should render the view with the lead appeal decision docs - child appeal', async () => {
+		determineUser.mockReturnValue('Appellant');
+		getUserFromSession.mockReturnValue({ email: 'test@example.com' });
+		isChildLinkedAppeal.mockReturnValue(true);
+		req.appealsApiClient.getUserByEmailV2.mockResolvedValue({ id: 'user-id' });
+		req.appealsApiClient.getAppealCaseWithRepresentations.mockResolvedValue({
+			LPACode: 'LPA123',
+			caseReference: '123',
+			caseDecisionOutcome: 'GRANTED',
+			Documents: [],
+			linkedCases: [
+				{
+					leadCaseReference: '122',
+					childCaseReference: '123'
+				}
+			]
+		});
+		req.appealsApiClient.getEventsByCaseRef.mockResolvedValue([]);
+		req.appealsApiClient.getDocumentsByCaseRef.mockResolvedValue([
+			{
+				id: '31c354b1-287b-4492-92d7-4e23e3aa211c',
+				publishedDocumentURI: 'https://example.com/published/doc_002',
+				filename: 'lpa-costs-doc.txt',
+				documentType: 'lpaCostsDecisionLetter',
+				datePublished: null,
+				redacted: true,
+				virusCheckStatus: 'scanned',
+				published: true
+			}
+		]);
+		getDepartmentFromCode.mockResolvedValue({ name: 'Test LPA' });
+
+		const handler = get();
+
+		await handler(req, res);
+
+		expect(res.render).toHaveBeenCalledWith(
+			VIEW.SELECTED_APPEAL.APPEAL,
+			expect.objectContaining({
+				appeal: expect.objectContaining({
+					appealNumber: '123',
+					baseUrl: '/appeals/123',
+					decisionDocuments: expect.arrayContaining([
+						expect.objectContaining({
+							id: '31c354b1-287b-4492-92d7-4e23e3aa211c',
+							documentType: 'lpaCostsDecisionLetter'
+						})
+					])
 				})
 			})
 		);

--- a/packages/forms-web-app/src/lib/dashboard-functions.js
+++ b/packages/forms-web-app/src/lib/dashboard-functions.js
@@ -139,7 +139,7 @@ const mapToLPADashboardDisplayData = (appealCaseData) => {
 		appealDecision: mapDecisionLabel(appealCaseData.caseDecisionOutcome, isEnforcement),
 		appealDecisionColor: mapDecisionColour(appealCaseData.caseDecisionOutcome),
 		caseDecisionOutcomeDate: formatDateForDisplay(appealCaseData.caseDecisionOutcomeDate),
-		caseWithdrawnDate: appealCaseData.caseWithdrawnDate,
+		caseWithdrawnDate: formatDateForDisplay(appealCaseData.caseWithdrawnDate),
 		linkedCaseDetails: formatDashboardLinkedCaseDetails(appealCaseData),
 		displayNextJourneyLink: displayNextJourneyLink(appealCaseData, LPA_USER_ROLE)
 	};
@@ -190,11 +190,11 @@ const mapToAppellantDashboardDisplayData = (appealData, featureFlags) => {
 			caseDecisionOutcomeDate:
 				isAppealSubmission(appealData) || isV2Submission(appealData)
 					? null
-					: appealData.caseDecisionOutcomeDate,
+					: formatDateForDisplay(appealData.caseDecisionOutcomeDate),
 			caseWithdrawnDate:
 				isAppealSubmission(appealData) || isV2Submission(appealData)
 					? null
-					: appealData.caseWithdrawnDate,
+					: formatDateForDisplay(appealData.caseWithdrawnDate),
 			linkedCaseDetails: isAppealSubmission(appealData)
 				? null
 				: formatDashboardLinkedCaseDetails(appealData),
@@ -235,7 +235,7 @@ const mapToRule6DashboardDisplayData = (appealCaseData) => {
 		appealDecision: mapDecisionLabel(appealCaseData.caseDecisionOutcome, isEnforcement),
 		appealDecisionColor: mapDecisionColour(appealCaseData.caseDecisionOutcome),
 		caseDecisionOutcomeDate: formatDateForDisplay(appealCaseData.caseDecisionOutcomeDate),
-		caseWithdrawnDate: appealCaseData.caseWithdrawnDate,
+		caseWithdrawnDate: formatDateForDisplay(appealCaseData.caseWithdrawnDate),
 		linkedCaseDetails: formatDashboardLinkedCaseDetails(appealCaseData)
 	};
 };


### PR DESCRIPTION
…f child linked appeal

### Description of change

BO no longer broadcasts decision documents for child linked appeals.  These changes put in place a new api route for retrieving documents for a case, with an option to specify docType in the query params.

It also fixes and issue with timezones for the decision date on Appellant dashboards.

Ticket: https://pins-ds.atlassian.net/browse/A2-8764
https://pins-ds.atlassian.net/browse/A2-8761

### Checklist

- [X] Feature complete and ready for users, or behind feature-flag
- [X] Commit history is linear with no merge commits
- [ ] Requires infrastructure changes

### Important

Please do not merge from `main` (please only [rebase](https://github.com/Planning-Inspectorate/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
