### PR TITLE
fix(A2-8884): fix ordering for CAS adverts and CAS planning LPAQ

### DIFF
--- a/packages/forms-web-app/src/dynamic-forms/cas-adverts-questionnaire-part-1/journey.js
+++ b/packages/forms-web-app/src/dynamic-forms/cas-adverts-questionnaire-part-1/journey.js
@@ -99,8 +99,8 @@ const makeSections = (response) => {
 			.addQuestion(questions.appealsNearSite)
 			.addQuestion(questions.nearbyAppeals)
 			.withCondition(() => questionHasAnswer(response, questions.appealsNearSite, 'yes'))
-			.addQuestion(questions.anySignificantChanges)
-			.addQuestion(questions.addNewConditions),
+			.addQuestion(questions.addNewConditions)
+			.addQuestion(questions.anySignificantChanges),
 		new Section('Original Evidence', 'original-evidence')
 			.addQuestion(questions.designAccessStatementPart1)
 			.addQuestion(questions.uploadDesignAccessStatementPart1)

--- a/packages/forms-web-app/src/dynamic-forms/cas-planning-questionnaire-part-1/journey.js
+++ b/packages/forms-web-app/src/dynamic-forms/cas-planning-questionnaire-part-1/journey.js
@@ -90,8 +90,8 @@ const makeSections = (response) => {
 			.withCondition(
 				() => response.answers && response.answers[questions.appealsNearSite.fieldName] == 'yes'
 			)
-			.addQuestion(questions.anySignificantChanges)
-			.addQuestion(questions.addNewConditions),
+			.addQuestion(questions.addNewConditions)
+			.addQuestion(questions.anySignificantChanges),
 		new Section('Original Evidence', 'original-evidence')
 			.addQuestion(questions.designAccessStatementPart1)
 			.addQuestion(questions.uploadDesignAccessStatementPart1)


### PR DESCRIPTION
### Description of change

Update ordering of Expedited questions in CAS adverts/Appeals LPAQ

Ticket: https://pins-ds.atlassian.net/browse/A2-8884

### Checklist

- [x] Feature complete and ready for users, or behind feature-flag
- [x] Commit history is linear with no merge commits
- [ ] Requires infrastructure changes

### Important

Please do not merge from `main` (please only [rebase](https://github.com/Planning-Inspectorate/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
