### PR TITLE
fix(A2-8676): typo in costs folder urls

### DIFF
--- a/packages/forms-web-app/src/controllers/selected-appeal/appellant-sections.js
+++ b/packages/forms-web-app/src/controllers/selected-appeal/appellant-sections.js
@@ -191,7 +191,7 @@ exports.sections = [
 		heading: 'Costs',
 		links: [
 			{
-				url: '/your-cost-application',
+				url: '/your-costs-applications',
 				text: 'View your costs applications',
 				condition: (appealCase) =>
 					appealCase.Documents.some(
@@ -210,7 +210,7 @@ exports.sections = [
 					)
 			},
 			{
-				url: '/your-cost-comments',
+				url: '/your-costs-comments',
 				text: 'View your costs comments',
 				condition: (appealCase) =>
 					appealCase.Documents.some(

--- a/packages/forms-web-app/src/controllers/selected-appeal/lpa-user-sections.js
+++ b/packages/forms-web-app/src/controllers/selected-appeal/lpa-user-sections.js
@@ -215,7 +215,7 @@ exports.sections = [
 		heading: 'Costs',
 		links: [
 			{
-				url: '/your-cost-application',
+				url: '/your-costs-applications',
 				text: 'View your costs applications',
 				condition: (appealCase) =>
 					appealCase.Documents.some(
@@ -235,7 +235,7 @@ exports.sections = [
 					)
 			},
 			{
-				url: '/your-cost-comments',
+				url: '/your-costs-comments',
 				text: 'View your costs comments',
 				condition: (appealCase) =>
 					appealCase.Documents.some(

--- a/packages/forms-web-app/src/controllers/selected-appeal/user-sections.test.js
+++ b/packages/forms-web-app/src/controllers/selected-appeal/user-sections.test.js
@@ -388,7 +388,7 @@ describe('LPA and Appellant Sections', () => {
 					}
 				];
 				const section = findSectionByHeading(lpaSections, 'Costs');
-				const link = findLinkByUrl(section, '/your-cost-application');
+				const link = findLinkByUrl(section, '/your-costs-applications');
 				expect(link?.condition(appealCase)).toBe(true);
 				expect(link?.text).toBe('View your costs applications');
 			});
@@ -400,7 +400,7 @@ describe('LPA and Appellant Sections', () => {
 					}
 				];
 				const section = findSectionByHeading(lpaSections, 'Costs');
-				const link = findLinkByUrl(section, '/your-cost-comments');
+				const link = findLinkByUrl(section, '/your-costs-comments');
 				expect(link?.condition(appealCase)).toBe(true);
 				expect(link?.text).toBe('View your costs comments');
 			});

--- a/packages/forms-web-app/src/routes/appeals/selected-appeal/selected-appeal.js
+++ b/packages/forms-web-app/src/routes/appeals/selected-appeal/selected-appeal.js
@@ -110,7 +110,7 @@ router.get('/:appealNumber/planning-obligation', planningObligationDetailsContro
 
 // costs
 router.get(
-	'/:appealNumber/your-cost-application',
+	'/:appealNumber/your-costs-application',
 	costsController.get({ userType, costsType: APPEAL_DOCUMENT_TYPE.APPELLANT_COSTS_APPLICATION })
 );
 router.get(
@@ -118,7 +118,7 @@ router.get(
 	costsController.get({ userType, costsType: APPEAL_DOCUMENT_TYPE.LPA_COSTS_APPLICATION })
 );
 router.get(
-	'/:appealNumber/your-cost-comments',
+	'/:appealNumber/your-costs-comments',
 	costsController.get({ userType, costsType: APPEAL_DOCUMENT_TYPE.APPELLANT_COSTS_CORRESPONDENCE })
 );
 router.get(

--- a/packages/forms-web-app/src/routes/lpa-dashboard/selected-appeal.js
+++ b/packages/forms-web-app/src/routes/lpa-dashboard/selected-appeal.js
@@ -145,7 +145,7 @@ router.get(
 	)
 );
 router.get(
-	'/:appealNumber/your-cost-application',
+	'/:appealNumber/your-costs-application',
 	costsController.get(
 		{ userType, costsType: APPEAL_DOCUMENT_TYPE.LPA_COSTS_APPLICATION },
 		'layouts/lpa-dashboard/main.njk'
@@ -159,7 +159,7 @@ router.get(
 	)
 );
 router.get(
-	'/:appealNumber/your-cost-comments',
+	'/:appealNumber/your-costs-comments',
 	costsController.get(
 		{ userType, costsType: APPEAL_DOCUMENT_TYPE.LPA_COSTS_CORRESPONDENCE },
 		'layouts/lpa-dashboard/main.njk'


### PR DESCRIPTION
### Description of change

This PR fixes a URL typo by renaming the costs-related routes and links from /your-**cost**-application and /your-**cost**-comments to /your-**costs**-application**s** and /your-**costs**-comments

Ticket: https://pins-ds.atlassian.net/browse/A2-8676

### Checklist

- [x] Feature complete and ready for users, or behind feature-flag
- [x] Commit history is linear with no merge commits
- [ ] Requires infrastructure changes

### Important

Please do not merge from `main` (please only [rebase](https://github.com/Planning-Inspectorate/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
