### PR TITLE
fix: hide cancelled hearings and inquiries on IP dashboard (A2-8488)

### DIFF
--- a/packages/forms-web-app/src/routes/file-based-router/comment-planning-appeal/appeals/_appealNumber/index.js
+++ b/packages/forms-web-app/src/routes/file-based-router/comment-planning-appeal/appeals/_appealNumber/index.js
@@ -54,7 +54,8 @@ router.get(
 		Events: {
 			select: {
 				type: true,
-				startDate: true
+				startDate: true,
+				status: true
 			}
 		},
 

--- a/packages/forms-web-app/src/utils/format-comment-hearing-text.js
+++ b/packages/forms-web-app/src/utils/format-comment-hearing-text.js
@@ -1,6 +1,7 @@
 const { EVENT_TYPES } = require('@pins/common/src/constants');
 const { format: formatDate } = require('date-fns');
 const { utcToZonedTime } = require('date-fns-tz');
+const { APPEAL_EVENT_STATUS } = require('@planning-inspectorate/data-model');
 
 /**
  * @typedef {import('appeals-service-api').Api.Event} Event
@@ -12,8 +13,10 @@ const { utcToZonedTime } = require('date-fns-tz');
  * @returns {Array<string>}
  */
 exports.formatCommentHearingText = (events, caseStatus) => {
-	const hearings = events.filter((event) => event.type === EVENT_TYPES.HEARING);
-	if (caseStatus === 'withdrawn') {
+	const hearings = events.filter(
+		(event) => event.type === EVENT_TYPES.HEARING && event.status !== APPEAL_EVENT_STATUS.WITHDRAWN
+	);
+	if (caseStatus === APPEAL_EVENT_STATUS.WITHDRAWN) {
 		return [];
 	}
 	return hearings.length

--- a/packages/forms-web-app/src/utils/format-comment-hearing-text.test.js
+++ b/packages/forms-web-app/src/utils/format-comment-hearing-text.test.js
@@ -1,4 +1,5 @@
 const { formatCommentHearingText } = require('./format-comment-hearing-text');
+const { APPEAL_EVENT_STATUS } = require('@planning-inspectorate/data-model');
 
 describe('formatCommentHearingText', () => {
 	const siteVisitEvent = {
@@ -28,5 +29,48 @@ describe('formatCommentHearingText', () => {
 		expect(formatCommentHearingText(events)).toEqual([
 			'The hearing will start on 29 December 2024.'
 		]);
+	});
+
+	it('returns empty array if hearing is withdrawn', () => {
+		const withdrawnHearing = {
+			...hearingEvent,
+			status: 'withdrawn'
+		};
+		const events = [withdrawnHearing];
+		expect(formatCommentHearingText(events)).toHaveLength(0);
+	});
+
+	it('filters out withdrawn hearings but includes active ones', () => {
+		const withdrawnHearing = {
+			...hearingEvent,
+			internalId: 'test456',
+			status: APPEAL_EVENT_STATUS.WITHDRAWN,
+			startDate: new Date(2024, 11, 29, 9)
+		};
+		const activeHearing = {
+			...hearingEvent,
+			internalId: 'test789',
+			startDate: new Date(2024, 12, 15, 10)
+		};
+		const events = [withdrawnHearing, activeHearing];
+		expect(formatCommentHearingText(events)).toEqual([
+			'The hearing will start on 15 January 2025.'
+		]);
+	});
+
+	it('returns empty array if event status is withdrawn', () => {
+		const withdrawnHearing = {
+			...hearingEvent,
+			internalId: 'test456',
+			status: APPEAL_EVENT_STATUS.WITHDRAWN,
+			startDate: new Date(2024, 11, 29, 9)
+		};
+		const events = [withdrawnHearing];
+		expect(formatCommentHearingText(events)).toHaveLength(0);
+	});
+
+	it('returns empty array if case status is withdrawn', () => {
+		const events = [hearingEvent];
+		expect(formatCommentHearingText(events, APPEAL_EVENT_STATUS.WITHDRAWN)).toHaveLength(0);
 	});
 });

--- a/packages/forms-web-app/src/utils/format-comment-inquiry-text.js
+++ b/packages/forms-web-app/src/utils/format-comment-inquiry-text.js
@@ -3,6 +3,7 @@
  */
 
 const { EVENT_TYPES } = require('@pins/common/src/constants');
+const { APPEAL_EVENT_STATUS } = require('@planning-inspectorate/data-model');
 const { format: formatDate } = require('date-fns');
 const { utcToZonedTime } = require('date-fns-tz');
 
@@ -11,7 +12,9 @@ const { utcToZonedTime } = require('date-fns-tz');
  * @returns {Array<string>}
  */
 exports.formatCommentInquiryText = (events) => {
-	const inquiries = events.filter((event) => event.type === EVENT_TYPES.INQUIRY);
+	const inquiries = events.filter(
+		(event) => event.type === EVENT_TYPES.INQUIRY && event.status !== APPEAL_EVENT_STATUS.WITHDRAWN
+	);
 	return inquiries.length
 		? inquiries.map((inquiry) => {
 				const date = inquiry.startDate;

--- a/packages/forms-web-app/src/utils/format-comment-inquiry-text.test.js
+++ b/packages/forms-web-app/src/utils/format-comment-inquiry-text.test.js
@@ -1,4 +1,5 @@
 const { formatCommentInquiryText } = require('./format-comment-inquiry-text');
+const { APPEAL_EVENT_STATUS } = require('@planning-inspectorate/data-model');
 
 describe('formatCommentInquiryText', () => {
 	const siteVisitEvent = {
@@ -26,6 +27,33 @@ describe('formatCommentInquiryText', () => {
 		const events = [siteVisitEvent, inquiryEvent];
 		expect(formatCommentInquiryText(events)).toEqual([
 			'The inquiry will start on 29 December 2024.'
+		]);
+	});
+
+	it('returns empty array if inquiry is withdrawn', () => {
+		const withdrawnInquiry = {
+			...inquiryEvent,
+			status: APPEAL_EVENT_STATUS.WITHDRAWN
+		};
+		const events = [withdrawnInquiry];
+		expect(formatCommentInquiryText(events)).toHaveLength(0);
+	});
+
+	it('filters out withdrawn inquiries but includes active ones', () => {
+		const withdrawnInquiry = {
+			...inquiryEvent,
+			internalId: 'test456',
+			status: APPEAL_EVENT_STATUS.WITHDRAWN,
+			startDate: new Date(2024, 11, 29, 9)
+		};
+		const activeInquiry = {
+			...inquiryEvent,
+			internalId: 'test789',
+			startDate: new Date(2024, 12, 15, 10)
+		};
+		const events = [withdrawnInquiry, activeInquiry];
+		expect(formatCommentInquiryText(events)).toEqual([
+			'The inquiry will start on 15 January 2025.'
 		]);
 	});
 });


### PR DESCRIPTION
### Description of change

Bug in testing found that hearings and inquiries were still appearing on IP dashboard after being cancelled.

This PR hides cancelled hearings and inquiries from the IP dashboard.

Ticket: https://pins-ds.atlassian.net/browse/A2-8488

### Checklist

- [x] Feature complete and ready for users, or behind feature-flag
- [x] Commit history is linear with no merge commits
- [ ] Requires infrastructure changes

### Important

Please do not merge from `main` (please only [rebase](https://github.com/Planning-Inspectorate/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
