### PR TITLE
fix(a2-8808): bump multer field limit for pdf

### DIFF
--- a/packages/pdf-service-api/src/app.test.js
+++ b/packages/pdf-service-api/src/app.test.js
@@ -1,7 +1,12 @@
 const supertest = require('supertest');
+
+const chunkSize = 512;
+const maxLength = 1 * chunkSize;
+process.env.FILE_MAX_SIZE_IN_BYTES = String(maxLength);
+const generatePdf = require('./lib/generatePdf');
+
 const app = require('./app');
 
-const generatePdf = require('./lib/generatePdf');
 jest.mock('../src/lib/generatePdf'); // needs mocking as dependency on chromium/linux machine
 
 describe('app', () => {
@@ -24,13 +29,32 @@ describe('app', () => {
 
 	describe('POST /api/v1/generate', () => {
 		it('should parse multipart form data and call postGeneratePdf with the correct data', async () => {
-			const htmlContent = '<html><body><h1>Test PDF</h1></body></html>';
+			const htmlContent = '<html><body></body></html>';
 
 			const response = await supertest(app).post('/api/v1/generate').field('html', htmlContent);
 
 			expect(generatePdf).toHaveBeenCalledWith(htmlContent);
 			expect(response.status).toBe(200);
 			expect(response.body).toBeInstanceOf(Buffer);
+		});
+
+		it('should error if request is too large', async () => {
+			const chunk = 'x'.repeat(chunkSize);
+			const chunks = ['<html><body>'];
+			let currentSize = chunks[0].length + '</body></html>'.length;
+
+			while (currentSize < maxLength + chunkSize) {
+				chunks.push(chunk);
+				currentSize += chunk.length;
+			}
+
+			chunks.push('</body></html>');
+
+			const htmlContent = chunks.join('');
+
+			const response = await supertest(app).post('/api/v1/generate').field('html', htmlContent);
+
+			expect(response.status).toBe(500);
 		});
 	});
 });

--- a/packages/pdf-service-api/src/routes/pdf.js
+++ b/packages/pdf-service-api/src/routes/pdf.js
@@ -8,7 +8,10 @@ const router = express.Router();
 router.post(
 	'/generate',
 	multer({
-		limits: { fileSize: config.fileUpload.maxSizeInBytes },
+		limits: {
+			fileSize: config.fileUpload.maxSizeInBytes,
+			fieldSize: config.fileUpload.maxSizeInBytes
+		},
 		dest: config.fileUpload.path
 	}).single('html'),
 	postGeneratePdf

--- a/packages/pdf-service-api/src/routes/pdf.test.js
+++ b/packages/pdf-service-api/src/routes/pdf.test.js
@@ -14,11 +14,13 @@ describe('routes/pdf', () => {
 		// eslint-disable-next-line global-require
 		require('./pdf');
 
-		expect(mockPost).toHaveBeenCalledTimes(1);
-		expect(mockPost).toHaveBeenCalledWith(
-			'/generate',
-			multer(config.fileUpload).single('html'),
-			postGeneratePdf
-		);
+		expect(multer).toHaveBeenCalledWith({
+			limits: {
+				fileSize: config.fileUpload.maxSizeInBytes,
+				fieldSize: config.fileUpload.maxSizeInBytes
+			},
+			dest: config.fileUpload.path
+		});
+		expect(mockPost).toHaveBeenCalledWith('/generate', undefined, postGeneratePdf);
 	});
 });


### PR DESCRIPTION
### Description of change

Bumps limit for multer in pdf service to allow larger pdf generation

Ticket: https://pins-ds.atlassian.net/browse/A2-8808

### Checklist

- [x] Feature complete and ready for users, or behind feature-flag
- [x] Commit history is linear with no merge commits
- [ ] Requires infrastructure changes

### Important

Please do not merge from `main` (please only [rebase](https://github.com/Planning-Inspectorate/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
