### PR TITLE
fix: include staging resource group in purge pipeline

### DIFF
--- a/azure-pipelines-purge-container-registry.yml
+++ b/azure-pipelines-purge-container-registry.yml
@@ -49,7 +49,7 @@ jobs:
           resourceGroupsBySub: >
             {
               "dev": ["pins-rg-appeals-service-dev-uks-001", "pins-rg-appeals-service-dev-ukw-001"],
-              "test": ["pins-rg-appeals-service-test-uks-001", "pins-rg-appeals-service-test-ukw-001"],
+              "test": ["pins-rg-appeals-service-test-uks-001", "pins-rg-appeals-service-test-ukw-001", pins-rg-appeals-service-staging-ukw-001],
               "training": ["pins-rg-appeals-service-training-uks-001", "pins-rg-appeals-service-training-ukw-001"],
               "prod": ["pins-rg-appeals-service-prod-uks-001", "pins-rg-appeals-service-prod-ukw-001"]
             }


### PR DESCRIPTION
### Description of change

Include staging resource group in container registry purge list (currently may purge an image in use in those envs)

### Checklist

- [x] Feature complete and ready for users, or behind feature-flag
- [x] Commit history is linear with no merge commits
- [ ] Requires infrastructure changes

### Important

Please do not merge from `main` (please only [rebase](https://github.com/Planning-Inspectorate/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
