### PR TITLE
feat(A2-8776): make display of Why are you appealing conditional for 1st april cutoff

### DIFF
--- a/packages/forms-web-app/src/controllers/selected-appeal/appeal-details/appeal-details-rows.js
+++ b/packages/forms-web-app/src/controllers/selected-appeal/appeal-details/appeal-details-rows.js
@@ -30,7 +30,10 @@ const {
 	APPEAL_APPLICATION_MADE_UNDER_ACT_SECTION
 } = require('@planning-inspectorate/data-model');
 const { isNotUndefinedOrNull } = require('#lib/is-not-undefined-or-null');
-const { isExpeditedPart1Eligible } = require('#lib/is-expedited-part1-eligible');
+const {
+	isExpeditedPart1Eligible,
+	isExpeditedAppealDate
+} = require('#lib/is-expedited-part1-eligible');
 const { nl2br } = require('@pins/common/src/utils');
 
 /**
@@ -328,7 +331,9 @@ const getStandardDetailsRows = (caseData, context) => {
 		{
 			keyText: 'Why are you appealing?',
 			valueText: caseData.reasonForAppealAppellant ?? '',
-			condition: (caseData) => isNotUndefinedOrNull(caseData.reasonForAppealAppellant),
+			condition: (caseData) =>
+				isNotUndefinedOrNull(caseData.reasonForAppealAppellant) ||
+				isExpeditedAppealDate(caseData.applicationDate),
 			isEscaped: true
 		},
 		{
@@ -870,7 +875,9 @@ const getExpeditedDetailsRows = (caseData, context) => {
 		{
 			keyText: 'Why are you appealing?',
 			valueText: caseData.reasonForAppealAppellant ?? '',
-			condition: (caseData) => isNotUndefinedOrNull(caseData.reasonForAppealAppellant),
+			condition: (caseData) =>
+				isNotUndefinedOrNull(caseData.reasonForAppealAppellant) ||
+				isExpeditedAppealDate(caseData.applicationDate),
 			isEscaped: true
 		},
 		{

--- a/packages/forms-web-app/src/controllers/selected-appeal/appeal-details/appeal-details-rows.test.js
+++ b/packages/forms-web-app/src/controllers/selected-appeal/appeal-details/appeal-details-rows.test.js
@@ -872,8 +872,18 @@ describe('appeal-details-rows', () => {
 			expect(rows[reasonForAppealIndex].valueText).toEqual('Some reason');
 		});
 
-		it('should not display the reason for appeal if not set', () => {
+		it('should display the reason for appeal if application date is after April 1 even if not set', () => {
 			const testCase = structuredClone(caseWithAppellant);
+			testCase.applicationDate = '2026-04-02';
+			testCase.reasonForAppealAppellant = null;
+			const rows = detailsRows(testCase, APPEAL_USER_ROLES.APPELLANT);
+			expect(rows[reasonForAppealIndex].condition(testCase)).toBeTruthy();
+		});
+
+		it('should not display the reason for appeal if not set and application date is before April 1', () => {
+			const testCase = structuredClone(caseWithAppellant);
+			testCase.applicationDate = '2026-03-01';
+			testCase.reasonForAppealAppellant = null;
 			const rows = detailsRows(testCase, APPEAL_USER_ROLES.APPELLANT);
 			expect(rows[reasonForAppealIndex].condition(testCase)).toBeFalsy();
 		});


### PR DESCRIPTION
### Description of change

Ensure the display of the "Why are you appealing?" on S78, HAS, CAS Planning, or CAS Advert after 1st april

Ticket: https://pins-ds.atlassian.net/browse/A2-8776

### Checklist

- [x] Feature complete and ready for users, or behind feature-flag
- [x] Commit history is linear with no merge commits
- [ ] Requires infrastructure changes

### Important

Please do not merge from `main` (please only [rebase](https://github.com/Planning-Inspectorate/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
