### PR TITLE
fix(web): including published on appeal docs for IP dashboard (A2-8865)

### DIFF
--- a/packages/forms-web-app/src/routes/file-based-router/comment-planning-appeal/appeals/_appealNumber/index.js
+++ b/packages/forms-web-app/src/routes/file-based-router/comment-planning-appeal/appeals/_appealNumber/index.js
@@ -38,7 +38,8 @@ router.get(
 			select: {
 				id: true,
 				filename: true,
-				documentType: true
+				documentType: true,
+				published: true
 			},
 			where: {
 				documentType: {


### PR DESCRIPTION
so that published check works as expected

### Description of change

- Adding include of published info onto the appeal for the IP dashboard as filterDecisionDocuments now checks that the document is published: https://github.com/Planning-Inspectorate/appeal-planning-decision/blob/473154bac8b2ea3565566118a087bfb9bd8f180e/packages/forms-web-app/src/utils/format-comment-decided-data.js#L43-L66

Ticket: https://pins-ds.atlassian.net/browse/A2-8865

Tested locally:
<img width="999" height="841" alt="image" src="https://github.com/user-attachments/assets/8fedce1b-7981-4b09-9767-6e28b4860be3" />

### Checklist

- [x] Feature complete and ready for users, or behind feature-flag
- [x] Commit history is linear with no merge commits
- [ ] Requires infrastructure changes

### Important

Please do not merge from `main` (please only [rebase](https://github.com/Planning-Inspectorate/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
