### PR TITLE
fix(A2-8764): show appeal decision documents on ip appeal page

### DIFF
--- a/packages/forms-web-app/src/controllers/selected-appeal/index.js
+++ b/packages/forms-web-app/src/controllers/selected-appeal/index.js
@@ -12,6 +12,8 @@ const {
 	isLPAFinalCommentOpen
 } = require('@pins/business-rules/src/rules/appeal-case/case-due-dates');
 
+const { filterDecisionDocuments } = require('../../utils/format-comment-decided-data');
+
 const { APPEAL_USER_ROLES, LPA_USER_ROLE } = require('@pins/common/src/constants');
 const {
 	formatSections,
@@ -180,35 +182,6 @@ exports.get = (layoutTemplate = 'layouts/no-banner-link/main.njk') => {
 const formatTitleSuffix = (userType) => {
 	if (userType === LPA_USER_ROLE) return 'Manage your appeals';
 	return 'Appeal a planning decision';
-};
-
-/**
- * @param {import('appeals-service-api').Api.Document[]} documents
- * @return {import('appeals-service-api').Api.Document[]}
- */
-const filterDecisionDocuments = (documents) => {
-	const decisionDocumentDisplayOrder = {
-		[APPEAL_DOCUMENT_TYPE.CASE_DECISION_LETTER]: 0,
-		[APPEAL_DOCUMENT_TYPE.APPELLANT_COSTS_DECISION_LETTER]: 1,
-		[APPEAL_DOCUMENT_TYPE.LPA_COSTS_DECISION_LETTER]: 2
-	};
-
-	const decisionDocuments = documents.filter((document) => {
-		if (!document.published) {
-			return false;
-		}
-
-		// @ts-ignore
-		if (decisionDocumentTypes.includes(document.documentType)) {
-			return true;
-		}
-		return false;
-	});
-
-	return decisionDocuments.sort(
-		(a, b) =>
-			decisionDocumentDisplayOrder[a.documentType] - decisionDocumentDisplayOrder[b.documentType]
-	);
 };
 
 /**

--- a/packages/forms-web-app/src/routes/file-based-router/comment-planning-appeal/appeals/_appealNumber/controller.js
+++ b/packages/forms-web-app/src/routes/file-based-router/comment-planning-appeal/appeals/_appealNumber/controller.js
@@ -9,6 +9,14 @@ const { getDepartmentFromCode } = require('../../../../../services/department.se
 const {
 	createInterestedPartySession
 } = require('../../../../../services/interested-party.service');
+const { APPEAL_DOCUMENT_TYPE } = require('@planning-inspectorate/data-model');
+const { isChildLinkedAppeal } = require('@pins/common/src/lib/linked-appeals');
+
+const decisionDocumentTypes = [
+	APPEAL_DOCUMENT_TYPE.APPELLANT_COSTS_DECISION_LETTER,
+	APPEAL_DOCUMENT_TYPE.LPA_COSTS_DECISION_LETTER,
+	APPEAL_DOCUMENT_TYPE.CASE_DECISION_LETTER
+];
 
 /** @type {import('express').Handler} */
 const selectedAppeal = async (req, res) => {
@@ -26,7 +34,15 @@ const selectedAppeal = async (req, res) => {
 
 	const deadlineText = formatCommentDeadlineText(appeal, status);
 
-	const decidedData = formatCommentDecidedData(appeal);
+	const unfilteredDecisionDocuments = isChildLinkedAppeal(appeal)
+		? await req.appealsApiClient.getDocumentsByCaseRef(
+				// @ts-ignore
+				appeal.linkedCases[0]?.leadCaseReference,
+				decisionDocumentTypes
+			)
+		: appeal.Documents;
+
+	const decidedData = formatCommentDecidedData(appeal, unfilteredDecisionDocuments);
 
 	const inquiries = appeal.Events ? formatCommentInquiryText(appeal.Events) : [];
 	const hearings = appeal.Events ? formatCommentHearingText(appeal.Events, appeal.caseStatus) : [];

--- a/packages/forms-web-app/src/routes/file-based-router/comment-planning-appeal/appeals/_appealNumber/controller.test.js
+++ b/packages/forms-web-app/src/routes/file-based-router/comment-planning-appeal/appeals/_appealNumber/controller.test.js
@@ -10,6 +10,8 @@ const { getDepartmentFromCode } = require('../../../../../services/department.se
 const {
 	createInterestedPartySession
 } = require('../../../../../services/interested-party.service');
+const { isChildLinkedAppeal } = require('@pins/common/src/lib/linked-appeals');
+const { APPEAL_DOCUMENT_TYPE } = require('@planning-inspectorate/data-model');
 
 jest.mock('#utils/appeal-status');
 jest.mock('../../../../../utils/format-deadline-text');
@@ -20,6 +22,7 @@ jest.mock('../../../../../utils/format-comment-hearing-text');
 jest.mock('@pins/common');
 jest.mock('../../../../../services/department.service');
 jest.mock('../../../../../services/interested-party.service');
+jest.mock('@pins/common/src/lib/linked-appeals');
 
 describe('selectedAppeal Controller Tests', () => {
 	let req, res;
@@ -31,7 +34,11 @@ describe('selectedAppeal Controller Tests', () => {
 				caseReference: '12345',
 				LPACode: 'LPA123',
 				siteAddressPostcode: 'AB12 3CD',
-				Events: []
+				Events: [],
+				Documents: []
+			},
+			appealsApiClient: {
+				getDocumentsByCaseRef: jest.fn()
 			}
 		};
 		res = {
@@ -39,7 +46,11 @@ describe('selectedAppeal Controller Tests', () => {
 		};
 	});
 
-	it('should render the appeal page with formatted data', async () => {
+	afterEach(() => {
+		jest.resetAllMocks();
+	});
+
+	it('should render the appeal page with formatted data - not child linked appeal', async () => {
 		const lpa = { name: 'Local Planning Authority' };
 		const status = 'In Progress';
 		const headlineText = 'Headline Text';
@@ -49,6 +60,105 @@ describe('selectedAppeal Controller Tests', () => {
 		const hearings = [];
 
 		getDepartmentFromCode.mockResolvedValue(lpa);
+		isChildLinkedAppeal.mockReturnValue(false);
+		getAppealStatus.mockReturnValue(status);
+		formatCommentHeadlineText.mockReturnValue(headlineText);
+		formatCommentDeadlineText.mockReturnValue(deadlineText);
+		formatCommentDecidedData.mockReturnValue(decidedData);
+		formatCommentInquiryText.mockReturnValue(inquiries);
+		formatCommentHearingText.mockReturnValue(hearings);
+		formatHeadlineData.mockReturnValue('Headline Data');
+
+		await selectedAppeal(req, res);
+
+		expect(createInterestedPartySession).toHaveBeenCalledWith(req, '12345', 'AB12 3CD');
+		expect(getDepartmentFromCode).toHaveBeenCalledWith('LPA123');
+		expect(req.appealsApiClient.getDocumentsByCaseRef).not.toHaveBeenCalled();
+		expect(getAppealStatus).toHaveBeenCalledWith(req.appealCase);
+		expect(formatCommentHeadlineText).toHaveBeenCalledWith('12345', status);
+		expect(formatCommentDeadlineText).toHaveBeenCalledWith(req.appealCase, status);
+		expect(formatCommentDecidedData).toHaveBeenCalledWith(req.appealCase, []);
+		expect(formatCommentInquiryText).toHaveBeenCalledWith(req.appealCase.Events);
+		expect(formatCommentHearingText).toHaveBeenCalledWith(
+			req.appealCase.Events,
+			req.appealCase.caseStatus
+		);
+		expect(formatHeadlineData).toHaveBeenCalledWith({
+			caseData: req.appealCase,
+			lpaName: lpa.name
+		});
+		expect(res.render).toHaveBeenCalledWith('comment-planning-appeal/appeals/_appealNumber/index', {
+			appeal: {
+				...req.appealCase,
+				status,
+				headlineText,
+				deadlineText,
+				decidedData,
+				inquiries,
+				hearings
+			},
+			headlineData: 'Headline Data'
+		});
+	});
+
+	it('should render the appeal page with formatted data - child linked appeal', async () => {
+		const lpa = { name: 'Local Planning Authority' };
+		const status = 'In Progress';
+		const headlineText = 'Headline Text';
+		const deadlineText = 'Deadline Text';
+		const decidedData = 'Decided Data';
+		const inquiries = [];
+		const hearings = [];
+
+		req.appealCase.linkedCases = [
+			{
+				leadCaseReference: 'testLeadRef',
+				childCaseReference: '12345'
+			}
+		];
+
+		const decisionDocumentTypes = [
+			APPEAL_DOCUMENT_TYPE.APPELLANT_COSTS_DECISION_LETTER,
+			APPEAL_DOCUMENT_TYPE.LPA_COSTS_DECISION_LETTER,
+			APPEAL_DOCUMENT_TYPE.CASE_DECISION_LETTER
+		];
+
+		const decisionDocuments = [
+			{
+				id: '31c354b1-287b-4492-92d7-4e23e3aa211c',
+				publishedDocumentURI: 'https://example.com/published/doc_002',
+				filename: 'lpa-costs-doc.txt',
+				documentType: 'lpaCostsDecisionLetter',
+				datePublished: null,
+				redacted: true,
+				virusCheckStatus: 'scanned',
+				published: true
+			},
+			{
+				id: '31c354b1-287b-4492-92d7-4e23e3aa211e',
+				publishedDocumentURI: 'https://example.com/published/doc_001',
+				filename: 'cost-decision-doc.txt',
+				documentType: 'appellantCostsDecisionLetter',
+				datePublished: null,
+				redacted: true,
+				virusCheckStatus: 'scanned',
+				published: true
+			},
+			{
+				id: '41c354b1-287b-4492-92d7-4e23e3aa211e',
+				publishedDocumentURI: 'https://example.com/published/doc_001',
+				filename: 'cost-decision-doc.txt',
+				documentType: 'appellantCostsDecisionLetter',
+				datePublished: null,
+				redacted: true,
+				virusCheckStatus: 'scanned',
+				published: false
+			}
+		];
+
+		getDepartmentFromCode.mockResolvedValue(lpa);
+		isChildLinkedAppeal.mockReturnValue(true);
+		req.appealsApiClient.getDocumentsByCaseRef.mockResolvedValue(decisionDocuments);
 		getAppealStatus.mockReturnValue(status);
 		formatCommentHeadlineText.mockReturnValue(headlineText);
 		formatCommentDeadlineText.mockReturnValue(deadlineText);
@@ -62,9 +172,13 @@ describe('selectedAppeal Controller Tests', () => {
 		expect(createInterestedPartySession).toHaveBeenCalledWith(req, '12345', 'AB12 3CD');
 		expect(getDepartmentFromCode).toHaveBeenCalledWith('LPA123');
 		expect(getAppealStatus).toHaveBeenCalledWith(req.appealCase);
+		expect(req.appealsApiClient.getDocumentsByCaseRef).toHaveBeenCalledWith(
+			'testLeadRef',
+			decisionDocumentTypes
+		);
 		expect(formatCommentHeadlineText).toHaveBeenCalledWith('12345', status);
 		expect(formatCommentDeadlineText).toHaveBeenCalledWith(req.appealCase, status);
-		expect(formatCommentDecidedData).toHaveBeenCalledWith(req.appealCase);
+		expect(formatCommentDecidedData).toHaveBeenCalledWith(req.appealCase, decisionDocuments);
 		expect(formatCommentInquiryText).toHaveBeenCalledWith(req.appealCase.Events);
 		expect(formatCommentHearingText).toHaveBeenCalledWith(
 			req.appealCase.Events,

--- a/packages/forms-web-app/src/utils/format-comment-decided-data.js
+++ b/packages/forms-web-app/src/utils/format-comment-decided-data.js
@@ -6,12 +6,19 @@ const { APPEAL_DOCUMENT_TYPE } = require('@planning-inspectorate/data-model');
 const { formatDateForDisplay } = require('@pins/common/src/lib/format-date');
 const { CASE_TYPES } = require('@pins/common/src/database/data-static');
 
+const decisionDocumentTypes = [
+	APPEAL_DOCUMENT_TYPE.APPELLANT_COSTS_DECISION_LETTER,
+	APPEAL_DOCUMENT_TYPE.LPA_COSTS_DECISION_LETTER,
+	APPEAL_DOCUMENT_TYPE.CASE_DECISION_LETTER
+];
+
 /**
  * @typedef {import("./appeals-view").AppealViewModel} AppealViewModel
  * @param {AppealViewModel} appeal
+ * @param {import('appeals-service-api').Api.Document[]} unfilteredDecisionDocuments
  * @returns {object }
  */
-exports.formatCommentDecidedData = (appeal) => {
+const formatCommentDecidedData = (appeal, unfilteredDecisionDocuments = []) => {
 	if (!appeal.caseDecisionOutcomeDate) return {};
 
 	const isEnforcement =
@@ -25,7 +32,7 @@ exports.formatCommentDecidedData = (appeal) => {
 		formattedDecisionColour: mapDecisionColour(appeal.caseDecisionOutcome),
 		caseDecisionOutcome:
 			mapDecisionLabel(appeal.caseDecisionOutcome, isEnforcement) ?? appeal.caseDecisionOutcome,
-		decisionDocuments: filterDecisionDocuments(appeal.Documents)
+		decisionDocuments: filterDecisionDocuments(unfilteredDecisionDocuments ?? [])
 	};
 };
 
@@ -33,10 +40,32 @@ exports.formatCommentDecidedData = (appeal) => {
  * @param {import('appeals-service-api').Api.Document[]} documents
  * @return {import('appeals-service-api').Api.Document[]}
  */
-const filterDecisionDocuments = (documents) =>
-	documents.filter(
-		(document) =>
-			document.documentType === APPEAL_DOCUMENT_TYPE.CASE_DECISION_LETTER ||
-			document.documentType === APPEAL_DOCUMENT_TYPE.LPA_COSTS_DECISION_LETTER ||
-			document.documentType === APPEAL_DOCUMENT_TYPE.APPELLANT_COSTS_DECISION_LETTER
+const filterDecisionDocuments = (documents) => {
+	const decisionDocumentDisplayOrder = {
+		[APPEAL_DOCUMENT_TYPE.CASE_DECISION_LETTER]: 0,
+		[APPEAL_DOCUMENT_TYPE.APPELLANT_COSTS_DECISION_LETTER]: 1,
+		[APPEAL_DOCUMENT_TYPE.LPA_COSTS_DECISION_LETTER]: 2
+	};
+
+	const decisionDocuments = documents.filter((document) => {
+		if (!document.published) {
+			return false;
+		}
+
+		// @ts-ignore
+		if (decisionDocumentTypes.includes(document.documentType)) {
+			return true;
+		}
+		return false;
+	});
+
+	return decisionDocuments.sort(
+		(a, b) =>
+			decisionDocumentDisplayOrder[a.documentType] - decisionDocumentDisplayOrder[b.documentType]
 	);
+};
+
+module.exports = {
+	formatCommentDecidedData,
+	filterDecisionDocuments
+};

--- a/packages/forms-web-app/src/utils/format-comment-decided-data.test.js
+++ b/packages/forms-web-app/src/utils/format-comment-decided-data.test.js
@@ -1,49 +1,60 @@
-const { formatCommentDecidedData } = require('./format-comment-decided-data');
+const {
+	formatCommentDecidedData,
+	filterDecisionDocuments
+} = require('./format-comment-decided-data');
 const { APPEAL_DOCUMENT_TYPE } = require('@planning-inspectorate/data-model');
 
 describe('formatCommentDecidedData', () => {
 	const appeal = {
 		caseDecisionOutcomeDate: '2024-12-31',
-		caseDecisionOutcome: 'allowed',
-		Documents: [
-			{ documentType: APPEAL_DOCUMENT_TYPE.CASE_DECISION_LETTER, id: 'doc1' },
-			{ documentType: APPEAL_DOCUMENT_TYPE.APPELLANT_COSTS_DECISION_LETTER, id: 'doc2' },
-			{ documentType: APPEAL_DOCUMENT_TYPE.LPA_COSTS_DECISION_LETTER, id: 'doc3' },
-			{ documentType: 'other', id: 'doc4' }
-		]
+		caseDecisionOutcome: 'allowed'
 	};
 
 	it('should return an empty object if caseDecisionOutcomeDate is not provided', () => {
 		const appealWithoutDate = { ...appeal, caseDecisionOutcomeDate: undefined };
-		expect(formatCommentDecidedData(appealWithoutDate)).toEqual({});
+		expect(formatCommentDecidedData(appealWithoutDate, [])).toEqual({});
 	});
 
 	it('should return formatted data when caseDecisionOutcomeDate is provided', () => {
-		const result = formatCommentDecidedData(appeal);
+		const result = formatCommentDecidedData(appeal, []);
 		expect(result).toEqual({
 			formattedCaseDecisionDate: '31 December 2024',
 			formattedDecisionColour: 'green',
 			caseDecisionOutcome: 'Allowed',
-			decisionDocuments: [
-				{ documentType: APPEAL_DOCUMENT_TYPE.CASE_DECISION_LETTER, id: 'doc1' },
-				{ documentType: APPEAL_DOCUMENT_TYPE.APPELLANT_COSTS_DECISION_LETTER, id: 'doc2' },
-				{ documentType: APPEAL_DOCUMENT_TYPE.LPA_COSTS_DECISION_LETTER, id: 'doc3' }
-			]
+			decisionDocuments: []
 		});
 	});
 
 	it('should return the caseDecisionOutcome as is if it is not in APPEAL_CASE_DECISION_OUTCOME', () => {
 		const appealWithUnknownOutcome = { ...appeal, caseDecisionOutcome: 'unknown' };
-		const result = formatCommentDecidedData(appealWithUnknownOutcome);
+		const result = formatCommentDecidedData(appealWithUnknownOutcome, []);
 		expect(result.caseDecisionOutcome).toBe('unknown');
 	});
+});
 
-	it('should filter decision documents correctly', () => {
-		const result = formatCommentDecidedData(appeal);
-		expect(result.decisionDocuments).toEqual([
-			{ documentType: APPEAL_DOCUMENT_TYPE.CASE_DECISION_LETTER, id: 'doc1' },
-			{ documentType: APPEAL_DOCUMENT_TYPE.APPELLANT_COSTS_DECISION_LETTER, id: 'doc2' },
-			{ documentType: APPEAL_DOCUMENT_TYPE.LPA_COSTS_DECISION_LETTER, id: 'doc3' }
+describe('filterDecisionDocuments', () => {
+	const unfilteredDecisionDocuments = [
+		{
+			documentType: APPEAL_DOCUMENT_TYPE.APPELLANT_COSTS_DECISION_LETTER,
+			published: true,
+			id: 'doc1'
+		},
+		{ documentType: APPEAL_DOCUMENT_TYPE.CASE_DECISION_LETTER, published: true, id: 'doc2' },
+		//not published
+		{ documentType: APPEAL_DOCUMENT_TYPE.LPA_COSTS_DECISION_LETTER, published: false, id: 'doc3' },
+		//not a decision documents
+		{ documentType: 'other', id: 'doc4' }
+	];
+
+	it('should filter decision documents correctly and return in the correct order', () => {
+		const result = filterDecisionDocuments(unfilteredDecisionDocuments);
+		expect(result).toEqual([
+			{ documentType: APPEAL_DOCUMENT_TYPE.CASE_DECISION_LETTER, published: true, id: 'doc2' },
+			{
+				documentType: APPEAL_DOCUMENT_TYPE.APPELLANT_COSTS_DECISION_LETTER,
+				published: true,
+				id: 'doc1'
+			}
 		]);
 	});
 });


### PR DESCRIPTION
### Description of change

Show appeal decision docs on child linked appeals.

Show decision docs in correct order.

Ticket: https://pins-ds.atlassian.net/browse/A2-8764
https://pins-ds.atlassian.net/browse/A2-8784

### Checklist

- [X] Feature complete and ready for users, or behind feature-flag
- [X] Commit history is linear with no merge commits
- [ ] Requires infrastructure changes

### Important

Please do not merge from `main` (please only [rebase](https://github.com/Planning-Inspectorate/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
