### PR TITLE
feat(A2-4696): direct old save and return links to dashboard + login

### DIFF
--- a/packages/forms-web-app/__tests__/unit/controllers/common/enter-code.test.js
+++ b/packages/forms-web-app/__tests__/unit/controllers/common/enter-code.test.js
@@ -10,8 +10,7 @@ const fullAppealViews = views.VIEW.FULL_APPEAL;
 const lpaViews = views.VIEW.LPA_DASHBOARD;
 const fullAppeal = require('@pins/business-rules/test/data/full-appeal');
 const { mockReq, mockRes } = require('../../mocks');
-const { getSavedAppeal, getExistingAppeal } = require('#lib/appeals-api-wrapper');
-const { getSessionEmail, setSessionEmail } = require('#lib/session-helper');
+const { getSessionEmail } = require('#lib/session-helper');
 const {
 	getLPAUserStatus,
 	setLPAUserStatus,
@@ -21,7 +20,6 @@ const { isTokenValid } = require('#lib/is-token-valid');
 const { enterCodeConfig } = require('@pins/common');
 const { STATUS_CONSTANTS, AUTH } = require('@pins/common/src/constants');
 const { isFeatureActive } = require('../../../../src/featureFlag');
-const { ApiClientError } = require('@pins/common/src/client/api-client-error');
 let { createOTPGrant } = require('@pins/common/src/client/auth-client');
 const config = require('../../../../src/config');
 
@@ -105,39 +103,6 @@ describe('controllers/common/enter-code', () => {
 			}
 		}
 
-		/**
-		 * @param {boolean} [newCode]
-		 */
-		async function getIsReturningFromEmailTest(newCode = undefined) {
-			req = {
-				...req,
-				params: { enterCodeId: TEST_ID },
-				session: { enterCode: { action: enterCodeConfig.actions.saveAndReturn, newCode } }
-			};
-
-			getExistingAppeal.mockResolvedValue(fullAppeal);
-
-			const returnedFunction = getEnterCode(householderAppealViews, { isGeneralLogin: false });
-			await returnedFunction(req, res);
-
-			expect(createOTPGrant).toHaveBeenCalledWith(
-				fullAppeal.email,
-				enterCodeConfig.actions.saveAndReturn
-			);
-
-			expect(setSessionEmail).toHaveBeenCalledWith(req.session, fullAppeal.email, false);
-			expect(res.render).toHaveBeenCalledWith(`${householderAppealViews.ENTER_CODE}`, {
-				requestNewCodeLink: `/${householderAppealViews.REQUEST_NEW_CODE}`,
-				confirmEmailLink: undefined,
-				showNewCode: newCode,
-				bannerHtmlOverride
-			});
-
-			if (newCode) {
-				expect(req.session.enterCode?.newCode).toBe(undefined);
-			}
-		}
-
 		beforeEach(() => {
 			isFeatureActive.mockResolvedValue(true);
 		});
@@ -170,22 +135,10 @@ describe('controllers/common/enter-code', () => {
 			getSessionEmail.mockReturnValue(TEST_EMAIL);
 			await getConfirmEmailTest(true);
 		});
-
-		it('should handle save and return', async () => {
-			await getIsReturningFromEmailTest();
-		});
-
-		it('should handle newCode save and return', async () => {
-			await getIsReturningFromEmailTest(true);
-		});
 	});
 
 	describe('postEnterCode', () => {
 		beforeEach(() => {
-			getSavedAppeal.mockReturnValue({
-				token: '12312',
-				createdAt: '2022-07-14T13:00:48.024Z'
-			});
 			isTokenValid.mockReturnValue({
 				valid: true,
 				action: 'unused'
@@ -218,16 +171,10 @@ describe('controllers/common/enter-code', () => {
 				errorSummary: errorSummary
 			});
 			expect(isTokenValid).not.toHaveBeenCalled();
-			expect(getSavedAppeal).not.toHaveBeenCalled();
-			expect(getExistingAppeal).not.toHaveBeenCalled();
 		});
 
 		it('should render need new code page if too many attempts have been made', async () => {
 			const { NEED_NEW_CODE } = fullAppealViews;
-
-			getExistingAppeal.mockReturnValue({
-				fullAppeal
-			});
 
 			isTokenValid.mockReturnValue({
 				tooManyAttempts: true
@@ -243,9 +190,6 @@ describe('controllers/common/enter-code', () => {
 		it('should render code expired page when token is expired', async () => {
 			const { CODE_EXPIRED } = fullAppealViews;
 
-			getExistingAppeal.mockReturnValue({
-				fullAppeal
-			});
 			isTokenValid.mockReturnValue({
 				expired: true
 			});
@@ -348,83 +292,6 @@ describe('controllers/common/enter-code', () => {
 
 				expect(res.redirect).toHaveBeenCalledWith('/test');
 				expect(req.appealsApiClient.linkUserToV2Appeal).toHaveBeenCalled();
-			});
-
-			it(`should show user error if returning from email and can't find appeal`, async () => {
-				const { ENTER_CODE } = fullAppealViews;
-				req.session.enterCode = {
-					action: enterCodeConfig.actions.saveAndReturn
-				};
-
-				const error = new ApiClientError('no appeal', 404);
-				getExistingAppeal.mockImplementation(() => Promise.reject(error));
-
-				const returnedFunction = postEnterCode({ ENTER_CODE }, { isGeneralLogin: false });
-				await returnedFunction(req, res);
-
-				const errorMessage = 'We did not find your appeal. Enter the correct code';
-				expect(res.render).toHaveBeenCalledWith(`${ENTER_CODE}`, {
-					token: req.body['email-code'],
-					errors: {
-						'email-code': { msg: errorMessage }
-					},
-					errorSummary: [{ href: '#email-code', text: errorMessage }]
-				});
-			});
-
-			it(`should redirect to custom url if for email return`, async () => {
-				req.session.enterCode = {
-					action: enterCodeConfig.actions.saveAndReturn
-				};
-				req.session.loginRedirect = '/test';
-				req.params = { enterCodeId: 'abc123' };
-
-				const appealLookup = { state: 'DRAFT' };
-
-				getExistingAppeal.mockImplementation(() => Promise.resolve(appealLookup));
-
-				const returnedFunction = postEnterCode({}, { isGeneralLogin: false });
-				await returnedFunction(req, res);
-
-				expect(res.redirect).toHaveBeenCalledWith('/test');
-				expect(req.session.appeal).toEqual(appealLookup);
-			});
-
-			it(`should redirect to appeal submitted for email return if submitted`, async () => {
-				const { APPEAL_ALREADY_SUBMITTED } = fullAppealViews;
-				req.session.enterCode = {
-					action: enterCodeConfig.actions.saveAndReturn
-				};
-
-				const appealLookup = { state: 'SUBMITTED' };
-
-				getExistingAppeal.mockImplementation(() => Promise.resolve(appealLookup));
-
-				const returnedFunction = postEnterCode(
-					{ APPEAL_ALREADY_SUBMITTED },
-					{ isGeneralLogin: false }
-				);
-				await returnedFunction(req, res);
-
-				expect(res.redirect).toHaveBeenCalledWith(`/${APPEAL_ALREADY_SUBMITTED}`);
-				expect(req.session.appeal).toEqual(appealLookup);
-			});
-
-			it(`should redirect to TASK_LIST for email return`, async () => {
-				const { TASK_LIST } = fullAppealViews;
-				req.session.enterCode = {
-					action: enterCodeConfig.actions.saveAndReturn
-				};
-
-				const appealLookup = { state: 'DRAFT' };
-
-				getExistingAppeal.mockImplementation(() => Promise.resolve(appealLookup));
-
-				const returnedFunction = postEnterCode({ TASK_LIST }, { isGeneralLogin: false });
-				await returnedFunction(req, res);
-
-				expect(res.redirect).toHaveBeenCalledWith(`/${TASK_LIST}`);
-				expect(req.session.appeal).toEqual(appealLookup);
 			});
 
 			it('should handle selected page request', async () => {

--- a/packages/forms-web-app/__tests__/unit/routes/appeal-householder-decision/enter-code.test.js
+++ b/packages/forms-web-app/__tests__/unit/routes/appeal-householder-decision/enter-code.test.js
@@ -1,15 +1,12 @@
 const { get, post } = require('../router-mock');
 
-const { getEnterCode, postEnterCode } = require('../../../../src/controllers/common/enter-code');
+const { postEnterCode } = require('../../../../src/controllers/common/enter-code');
 
 const { rules: ruleEnterCode } = require('../../../../src/validators/common/enter-code');
-
-const { rules: idValidationRules } = require('../../../../src/validators/common/check-id-is-uuid');
 
 const { validationErrorHandler } = require('../../../../src/validators/validation-error-handler');
 
 jest.mock('../../../../src/validators/common/enter-code');
-jest.mock('../../../../src/validators/common/check-id-is-uuid');
 jest.mock('../../../../src/validators/validation-error-handler');
 jest.mock('../../../../src/controllers/common/enter-code');
 
@@ -24,12 +21,7 @@ describe('routes/appeal-householder-planning/enter-code', () => {
 	});
 
 	it('should define the expected routes', () => {
-		expect(get).toHaveBeenCalledWith(
-			'/enter-code/:enterCodeId',
-			idValidationRules(),
-			validationErrorHandler,
-			getEnterCode()
-		);
+		expect(get).toHaveBeenCalledWith('/enter-code/:enterCodeId', expect.any(Function));
 		expect(post).toHaveBeenCalledWith(
 			'/enter-code/:enterCodeId',
 			ruleEnterCode(),

--- a/packages/forms-web-app/__tests__/unit/routes/full-appeal/submit-appeal/enter-code.test.js
+++ b/packages/forms-web-app/__tests__/unit/routes/full-appeal/submit-appeal/enter-code.test.js
@@ -1,18 +1,13 @@
 const { get, post } = require('../../router-mock');
 
-const { getEnterCode, postEnterCode } = require('../../../../../src/controllers/common/enter-code');
+const { postEnterCode } = require('../../../../../src/controllers/common/enter-code');
 
 const { rules: ruleEnterCode } = require('../../../../../src/validators/common/enter-code');
-
-const {
-	rules: idValidationRules
-} = require('../../../../../src/validators/common/check-id-is-uuid');
 
 const {
 	validationErrorHandler
 } = require('../../../../../src/validators/validation-error-handler');
 
-jest.mock('../../../../../src/validators/common/check-id-is-uuid');
 jest.mock('../../../../../src/validators/common/enter-code');
 jest.mock('../../../../../src/validators/validation-error-handler');
 jest.mock('../../../../../src/controllers/common/enter-code');
@@ -30,9 +25,7 @@ describe('routes/full-appeal/submit-appeal/enter-code', () => {
 	it('should define the expected routes', () => {
 		expect(get).toHaveBeenCalledWith(
 			'/submit-appeal/enter-code/:enterCodeId',
-			idValidationRules(),
-			validationErrorHandler,
-			getEnterCode()
+			expect.any(Function)
 		);
 		expect(post).toHaveBeenCalledWith(
 			'/submit-appeal/enter-code/:enterCodeId',

--- a/packages/forms-web-app/src/controllers/common/enter-code.js
+++ b/packages/forms-web-app/src/controllers/common/enter-code.js
@@ -1,11 +1,9 @@
-const { getExistingAppeal } = require('#lib/appeals-api-wrapper');
 const { handleCustomRedirect } = require('../../lib/handle-custom-redirect');
 const {
 	getLPAUser,
 	createLPAUserSession,
 	getLPAUserStatus,
-	setLPAUserStatus,
-	logoutUser
+	setLPAUserStatus
 } = require('../../services/user.service');
 const { createAppealUserSession } = require('../../services/user.service');
 const { isTokenValid } = require('#lib/is-token-valid');
@@ -13,7 +11,7 @@ const { enterCodeConfig } = require('@pins/common');
 const logger = require('#lib/logger');
 const { STATUS_CONSTANTS, AUTH } = require('@pins/common/src/constants');
 
-const { getSessionEmail, setSessionEmail, getSessionAppealSqlId } = require('#lib/session-helper');
+const { getSessionEmail, getSessionAppealSqlId } = require('#lib/session-helper');
 const { getAuthClientConfig, createOTPGrant } = require('@pins/common/src/client/auth-client');
 const config = require('../../config');
 const { caseTypeLookup } = require('@pins/common/src/database/data-static');
@@ -34,19 +32,8 @@ const { caseTypeLookup } = require('@pins/common/src/database/data-static');
  */
 const getEnterCode = (views, { isGeneralLogin = true }) => {
 	return async (req, res) => {
-		const {
-			body: { errors = {} }
-		} = req;
-
-		/** @type {string|undefined} */
-		const enterCodeId = req.params.enterCodeId;
-		if (enterCodeId) {
-			req.session.enterCodeId = enterCodeId;
-		}
-
 		const action = req.session?.enterCode?.action ?? enterCodeConfig.actions.saveAndReturn;
-		const isReturningFromEmail = action === enterCodeConfig.actions.saveAndReturn;
-		const isAppealConfirmation = !isGeneralLogin && !isReturningFromEmail;
+		const isAppealConfirmation = !isGeneralLogin;
 		const appealType = caseTypeLookup(req.session?.appeal?.appealType, 'id')?.processCode;
 		const bannerHtmlOverride =
 			config.betaBannerText +
@@ -58,10 +45,7 @@ const getEnterCode = (views, { isGeneralLogin = true }) => {
 			delete req.session?.enterCode?.newCode;
 		}
 
-		logger.info(
-			{ isGeneralLogin, isAppealConfirmation, isReturningFromEmail, action },
-			`getEnterCode`
-		);
+		logger.debug({ isAppealConfirmation, action }, `getEnterCode`);
 
 		if (isGeneralLogin) {
 			const email = getSessionEmail(req.session, false);
@@ -96,37 +80,6 @@ const getEnterCode = (views, { isGeneralLogin = true }) => {
 			return renderEnterCodePage(`/${views.EMAIL_ADDRESS}`);
 		}
 
-		if (isReturningFromEmail) {
-			logoutUser(req);
-			req.session.enterCode = req.session.enterCode || {};
-			req.session.enterCode.action = enterCodeConfig.actions.saveAndReturn;
-
-			// lookup user email from appeal id, user hasn't proved they own this appeal/email yet
-			const savedAppeal = await getExistingAppeal(enterCodeId);
-			setSessionEmail(req.session, savedAppeal.email, false);
-
-			//if middleware UUID validation fails, render the page
-			//but do not attempt to send code email to user
-			if (Object.keys(errors).length > 0) {
-				logger.error(errors, 'failed to send token to returning user');
-				return renderEnterCodePage();
-			}
-
-			// attempt to send code email to user, render page on failure
-			try {
-				await getAuthClientConfig(
-					config.oauth.baseUrl,
-					config.oauth.clientID,
-					config.oauth.clientSecret
-				);
-				await createOTPGrant(savedAppeal.email, action);
-			} catch (e) {
-				logger.error(e, 'failed to send token to returning user');
-			}
-
-			return renderEnterCodePage();
-		}
-
 		throw new Error('unhandled journey for GET: enter-code');
 
 		/**
@@ -159,8 +112,7 @@ const getEnterCode = (views, { isGeneralLogin = true }) => {
 const postEnterCode = (views, { isGeneralLogin = true }) => {
 	return async (req, res) => {
 		const {
-			body: { errors = {}, errorSummary = [] },
-			params: { enterCodeId }
+			body: { errors = {}, errorSummary = [] }
 		} = req;
 		const token = req.body['email-code']?.trim();
 
@@ -170,8 +122,7 @@ const postEnterCode = (views, { isGeneralLogin = true }) => {
 		}
 
 		const action = req.session?.enterCode?.action ?? enterCodeConfig.actions.saveAndReturn;
-		const isReturningFromEmail = action === enterCodeConfig.actions.saveAndReturn;
-		const isAppealConfirmation = !isGeneralLogin && !isReturningFromEmail;
+		const isAppealConfirmation = !isGeneralLogin;
 		const isLoginRedirect = Boolean(req.session?.loginRedirect);
 
 		const sessionEmail = getSessionEmail(req.session, isAppealConfirmation);
@@ -190,12 +141,11 @@ const postEnterCode = (views, { isGeneralLogin = true }) => {
 			sessionEmail
 		);
 
-		logger.info(
+		logger.debug(
 			{
 				isLoginRedirect,
 				isGeneralLogin,
 				isAppealConfirmation,
-				isReturningFromEmail,
 				action
 			},
 			`postEnterCode`
@@ -204,18 +154,7 @@ const postEnterCode = (views, { isGeneralLogin = true }) => {
 		/** @type {string|undefined} */
 		let redirect;
 
-		if (isReturningFromEmail) {
-			try {
-				req.session.appeal = await getExistingAppeal(enterCodeId);
-			} catch (err) {
-				return renderError('We did not find your appeal. Enter the correct code');
-			}
-
-			redirect =
-				req.session.appeal?.state === 'SUBMITTED'
-					? `/${views.APPEAL_ALREADY_SUBMITTED}`
-					: `/${views.TASK_LIST}`;
-		} else if (isAppealConfirmation) {
+		if (isAppealConfirmation) {
 			await req.appealsApiClient.linkUserToV2Appeal(
 				sessionEmail,
 				getSessionAppealSqlId(req.session)

--- a/packages/forms-web-app/src/routes/appeal-householder-decision/login/enter-code.js
+++ b/packages/forms-web-app/src/routes/appeal-householder-decision/login/enter-code.js
@@ -1,9 +1,8 @@
 const express = require('express');
 
 const { rules: ruleEnterCode } = require('../../../validators/common/enter-code');
-const { rules: idValidationRules } = require('../../../validators/common/check-id-is-uuid');
 const { validationErrorHandler } = require('../../../validators/validation-error-handler');
-const { getEnterCode, postEnterCode } = require('../../../controllers/common/enter-code');
+const { postEnterCode } = require('../../../controllers/common/enter-code');
 
 const {
 	VIEW: {
@@ -39,9 +38,10 @@ const router = express.Router();
 
 router.get(
 	'/enter-code/:enterCodeId',
-	idValidationRules('enterCodeId'),
-	validationErrorHandler,
-	getEnterCode(views, { isGeneralLogin: false })
+	/** @type {import('express').RequestHandler} */
+	(_, res) => {
+		return res.redirect(`/${views.YOUR_APPEALS}`);
+	}
 );
 router.post(
 	'/enter-code/:enterCodeId',

--- a/packages/forms-web-app/src/routes/full-appeal/login/enter-code.js
+++ b/packages/forms-web-app/src/routes/full-appeal/login/enter-code.js
@@ -1,9 +1,8 @@
 const express = require('express');
 
 const { rules: ruleEnterCode } = require('../../../validators/common/enter-code');
-const { rules: idValidationRules } = require('../../../validators/common/check-id-is-uuid');
 const { validationErrorHandler } = require('../../../validators/validation-error-handler');
-const { getEnterCode, postEnterCode } = require('../../../controllers/common/enter-code');
+const { postEnterCode } = require('../../../controllers/common/enter-code');
 
 const {
 	VIEW: {
@@ -39,9 +38,10 @@ const router = express.Router();
 
 router.get(
 	'/submit-appeal/enter-code/:enterCodeId',
-	idValidationRules('enterCodeId'),
-	validationErrorHandler,
-	getEnterCode(views, { isGeneralLogin: false })
+	/** @type {import('express').RequestHandler} */
+	(_, res) => {
+		return res.redirect(`/${views.YOUR_APPEALS}`);
+	}
 );
 
 router.post(


### PR DESCRIPTION
### Description of change

Removes code for v1 return to appeal email link, redirects to dashboard as a fallback

Ticket: https://pins-ds.atlassian.net/browse/A2-4696

### Checklist

- [x] Feature complete and ready for users, or behind feature-flag
- [x] Commit history is linear with no merge commits
- [ ] Requires infrastructure changes

### Important

Please do not merge from `main` (please only [rebase](https://github.com/Planning-Inspectorate/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
