### PR TITLE
test: expedited pages added in lpa questionnaire

### DIFF
--- a/test-packages/platform-feature-tests/cypress/fixtures/lpaManageAppealsData.json
+++ b/test-packages/platform-feature-tests/cypress/fixtures/lpaManageAppealsData.json
@@ -99,6 +99,10 @@
         "addAnotherAppeal": "Add another appeal?",
         "nearByAppealReference": "1234567",
         "conditionsAndDetails": "newConditions newConditionDetails",
+        "significantChangesLocalPlanDetails": "Adopted local plan changes relevant to this appeal.",
+        "significantChangesNationalPolicyDetails": "National policy changes relevant to this appeal.",
+        "significantChangesCourtJudgmentDetails": "Court judgment changes relevant to this appeal.",
+        "significantChangesOtherDetails": "Other significant changes relevant to this appeal.",
         "lpaPreferHearingDetails": "Lpa Pefer Hearing Details !£$%^&*(123456789 ",
         "lpaProcedurePreferenceLpaPreferInquiryDuration": "99",
         "lpaPreferInquiryDetails": "Lpa Pefer Inquiry Details !£$%^&*(123456789 "

--- a/test-packages/platform-feature-tests/cypress/helpers/appellantAAPD/casPlanningAppeal/casPlanningAppealGrantedData.js
+++ b/test-packages/platform-feature-tests/cypress/helpers/appellantAAPD/casPlanningAppeal/casPlanningAppealGrantedData.js
@@ -23,7 +23,7 @@ export const casPlanningAppealGrantedTestCases = [
         statusOfPlanningObligation: 'in draft',
         typeOfPlanningApplication: 'answer-minor-commercial-development',
         selectAllPlanningApplicationAbout: false,
-        endToEndIntegration: false,
+        endToEndIntegration: true,
         expeditedAppeal: true,
         applicationForm: {
             isAppellant: true,

--- a/test-packages/platform-feature-tests/cypress/helpers/appellantAAPD/fullAppeal/fullAppealGrantedData.js
+++ b/test-packages/platform-feature-tests/cypress/helpers/appellantAAPD/fullAppeal/fullAppealGrantedData.js
@@ -19,12 +19,12 @@ const documents = {
 };
 export const fullAppealGrantedTestCases = [
     {
-        tags: ['smoke','expedited'],
+        tags: ['smoke', 'expedited'],
         statusOfOriginalApplication: 'granted',
         typeOfDecisionRequested: 'written',
         statusOfPlanningObligation: 'in draft',
         typeOfPlanningApplication: 'answer-full-appeal',
-        endToEndIntegration: false,
+        endToEndIntegration: true,
         expeditedAppeal: true,
         applicationForm: {
             isAppellant: true,

--- a/test-packages/platform-feature-tests/cypress/helpers/appellantAAPD/fullAppeal/fullAppealRefusedData.js
+++ b/test-packages/platform-feature-tests/cypress/helpers/appellantAAPD/fullAppeal/fullAppealRefusedData.js
@@ -19,12 +19,12 @@ const documents = {
 };
 export const fullAppealRefusedTestCases = [
     {
-        tags: ['smoke','expedited'],
+        tags: ['smoke', 'expedited'],
         statusOfOriginalApplication: 'refused',
         typeOfDecisionRequested: 'written',
         statusOfPlanningObligation: 'in draft',
         typeOfPlanningApplication: 'answer-full-appeal',
-        endToEndIntegration: false,
+        endToEndIntegration: true,
         expeditedAppeal: true,
         applicationForm: {
             isAppellant: true,

--- a/test-packages/platform-feature-tests/cypress/helpers/appellantAAPD/houseHolderAppeal/houseHolderAppealGrantedData.js
+++ b/test-packages/platform-feature-tests/cypress/helpers/appellantAAPD/houseHolderAppeal/houseHolderAppealGrantedData.js
@@ -16,13 +16,13 @@ const documents = {
     uploadPlanningObligation: 'planning-obligation.pdf'
 };
 export const houseHolderAppealGrantedTestCases = [
-     {
+    {
         tags: ['smoke', 'expedited'],
         statusOfOriginalApplication: 'granted',
         typeOfDecisionRequested: 'written',
         statusOfPlanningObligation: 'in draft',
         typeOfPlanningApplication: 'answer-householder-planning',
-        endToEndIntegration: false,
+        endToEndIntegration: true,
         expeditedAppeal: true,
         applicationForm: {
             isAppellant: true,
@@ -110,5 +110,5 @@ export const houseHolderAppealGrantedTestCases = [
             check: false, // TODO: set these to true after feature flag introduced
             uploadAdditionalDocuments: false
         }
-    }   
+    }
 ];

--- a/test-packages/platform-feature-tests/cypress/helpers/lpaManageAppeals/advertQuestionnaireData.js
+++ b/test-packages/platform-feature-tests/cypress/helpers/lpaManageAppeals/advertQuestionnaireData.js
@@ -1,4 +1,10 @@
 const documents = {
+    uploadDesignAccess: 'appeal-statement-valid.pdf',
+    uploadPlansAndDrawings: 'plans-drawings.pdf',
+    uploadOtherDocuments: 'appeal-statement-valid.pdf',
+    uploadDesignAccessStatement: 'appeal-statement-valid.pdf',
+    uploadPlansDrawings: 'plans-drawings.pdf',
+    uploadAdditionalDocuments: 'other-policies.pdf',
     uploadAppealStmt: 'appeal-statement-valid.pdf',
     uploadConservationMapGuidance: 'conservation-map-guidance.pdf',
     uploadPlanExtentOrder: 'plan-extent-order.pdf',
@@ -19,14 +25,14 @@ const documents = {
     uploadEmergingPlan: 'emerging-plan.pdf',
     uploadOtherPolicies: 'other-policies.pdf',
     uploadSupplementaryPlanningDocs: 'supplementary-planning-docs.pdf',
-    uploadCommunityInfrastructureLevy: 'community-infrastructure-levy.pdf'  
+    uploadCommunityInfrastructureLevy: 'community-infrastructure-levy.pdf'
 };
 export const advertQuestionnaireTestCases = [
-    {  
-        constraintsAndDesignations:{
+    {
+        constraintsAndDesignations: {
             isCorrectTypeOfAppeal: true,
             isChangesListedBuilding: true,
-            isAffectListedBuildings: true,           
+            isAffectListedBuildings: true,
             isAffectedListedBuildings: true,
             isScheduledMonuments: true,
             isConservationArea: true,
@@ -36,85 +42,91 @@ export const advertQuestionnaireTestCases = [
             isNationalLandscape: true,
             isAllDesignatedSite: true,
         },
-        notifyParties:{
+        notifyParties: {
 
         },
-        consultResponseAndRepresent:{
-            isStatutoryConsultees: true,            
+        consultResponseAndRepresent: {
+            isStatutoryConsultees: true,
             isOtherPartyRepresentations: true,
         },
-        poReportAndSupportDocs:{
-            isHighway:true,
-            isPhotographsPlans:true,
-            isStatutoryPlan:true,
+        poReportAndSupportDocs: {
+            isHighway: true,
+            isPhotographsPlans: true,
+            isStatutoryPlan: true,
             isEmergingPlan: true,
-            isRelevantPolcies:true,    
+            isRelevantPolcies: true,
             isSupplementaryPlanningDocs: true,
         },
-        siteAccess:{
+        siteAccess: {
             isLpaSiteAccess: true,
             isNeighbourSiteAccess: true,
             isLpaSiteSafetyRisks: true,
         },
-        appealProcess:{
+        appealProcess: {
             isProcedureType: 'written',
             isOngoingAppeals: true,
             isNearbyAppeals: true,
             isNewConditions: true,
         },
+        originalEvidence: {
+            isDesignAccessStatement: true,
+            isPlansAndDrawingsSubmitted: true,
+            isOtherDocumentsSubmitted: true,
+            listOfDocumentsBeforeDecision: 'Officer report, approved plans, consultation responses and decision notice.',
+        },
         documents,
-        submit:{}
+        submit: {}
     },
-    {  
-        constraintsAndDesignations:{
+    {
+        constraintsAndDesignations: {
             isCorrectTypeOfAppeal: false,
             isChangesListedBuilding: false,
-            isAffectListedBuildings: false,           
+            isAffectListedBuildings: false,
             isAffectedListedBuildings: false,
             isScheduledMonuments: false,
-            isConservationArea: false,  
+            isConservationArea: false,
             isProtectedSpecies: true,
             isSpecialControl: true,
             isGreenBelt: true,
             isNationalLandscape: true,
             isAllDesignatedSite: true,
         },
-        
-        notifyParties:{
+
+        notifyParties: {
 
         },
-        consultResponseAndRepresent:{
-            isStatutoryConsultees: true,            
+        consultResponseAndRepresent: {
+            isStatutoryConsultees: true,
             isOtherPartyRepresentations: true,
         },
-        poReportAndSupportDocs:{
-            isHighway:true,
-            isPhotographsPlans:true,
-            isStatutoryPlan:true,
+        poReportAndSupportDocs: {
+            isHighway: true,
+            isPhotographsPlans: true,
+            isStatutoryPlan: true,
             isEmergingPlan: false,
-            isRelevantPolcies:true,    
+            isRelevantPolcies: true,
             isSupplementaryPlanningDocs: true,
         },
-        siteAccess:{
+        siteAccess: {
             isLpaSiteAccess: true,
             isNeighbourSiteAccess: false,
-            isLpaSiteSafetyRisks: true,           
+            isLpaSiteSafetyRisks: true,
         },
-        appealProcess:{
+        appealProcess: {
             isProcedureType: 'written',
             isOngoingAppeals: false,
             isNearbyAppeals: false,
             isNewConditions: true,
         },
         documents,
-        submit:{}
-    },    
-    
-    {  
-        constraintsAndDesignations:{
+        submit: {}
+    },
+
+    {
+        constraintsAndDesignations: {
             isCorrectTypeOfAppeal: true,
             isChangesListedBuilding: false,
-            isAffectListedBuildings: false,           
+            isAffectListedBuildings: false,
             isAffectedListedBuildings: false,
             isScheduledMonuments: false,
             isConservationArea: false,
@@ -124,33 +136,33 @@ export const advertQuestionnaireTestCases = [
             isNationalLandscape: false,
             isAllDesignatedSite: false,
         },
-        notifyParties:{
+        notifyParties: {
 
         },
-        consultResponseAndRepresent:{
-            isStatutoryConsultees: true,            
+        consultResponseAndRepresent: {
+            isStatutoryConsultees: true,
             isOtherPartyRepresentations: true,
         },
-        poReportAndSupportDocs:{
-            isHighway:true,
-            isPhotographsPlans:true,
-            isStatutoryPlan:true,
+        poReportAndSupportDocs: {
+            isHighway: true,
+            isPhotographsPlans: true,
+            isStatutoryPlan: true,
             isEmergingPlan: true,
-            isRelevantPolcies:true,    
+            isRelevantPolcies: true,
             isSupplementaryPlanningDocs: true,
         },
-        siteAccess:{
+        siteAccess: {
             isLpaSiteAccess: true,
             isNeighbourSiteAccess: false,
             isLpaSiteSafetyRisks: true,
         },
-        appealProcess:{
+        appealProcess: {
             isProcedureType: 'written',
             isOngoingAppeals: true,
             isNearbyAppeals: true,
             isNewConditions: false,
         },
         documents,
-        submit:{}
+        submit: {}
     }
 ];

--- a/test-packages/platform-feature-tests/cypress/helpers/lpaManageAppeals/casPlanningQuestionnaireData.js
+++ b/test-packages/platform-feature-tests/cypress/helpers/lpaManageAppeals/casPlanningQuestionnaireData.js
@@ -1,4 +1,10 @@
 const documents = {
+    uploadDesignAccess: 'appeal-statement-valid.pdf',
+    uploadPlansAndDrawings: 'plans-drawings.pdf',
+    uploadOtherDocuments: 'appeal-statement-valid.pdf',
+    uploadDesignAccessStatement: 'appeal-statement-valid.pdf',
+    uploadPlansDrawings: 'plans-drawings.pdf',
+    uploadAdditionalDocuments: 'other-policies.pdf',
     uploadAppealStmt: 'appeal-statement-valid.pdf',
     uploadConservationMapGuidance: 'conservation-map-guidance.pdf',
     uploadPlanExtentOrder: 'plan-extent-order.pdf',
@@ -19,101 +25,107 @@ const documents = {
     uploadEmergingPlan: 'emerging-plan.pdf',
     uploadOtherPolicies: 'other-policies.pdf',
     uploadSupplementaryPlanningDocs: 'supplementary-planning-docs.pdf',
-    uploadCommunityInfrastructureLevy: 'community-infrastructure-levy.pdf'  
+    uploadCommunityInfrastructureLevy: 'community-infrastructure-levy.pdf'
 };
 export const casPlanningQuestionnaireTestCases = [
-    {  
-        constraintsAndDesignations:{
+    {
+        constraintsAndDesignations: {
             isCorrectTypeOfAppeal: true,
-            isAffectListedBuildings: true,           
+            isAffectListedBuildings: true,
             isAffectedListedBuildings: true,
             isConservationArea: true,
             isGreenBelt: true,
         },
-        notifyParties:{
+        notifyParties: {
 
         },
-        consultResponseAndRepresent:{
+        consultResponseAndRepresent: {
             isOtherPartyRepresentations: true,
         },
-        poReportAndSupportDocs:{
+        poReportAndSupportDocs: {
             isEmergingPlan: true,
             isSupplementaryPlanningDocs: true,
         },
-        siteAccess:{
+        siteAccess: {
             isLpaSiteAccess: true,
             isNeighbourSiteAccess: true,
             isLpaSiteSafetyRisks: true,
         },
-        appealProcess:{
+        appealProcess: {
             isOngoingAppeals: true,
             isNearbyAppeals: true,
             isNewConditions: true,
         },
+        originalEvidence: {
+            isDesignAccessStatement: true,
+            isPlansAndDrawingsSubmitted: true,
+            isOtherDocumentsSubmitted: true,
+            listOfDocumentsBeforeDecision: 'Officer report, approved plans, consultation responses and decision notice.',
+        },
         documents,
-        submit:{}
+        submit: {}
     },
-    {  
-        constraintsAndDesignations:{
+    {
+        constraintsAndDesignations: {
             isCorrectTypeOfAppeal: false,
-            isAffectListedBuildings: false,           
+            isAffectListedBuildings: false,
             isAffectedListedBuildings: false,
             isConservationArea: true,
             isGreenBelt: false,
         },
-        notifyParties:{
+        notifyParties: {
 
         },
-        consultResponseAndRepresent:{
+        consultResponseAndRepresent: {
             isOtherPartyRepresentations: true,
         },
-        poReportAndSupportDocs:{
+        poReportAndSupportDocs: {
             isEmergingPlan: false,
             isSupplementaryPlanningDocs: true,
         },
-        siteAccess:{
+        siteAccess: {
             isLpaSiteAccess: true,
             isNeighbourSiteAccess: false,
             isLpaSiteSafetyRisks: true,
         },
-        appealProcess:{
+        appealProcess: {
             isOngoingAppeals: false,
             isNearbyAppeals: false,
             isNewConditions: true,
         },
         documents,
-        submit:{}
-    },    
-    
-    {  
-        constraintsAndDesignations:{
+        submit: {}
+    },
+
+    {
+        constraintsAndDesignations: {
             isCorrectTypeOfAppeal: true,
-            isAffectListedBuildings: false,            
+            isAffectListedBuildings: false,
             isAffectedListedBuildings: false,
             isConservationArea: false,
             isGreenBelt: false,
         },
-        notifyParties:{
+        notifyParties: {
 
         },
-        consultResponseAndRepresent:{
+        consultResponseAndRepresent: {
             isOtherPartyRepresentations: false,
         },
-        poReportAndSupportDocs:{
+        poReportAndSupportDocs: {
             isEmergingPlan: false,
             isSupplementaryPlanningDocs: false,
         },
-        siteAccess:{
+        siteAccess: {
             isLpaSiteAccess: false,
             isNeighbourSiteAccess: false,
             isLpaSiteSafetyRisks: false,
         },
-        appealProcess:{
+        appealProcess: {
             isOngoingAppeals: false,
             isNearbyAppeals: false,
             isNewConditions: false,
         },
         documents,
-        submit:{}
+        submit: {}
     }
 ];

--- a/test-packages/platform-feature-tests/cypress/helpers/lpaManageAppeals/commercialAdvertQuestionnaireData.js
+++ b/test-packages/platform-feature-tests/cypress/helpers/lpaManageAppeals/commercialAdvertQuestionnaireData.js
@@ -1,4 +1,10 @@
 const documents = {
+    uploadDesignAccess: 'appeal-statement-valid.pdf',
+    uploadPlansAndDrawings: 'plans-drawings.pdf',
+    uploadOtherDocuments: 'appeal-statement-valid.pdf',
+    uploadDesignAccessStatement: 'appeal-statement-valid.pdf',
+    uploadPlansDrawings: 'plans-drawings.pdf',
+    uploadAdditionalDocuments: 'other-policies.pdf',
     uploadAppealStmt: 'appeal-statement-valid.pdf',
     uploadConservationMapGuidance: 'conservation-map-guidance.pdf',
     uploadPlanExtentOrder: 'plan-extent-order.pdf',
@@ -19,13 +25,13 @@ const documents = {
     uploadEmergingPlan: 'emerging-plan.pdf',
     uploadOtherPolicies: 'other-policies.pdf',
     uploadSupplementaryPlanningDocs: 'supplementary-planning-docs.pdf',
-    uploadCommunityInfrastructureLevy: 'community-infrastructure-levy.pdf'  
+    uploadCommunityInfrastructureLevy: 'community-infrastructure-levy.pdf'
 };
 export const commercialAdvertQuestionnaireTestCases = [
-    {  
-        constraintsAndDesignations:{
-            isCorrectTypeOfAppeal: true,          
-            isAffectListedBuildings: true,           
+    {
+        constraintsAndDesignations: {
+            isCorrectTypeOfAppeal: true,
+            isAffectListedBuildings: true,
             isAffectedListedBuildings: true,
             isScheduledMonuments: true,
             isConservationArea: true,
@@ -35,83 +41,89 @@ export const commercialAdvertQuestionnaireTestCases = [
             isNationalLandscape: true,
             isAllDesignatedSite: true,
         },
-        notifyParties:{
+        notifyParties: {
 
         },
-        consultResponseAndRepresent:{
-            isStatutoryConsultees: true,            
+        consultResponseAndRepresent: {
+            isStatutoryConsultees: true,
             isOtherPartyRepresentations: true,
         },
-        poReportAndSupportDocs:{
-            isHighway:true,
-            isPhotographsPlans:true,
-            isStatutoryPlan:true,
+        poReportAndSupportDocs: {
+            isHighway: true,
+            isPhotographsPlans: true,
+            isStatutoryPlan: true,
             isEmergingPlan: true,
-            isRelevantPolcies:true,    
+            isRelevantPolcies: true,
             isSupplementaryPlanningDocs: true,
         },
-        siteAccess:{
+        siteAccess: {
             isLpaSiteAccess: true,
             isNeighbourSiteAccess: true,
             isLpaSiteSafetyRisks: true,
         },
-        appealProcess:{
+        appealProcess: {
             isProcedureType: 'written',
             isOngoingAppeals: true,
             isNearbyAppeals: true,
             isNewConditions: true,
         },
+        originalEvidence: {
+            isDesignAccessStatement: true,
+            isPlansAndDrawingsSubmitted: true,
+            isOtherDocumentsSubmitted: true,
+            listOfDocumentsBeforeDecision: 'Officer report, approved plans, consultation responses and decision notice.',
+        },
         documents,
-        submit:{}
+        submit: {}
     },
-    {  
-        constraintsAndDesignations:{
+    {
+        constraintsAndDesignations: {
             isCorrectTypeOfAppeal: false,
-            isAffectListedBuildings: false,           
+            isAffectListedBuildings: false,
             isAffectedListedBuildings: false,
             isScheduledMonuments: false,
-            isConservationArea: false,  
+            isConservationArea: false,
             isProtectedSpecies: true,
             isSpecialControl: true,
             isGreenBelt: true,
             isNationalLandscape: true,
             isAllDesignatedSite: true,
         },
-        
-        notifyParties:{
+
+        notifyParties: {
 
         },
-        consultResponseAndRepresent:{
-            isStatutoryConsultees: true,            
+        consultResponseAndRepresent: {
+            isStatutoryConsultees: true,
             isOtherPartyRepresentations: true,
         },
-        poReportAndSupportDocs:{
-            isHighway:true,
-            isPhotographsPlans:true,
-            isStatutoryPlan:true,
+        poReportAndSupportDocs: {
+            isHighway: true,
+            isPhotographsPlans: true,
+            isStatutoryPlan: true,
             isEmergingPlan: false,
-            isRelevantPolcies:true,    
+            isRelevantPolcies: true,
             isSupplementaryPlanningDocs: true,
         },
-        siteAccess:{
+        siteAccess: {
             isLpaSiteAccess: true,
             isNeighbourSiteAccess: false,
-            isLpaSiteSafetyRisks: true,           
+            isLpaSiteSafetyRisks: true,
         },
-        appealProcess:{
+        appealProcess: {
             isProcedureType: 'written',
             isOngoingAppeals: false,
             isNearbyAppeals: false,
             isNewConditions: true,
         },
         documents,
-        submit:{}
-    },    
-    
-    {  
-        constraintsAndDesignations:{
+        submit: {}
+    },
+
+    {
+        constraintsAndDesignations: {
             isCorrectTypeOfAppeal: true,
-            isAffectListedBuildings: false,           
+            isAffectListedBuildings: false,
             isAffectedListedBuildings: false,
             isScheduledMonuments: false,
             isConservationArea: false,
@@ -121,33 +133,33 @@ export const commercialAdvertQuestionnaireTestCases = [
             isNationalLandscape: false,
             isAllDesignatedSite: false,
         },
-        notifyParties:{
+        notifyParties: {
 
         },
-        consultResponseAndRepresent:{
-            isStatutoryConsultees: true,            
+        consultResponseAndRepresent: {
+            isStatutoryConsultees: true,
             isOtherPartyRepresentations: true,
         },
-        poReportAndSupportDocs:{
-            isHighway:true,
-            isPhotographsPlans:true,
-            isStatutoryPlan:true,
+        poReportAndSupportDocs: {
+            isHighway: true,
+            isPhotographsPlans: true,
+            isStatutoryPlan: true,
             isEmergingPlan: true,
-            isRelevantPolcies:true,    
+            isRelevantPolcies: true,
             isSupplementaryPlanningDocs: true,
         },
-        siteAccess:{
+        siteAccess: {
             isLpaSiteAccess: true,
             isNeighbourSiteAccess: false,
             isLpaSiteSafetyRisks: true,
         },
-        appealProcess:{
+        appealProcess: {
             isProcedureType: 'written',
             isOngoingAppeals: true,
             isNearbyAppeals: true,
             isNewConditions: false,
         },
         documents,
-        submit:{}
+        submit: {}
     }
 ];

--- a/test-packages/platform-feature-tests/cypress/helpers/lpaManageAppeals/fullAppealQuestionnaireData.js
+++ b/test-packages/platform-feature-tests/cypress/helpers/lpaManageAppeals/fullAppealQuestionnaireData.js
@@ -1,5 +1,11 @@
 const documents = {
     uploadAppealStmt: 'appeal-statement-valid.pdf',
+    uploadDesignAccess: 'appeal-statement-valid.pdf',
+    uploadPlansAndDrawings: 'plans-drawings.pdf',
+    uploadOtherDocuments: 'appeal-statement-valid.pdf',
+    uploadDesignAccessStatement: 'appeal-statement-valid.pdf',
+    uploadPlansDrawings: 'plans-drawings.pdf',
+    uploadAdditionalDocuments: 'other-policies.pdf',
     uploadConservationMapGuidance: 'conservation-map-guidance.pdf',
     uploadPlanExtentOrder: 'plan-extent-order.pdf',
     uploadDefinitiveMapStmt: 'definitive-map-stmt.pdf',
@@ -87,6 +93,12 @@ export const fullAppealQuestionnaireTestCases = [
             isOngoingAppeals: true,
             isNearbyAppeals: true,
             isNewConditions: false,
+        },
+        originalEvidence: {
+            isDesignAccessStatement: true,
+            isPlansAndDrawingsSubmitted: true,
+            isOtherDocumentsSubmitted: true,
+            listOfDocumentsBeforeDecision: 'Officer report, approved plans, consultation responses and decision notice.',
         },
         documents,
         submit: {}

--- a/test-packages/platform-feature-tests/cypress/helpers/lpaManageAppeals/houseHolderQuestionnaireData.js
+++ b/test-packages/platform-feature-tests/cypress/helpers/lpaManageAppeals/houseHolderQuestionnaireData.js
@@ -1,4 +1,10 @@
 const documents = {
+    uploadDesignAccess: 'appeal-statement-valid.pdf',
+    uploadPlansAndDrawings: 'plans-drawings.pdf',
+    uploadOtherDocuments: 'appeal-statement-valid.pdf',
+    uploadDesignAccessStatement: 'appeal-statement-valid.pdf',
+    uploadPlansDrawings: 'plans-drawings.pdf',
+    uploadAdditionalDocuments: 'other-policies.pdf',
     uploadAppealStmt: 'appeal-statement-valid.pdf',
     uploadConservationMapGuidance: 'conservation-map-guidance.pdf',
     uploadPlanExtentOrder: 'plan-extent-order.pdf',
@@ -19,76 +25,89 @@ const documents = {
     uploadEmergingPlan: 'emerging-plan.pdf',
     uploadOtherPolicies: 'other-policies.pdf',
     uploadSupplementaryPlanningDocs: 'supplementary-planning-docs.pdf',
-    uploadCommunityInfrastructureLevy: 'community-infrastructure-levy.pdf'  
+    uploadCommunityInfrastructureLevy: 'community-infrastructure-levy.pdf'
 };
 export const houseHolderQuestionnaireTestCases = [
-    {  
-        constraintsAndDesignations:{
+    {
+        constraintsAndDesignations: {
             isCorrectTypeOfAppeal: true,
-            isAffectListedBuildings: true,           
+            isAffectListedBuildings: true,
             isAffectedListedBuildings: true,
             isConservationArea: true,
             isGreenBelt: true,
         },
-        notifyParties:{
+        notifyParties: {
 
         },
-        consultResponseAndRepresent:{
+        consultResponseAndRepresent: {
             isOtherPartyRepresentations: true,
         },
-        poReportAndSupportDocs:{
+        poReportAndSupportDocs: {
             isEmergingPlan: true,
             isSupplementaryPlanningDocs: true,
         },
-        siteAccess:{
+        siteAccess: {
             isLpaSiteAccess: true,
             isNeighbourSiteAccess: true,
             isLpaSiteSafetyRisks: true,
         },
-        appealProcess:{
+        appealProcess: {
             isOngoingAppeals: true,
             isNearbyAppeals: true,
             isNewConditions: true,
         },
+        originalEvidence: {
+            isDesignAccessStatement: true,
+            isPlansAndDrawingsSubmitted: true,
+            isOtherDocumentsSubmitted: true,
+            listOfDocumentsBeforeDecision: 'Officer report, approved plans, consultation responses and decision notice.',
+        },
         documents,
-        submit:{}
+        submit: {}
     },
-    {  
-        constraintsAndDesignations:{
+    {
+        constraintsAndDesignations: {
             isCorrectTypeOfAppeal: false,
-            isAffectListedBuildings: false,           
+            isAffectListedBuildings: false,
             isAffectedListedBuildings: false,
             isConservationArea: false,
             isGreenBelt: false,
         },
-        notifyParties:{
+        notifyParties: {
 
         },
-        consultResponseAndRepresent:{
+        consultResponseAndRepresent: {
             isOtherPartyRepresentations: false,
         },
-        poReportAndSupportDocs:{
+        poReportAndSupportDocs: {
             isEmergingPlan: false,
             isSupplementaryPlanningDocs: false,
         },
-        siteAccess:{
+        siteAccess: {
             isLpaSiteAccess: false,
             isNeighbourSiteAccess: false,
             isLpaSiteSafetyRisks: false,
         },
-        appealProcess:{
+        appealProcess: {
             isOngoingAppeals: false,
             isNearbyAppeals: false,
             isNewConditions: false,
         },
+        originalEvidence: {
+            isDesignAccessStatement: true,
+            isPlansAndDrawingsSubmitted: true,
+            isOtherDocumentsSubmitted: true,
+            listOfDocumentsBeforeDecision: 'Officer report, approved plans, consultation responses and decision notice.',
+        },
+
         documents,
-        submit:{}
+        submit: {}
     },
     // {  
     //     constraintsAndDesignations:{
     //         isCorrectTypeOfAppeal: true,
     //         isAffectListedBuildings: false,
-            
+
     //         isAffectedListedBuildings: true,
     //         isConservationArea: true,
     //         isGreenBelt: true,
@@ -120,7 +139,7 @@ export const houseHolderQuestionnaireTestCases = [
     //     constraintsAndDesignations:{
     //         isCorrectTypeOfAppeal: true,
     //         isAffectListedBuildings: false,
-            
+
     //         isAffectedListedBuildings: false,
     //         isConservationArea: true,
     //         isGreenBelt: true,
@@ -152,7 +171,7 @@ export const houseHolderQuestionnaireTestCases = [
     //     constraintsAndDesignations:{
     //         isCorrectTypeOfAppeal: true,
     //         isAffectListedBuildings: false,
-            
+
     //         isAffectedListedBuildings: false,
     //         isConservationArea: false,
     //         isGreenBelt: true,
@@ -184,7 +203,7 @@ export const houseHolderQuestionnaireTestCases = [
     //     constraintsAndDesignations:{
     //         isCorrectTypeOfAppeal: true,
     //         isAffectListedBuildings: false,
-            
+
     //         isAffectedListedBuildings: false,
     //         isConservationArea: false,
     //         isGreenBelt: false,
@@ -216,7 +235,7 @@ export const houseHolderQuestionnaireTestCases = [
     //     constraintsAndDesignations:{
     //         isCorrectTypeOfAppeal: true,
     //         isAffectListedBuildings: false,
-            
+
     //         isAffectedListedBuildings: false,
     //         isConservationArea: false,
     //         isGreenBelt: false,
@@ -248,7 +267,7 @@ export const houseHolderQuestionnaireTestCases = [
     //     constraintsAndDesignations:{
     //         isCorrectTypeOfAppeal: true,
     //         isAffectListedBuildings: false,
-            
+
     //         isAffectedListedBuildings: false,
     //         isConservationArea: false,
     //         isGreenBelt: false,
@@ -280,7 +299,7 @@ export const houseHolderQuestionnaireTestCases = [
     //     constraintsAndDesignations:{
     //         isCorrectTypeOfAppeal: true,
     //         isAffectListedBuildings: false,
-            
+
     //         isAffectedListedBuildings: false,
     //         isConservationArea: false,
     //         isGreenBelt: false,
@@ -312,7 +331,7 @@ export const houseHolderQuestionnaireTestCases = [
     //     constraintsAndDesignations:{
     //         isCorrectTypeOfAppeal: true,
     //         isAffectListedBuildings: false,
-            
+
     //         isAffectedListedBuildings: false,
     //         isConservationArea: false,
     //         isGreenBelt: false,
@@ -344,7 +363,7 @@ export const houseHolderQuestionnaireTestCases = [
     //     constraintsAndDesignations:{
     //         isCorrectTypeOfAppeal: true,
     //         isAffectListedBuildings: false,
-            
+
     //         isAffectedListedBuildings: false,
     //         isConservationArea: false,
     //         isGreenBelt: false,
@@ -376,7 +395,7 @@ export const houseHolderQuestionnaireTestCases = [
     //     constraintsAndDesignations:{
     //         isCorrectTypeOfAppeal: true,
     //         isAffectListedBuildings: false,
-            
+
     //         isAffectedListedBuildings: false,
     //         isConservationArea: false,
     //         isGreenBelt: false,
@@ -408,7 +427,7 @@ export const houseHolderQuestionnaireTestCases = [
     //     constraintsAndDesignations:{
     //         isCorrectTypeOfAppeal: true,
     //         isAffectListedBuildings: false,
-            
+
     //         isAffectedListedBuildings: false,
     //         isConservationArea: false,
     //         isGreenBelt: false,
@@ -440,7 +459,7 @@ export const houseHolderQuestionnaireTestCases = [
     //     constraintsAndDesignations:{
     //         isCorrectTypeOfAppeal: true,
     //         isAffectListedBuildings: false,
-            
+
     //         isAffectedListedBuildings: false,
     //         isConservationArea: false,
     //         isGreenBelt: false,
@@ -472,7 +491,7 @@ export const houseHolderQuestionnaireTestCases = [
     //     constraintsAndDesignations:{
     //         isCorrectTypeOfAppeal: true,
     //         isAffectListedBuildings: false,
-            
+
     //         isAffectedListedBuildings: false,
     //         isConservationArea: false,
     //         isGreenBelt: false,
@@ -504,7 +523,7 @@ export const houseHolderQuestionnaireTestCases = [
     //     constraintsAndDesignations:{
     //         isCorrectTypeOfAppeal: true,
     //         isAffectListedBuildings: false,
-            
+
     //         isAffectedListedBuildings: false,
     //         isConservationArea: true,
     //         isGreenBelt: true,
@@ -536,7 +555,7 @@ export const houseHolderQuestionnaireTestCases = [
     //     constraintsAndDesignations:{
     //         isCorrectTypeOfAppeal: true,
     //         isAffectListedBuildings: false,
-            
+
     //         isAffectedListedBuildings: false,
     //         isConservationArea: false,
     //         isGreenBelt: true,
@@ -567,7 +586,7 @@ export const houseHolderQuestionnaireTestCases = [
     //     constraintsAndDesignations:{
     //         isCorrectTypeOfAppeal: true,
     //         isAffectListedBuildings: false,
-            
+
     //         isAffectedListedBuildings: false,
     //         isConservationArea: false,
     //         isGreenBelt: false,
@@ -599,7 +618,7 @@ export const houseHolderQuestionnaireTestCases = [
     //     constraintsAndDesignations:{
     //         isCorrectTypeOfAppeal: true,
     //         isAffectListedBuildings: false,
-            
+
     //         isAffectedListedBuildings: false,
     //         isConservationArea: false,
     //         isGreenBelt: false,
@@ -663,7 +682,7 @@ export const houseHolderQuestionnaireTestCases = [
     //     constraintsAndDesignations:{
     //         isCorrectTypeOfAppeal: true,
     //         isAffectListedBuildings: false,
-            
+
     //         isAffectedListedBuildings: false,
     //         isConservationArea: false,
     //         isGreenBelt: false,
@@ -695,7 +714,7 @@ export const houseHolderQuestionnaireTestCases = [
     //     constraintsAndDesignations:{
     //         isCorrectTypeOfAppeal: true,
     //         isAffectListedBuildings: false,
-            
+
     //         isAffectedListedBuildings: false,
     //         isConservationArea: false,
     //         isGreenBelt: false,
@@ -727,7 +746,7 @@ export const houseHolderQuestionnaireTestCases = [
     //     constraintsAndDesignations:{
     //         isCorrectTypeOfAppeal: true,
     //         isAffectListedBuildings: false,
-            
+
     //         isAffectedListedBuildings: false,
     //         isConservationArea: false,
     //         isGreenBelt: false,
@@ -759,7 +778,7 @@ export const houseHolderQuestionnaireTestCases = [
     //     constraintsAndDesignations:{
     //         isCorrectTypeOfAppeal: true,
     //         isAffectListedBuildings: false,
-            
+
     //         isAffectedListedBuildings: false,
     //         isConservationArea: false,
     //         isGreenBelt: false,
@@ -791,7 +810,7 @@ export const houseHolderQuestionnaireTestCases = [
     //     constraintsAndDesignations:{
     //         isCorrectTypeOfAppeal: true,
     //         isAffectListedBuildings: false,
-            
+
     //         isAffectedListedBuildings: false,
     //         isConservationArea: false,
     //         isGreenBelt: false,
@@ -823,7 +842,7 @@ export const houseHolderQuestionnaireTestCases = [
     //     constraintsAndDesignations:{
     //         isCorrectTypeOfAppeal: true,
     //         isAffectListedBuildings: false,
-            
+
     //         isAffectedListedBuildings: false,
     //         isConservationArea: false,
     //         isGreenBelt: false,
@@ -855,7 +874,7 @@ export const houseHolderQuestionnaireTestCases = [
     //     constraintsAndDesignations:{
     //         isCorrectTypeOfAppeal: true,
     //         isAffectListedBuildings: false,
-            
+
     //         isAffectedListedBuildings: false,
     //         isConservationArea: false,
     //         isGreenBelt: false,
@@ -887,7 +906,7 @@ export const houseHolderQuestionnaireTestCases = [
     //     constraintsAndDesignations:{
     //         isCorrectTypeOfAppeal: true,
     //         isAffectListedBuildings: false,
-            
+
     //         isAffectedListedBuildings: false,
     //         isConservationArea: false,
     //         isGreenBelt: false,
@@ -919,7 +938,7 @@ export const houseHolderQuestionnaireTestCases = [
     //     constraintsAndDesignations:{
     //         isCorrectTypeOfAppeal: true,
     //         isAffectListedBuildings: false,
-            
+
     //         isAffectedListedBuildings: false,
     //         isConservationArea: false,
     //         isGreenBelt: false,
@@ -947,36 +966,36 @@ export const houseHolderQuestionnaireTestCases = [
     //     documents,
     //     submit:{}
     // },
-    {  
-        constraintsAndDesignations:{
+    {
+        constraintsAndDesignations: {
             isCorrectTypeOfAppeal: true,
             isAffectListedBuildings: false,
-            
+
             isAffectedListedBuildings: false,
             isConservationArea: false,
             isGreenBelt: false,
         },
-        notifyParties:{
+        notifyParties: {
 
         },
-        consultResponseAndRepresent:{
+        consultResponseAndRepresent: {
             isOtherPartyRepresentations: false,
         },
-        poReportAndSupportDocs:{
+        poReportAndSupportDocs: {
             isEmergingPlan: false,
             isSupplementaryPlanningDocs: false,
         },
-        siteAccess:{
+        siteAccess: {
             isLpaSiteAccess: false,
             isNeighbourSiteAccess: false,
             isLpaSiteSafetyRisks: false,
         },
-        appealProcess:{
+        appealProcess: {
             isOngoingAppeals: false,
             isNearbyAppeals: false,
             isNewConditions: false,
         },
         documents,
-        submit:{}
+        submit: {}
     }
 ];

--- a/test-packages/platform-feature-tests/cypress/support/flows/pages/lpa-manage-appeals/appealProcess.js
+++ b/test-packages/platform-feature-tests/cypress/support/flows/pages/lpa-manage-appeals/appealProcess.js
@@ -6,6 +6,15 @@ export class AppealProcess {
     _selectors = {
         nearbyAppealReference: '#nearbyAppealReference',
         newConditionsNewConditionDetails: '#newConditions_newConditionDetails',
+        significantChangesLocalPlan: 'answer-local-plan',
+        significantChangesNationalPolicy: 'answer-national-policy',
+        significantChangesCourtJudgment: 'answer-court-judgment',
+        significantChangesOther: 'answer-other',
+        significantChangesNone: 'answer-none',
+        significantChangesLocalPlanDetails: '#anySignificantChanges_localPlanSignificantChanges',
+        significantChangesNationalPolicyDetails: '#anySignificantChanges_nationalPolicySignificantChanges',
+        significantChangesCourtJudgmentDetails: '#anySignificantChanges_courtJudgementSignificantChanges',
+        significantChangesOtherDetails: '#anySignificantChanges_otherSignificantChanges',
         answerWritten: 'answer-written',
         answerHearing: 'answer-hearing',
         answerInquiry: 'answer-inquiry',
@@ -88,13 +97,142 @@ export class AppealProcess {
     };
     selectNewConditions(context, lpaManageAppealsData) {
         const basePage = new BasePage();
-        if (context?.appealProcess?.isNewConditions) {
-            cy.getByData(basePage?._selectors.answerYes).click();
-            cy.get(this._selectors?.newConditionsNewConditionDetails).type(lpaManageAppealsData?.appealProcess?.conditionsAndDetails)
-            cy.advanceToNextPage();
-        } else {
-            cy.getByData(basePage?._selectors.answerNo).click();
-            cy.advanceToNextPage();
-        }
+        cy.location('pathname').then((pathname) => {
+            const isNewConditionsPage = pathname.includes('/appeal-process/new-conditions');
+
+            cy.get('body').then(($body) => {
+                const hasQuestion = $body
+                    .find('.govuk-fieldset__heading')
+                    .toArray()
+                    .some((el) => /new conditions/i.test(el.textContent || ''));
+
+                if (!isNewConditionsPage && !hasQuestion) {
+                    return;
+                }
+
+                if (context?.appealProcess?.isNewConditions) {
+                    cy.getByData(basePage?._selectors.answerYes).click();
+                    cy.get(this._selectors?.newConditionsNewConditionDetails).type(
+                        lpaManageAppealsData?.appealProcess?.conditionsAndDetails
+                    );
+                    cy.advanceToNextPage();
+                } else {
+                    cy.getByData(basePage?._selectors.answerNo).click();
+                    cy.advanceToNextPage();
+                }
+            });
+        });
     };
+
+    selectSignificantChanges(context, lpaManageAppealsData) {
+        const appealProcessData = lpaManageAppealsData?.appealProcess || {};
+        const appealProcessContext = context?.appealProcess || {};
+        const option = appealProcessContext?.significantChangesOption;
+
+        const localPlanDetails = appealProcessData?.significantChangesLocalPlanDetails;
+        const nationalPolicyDetails = appealProcessData?.significantChangesNationalPolicyDetails;
+        const courtJudgmentDetails = appealProcessData?.significantChangesCourtJudgmentDetails;
+        const otherDetails = appealProcessData?.significantChangesOtherDetails;
+
+        const selectCheckboxWithDetails = (checkboxSelector, detailSelector, detailsText) => {
+            cy.getByData(checkboxSelector).click();
+            cy.get(detailSelector).type(detailsText);
+        };
+
+        cy.get('body').then(($body) => {
+            const hasQuestion = $body
+                .find('.govuk-fieldset__heading')
+                .toArray()
+                .some((el) => /significant changes that would affect the application/i.test(el.textContent || ''));
+
+            if (!hasQuestion) {
+                return;
+            }
+
+            // Supports both boolean flags and legacy option mode.
+            const hasAnySignificantChanges =
+                appealProcessContext?.anySignificantChangesCondition === true ||
+                appealProcessContext?.isSignificantChanges === true ||
+                option === 'local-plan' ||
+                option === 'national-policy' ||
+                option === 'court-judgment' ||
+                option === 'other';
+
+            if (!hasAnySignificantChanges) {
+                cy.getByData(this._selectors.significantChangesNone).click();
+                cy.advanceToNextPage();
+                return;
+            }
+
+            const selectLocalPlan =
+                option === 'local-plan' ||
+                appealProcessContext?.isSignificantChangesLocalPlan === true;
+            const selectNationalPolicy =
+                option === 'national-policy' ||
+                appealProcessContext?.isSignificantChangesNationalPolicy === true;
+            const selectCourtJudgment =
+                option === 'court-judgment' ||
+                appealProcessContext?.isSignificantChangesCourtJudgment === true;
+            const selectOther =
+                option === 'other' ||
+                appealProcessContext?.isSignificantChangesOther === true;
+
+            if (selectLocalPlan) {
+                selectCheckboxWithDetails(
+                    this._selectors.significantChangesLocalPlan,
+                    this._selectors.significantChangesLocalPlanDetails,
+                    localPlanDetails
+                );
+            }
+
+            if (selectNationalPolicy) {
+                selectCheckboxWithDetails(
+                    this._selectors.significantChangesNationalPolicy,
+                    this._selectors.significantChangesNationalPolicyDetails,
+                    nationalPolicyDetails
+                );
+            }
+
+            if (selectCourtJudgment) {
+                selectCheckboxWithDetails(
+                    this._selectors.significantChangesCourtJudgment,
+                    this._selectors.significantChangesCourtJudgmentDetails,
+                    courtJudgmentDetails
+                );
+            }
+
+            if (selectOther) {
+                selectCheckboxWithDetails(
+                    this._selectors.significantChangesOther,
+                    this._selectors.significantChangesOtherDetails,
+                    otherDetails
+                );
+            }
+
+            const selectedCount =
+                Number(selectLocalPlan) +
+                Number(selectNationalPolicy) +
+                Number(selectCourtJudgment) +
+                Number(selectOther);
+
+            if (selectedCount === 0) {
+                // Keep behavior deterministic: if "yes path" is selected but no options are true,
+                // choose local plan by default instead of submitting no answer.
+                selectCheckboxWithDetails(
+                    this._selectors.significantChangesLocalPlan,
+                    this._selectors.significantChangesLocalPlanDetails,
+                    localPlanDetails
+                );
+            }
+
+            // Ensure none is not selected when specific options are chosen.
+            cy.getByData(this._selectors.significantChangesNone).then(($noneCheckbox) => {
+                if ($noneCheckbox.is(':checked') && selectedCount > 0) {
+                    cy.wrap($noneCheckbox).click();
+                }
+            });
+
+            cy.advanceToNextPage();
+        });
+    }
 }

--- a/test-packages/platform-feature-tests/cypress/support/flows/pages/lpa-manage-appeals/originalEvidence.js
+++ b/test-packages/platform-feature-tests/cypress/support/flows/pages/lpa-manage-appeals/originalEvidence.js
@@ -1,0 +1,147 @@
+// @ts-nocheck
+/// <reference types="cypress"/>
+import { BasePage } from "../../../../page-objects/base-page";
+
+export class OriginalEvidence {
+    _selectors = {
+        listOfDocumentsBeforeDecision: '#listOfDocumentsBeforeDecision'
+    }
+
+    isQuestionPageVisible(questionRegex) {
+        return cy.get('body').then(($body) => {
+            return $body
+                .find('.govuk-fieldset__heading')
+                .toArray()
+                .some((el) => questionRegex.test(el.textContent || ''));
+        });
+    }
+
+    uploadIfPagePresent(uploadFileName) {
+        cy.get('body').then(($body) => {
+            if ($body.find('input[type="file"]').length > 0) {
+                cy.uploadFileFromFixtureDirectories(uploadFileName);
+                cy.advanceToNextPage();
+            }
+        });
+    }
+
+    getOriginalEvidenceConfig(context, lpaManageAppealsData) {
+        return {
+            ...(lpaManageAppealsData?.originalEvidence || {}),
+            ...(context?.originalEvidence || {})
+        };
+    }
+
+    getOriginalEvidenceUploads(context, lpaManageAppealsData, originalEvidenceConfig) {
+        const fallbackUpload =
+            lpaManageAppealsData?.documents?.uploadAppealStmt || 'appeal-statement-valid.pdf';
+
+        return {
+            designAccessUpload:
+                context?.documents?.uploadDesignAccess ||
+                context?.documents?.uploadDesignAccessStatement ||
+                originalEvidenceConfig?.designAccessUpload ||
+                lpaManageAppealsData?.documents?.uploadDesignAccessStatement ||
+                fallbackUpload,
+            plansAndDrawingsUpload:
+                context?.documents?.uploadPlansAndDrawings ||
+                context?.documents?.uploadPlansDrawings ||
+                originalEvidenceConfig?.plansAndDrawingsUpload ||
+                lpaManageAppealsData?.documents?.uploadPlansDrawings ||
+                fallbackUpload,
+            otherDocumentsUpload:
+                context?.documents?.uploadOtherDocuments ||
+                context?.documents?.uploadAdditionalDocuments ||
+                originalEvidenceConfig?.otherDocumentsUpload ||
+                lpaManageAppealsData?.documents?.uploadAdditionalDocuments ||
+                fallbackUpload
+        };
+    }
+
+    selectDesignAccessStatement(context, lpaManageAppealsData) {
+        const basePage = new BasePage();
+        const config = this.getOriginalEvidenceConfig(context, lpaManageAppealsData);
+        const uploads = this.getOriginalEvidenceUploads(context, lpaManageAppealsData, config);
+        return this.isQuestionPageVisible(/design and access statement with the application/i).then(
+            (isVisible) => {
+                if (!isVisible) {
+                    return;
+                }
+
+                if (config?.isDesignAccessStatement === true) {
+                    cy.getByData(basePage?._selectors.answerYes).click();
+                    cy.advanceToNextPage();
+                    this.uploadIfPagePresent(uploads?.designAccessUpload);
+                } else {
+                    cy.getByData(basePage?._selectors.answerNo).click();
+                    cy.advanceToNextPage();
+                }
+            }
+        );
+    }
+
+    selectPlansAndDrawingsSubmitted(context, lpaManageAppealsData) {
+        const basePage = new BasePage();
+        const config = this.getOriginalEvidenceConfig(context, lpaManageAppealsData);
+        const uploads = this.getOriginalEvidenceUploads(context, lpaManageAppealsData, config);
+        return this.isQuestionPageVisible(/plans and drawings with the application/i).then((isVisible) => {
+            if (!isVisible) {
+                return;
+            }
+
+            if (config?.isPlansAndDrawingsSubmitted === true) {
+                cy.getByData(basePage?._selectors.answerYes).click();
+                cy.advanceToNextPage();
+                this.uploadIfPagePresent(uploads?.plansAndDrawingsUpload);
+            } else {
+                cy.getByData(basePage?._selectors.answerNo).click();
+                cy.advanceToNextPage();
+            }
+        });
+    }
+
+    selectOtherDocumentsSubmitted(context, lpaManageAppealsData) {
+        const basePage = new BasePage();
+        const config = this.getOriginalEvidenceConfig(context, lpaManageAppealsData);
+        const uploads = this.getOriginalEvidenceUploads(context, lpaManageAppealsData, config);
+        return this.isQuestionPageVisible(/any other documents with the application/i).then((isVisible) => {
+            if (!isVisible) {
+                return;
+            }
+
+            if (config?.isOtherDocumentsSubmitted === true) {
+                cy.getByData(basePage?._selectors.answerYes).click();
+                cy.advanceToNextPage();
+                this.uploadIfPagePresent(uploads?.otherDocumentsUpload);
+            } else {
+                cy.getByData(basePage?._selectors.answerNo).click();
+                cy.advanceToNextPage();
+            }
+        });
+    }
+
+    selectListOfDocumentsBeforeDecision(context, lpaManageAppealsData) {
+        const config = this.getOriginalEvidenceConfig(context, lpaManageAppealsData);
+        const listOfDocumentsText =
+            config?.listOfDocumentsBeforeDecision ||
+            'Officer report, approved plans, consultation responses and decision notice.';
+
+        cy.get('body').then(($body) => {
+            const hasListField =
+                $body.find(this._selectors.listOfDocumentsBeforeDecision).length > 0 ||
+                $body.find('textarea[name="listOfDocumentsBeforeDecision"]').length > 0;
+
+            if (!hasListField) {
+                return;
+            }
+
+            if ($body.find(this._selectors.listOfDocumentsBeforeDecision).length > 0) {
+                cy.get(this._selectors.listOfDocumentsBeforeDecision).type(listOfDocumentsText);
+            } else {
+                cy.get('textarea[name="listOfDocumentsBeforeDecision"]').type(listOfDocumentsText);
+            }
+
+            cy.advanceToNextPage();
+        });
+    }
+}

--- a/test-packages/platform-feature-tests/cypress/support/flows/sections/lpaManageAppeals/houseHolderQuestionnaire.js
+++ b/test-packages/platform-feature-tests/cypress/support/flows/sections/lpaManageAppeals/houseHolderQuestionnaire.js
@@ -9,6 +9,7 @@ import { ConsultResponseAndRepresent } from "../../pages/lpa-manage-appeals/cons
 import { NotifyParties } from "../../pages/lpa-manage-appeals/notifyParties";
 import { PoReportAndSupportDocs } from "../../pages/lpa-manage-appeals/poReportAndSupportDocs";
 import { SiteAccess } from "../../pages/lpa-manage-appeals/siteAccess";
+import { OriginalEvidence } from "../../pages/lpa-manage-appeals/originalEvidence";
 import { waitingForReview } from "../../pages/lpa-manage-appeals/waitingForReview";
 
 // Unified questionnaire flow for Householder and CAS Planning (adverts) appeals.
@@ -22,6 +23,7 @@ export const householderQuestionnaire = (context, lpaManageAppealsData, lpaAppea
 	const siteAccess = new SiteAccess();
 	const notifyParties = new NotifyParties();
 	const poReportAndSupportDocs = new PoReportAndSupportDocs();
+	const originalEvidence = new OriginalEvidence();
 
 	let appealId = '';
 	const targetAppealType = lpaAppealType || lpaManageAppealsData?.hasAppealType; // fallback
@@ -89,7 +91,7 @@ export const householderQuestionnaire = (context, lpaManageAppealsData, lpaAppea
 		// Determine the correct "Is this the correct type" label.
 		const correctTypeText = targetAppealType === lpaManageAppealsData?.casPlanningAppealType
 			? lpaManageAppealsData?.constraintsAndDesignations?.correctTypeOfAppealCASPlanning
-			: lpaManageAppealsData?.constraintsAndDesignations?.correctTypeOfAppealHouseHolder;	
+			: lpaManageAppealsData?.constraintsAndDesignations?.correctTypeOfAppealHouseHolder;
 		cy.contains(correctTypeText)
 			.closest(basePage?._selectors.govukSummaryListRow)
 			.find(basePage?._selectors.agovukLink)
@@ -123,7 +125,21 @@ export const householderQuestionnaire = (context, lpaManageAppealsData, lpaAppea
 
 		// Appeals process
 		appealProcess.selectNearbyAppeals(context, lpaManageAppealsData, lpaManageAppealsData?.hasAppealType);
-		appealProcess.selectNewConditions(context, lpaManageAppealsData);
+		if (lpaAppealType === lpaManageAppealsData?.hasAppealType) {
+			appealProcess.selectNewConditions(context, lpaManageAppealsData);
+		}
+		appealProcess.selectSignificantChanges(context, lpaManageAppealsData);
+		if (lpaAppealType != lpaManageAppealsData?.hasAppealType) {
+			appealProcess.selectNewConditions(context, lpaManageAppealsData);
+		}
+
+		// Original Evidence
+		originalEvidence.selectDesignAccessStatement(context, lpaManageAppealsData);
+		if (lpaAppealType != lpaManageAppealsData?.hasAppealType) {
+			originalEvidence.selectPlansAndDrawingsSubmitted(context, lpaManageAppealsData);
+			originalEvidence.selectOtherDocumentsSubmitted(context, lpaManageAppealsData);
+		}
+		originalEvidence.selectListOfDocumentsBeforeDecision(context, lpaManageAppealsData);
 
 		// Submit
 		cy.getByData(lpaManageAppealsData?.submitQuestionnaire).click();

--- a/test-packages/platform-feature-tests/cypress/support/flows/sections/lpaManageAppeals/questionnaire.js
+++ b/test-packages/platform-feature-tests/cypress/support/flows/sections/lpaManageAppeals/questionnaire.js
@@ -10,6 +10,7 @@ import { ConsultResponseAndRepresent } from "../../pages/lpa-manage-appeals/cons
 import { NotifyParties } from "../../pages/lpa-manage-appeals/notifyParties";
 import { PoReportAndSupportDocs } from "../../pages/lpa-manage-appeals/poReportAndSupportDocs";
 import { SiteAccess } from "../../pages/lpa-manage-appeals/siteAccess";
+import { OriginalEvidence } from "../../pages/lpa-manage-appeals/originalEvidence";
 import { waitingForReview } from "../../pages/lpa-manage-appeals/waitingForReview";
 
 
@@ -70,6 +71,7 @@ export const questionnaire = (context, lpaManageAppealsData, lpaAppealType, case
 	const siteAccess = new SiteAccess();
 	const notifyParties = new NotifyParties();
 	const poReportAndSupportDocs = new PoReportAndSupportDocs();
+	const originalEvidence = new OriginalEvidence();
 	selectAppealIdFromTable(context, lpaManageAppealsData, lpaAppealType, caseRef).then(($link) => {
 		if (caseRef) {
 			appealId = caseRef;
@@ -187,7 +189,18 @@ export const questionnaire = (context, lpaManageAppealsData, lpaAppealType, case
 		appealProcess.selectProcedureType(context, lpaManageAppealsData);
 		appealProcess.selectOngoingAppealsNextToSite(context, lpaManageAppealsData, lpaManageAppealsData?.s78AppealType);
 		if (lpaAppealType != lpaManageAppealsData?.ldcAppealType) {
-			appealProcess.selectNewConditions(context, lpaManageAppealsData);
+			if (lpaAppealType === lpaManageAppealsData?.s78AppealType) {
+				appealProcess.selectNewConditions(context, lpaManageAppealsData);
+			}
+			appealProcess.selectSignificantChanges(context, lpaManageAppealsData);
+			if (lpaAppealType != lpaManageAppealsData?.s78AppealType) {
+				appealProcess.selectNewConditions(context, lpaManageAppealsData);
+			}
+			// Original Evidence
+			originalEvidence.selectDesignAccessStatement(context, lpaManageAppealsData);
+			originalEvidence.selectPlansAndDrawingsSubmitted(context, lpaManageAppealsData);
+			originalEvidence.selectOtherDocumentsSubmitted(context, lpaManageAppealsData);
+			originalEvidence.selectListOfDocumentsBeforeDecision(context, lpaManageAppealsData);
 		}
 		cy.getByData(lpaManageAppealsData?.submitQuestionnaire).click();
 		cy.get(basePage?._selectors.govukPanelTitle).contains(lpaManageAppealsData?.questionnaireSubmitted);


### PR DESCRIPTION
### Description of change

S78/HAS /CAS/CAS ADVERT  Expedited LPAQ & E2E .

Added new rows for Expedited LPAQ's and enabled the E2E flows for Expedited automation tests.

Ticket: https://pins-ds.atlassian.net/browse/A2-8177

### Checklist

- [ ] Feature complete and ready for users, or behind feature-flag
- [ ] Commit history is linear with no merge commits
- [ ] Requires infrastructure changes

### Important

Please do not merge from `main` (please only [rebase](https://github.com/Planning-Inspectorate/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
