### PR TITLE
fix(A2-8889): broadcast HAS expedited fields

### DIFF
--- a/packages/appeals-service-api/src/routes/v2/appeal-cases/_caseReference/lpa-questionnaire-submission/submit/index.test.js
+++ b/packages/appeals-service-api/src/routes/v2/appeal-cases/_caseReference/lpa-questionnaire-submission/submit/index.test.js
@@ -487,7 +487,16 @@ const expectedHAS = {
 	]
 };
 
-const formattedHAS = [expect.objectContaining(expectedHAS)];
+const formattedHAS = [
+	expect.objectContaining({
+		casedata: {
+			...expectedHAS.casedata,
+			significantChangesAffectingApplicationLpa: null,
+			listOfDocumentsBeforeDecision: undefined
+		},
+		documents: [...expectedHAS.documents]
+	})
+];
 
 const formattedS78 = [
 	expect.objectContaining({

--- a/packages/appeals-service-api/src/services/back-office-v2/formatters/has/questionnaire.js
+++ b/packages/appeals-service-api/src/services/back-office-v2/formatters/has/questionnaire.js
@@ -6,7 +6,8 @@
 const {
 	getDocuments,
 	getCommonLPAQSubmissionFields,
-	getHASLPAQSubmissionFields
+	getHASLPAQSubmissionFields,
+	getExpeditedLPAQSubmissionFields
 } = require('../utils');
 const { documentTypes } = require('@pins/common/src/document-types');
 const { CASE_TYPES } = require('@pins/common/src/database/data-static');
@@ -25,7 +26,8 @@ exports.formatter = async (caseReference, { ...answers }) => {
 			// Common
 			...getCommonLPAQSubmissionFields(caseReference, answers),
 			// HAS
-			...getHASLPAQSubmissionFields(answers)
+			...getHASLPAQSubmissionFields(answers),
+			...getExpeditedLPAQSubmissionFields(answers)
 		},
 		documents: await getDocuments(answers, documentTypes.planningOfficersReportUpload.dataModelName)
 	};

--- a/packages/appeals-service-api/src/services/back-office-v2/formatters/has/questionnaire.test.js
+++ b/packages/appeals-service-api/src/services/back-office-v2/formatters/has/questionnaire.test.js
@@ -72,7 +72,9 @@ describe('formatter', () => {
 				nearbyCaseReferences: ['CASE123'],
 				newConditionDetails: 'New condition details',
 				lpaStatement: '',
-				lpaCostsAppliedFor: null
+				lpaCostsAppliedFor: null,
+				significantChangesAffectingApplicationLpa: null,
+				listOfDocumentsBeforeDecision: undefined
 			},
 			documents: [1]
 		});
@@ -101,7 +103,9 @@ describe('formatter', () => {
 				nearbyCaseReferences: undefined,
 				newConditionDetails: null,
 				lpaStatement: '',
-				lpaCostsAppliedFor: null
+				lpaCostsAppliedFor: null,
+				significantChangesAffectingApplicationLpa: null,
+				listOfDocumentsBeforeDecision: undefined
 			},
 			documents: [1]
 		});

--- a/packages/appeals-service-api/src/services/back-office-v2/formatters/utils.js
+++ b/packages/appeals-service-api/src/services/back-office-v2/formatters/utils.js
@@ -1453,3 +1453,16 @@ exports.getChangedListedBuildingNumbersFields = (answers) => {
 		)
 	};
 };
+
+/**
+ * @param {LPAQAnswers} answers
+ * @returns {LPAQS78SubmissionProperties}
+ */
+exports.getExpeditedLPAQSubmissionFields = (answers) => {
+	return {
+		// Appeal process
+		significantChangesAffectingApplicationLpa: exports.formatSignificantChanges(answers),
+		// Original Evidence
+		listOfDocumentsBeforeDecision: answers.listOfDocumentsBeforeDecision
+	};
+};


### PR DESCRIPTION
### Description of change

Add the expedited HAS fields to the LPAQ broadcast

Verified data in logs

Ticket: https://pins-ds.atlassian.net/browse/A2-8889

### Checklist

- [x] Feature complete and ready for users, or behind feature-flag
- [x] Commit history is linear with no merge commits
- [ ] Requires infrastructure changes

### Important

Please do not merge from `main` (please only [rebase](https://github.com/Planning-Inspectorate/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
