### PR TITLE
Feat/shift code generation

### DIFF
--- a/packages/common/src/enter-code-config.js
+++ b/packages/common/src/enter-code-config.js
@@ -2,7 +2,8 @@ const enterCodeConfig = {
 	actions: {
 		saveAndReturn: 'saveAndReturn',
 		confirmEmail: 'confirmEmail',
-		lpaDashboard: 'lpa-dashboard'
+		lpaDashboard: 'lpa-dashboard',
+		rule6Dashboard: 'rule6-dashboard'
 	}
 };
 

--- a/packages/forms-web-app/__tests__/unit/controllers/common/enter-code.test.js
+++ b/packages/forms-web-app/__tests__/unit/controllers/common/enter-code.test.js
@@ -10,8 +10,6 @@ const fullAppealViews = views.VIEW.FULL_APPEAL;
 const lpaViews = views.VIEW.LPA_DASHBOARD;
 const fullAppeal = require('@pins/business-rules/test/data/full-appeal');
 const { mockReq, mockRes } = require('../../mocks');
-const { getSavedAppeal, getExistingAppeal } = require('#lib/appeals-api-wrapper');
-const { getSessionEmail, setSessionEmail } = require('#lib/session-helper');
 const {
 	getLPAUserStatus,
 	setLPAUserStatus,
@@ -21,11 +19,8 @@ const { isTokenValid } = require('#lib/is-token-valid');
 const { enterCodeConfig } = require('@pins/common');
 const { STATUS_CONSTANTS, AUTH } = require('@pins/common/src/constants');
 const { isFeatureActive } = require('../../../../src/featureFlag');
-const { ApiClientError } = require('@pins/common/src/client/api-client-error');
-let { createOTPGrant } = require('@pins/common/src/client/auth-client');
 const config = require('../../../../src/config');
 
-jest.mock('#lib/appeals-api-wrapper');
 jest.mock('#lib/is-token-valid');
 jest.mock('@pins/common/src/utils', () => {
 	return {
@@ -51,8 +46,6 @@ jest.mock('../../../../src/services/user.service', () => {
 	};
 });
 jest.mock('../../../../src/featureFlag');
-jest.mock('#lib/session-helper');
-jest.mock('@pins/common/src/client/auth-client');
 const TEST_EMAIL = 'test@example.com';
 const TEST_ID = '89aa8504-773c-42be-bb68-029716ad9756';
 
@@ -91,44 +84,9 @@ describe('controllers/common/enter-code', () => {
 
 			await returnedFunction(req, res);
 
-			expect(createOTPGrant).toHaveBeenCalledWith(TEST_EMAIL, enterCodeConfig.actions.confirmEmail);
-
 			expect(res.render).toHaveBeenCalledWith(`${householderAppealViews.ENTER_CODE}`, {
 				requestNewCodeLink: `/${householderAppealViews.REQUEST_NEW_CODE}`,
 				confirmEmailLink: `/${householderAppealViews.EMAIL_ADDRESS}`,
-				showNewCode: newCode,
-				bannerHtmlOverride
-			});
-
-			if (newCode) {
-				expect(req.session.enterCode?.newCode).toBe(undefined);
-			}
-		}
-
-		/**
-		 * @param {boolean} [newCode]
-		 */
-		async function getIsReturningFromEmailTest(newCode = undefined) {
-			req = {
-				...req,
-				params: { enterCodeId: TEST_ID },
-				session: { enterCode: { action: enterCodeConfig.actions.saveAndReturn, newCode } }
-			};
-
-			getExistingAppeal.mockResolvedValue(fullAppeal);
-
-			const returnedFunction = getEnterCode(householderAppealViews, { isGeneralLogin: false });
-			await returnedFunction(req, res);
-
-			expect(createOTPGrant).toHaveBeenCalledWith(
-				fullAppeal.email,
-				enterCodeConfig.actions.saveAndReturn
-			);
-
-			expect(setSessionEmail).toHaveBeenCalledWith(req.session, fullAppeal.email, false);
-			expect(res.render).toHaveBeenCalledWith(`${householderAppealViews.ENTER_CODE}`, {
-				requestNewCodeLink: `/${householderAppealViews.REQUEST_NEW_CODE}`,
-				confirmEmailLink: undefined,
 				showNewCode: newCode,
 				bannerHtmlOverride
 			});
@@ -143,15 +101,10 @@ describe('controllers/common/enter-code', () => {
 		});
 
 		it('should handle general log in', async () => {
-			getSessionEmail.mockReturnValue(TEST_EMAIL);
+			req.session.email = TEST_EMAIL;
 			const returnedFunction = getEnterCode(householderAppealViews, { isGeneralLogin: true });
 
 			await returnedFunction(req, res);
-
-			expect(createOTPGrant).toHaveBeenCalledWith(
-				TEST_EMAIL,
-				enterCodeConfig.actions.saveAndReturn
-			);
 
 			expect(res.render).toHaveBeenCalledWith(`${householderAppealViews.ENTER_CODE}`, {
 				confirmEmailLink: `/${householderAppealViews.EMAIL_ADDRESS}`,
@@ -162,30 +115,18 @@ describe('controllers/common/enter-code', () => {
 		});
 
 		it('should handle confirm email for appeal', async () => {
-			getSessionEmail.mockReturnValue(TEST_EMAIL);
+			req.session.email = TEST_EMAIL;
 			await getConfirmEmailTest();
 		});
 
 		it('should handle newCode confirm email', async () => {
-			getSessionEmail.mockReturnValue(TEST_EMAIL);
+			req.session.email = TEST_EMAIL;
 			await getConfirmEmailTest(true);
-		});
-
-		it('should handle save and return', async () => {
-			await getIsReturningFromEmailTest();
-		});
-
-		it('should handle newCode save and return', async () => {
-			await getIsReturningFromEmailTest(true);
 		});
 	});
 
 	describe('postEnterCode', () => {
 		beforeEach(() => {
-			getSavedAppeal.mockReturnValue({
-				token: '12312',
-				createdAt: '2022-07-14T13:00:48.024Z'
-			});
 			isTokenValid.mockReturnValue({
 				valid: true,
 				action: 'unused'
@@ -194,7 +135,7 @@ describe('controllers/common/enter-code', () => {
 		});
 
 		it('should show validation errors to user', async () => {
-			const { ENTER_CODE } = fullAppealViews;
+			const { ENTER_CODE, REQUEST_NEW_CODE, EMAIL_ADDRESS } = fullAppealViews;
 
 			const errors = { 'mock-error': 'Error message' };
 			const errorSummary = [{ text: 'There was an error', href: '#' }];
@@ -209,25 +150,30 @@ describe('controllers/common/enter-code', () => {
 				params: { enterCodeId: 'not-a-valid-id' }
 			};
 
-			const returnedFunction = postEnterCode({ ENTER_CODE }, { isGeneralLogin: false });
+			const returnedFunction = postEnterCode(
+				{ ENTER_CODE, REQUEST_NEW_CODE, EMAIL_ADDRESS },
+				{ isGeneralLogin: false }
+			);
 			await returnedFunction(req, res);
 
 			expect(res.render).toHaveBeenCalledWith(`${ENTER_CODE}`, {
+				confirmEmailLink: '/full-appeal/submit-appeal/email-address',
+				requestNewCodeLink: '/full-appeal/submit-appeal/request-new-code',
 				token: req.body['email-code'],
 				errors: errors,
 				errorSummary: errorSummary
 			});
 			expect(isTokenValid).not.toHaveBeenCalled();
-			expect(getSavedAppeal).not.toHaveBeenCalled();
-			expect(getExistingAppeal).not.toHaveBeenCalled();
 		});
 
 		it('should render need new code page if too many attempts have been made', async () => {
 			const { NEED_NEW_CODE } = fullAppealViews;
-
-			getExistingAppeal.mockReturnValue({
-				fullAppeal
-			});
+			req.session.appeal = {
+				email: 'test@example.com'
+			};
+			req.session.enterCode = {
+				action: enterCodeConfig.actions.confirmEmail
+			};
 
 			isTokenValid.mockReturnValue({
 				tooManyAttempts: true
@@ -242,10 +188,9 @@ describe('controllers/common/enter-code', () => {
 
 		it('should render code expired page when token is expired', async () => {
 			const { CODE_EXPIRED } = fullAppealViews;
-
-			getExistingAppeal.mockReturnValue({
-				fullAppeal
-			});
+			req.session.enterCode = {
+				action: enterCodeConfig.actions.confirmEmail
+			};
 			isTokenValid.mockReturnValue({
 				expired: true
 			});
@@ -258,18 +203,25 @@ describe('controllers/common/enter-code', () => {
 		});
 
 		it('should render page with error message if token invalid', async () => {
-			const { ENTER_CODE } = fullAppealViews;
-
+			const { ENTER_CODE, REQUEST_NEW_CODE, EMAIL_ADDRESS } = fullAppealViews;
+			req.session.enterCode = {
+				action: enterCodeConfig.actions.confirmEmail
+			};
 			isTokenValid.mockReturnValue({
 				valid: false
 			});
 
-			const returnedFunction = postEnterCode({ ENTER_CODE }, { isGeneralLogin: true });
+			const returnedFunction = postEnterCode(
+				{ ENTER_CODE, REQUEST_NEW_CODE, EMAIL_ADDRESS },
+				{ isGeneralLogin: true }
+			);
 			await returnedFunction(req, res);
 
 			const errorMessage = 'Enter the code we sent to your email address';
 
 			expect(res.render).toHaveBeenCalledWith(`${ENTER_CODE}`, {
+				confirmEmailLink: '/full-appeal/submit-appeal/email-address',
+				requestNewCodeLink: '/full-appeal/submit-appeal/request-new-code',
 				token: req.body['email-code'],
 				errors: {
 					'email-code': { msg: errorMessage }
@@ -285,6 +237,7 @@ describe('controllers/common/enter-code', () => {
 
 			const expectUserInSession = () => {
 				expect(req.session.user).toEqual({
+					email: expect.any(String),
 					access_token: 'access',
 					id_token: 'id',
 					expiry: 'expiry'
@@ -293,7 +246,10 @@ describe('controllers/common/enter-code', () => {
 
 			it('should redirect to your appeals for general log on', async () => {
 				const { YOUR_APPEALS } = fullAppealViews;
-
+				req.session.email = 'test@example.com';
+				req.session.enterCode = {
+					action: enterCodeConfig.actions.confirmEmail
+				};
 				isTokenValid.mockResolvedValue({
 					valid: true,
 					access_token: 'access',
@@ -310,6 +266,7 @@ describe('controllers/common/enter-code', () => {
 
 			it('should redirect to confirmed page if email action', async () => {
 				const { EMAIL_CONFIRMED } = fullAppealViews;
+				req.session.appeal = { email: 'test@example.com' };
 				req.session.enterCode = {
 					action: enterCodeConfig.actions.confirmEmail
 				};
@@ -330,6 +287,7 @@ describe('controllers/common/enter-code', () => {
 
 			it('should redirect to custom url if email action', async () => {
 				const { EMAIL_CONFIRMED } = fullAppealViews;
+				req.session.appeal = { email: 'test@example.com' };
 				req.session.enterCode = {
 					action: enterCodeConfig.actions.confirmEmail
 				};
@@ -350,88 +308,12 @@ describe('controllers/common/enter-code', () => {
 				expect(req.appealsApiClient.linkUserToV2Appeal).toHaveBeenCalled();
 			});
 
-			it(`should show user error if returning from email and can't find appeal`, async () => {
-				const { ENTER_CODE } = fullAppealViews;
-				req.session.enterCode = {
-					action: enterCodeConfig.actions.saveAndReturn
-				};
-
-				const error = new ApiClientError('no appeal', 404);
-				getExistingAppeal.mockImplementation(() => Promise.reject(error));
-
-				const returnedFunction = postEnterCode({ ENTER_CODE }, { isGeneralLogin: false });
-				await returnedFunction(req, res);
-
-				const errorMessage = 'We did not find your appeal. Enter the correct code';
-				expect(res.render).toHaveBeenCalledWith(`${ENTER_CODE}`, {
-					token: req.body['email-code'],
-					errors: {
-						'email-code': { msg: errorMessage }
-					},
-					errorSummary: [{ href: '#email-code', text: errorMessage }]
-				});
-			});
-
-			it(`should redirect to custom url if for email return`, async () => {
-				req.session.enterCode = {
-					action: enterCodeConfig.actions.saveAndReturn
-				};
-				req.session.loginRedirect = '/test';
-				req.params = { enterCodeId: 'abc123' };
-
-				const appealLookup = { state: 'DRAFT' };
-
-				getExistingAppeal.mockImplementation(() => Promise.resolve(appealLookup));
-
-				const returnedFunction = postEnterCode({}, { isGeneralLogin: false });
-				await returnedFunction(req, res);
-
-				expect(res.redirect).toHaveBeenCalledWith('/test');
-				expect(req.session.appeal).toEqual(appealLookup);
-			});
-
-			it(`should redirect to appeal submitted for email return if submitted`, async () => {
-				const { APPEAL_ALREADY_SUBMITTED } = fullAppealViews;
-				req.session.enterCode = {
-					action: enterCodeConfig.actions.saveAndReturn
-				};
-
-				const appealLookup = { state: 'SUBMITTED' };
-
-				getExistingAppeal.mockImplementation(() => Promise.resolve(appealLookup));
-
-				const returnedFunction = postEnterCode(
-					{ APPEAL_ALREADY_SUBMITTED },
-					{ isGeneralLogin: false }
-				);
-				await returnedFunction(req, res);
-
-				expect(res.redirect).toHaveBeenCalledWith(`/${APPEAL_ALREADY_SUBMITTED}`);
-				expect(req.session.appeal).toEqual(appealLookup);
-			});
-
-			it(`should redirect to TASK_LIST for email return`, async () => {
-				const { TASK_LIST } = fullAppealViews;
-				req.session.enterCode = {
-					action: enterCodeConfig.actions.saveAndReturn
-				};
-
-				const appealLookup = { state: 'DRAFT' };
-
-				getExistingAppeal.mockImplementation(() => Promise.resolve(appealLookup));
-
-				const returnedFunction = postEnterCode({ TASK_LIST }, { isGeneralLogin: false });
-				await returnedFunction(req, res);
-
-				expect(res.redirect).toHaveBeenCalledWith(`/${TASK_LIST}`);
-				expect(req.session.appeal).toEqual(appealLookup);
-			});
-
 			it('should handle selected page request', async () => {
 				const redirectPath = '/appeals/1234567';
 				req.session.enterCode = {
 					action: enterCodeConfig.actions.confirmEmail
 				};
+				req.session.appeal = { email: 'test@example.com' };
 
 				req.session.loginRedirect = redirectPath;
 				req.session.navigationHistory = ['existing/path'];
@@ -454,10 +336,8 @@ describe('controllers/common/enter-code', () => {
 
 	describe('getEnterCodeLPA', () => {
 		it('should render page', async () => {
-			const userId = '649418158b915f0018524cb7';
 			const expectedURL = 'manage-appeals/enter-code';
 			const expectedContext = {
-				lpaUserId: userId,
 				requestNewCodeLink: '/manage-appeals/request-new-code'
 			};
 			const { ENTER_CODE, CODE_EXPIRED, NEED_NEW_CODE, REQUEST_NEW_CODE, DASHBOARD } = lpaViews;
@@ -469,37 +349,12 @@ describe('controllers/common/enter-code', () => {
 				DASHBOARD
 			};
 			const returnedFunction = getEnterCodeLPA(views);
-			req.params.id = userId;
 			await returnedFunction(req, res);
 			expect(res.render).toHaveBeenCalledWith(expectedURL, expectedContext);
 		});
-		it('should redirect if user id is not supplied', async () => {
-			const {
-				ENTER_CODE,
-				CODE_EXPIRED,
-				NEED_NEW_CODE,
-				REQUEST_NEW_CODE,
-				DASHBOARD,
-				YOUR_EMAIL_ADDRESS
-			} = lpaViews;
-			const views = {
-				ENTER_CODE,
-				CODE_EXPIRED,
-				NEED_NEW_CODE,
-				REQUEST_NEW_CODE,
-				DASHBOARD,
-				YOUR_EMAIL_ADDRESS
-			};
-			const expectedURL = `/${views.YOUR_EMAIL_ADDRESS}`;
-			const returnedFunction = getEnterCodeLPA(views);
-			await returnedFunction(req, res);
-			expect(res.redirect).toHaveBeenCalledWith(expectedURL);
-		});
 		it('should send new code param to view and remove from session', async () => {
-			const userId = '649418158b915f0018524cb7';
 			const expectedURL = 'manage-appeals/enter-code';
 			const expectedContext = {
-				lpaUserId: userId,
 				requestNewCodeLink: '/manage-appeals/request-new-code',
 				showNewCode: true
 			};
@@ -512,71 +367,12 @@ describe('controllers/common/enter-code', () => {
 				DASHBOARD
 			};
 			const returnedFunction = getEnterCodeLPA(views);
-			req.params.id = userId;
 			req.session.enterCode = {
 				newCode: true
 			};
 			await returnedFunction(req, res);
 			expect(res.render).toHaveBeenCalledWith(expectedURL, expectedContext);
-			expect(req.enterCode?.newCode).toBe(undefined);
-		});
-		it('should send token to user if user exists', async () => {
-			const userId = '649418158b915f0018524cb7';
-			const expectedURL = 'manage-appeals/enter-code';
-			const expectedContext = {
-				lpaUserId: userId,
-				requestNewCodeLink: '/manage-appeals/request-new-code'
-			};
-			const fakeUserResponse = {
-				email: 'test@example.com'
-			};
-			const { ENTER_CODE, CODE_EXPIRED, NEED_NEW_CODE, REQUEST_NEW_CODE, DASHBOARD } = lpaViews;
-			const views = {
-				ENTER_CODE,
-				CODE_EXPIRED,
-				NEED_NEW_CODE,
-				REQUEST_NEW_CODE,
-				DASHBOARD
-			};
-
-			getLPAUser.mockResolvedValue(fakeUserResponse);
-
-			const returnedFunction = getEnterCodeLPA(views);
-			req.params.id = userId;
-
-			await returnedFunction(req, res);
-
-			expect(res.render).toHaveBeenCalledWith(expectedURL, expectedContext);
-			expect(createOTPGrant).toHaveBeenCalledWith(
-				fakeUserResponse.email,
-				enterCodeConfig.actions.lpaDashboard
-			);
-		});
-		it('should not send token to user if user lookup fails, but still render page', async () => {
-			const userId = '649418158b915f0018524cb7';
-			const expectedURL = 'manage-appeals/enter-code';
-			const expectedContext = {
-				lpaUserId: userId,
-				requestNewCodeLink: '/manage-appeals/request-new-code'
-			};
-			const { ENTER_CODE, CODE_EXPIRED, NEED_NEW_CODE, REQUEST_NEW_CODE, DASHBOARD } = lpaViews;
-			const views = {
-				ENTER_CODE,
-				CODE_EXPIRED,
-				NEED_NEW_CODE,
-				REQUEST_NEW_CODE,
-				DASHBOARD
-			};
-
-			getLPAUser.mockRejectedValue(new Error('Failed'));
-
-			const returnedFunction = getEnterCodeLPA(views);
-			req.params.id = userId;
-
-			await returnedFunction(req, res);
-
-			expect(res.render).toHaveBeenCalledWith(expectedURL, expectedContext);
-			expect(getLPAUser).toHaveBeenCalledWith(req, userId);
+			expect(req.session.enterCode?.newCode).toBe(undefined);
 		});
 	});
 
@@ -590,8 +386,8 @@ describe('controllers/common/enter-code', () => {
 				REQUEST_NEW_CODE,
 				DASHBOARD
 			};
-			const userId = '649418158b915f0018524cb7';
 			const code = '12345';
+			req.session.email = TEST_EMAIL;
 			isTokenValid.mockResolvedValue({
 				valid: true
 			});
@@ -603,7 +399,6 @@ describe('controllers/common/enter-code', () => {
 
 			const returnedFunction = postEnterCodeLPA(views);
 
-			req.params.id = userId;
 			req.body = {
 				'email-code': code
 			};
@@ -612,8 +407,8 @@ describe('controllers/common/enter-code', () => {
 			expect(isTokenValid).toHaveBeenCalledWith(code, mockUser.email, undefined, [
 				AUTH.SCOPES.USER_DETAILS.LPA
 			]);
-			expect(getLPAUserStatus).toHaveBeenCalledWith(req, userId);
-			expect(setLPAUserStatus).toHaveBeenCalledWith(req, userId, STATUS_CONSTANTS.CONFIRMED);
+			expect(getLPAUserStatus).toHaveBeenCalledWith(req, TEST_EMAIL);
+			expect(setLPAUserStatus).toHaveBeenCalledWith(req, TEST_EMAIL, STATUS_CONSTANTS.CONFIRMED);
 			expect(res.redirect).toHaveBeenCalledWith('/manage-appeals/your-appeals');
 		});
 		it('should redirect on too many attempts', async () => {
@@ -625,9 +420,8 @@ describe('controllers/common/enter-code', () => {
 				REQUEST_NEW_CODE,
 				DASHBOARD
 			};
-			const userId = '649418158b915f0018524cb7';
 			const code = '12345';
-
+			req.session.email = TEST_EMAIL;
 			isTokenValid.mockReturnValue({
 				valid: false,
 				tooManyAttempts: true
@@ -641,13 +435,12 @@ describe('controllers/common/enter-code', () => {
 
 			const returnedFunction = postEnterCodeLPA(views);
 
-			req.params.id = userId;
 			req.body = {
 				'email-code': code
 			};
 
 			await returnedFunction(req, res);
-			expect(res.redirect).toHaveBeenCalledWith(`/manage-appeals/need-new-code/${userId}`);
+			expect(res.redirect).toHaveBeenCalledWith(`/manage-appeals/need-new-code`);
 		});
 		it('should redirect on token expired', async () => {
 			const { ENTER_CODE, CODE_EXPIRED, NEED_NEW_CODE, REQUEST_NEW_CODE, DASHBOARD } = lpaViews;
@@ -658,9 +451,8 @@ describe('controllers/common/enter-code', () => {
 				REQUEST_NEW_CODE,
 				DASHBOARD
 			};
-			const userId = '649418158b915f0018524cb7';
 			const code = '12345';
-
+			req.session.email = TEST_EMAIL;
 			isTokenValid.mockReturnValue({
 				valid: false,
 				expired: true
@@ -674,13 +466,12 @@ describe('controllers/common/enter-code', () => {
 
 			const returnedFunction = postEnterCodeLPA(views);
 
-			req.params.id = userId;
 			req.body = {
 				'email-code': code
 			};
 
 			await returnedFunction(req, res);
-			expect(res.redirect).toHaveBeenCalledWith(`/manage-appeals/code-expired/${userId}`);
+			expect(res.redirect).toHaveBeenCalledWith(`/manage-appeals/code-expired`);
 		});
 
 		it('should set the user session', async () => {
@@ -692,12 +483,12 @@ describe('controllers/common/enter-code', () => {
 				REQUEST_NEW_CODE,
 				DASHBOARD
 			};
-			const userId = '649418158b915f0018524cb7';
 			const code = '12345';
 			const mockUser = {
 				email: 'a',
 				enabled: true
 			};
+			req.session.email = TEST_EMAIL;
 			isTokenValid.mockReturnValue({
 				valid: true
 			});
@@ -706,7 +497,6 @@ describe('controllers/common/enter-code', () => {
 
 			const returnedFunction = postEnterCodeLPA(views);
 
-			req.params.id = userId;
 			req.body = {
 				'email-code': code
 			};
@@ -718,8 +508,8 @@ describe('controllers/common/enter-code', () => {
 
 		it('redirects using session property if a document request', async () => {
 			const views = {};
-			const userId = '649418158b915f0018524cb7';
 			const code = '12345';
+			req.session.email = TEST_EMAIL;
 			isTokenValid.mockResolvedValue({
 				valid: true
 			});
@@ -732,28 +522,25 @@ describe('controllers/common/enter-code', () => {
 			const returnedFunction = postEnterCodeLPA(views);
 
 			req.session.loginRedirect = '/lpa-questionnaire-document/1010101';
-			req.params.id = userId;
 			req.body = {
 				'email-code': code
 			};
 			getLPAUserStatus.mockResolvedValue(STATUS_CONSTANTS.ADDED);
 			await returnedFunction(req, res);
-			expect(getLPAUserStatus).toHaveBeenCalledWith(req, userId);
-			expect(setLPAUserStatus).toHaveBeenCalledWith(req, userId, STATUS_CONSTANTS.CONFIRMED);
+			expect(getLPAUserStatus).toHaveBeenCalledWith(req, TEST_EMAIL);
+			expect(setLPAUserStatus).toHaveBeenCalledWith(req, TEST_EMAIL, STATUS_CONSTANTS.CONFIRMED);
 			expect(res.redirect).toHaveBeenCalledWith('/lpa-questionnaire-document/1010101');
 			expect(req.session.loginRedirect).toEqual(undefined);
 		});
 
 		it('should handle selected page request', async () => {
 			const views = {};
-			const userId = '649418158b915f0018524cb7';
 			const code = '12345';
-
+			req.session.email = TEST_EMAIL;
 			isTokenValid.mockResolvedValue({ valid: true });
 			getLPAUser.mockResolvedValue({ email: 'lpa@example.com' });
 			getLPAUserStatus.mockResolvedValue(STATUS_CONSTANTS.ADDED);
 
-			req.params.id = userId;
 			req.body = { 'email-code': code };
 
 			req.session.loginRedirect = '/manage-appeals/1234567/';

--- a/packages/forms-web-app/__tests__/unit/controllers/common/need-new-code.test.js
+++ b/packages/forms-web-app/__tests__/unit/controllers/common/need-new-code.test.js
@@ -47,7 +47,7 @@ describe('controllers/common/enter-code', () => {
 			};
 			await returnedFunction(req, res);
 
-			expect(res.redirect).toHaveBeenCalledWith(`/${ENTER_CODE}/${tokenId}`);
+			expect(res.redirect).toHaveBeenCalledWith(`/${ENTER_CODE}`);
 		});
 	});
 });

--- a/packages/forms-web-app/__tests__/unit/controllers/common/request-new-code.test.js
+++ b/packages/forms-web-app/__tests__/unit/controllers/common/request-new-code.test.js
@@ -4,6 +4,8 @@ const {
 	postRequestNewCodeLPA
 } = require('../../../../src/controllers/common/request-new-code');
 const { mockRes, mockReq } = require('../../mocks');
+jest.mock('#lib/logger');
+jest.mock('@pins/common/src/client/auth-client');
 
 describe('controllers/common/enter-code', () => {
 	let req;
@@ -50,21 +52,23 @@ describe('controllers/common/enter-code', () => {
 	});
 
 	describe('postRequestNewCode', () => {
-		it('should redirect to correct page', () => {
+		it('should redirect to correct page', async () => {
 			const {
 				VIEW: {
 					APPELLANT_SUBMISSION: { ENTER_CODE }
 				}
-			} = require('../../../../src/lib/views');
-			const tokenId = '1552441a-1e56-4e83-8d85-de7b246d2594';
+			} = require('#lib/views');
 			req.session = {
-				enterCodeId: tokenId
+				email: 'test@example.com',
+				enterCode: {
+					action: 'test-action'
+				}
 			};
 
 			const returnedFunction = postRequestNewCode(ENTER_CODE);
-			returnedFunction(req, res);
+			await returnedFunction(req, res);
 
-			expect(res.redirect).toHaveBeenCalledWith(`/${ENTER_CODE}/${tokenId}`);
+			expect(res.redirect).toHaveBeenCalledWith(`/${ENTER_CODE}`);
 			expect(req.session.enterCodeId).not.toBeDefined();
 			expect(req.session.enterCode.newCode).toBe(true);
 		});
@@ -82,6 +86,12 @@ describe('controllers/common/enter-code', () => {
 				ENTER_CODE
 			};
 			const email_address = 'admin1@planninginspectorate.gov.uk';
+			req.session = {
+				email: email_address,
+				enterCode: {
+					action: 'test-action'
+				}
+			};
 			const user = {
 				_id: '649954a21134d20012a8eb12',
 				email: 'admin1@planninginspectorate.gov.uk',
@@ -94,40 +104,11 @@ describe('controllers/common/enter-code', () => {
 			req.body = {
 				emailAddress: email_address
 			};
-			const returnedFunction = postRequestNewCodeLPA(views);
+			const returnedFunction = postRequestNewCodeLPA(views.ENTER_CODE);
 			await returnedFunction(req, res);
 			expect(req.appealsApiClient.getUserByEmailV2).toHaveBeenCalledWith(email_address);
 			expect(res.render).not.toHaveBeenCalled();
-			expect(res.redirect).toHaveBeenCalledWith(`/${ENTER_CODE}/${user.id}`);
-		});
-
-		it('should redirect to request-new-code page if the email is incorrect', async () => {
-			const {
-				VIEW: {
-					LPA_DASHBOARD: { REQUEST_NEW_CODE, ENTER_CODE }
-				}
-			} = require('../../../../src/lib/views');
-			const views = {
-				REQUEST_NEW_CODE,
-				ENTER_CODE
-			};
-			const email_address = 'admin1@planninginspectorate.gov.uk';
-			const customErrorSummary = [{ text: 'Enter a correct email address', href: '#' }];
-
-			req.body = {
-				emailAddress: email_address
-			};
-
-			req.appealsApiClient.getUserByEmailV2.mockImplementation(() => Promise.reject(new Error()));
-
-			const returnedFunction = postRequestNewCodeLPA(views);
-			await returnedFunction(req, res);
-			expect(req.appealsApiClient.getUserByEmailV2).toHaveBeenCalledWith(email_address);
-			expect(res.redirect).not.toHaveBeenCalled();
-			expect(res.render).toHaveBeenCalledWith(`${REQUEST_NEW_CODE}`, {
-				errorSummary: customErrorSummary,
-				errors: {}
-			});
+			expect(res.redirect).toHaveBeenCalledWith(`/${views.ENTER_CODE}`);
 		});
 	});
 });

--- a/packages/forms-web-app/__tests__/unit/controllers/common/your-email-address.test.js
+++ b/packages/forms-web-app/__tests__/unit/controllers/common/your-email-address.test.js
@@ -1,14 +1,11 @@
 const {
-	getYourEmailAddress,
-	postYourEmailAddress
+	getYourEmailAddressLPA,
+	postYourEmailAddressLPA
 } = require('../../../../src/controllers/common/your-email-address');
-
-const mapCache = require('../../../../src/lib/map-cache');
 
 const { mockReq, mockRes } = require('../../mocks');
 const views = require('#lib/views');
 const lpaViews = views.VIEW.LPA_DASHBOARD;
-const mockEmailUUIDcache = new mapCache(5);
 
 describe('controllers/full-appeal/submit-appeal/enter-code', () => {
 	let req;
@@ -27,11 +24,11 @@ describe('controllers/full-appeal/submit-appeal/enter-code', () => {
 		jest.resetAllMocks();
 	});
 
-	describe('getYourEmailAddress', () => {
+	describe('getYourEmailAddressLPA', () => {
 		it('controllers/common/getYourEmailAddress.js', async () => {
 			const testEmail = 'iamnoone@@planninginspectorate.gov.uk';
 			req.session.email = testEmail;
-			const returnedFunction = getYourEmailAddress(lpaViews);
+			const returnedFunction = getYourEmailAddressLPA(lpaViews);
 			await returnedFunction(req, res);
 			expect(res.render).toHaveBeenCalledWith(`${lpaViews.YOUR_EMAIL_ADDRESS}`, {
 				email: testEmail
@@ -39,9 +36,8 @@ describe('controllers/full-appeal/submit-appeal/enter-code', () => {
 		});
 	});
 
-	describe('postYourEmailAddress', () => {
+	describe('postYourEmailAddressLPA', () => {
 		it('redirect to enter code', async () => {
-			const testId = '64c789bf8672ef00122fe30c';
 			const testEmail = 'iamnoone@@planninginspectorate.gov.uk';
 			req.appealsApiClient.getUserByEmailV2.mockImplementation(() =>
 				Promise.resolve({
@@ -54,13 +50,12 @@ describe('controllers/full-appeal/submit-appeal/enter-code', () => {
 			);
 
 			req.body['email-address'] = testEmail;
-			const returnedFunction = postYourEmailAddress(lpaViews, mockEmailUUIDcache);
+			const returnedFunction = postYourEmailAddressLPA(lpaViews);
 			await returnedFunction(req, res);
-			expect(res.redirect).toHaveBeenCalledWith(`/${lpaViews.ENTER_CODE}/${testId}`);
+			expect(res.redirect).toHaveBeenCalledWith(`/${lpaViews.ENTER_CODE}`);
 		});
 
 		it('redirect to enter code when a non LPA email which exists in the database is used', async () => {
-			const testId = '64c789bf8672ef00122fe30c';
 			const testEmail = 'iamnoone@planninginspectorate.gov.uk';
 			req.appealsApiClient.getUserByEmailV2.mockImplementation(() =>
 				Promise.resolve({
@@ -73,9 +68,9 @@ describe('controllers/full-appeal/submit-appeal/enter-code', () => {
 			);
 
 			req.body['email-address'] = testEmail;
-			const returnedFunction = postYourEmailAddress(lpaViews, mockEmailUUIDcache);
+			const returnedFunction = postYourEmailAddressLPA(lpaViews);
 			await returnedFunction(req, res);
-			expect(res.redirect).toHaveBeenCalledWith(`/${lpaViews.ENTER_CODE}/${testId}`);
+			expect(res.redirect).toHaveBeenCalledWith(`/${lpaViews.ENTER_CODE}`);
 		});
 
 		it('redirect to enter code when an email is used which is not in the database', async () => {
@@ -85,13 +80,9 @@ describe('controllers/full-appeal/submit-appeal/enter-code', () => {
 			);
 
 			req.body['email-address'] = testEmail;
-			const returnedFunction = postYourEmailAddress(lpaViews, mockEmailUUIDcache);
+			const returnedFunction = postYourEmailAddressLPA(lpaViews);
 			await returnedFunction(req, res);
-			// we want to check that we have a UUID in the redirect URL, but as it is generated at runtime, we use a regex to match it
-			const expectedURLRegex = new RegExp(
-				`${lpaViews.ENTER_CODE}/[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}`
-			);
-			expect(res.redirect).toHaveBeenCalledWith(expect.stringMatching(expectedURLRegex));
+			expect(res.redirect).toHaveBeenCalledWith(`/${lpaViews.ENTER_CODE}`);
 		});
 
 		it('redirect to enter code when an email is used which is not in the database should be called with the same id within 5 minutes', async () => {
@@ -109,13 +100,13 @@ describe('controllers/full-appeal/submit-appeal/enter-code', () => {
 			laterReq = { ...req };
 			let laterRes = mockRes();
 
-			const returnedFunction = postYourEmailAddress(lpaViews, mockEmailUUIDcache);
+			const returnedFunction = postYourEmailAddressLPA(lpaViews);
 			await returnedFunction(req, res);
 			const redirectURL = res.redirect.mock.calls[0][0];
 
 			// 5 minutes later, we expect to call the same redirect URL
 			jest.setSystemTime(new Date('2025-01-30T00:04:00.000Z'));
-			const laterReturnedFunction = postYourEmailAddress(lpaViews, mockEmailUUIDcache);
+			const laterReturnedFunction = postYourEmailAddressLPA(lpaViews);
 			await laterReturnedFunction(laterReq, laterRes);
 			expect(laterRes.redirect).toHaveBeenCalledWith(redirectURL);
 
@@ -129,7 +120,7 @@ describe('controllers/full-appeal/submit-appeal/enter-code', () => {
 					href: '#your-email-address'
 				}
 			];
-			const returnedFunction = postYourEmailAddress(lpaViews, mockEmailUUIDcache);
+			const returnedFunction = postYourEmailAddressLPA(lpaViews);
 			await returnedFunction(req, res);
 			expect(res.render).toHaveBeenCalledWith(lpaViews.YOUR_EMAIL_ADDRESS, {
 				errors: {},

--- a/packages/forms-web-app/__tests__/unit/controllers/rule-6/email-address.test.js
+++ b/packages/forms-web-app/__tests__/unit/controllers/rule-6/email-address.test.js
@@ -43,11 +43,9 @@ describe('controllers/rule-6/email-address', () => {
 
 	describe('postR6Address', () => {
 		it('redirect to enter code', async () => {
-			const testId = '64c789bf8672ef00122fe30c';
 			const testEmail = 'testR6user@planninginspectorate.gov.uk';
 			req.appealsApiClient.getUserByEmailV2.mockImplementation(() =>
 				Promise.resolve({
-					id: testId,
 					email: 'testR6user@planninginspectorate.gov.uk'
 				})
 			);
@@ -55,7 +53,7 @@ describe('controllers/rule-6/email-address', () => {
 			req.body['email-address'] = testEmail;
 			const returnedFunction = postR6EmailAddress(rule6Views);
 			await returnedFunction(req, res);
-			expect(res.redirect).toHaveBeenCalledWith(`/${rule6Views.ENTER_CODE}/${testId}`);
+			expect(res.redirect).toHaveBeenCalledWith(`/${rule6Views.ENTER_CODE}`);
 		});
 		it('should error with missing email address', async () => {
 			const customErrorSummary = [

--- a/packages/forms-web-app/__tests__/unit/controllers/rule-6/enter-code.test.js
+++ b/packages/forms-web-app/__tests__/unit/controllers/rule-6/enter-code.test.js
@@ -5,7 +5,7 @@ const {
 const views = require('../../../../src/lib/views');
 const rule6Views = views.VIEW.RULE_6;
 const { mockReq, mockRes } = require('../../mocks');
-const { getSessionEmail } = require('#lib/session-helper');
+const { getSessionEmail, getSessionNewCode, deleteSessionNewCode } = require('#lib/session-helper');
 const { isTokenValid } = require('#lib/is-token-valid');
 const { enterCodeConfig } = require('@pins/common');
 const { isRule6UserByEmail } = require('../../../../src/services/user.service');
@@ -76,8 +76,6 @@ describe('controllers/rule-6/enter-code', () => {
 
 			await returnedFunction(req, res);
 
-			expect(createOTPGrant).toHaveBeenCalledWith(TEST_EMAIL, enterCodeConfig.actions.confirmEmail);
-
 			expect(res.render).toHaveBeenCalledWith(`${rule6Views.ENTER_CODE}`, {
 				requestNewCodeLink: `/${rule6Views.REQUEST_NEW_CODE}`,
 				confirmEmailLink: `/${rule6Views.EMAIL_ADDRESS}`,
@@ -96,11 +94,6 @@ describe('controllers/rule-6/enter-code', () => {
 				isRule6UserByEmail.mockResolvedValue(true);
 
 				await returnedFunction(req, res);
-
-				expect(createOTPGrant).toHaveBeenCalledWith(
-					TEST_EMAIL,
-					enterCodeConfig.actions.confirmEmail
-				);
 
 				expect(res.render).toHaveBeenCalledWith(`${rule6Views.ENTER_CODE}`, {
 					confirmEmailLink: `/${rule6Views.EMAIL_ADDRESS}`,
@@ -127,6 +120,10 @@ describe('controllers/rule-6/enter-code', () => {
 
 			it('should handle newCode confirm email', async () => {
 				getSessionEmail.mockReturnValue(TEST_EMAIL);
+				getSessionNewCode.mockReturnValue(true);
+				deleteSessionNewCode.mockImplementation(() => {
+					req.session.enterCode.newCode = undefined;
+				});
 				await getConfirmEmailTest(true);
 			});
 		});

--- a/packages/forms-web-app/__tests__/unit/routes/appeal-householder-decision/enter-code.test.js
+++ b/packages/forms-web-app/__tests__/unit/routes/appeal-householder-decision/enter-code.test.js
@@ -4,12 +4,9 @@ const { getEnterCode, postEnterCode } = require('../../../../src/controllers/com
 
 const { rules: ruleEnterCode } = require('../../../../src/validators/common/enter-code');
 
-const { rules: idValidationRules } = require('../../../../src/validators/common/check-id-is-uuid');
-
 const { validationErrorHandler } = require('../../../../src/validators/validation-error-handler');
 
 jest.mock('../../../../src/validators/common/enter-code');
-jest.mock('../../../../src/validators/common/check-id-is-uuid');
 jest.mock('../../../../src/validators/validation-error-handler');
 jest.mock('../../../../src/controllers/common/enter-code');
 
@@ -24,17 +21,13 @@ describe('routes/appeal-householder-planning/enter-code', () => {
 	});
 
 	it('should define the expected routes', () => {
-		expect(get).toHaveBeenCalledWith(
-			'/enter-code/:enterCodeId',
-			idValidationRules(),
-			validationErrorHandler,
-			getEnterCode()
-		);
+		expect(get).toHaveBeenNthCalledWith(1, '/enter-code/:enterCodeId', expect.any(Function));
+		expect(get).toHaveBeenNthCalledWith(2, '/enter-code', getEnterCode(expect.any(Object)));
 		expect(post).toHaveBeenCalledWith(
-			'/enter-code/:enterCodeId',
+			'/enter-code',
 			ruleEnterCode(),
 			validationErrorHandler,
-			postEnterCode()
+			postEnterCode(expect.any(Object), { isGeneralLogin: false })
 		);
 	});
 });

--- a/packages/forms-web-app/__tests__/unit/routes/full-appeal/submit-appeal/enter-code.test.js
+++ b/packages/forms-web-app/__tests__/unit/routes/full-appeal/submit-appeal/enter-code.test.js
@@ -5,14 +5,9 @@ const { getEnterCode, postEnterCode } = require('../../../../../src/controllers/
 const { rules: ruleEnterCode } = require('../../../../../src/validators/common/enter-code');
 
 const {
-	rules: idValidationRules
-} = require('../../../../../src/validators/common/check-id-is-uuid');
-
-const {
 	validationErrorHandler
 } = require('../../../../../src/validators/validation-error-handler');
 
-jest.mock('../../../../../src/validators/common/check-id-is-uuid');
 jest.mock('../../../../../src/validators/common/enter-code');
 jest.mock('../../../../../src/validators/validation-error-handler');
 jest.mock('../../../../../src/controllers/common/enter-code');
@@ -28,14 +23,20 @@ describe('routes/full-appeal/submit-appeal/enter-code', () => {
 	});
 
 	it('should define the expected routes', () => {
-		expect(get).toHaveBeenCalledWith(
+		expect(get).toHaveBeenNthCalledWith(
+			1,
 			'/submit-appeal/enter-code/:enterCodeId',
-			idValidationRules(),
-			validationErrorHandler,
-			getEnterCode()
+			expect.any(Function)
 		);
+		expect(get).toHaveBeenNthCalledWith(
+			2,
+			'/submit-appeal/enter-code',
+			validationErrorHandler,
+			getEnterCode(expect.any(Object))
+		);
+
 		expect(post).toHaveBeenCalledWith(
-			'/submit-appeal/enter-code/:enterCodeId',
+			'/submit-appeal/enter-code',
 			ruleEnterCode(),
 			validationErrorHandler,
 			postEnterCode()

--- a/packages/forms-web-app/__tests__/unit/routes/lpa/enter-code.test.js
+++ b/packages/forms-web-app/__tests__/unit/routes/lpa/enter-code.test.js
@@ -21,9 +21,9 @@ describe('routes/lpa/enter-code', () => {
 	});
 
 	it('should define the expected routes', () => {
-		expect(get).toHaveBeenCalledWith('/enter-code/:id', validationErrorHandler, getEnterCodeLPA());
+		expect(get).toHaveBeenCalledWith('/enter-code', validationErrorHandler, getEnterCodeLPA());
 		expect(post).toHaveBeenCalledWith(
-			'/enter-code/:id',
+			'/enter-code',
 			ruleEnterCode(),
 			validationErrorHandler,
 			postEnterCodeLPA()

--- a/packages/forms-web-app/__tests__/unit/routes/lpa/need-new-code.test.js
+++ b/packages/forms-web-app/__tests__/unit/routes/lpa/need-new-code.test.js
@@ -14,10 +14,7 @@ describe('routes/lpa/request-new-code', () => {
 	});
 
 	it('should define the expected routes', () => {
-		expect(get).toHaveBeenCalledWith('/need-new-code/:id', needNewCodeController.getNeedNewCode());
-		expect(post).toHaveBeenCalledWith(
-			'/need-new-code/:id',
-			needNewCodeController.postNeedNewCode()
-		);
+		expect(get).toHaveBeenCalledWith('/need-new-code', needNewCodeController.getNeedNewCode());
+		expect(post).toHaveBeenCalledWith('/need-new-code', needNewCodeController.postNeedNewCode());
 	});
 });

--- a/packages/forms-web-app/src/controllers/appeal-householder-decision/email-address.js
+++ b/packages/forms-web-app/src/controllers/appeal-householder-decision/email-address.js
@@ -5,7 +5,8 @@ const { VIEW } = require('../../lib/views');
 const { logoutUser } = require('../../services/user.service');
 const config = require('../../config');
 const { caseTypeLookup } = require('@pins/common/src/database/data-static');
-
+const { getAuthClientConfig, createOTPGrant } = require('@pins/common/src/client/auth-client');
+const { setSessionEnterCodeAction } = require('../../lib/session-helper');
 const getEmailAddress = (req, res) => {
 	const {
 		appeal,
@@ -56,10 +57,20 @@ const postEmailAddress = async (req, res) => {
 	}
 
 	logoutUser(req);
-	req.session.enterCode = req.session.enterCode || {};
-	req.session.enterCode.action = enterCodeConfig.actions.confirmEmail;
+	setSessionEnterCodeAction(req.session, enterCodeConfig.actions.confirmEmail);
 
-	res.redirect(`/appeal-householder-decision/enter-code/${req.session.appeal.id}`);
+	try {
+		await getAuthClientConfig(
+			config.oauth.baseUrl,
+			config.oauth.clientID,
+			config.oauth.clientSecret
+		);
+		await createOTPGrant(email, enterCodeConfig.actions.confirmEmail);
+	} catch (e) {
+		logger.error(e, 'failed to send token to general login user');
+	}
+
+	res.redirect(`/appeal-householder-decision/enter-code`);
 };
 
 module.exports = {

--- a/packages/forms-web-app/src/controllers/common/email-address.js
+++ b/packages/forms-web-app/src/controllers/common/email-address.js
@@ -6,13 +6,12 @@ const {
 	setSessionAppeal,
 	getSessionAppeal,
 	setSessionEmail,
-	setSessionEnterCode,
-	setSessionEnterCodeAction,
-	getSessionAppealId
+	setSessionEnterCodeAction
 } = require('../../lib/session-helper');
 const { logoutUser } = require('../../services/user.service');
 const config = require('../../config');
 const { caseTypeLookup } = require('@pins/common/src/database/data-static');
+const { getAuthClientConfig, createOTPGrant } = require('@pins/common/src/client/auth-client');
 
 const getEmailAddress = (views, appealInSession) => {
 	return (req, res) => {
@@ -26,6 +25,27 @@ const getEmailAddress = (views, appealInSession) => {
 				config.generateBetaBannerFeedbackLink(config.getAppealTypeFeedbackUrl(appealType))
 		});
 	};
+};
+
+/**
+ * @param {import('express').Request} req
+ * @param {string} email
+ * @param {string} action
+ * @returns {Promise<void>}
+ */
+const sendTokenToUser = async (req, email, action) => {
+	logoutUser(req);
+	setSessionEnterCodeAction(req.session, action);
+	try {
+		await getAuthClientConfig(
+			config.oauth.baseUrl,
+			config.oauth.clientID,
+			config.oauth.clientSecret
+		);
+		await createOTPGrant(email, action);
+	} catch (e) {
+		logger.error(e, 'failed to send token to general login user');
+	}
 };
 
 const postEmailAddress = (views, appealInSession) => {
@@ -57,8 +77,8 @@ const postEmailAddress = (views, appealInSession) => {
 		if (appealInSession) {
 			try {
 				setSessionAppeal(req.session, await createOrUpdateAppeal(appeal));
-				setSession();
-				res.redirect(`/${views.ENTER_CODE}/${getSessionAppealId(req.session)}`);
+				await sendTokenToUser(req, email, enterCodeConfig.actions.confirmEmail);
+				res.redirect(`/${views.ENTER_CODE}`);
 				return;
 			} catch (e) {
 				logger.error(e);
@@ -90,14 +110,8 @@ const postEmailAddress = (views, appealInSession) => {
 			});
 		}
 
-		setSession();
+		await sendTokenToUser(req, email, enterCodeConfig.actions.saveAndReturn);
 		res.redirect(`/${views.ENTER_CODE}`);
-
-		function setSession() {
-			logoutUser(req);
-			setSessionEnterCode(req.session, {}, true);
-			setSessionEnterCodeAction(req.session, enterCodeConfig.actions.confirmEmail);
-		}
 	};
 };
 

--- a/packages/forms-web-app/src/controllers/common/enter-code.js
+++ b/packages/forms-web-app/src/controllers/common/enter-code.js
@@ -1,11 +1,9 @@
-const { getExistingAppeal } = require('#lib/appeals-api-wrapper');
 const { handleCustomRedirect } = require('../../lib/handle-custom-redirect');
 const {
 	getLPAUser,
 	createLPAUserSession,
 	getLPAUserStatus,
-	setLPAUserStatus,
-	logoutUser
+	setLPAUserStatus
 } = require('../../services/user.service');
 const { createAppealUserSession } = require('../../services/user.service');
 const { isTokenValid } = require('#lib/is-token-valid');
@@ -13,8 +11,14 @@ const { enterCodeConfig } = require('@pins/common');
 const logger = require('#lib/logger');
 const { STATUS_CONSTANTS, AUTH } = require('@pins/common/src/constants');
 
-const { getSessionEmail, setSessionEmail, getSessionAppealSqlId } = require('#lib/session-helper');
-const { getAuthClientConfig, createOTPGrant } = require('@pins/common/src/client/auth-client');
+const {
+	getSessionEmail,
+	getSessionAppealSqlId,
+	getSessionEnterCodeAction,
+	deleteSessionEnterCodeAction,
+	getSessionNewCode,
+	deleteSessionNewCode
+} = require('#lib/session-helper');
 const config = require('../../config');
 const { caseTypeLookup } = require('@pins/common/src/database/data-static');
 
@@ -29,24 +33,10 @@ const { caseTypeLookup } = require('@pins/common/src/database/data-static');
 
 /**
  * @param {{EMAIL_ADDRESS: string, ENTER_CODE: string, REQUEST_NEW_CODE: string}} views
- * @param {enterCodeOptions} enterCodeOptions
  * @returns {import('express').Handler}
  */
-const getEnterCode = (views, { isGeneralLogin = true }) => {
+const getEnterCode = (views) => {
 	return async (req, res) => {
-		const {
-			body: { errors = {} }
-		} = req;
-
-		/** @type {string|undefined} */
-		const enterCodeId = req.params.enterCodeId;
-		if (enterCodeId) {
-			req.session.enterCodeId = enterCodeId;
-		}
-
-		const action = req.session?.enterCode?.action ?? enterCodeConfig.actions.saveAndReturn;
-		const isReturningFromEmail = action === enterCodeConfig.actions.saveAndReturn;
-		const isAppealConfirmation = !isGeneralLogin && !isReturningFromEmail;
 		const appealType = caseTypeLookup(req.session?.appeal?.appealType, 'id')?.processCode;
 		const bannerHtmlOverride =
 			config.betaBannerText +
@@ -58,88 +48,12 @@ const getEnterCode = (views, { isGeneralLogin = true }) => {
 			delete req.session?.enterCode?.newCode;
 		}
 
-		logger.info(
-			{ isGeneralLogin, isAppealConfirmation, isReturningFromEmail, action },
-			`getEnterCode`
-		);
-
-		if (isGeneralLogin) {
-			const email = getSessionEmail(req.session, false);
-
-			try {
-				await getAuthClientConfig(
-					config.oauth.baseUrl,
-					config.oauth.clientID,
-					config.oauth.clientSecret
-				);
-				await createOTPGrant(email, action);
-			} catch (e) {
-				logger.error(e, 'failed to send token to general login user');
-			}
-
-			return renderEnterCodePage(`/${views.EMAIL_ADDRESS}`);
-		}
-
-		if (isAppealConfirmation) {
-			try {
-				const email = getSessionEmail(req.session, true);
-				await getAuthClientConfig(
-					config.oauth.baseUrl,
-					config.oauth.clientID,
-					config.oauth.clientSecret
-				);
-				await createOTPGrant(email, action);
-			} catch (e) {
-				logger.error(e, 'failed to send token for appeal email confirmation');
-			}
-
-			return renderEnterCodePage(`/${views.EMAIL_ADDRESS}`);
-		}
-
-		if (isReturningFromEmail) {
-			logoutUser(req);
-			req.session.enterCode = req.session.enterCode || {};
-			req.session.enterCode.action = enterCodeConfig.actions.saveAndReturn;
-
-			// lookup user email from appeal id, user hasn't proved they own this appeal/email yet
-			const savedAppeal = await getExistingAppeal(enterCodeId);
-			setSessionEmail(req.session, savedAppeal.email, false);
-
-			//if middleware UUID validation fails, render the page
-			//but do not attempt to send code email to user
-			if (Object.keys(errors).length > 0) {
-				logger.error(errors, 'failed to send token to returning user');
-				return renderEnterCodePage();
-			}
-
-			// attempt to send code email to user, render page on failure
-			try {
-				await getAuthClientConfig(
-					config.oauth.baseUrl,
-					config.oauth.clientID,
-					config.oauth.clientSecret
-				);
-				await createOTPGrant(savedAppeal.email, action);
-			} catch (e) {
-				logger.error(e, 'failed to send token to returning user');
-			}
-
-			return renderEnterCodePage();
-		}
-
-		throw new Error('unhandled journey for GET: enter-code');
-
-		/**
-		 * @param {string} [confirmEmailUrl]
-		 */
-		function renderEnterCodePage(confirmEmailUrl) {
-			res.render(views.ENTER_CODE, {
-				requestNewCodeLink: `/${views.REQUEST_NEW_CODE}`,
-				confirmEmailLink: confirmEmailUrl,
-				showNewCode: newCode,
-				bannerHtmlOverride
-			});
-		}
+		res.render(views.ENTER_CODE, {
+			requestNewCodeLink: `/${views.REQUEST_NEW_CODE}`,
+			confirmEmailLink: `/${views.EMAIL_ADDRESS}`,
+			showNewCode: newCode,
+			bannerHtmlOverride
+		});
 	};
 };
 
@@ -148,10 +62,10 @@ const getEnterCode = (views, { isGeneralLogin = true }) => {
  *  NEED_NEW_CODE: string,
  *  CODE_EXPIRED: string,
  *  ENTER_CODE: string,
- *  YOUR_APPEALS: string
- *  APPEAL_ALREADY_SUBMITTED : string
- *  TASK_LIST: string
- *  EMAIL_CONFIRMED: string
+ *  YOUR_APPEALS: string,
+ *  EMAIL_CONFIRMED: string,
+ *  REQUEST_NEW_CODE: string,
+ * 	EMAIL_ADDRESS: string
  * }} views
  * @param {enterCodeOptions} enterCodeOptions
  * @returns {import('express').Handler}
@@ -159,8 +73,7 @@ const getEnterCode = (views, { isGeneralLogin = true }) => {
 const postEnterCode = (views, { isGeneralLogin = true }) => {
 	return async (req, res) => {
 		const {
-			body: { errors = {}, errorSummary = [] },
-			params: { enterCodeId }
+			body: { errors = {}, errorSummary = [] }
 		} = req;
 		const token = req.body['email-code']?.trim();
 
@@ -169,9 +82,8 @@ const postEnterCode = (views, { isGeneralLogin = true }) => {
 			return renderError(errorSummary, errors);
 		}
 
-		const action = req.session?.enterCode?.action ?? enterCodeConfig.actions.saveAndReturn;
-		const isReturningFromEmail = action === enterCodeConfig.actions.saveAndReturn;
-		const isAppealConfirmation = !isGeneralLogin && !isReturningFromEmail;
+		const action = getSessionEnterCodeAction(req.session) ?? enterCodeConfig.actions.saveAndReturn;
+		const isAppealConfirmation = !isGeneralLogin;
 		const isLoginRedirect = Boolean(req.session?.loginRedirect);
 
 		const sessionEmail = getSessionEmail(req.session, isAppealConfirmation);
@@ -190,12 +102,11 @@ const postEnterCode = (views, { isGeneralLogin = true }) => {
 			sessionEmail
 		);
 
-		logger.info(
+		logger.debug(
 			{
 				isLoginRedirect,
 				isGeneralLogin,
 				isAppealConfirmation,
-				isReturningFromEmail,
 				action
 			},
 			`postEnterCode`
@@ -204,18 +115,7 @@ const postEnterCode = (views, { isGeneralLogin = true }) => {
 		/** @type {string|undefined} */
 		let redirect;
 
-		if (isReturningFromEmail) {
-			try {
-				req.session.appeal = await getExistingAppeal(enterCodeId);
-			} catch (err) {
-				return renderError('We did not find your appeal. Enter the correct code');
-			}
-
-			redirect =
-				req.session.appeal?.state === 'SUBMITTED'
-					? `/${views.APPEAL_ALREADY_SUBMITTED}`
-					: `/${views.TASK_LIST}`;
-		} else if (isAppealConfirmation) {
+		if (isAppealConfirmation) {
 			await req.appealsApiClient.linkUserToV2Appeal(
 				sessionEmail,
 				getSessionAppealSqlId(req.session)
@@ -237,8 +137,7 @@ const postEnterCode = (views, { isGeneralLogin = true }) => {
 		return res.redirect(redirect);
 
 		function deleteTempSessionValues() {
-			delete req.session?.enterCodeId;
-			delete req.session?.enterCode?.action;
+			deleteSessionEnterCodeAction(req.session);
 		}
 
 		/**
@@ -252,6 +151,8 @@ const postEnterCode = (views, { isGeneralLogin = true }) => {
 			}
 
 			res.render(views.ENTER_CODE, {
+				requestNewCodeLink: `/${views.REQUEST_NEW_CODE}`,
+				confirmEmailLink: `/${views.EMAIL_ADDRESS}`,
 				token,
 				errors,
 				errorSummary
@@ -263,24 +164,36 @@ const postEnterCode = (views, { isGeneralLogin = true }) => {
 /**
  * The Context for the View to be rendered, with any error information
  * @typedef {Object} ViewContext
- * @property {TokenValidResult} token
- * @property {Array<Object>} errors
- * @property {Object} errorSummary
+ * @property {string} requestNewCodeLink
+ * @property {boolean} [showNewCode]
+ * @property {Array<Object>} [errors]
+ * @property {Object} [errorSummary]
  */
 
 /**
- * Renders the Error Page for the LPA User who was unsuccessful at logging in
- * @param {string} view The view file to be rendered by Nunjucks
+ * @typedef {Object} LPAViews
+ * @property {string} ENTER_CODE
+ * @property {string} CODE_EXPIRED
+ * @property {string} NEED_NEW_CODE
+ * @property {string} REQUEST_NEW_CODE
+ * @property {string} DASHBOARD
+ * @property {string} YOUR_EMAIL_ADDRESS
+ */
+
+/**
+ * Renders enter code page for LPA
+ * @param {import('express').Response} res
+ * @param {string} view
  * @param {ViewContext} context
  */
-const renderErrorPageLPA = (res, view, context) => {
+const renderEnterCodePageLPA = (res, view, context) => {
 	return res.render(view, context);
 };
 
-const redirectToEnterLPAEmail = (res, views) => {
-	res.redirect(`/${views.YOUR_EMAIL_ADDRESS}`);
-};
-
+/**
+ * @param {import('express').Response} res
+ * @param {LPAViews} views
+ */
 const redirectToLPADashboard = (res, views) => {
 	res.redirect(`/${views.DASHBOARD}`);
 };
@@ -289,22 +202,21 @@ const redirectToLPADashboard = (res, views) => {
  * Verifies the token and redirects on failure
  * @param {import('express').Response} res
  * @param {TokenValidResult} token
- * @param {Object} views
- * @returns
+ * @param {LPAViews} views
+ * @returns {boolean}
  */
-const lpaTokenVerification = (res, token, views, id) => {
+const lpaTokenVerification = (res, token, views) => {
 	if (token.tooManyAttempts) {
-		res.redirect(`/${views.NEED_NEW_CODE}/${id}`);
+		res.redirect(`/${views.NEED_NEW_CODE}`);
 		return false;
 	} else if (token.expired) {
-		res.redirect(`/${views.CODE_EXPIRED}/${id}`);
+		res.redirect(`/${views.CODE_EXPIRED}`);
 		return false;
 	} else if (!token.valid) {
 		const errorMessage = 'Enter the code we sent to your email address';
 
-		renderErrorPageLPA(res, views.ENTER_CODE, {
-			lpaUserId: id,
-			token,
+		renderEnterCodePageLPA(res, views.ENTER_CODE, {
+			requestNewCodeLink: `/${views.REQUEST_NEW_CODE}`,
 			errors: { 'email-code': { msg: errorMessage } },
 			errorSummary: [{ text: errorMessage, href: '#email-code' }]
 		});
@@ -316,81 +228,61 @@ const lpaTokenVerification = (res, token, views, id) => {
 };
 
 /**
- * Sends a new token to the lpa user referenced by the id in the url params
- * @async
- * @param {import('express').Request} req
- * @returns {Promise<void>}
+ * @param {LPAViews} views
  */
-const sendTokenToLpaUser = async (req) => {
-	const user = await getLPAUser(req, req.params.id);
-
-	if (user?.email) {
-		await getAuthClientConfig(
-			config.oauth.baseUrl,
-			config.oauth.clientID,
-			config.oauth.clientSecret
-		);
-		await createOTPGrant(user.email, enterCodeConfig.actions.lpaDashboard);
-	}
-};
-
 const getEnterCodeLPA = (views) => {
+	/**
+	 * @param {import('express').Request} req
+	 * @param {import('express').Response} res
+	 * @returns {Promise<void>}
+	 */
 	return async (req, res) => {
 		const {
-			body: { errors = {} },
-			params: { id }
+			body: { errors = {} }
 		} = req;
 
-		if (!id) {
-			redirectToEnterLPAEmail(res, views);
-			return;
-		}
-
-		// even if we error, display the enter code page so as to not give anyway any user detail
-		try {
-			await sendTokenToLpaUser(req);
-		} catch (err) {
-			logger.error(err);
-		}
-
 		// show new code success message only once
-		const newCode = req.session?.enterCode?.newCode;
-
+		const newCode = getSessionNewCode(req.session);
 		if (newCode) {
-			delete req.session?.enterCode?.newCode;
+			deleteSessionNewCode(req.session);
 		}
 
 		if (Object.keys(errors).length > 0) {
-			res.render(views.ENTER_CODE, {
-				errors: errors,
-				errorSummary: [{ text: errors.id.msg, href: '' }],
-				requestNewCodeLink: `/${views.REQUEST_NEW_CODE}`
-			});
-		} else {
-			res.render(views.ENTER_CODE, {
+			return renderEnterCodePageLPA(res, views.ENTER_CODE, {
 				requestNewCodeLink: `/${views.REQUEST_NEW_CODE}`,
-				lpaUserId: id,
-				showNewCode: newCode
+				errors: errors,
+				errorSummary: [{ text: errors.id.msg, href: '' }]
 			});
 		}
-		return;
+
+		renderEnterCodePageLPA(res, views.ENTER_CODE, {
+			showNewCode: newCode,
+			requestNewCodeLink: `/${views.REQUEST_NEW_CODE}`
+		});
 	};
 };
 
+/**
+ * @param {LPAViews} views
+ */
 const postEnterCodeLPA = (views) => {
+	/**
+	 * @param {import('express').Request} req
+	 * @param {import('express').Response} res
+	 * @returns {Promise<void>}
+	 */
 	return async (req, res) => {
 		const {
-			body: { errors = {}, errorSummary = [] },
-			params: { id }
+			body: { errors = {}, errorSummary = [] }
 		} = req;
 
 		const emailCode = req.body['email-code']?.trim();
+		const email = getSessionEmail(req.session, false);
 
 		// if there are errors show error page
 		if (Object.keys(errors).length > 0) {
-			return renderErrorPageLPA(res, views.ENTER_CODE, {
-				lpaUserId: id,
-				emailCode,
+			return renderEnterCodePageLPA(res, views.ENTER_CODE, {
+				requestNewCodeLink: `/${views.REQUEST_NEW_CODE}`,
 				errors,
 				errorSummary
 			});
@@ -401,15 +293,17 @@ const postEnterCodeLPA = (views) => {
 		let user;
 
 		try {
-			user = await getLPAUser(req, id);
+			user = await getLPAUser(req, email);
 		} catch (e) {
-			logger.error(`Failed to lookup user for id ${id}`);
+			logger.error(`Failed to lookup user for email ${email}`);
 			logger.error(e);
-			const failedToken = {
-				valid: false
-			};
 
-			return lpaTokenVerification(res, failedToken, views, id);
+			const errorMessage = 'Enter the code we sent to your email address';
+			return renderEnterCodePageLPA(res, views.ENTER_CODE, {
+				requestNewCodeLink: `/${views.REQUEST_NEW_CODE}`,
+				errors: { 'email-code': { msg: errorMessage } },
+				errorSummary: [{ text: errorMessage, href: '#email-code' }]
+			});
 		}
 
 		// check token
@@ -417,12 +311,12 @@ const postEnterCodeLPA = (views) => {
 			AUTH.SCOPES.USER_DETAILS.LPA
 		]);
 
-		if (!lpaTokenVerification(res, tokenResult, views, id)) return;
+		if (!lpaTokenVerification(res, tokenResult, views)) return;
 
 		try {
-			const currentUserStatus = await getLPAUserStatus(req, id);
+			const currentUserStatus = await getLPAUserStatus(req, email);
 			if (currentUserStatus === STATUS_CONSTANTS.ADDED) {
-				await setLPAUserStatus(req, id, STATUS_CONSTANTS.CONFIRMED);
+				await setLPAUserStatus(req, email, STATUS_CONSTANTS.CONFIRMED);
 			}
 			await createLPAUserSession(
 				req,
@@ -432,7 +326,7 @@ const postEnterCodeLPA = (views) => {
 				tokenResult.access_token_expiry
 			);
 		} catch (err) {
-			logger.error(err, `Failed to create user session for user id ${id}`);
+			logger.error(err, `Failed to create lpa user session for user ${email}`);
 			throw err;
 		}
 

--- a/packages/forms-web-app/src/controllers/common/need-new-code.js
+++ b/packages/forms-web-app/src/controllers/common/need-new-code.js
@@ -1,21 +1,77 @@
+const logger = require('../../lib/logger');
+const config = require('../../config');
+const { enterCodeConfig } = require('@pins/common');
+const { getAuthClientConfig, createOTPGrant } = require('@pins/common/src/client/auth-client');
+const {
+	getSessionEmail,
+	getSessionEnterCodeAction,
+	setSessionNewCode
+} = require('../../lib/session-helper');
+const { isRule6UserByEmail } = require('../../services/user.service');
+
 const getNeedNewCode = (views) => {
 	return async (_, res) => {
 		res.render(views.NEED_NEW_CODE);
 	};
 };
 
+const sendToken = async (email, action) => {
+	try {
+		await getAuthClientConfig(
+			config.oauth.baseUrl,
+			config.oauth.clientID,
+			config.oauth.clientSecret
+		);
+		await createOTPGrant(email, action);
+	} catch (e) {
+		logger.error(e, 'failed to send token to general login user');
+	}
+};
+
 const postNeedNewCode = (views) => {
 	return async (req, res) => {
-		req.session.enterCode = req.session.enterCode || {};
-		req.session.enterCode.newCode = true;
+		setSessionNewCode(req.session);
+		const email = getSessionEmail(req.session, false);
+		const action = getSessionEnterCodeAction(req.session);
 
-		const params = req.params.id ? `/${req.params.id}` : '';
-		const url = `/${views.ENTER_CODE}${params}`;
+		await sendToken(email, action);
+
+		const url = `/${views.ENTER_CODE}`;
+		res.redirect(url);
+	};
+};
+
+const postNeedNewCodeLPA = (views) => {
+	return async (req, res) => {
+		setSessionNewCode(req.session);
+		const email = getSessionEmail(req.session, false);
+
+		await sendToken(email, enterCodeConfig.actions.lpaDashboard);
+
+		const url = `/${views.ENTER_CODE}`;
+		res.redirect(url);
+	};
+};
+
+const postNeedNewCodeRule6 = (views) => {
+	return async (req, res) => {
+		setSessionNewCode(req.session);
+
+		const email = getSessionEmail(req.session, false);
+
+		const isValidRule6 = await isRule6UserByEmail(req, email);
+		if (isValidRule6) {
+			await sendToken(email, enterCodeConfig.actions.rule6Dashboard);
+		}
+
+		const url = `/${views.ENTER_CODE}`;
 		res.redirect(url);
 	};
 };
 
 module.exports = {
 	getNeedNewCode,
-	postNeedNewCode
+	postNeedNewCode,
+	postNeedNewCodeLPA,
+	postNeedNewCodeRule6
 };

--- a/packages/forms-web-app/src/controllers/common/request-new-code.js
+++ b/packages/forms-web-app/src/controllers/common/request-new-code.js
@@ -1,61 +1,83 @@
-const logger = require('../../lib/logger');
+const logger = require('#lib/logger');
+const { enterCodeConfig } = require('@pins/common');
+const config = require('../../config');
+const { getAuthClientConfig, createOTPGrant } = require('@pins/common/src/client/auth-client');
+const {
+	getSessionEnterCodeAction,
+	getSessionEmail,
+	setSessionNewCode
+} = require('#lib/session-helper');
+const { STATUS_CONSTANTS } = require('@pins/common/src/constants');
 
+/**
+ * @param {string} requestNewCodeView
+ * @returns {import('express').RequestHandler}
+ */
 const getRequestNewCode = (requestNewCodeView) => {
 	return async (_, res) => {
 		res.render(requestNewCodeView);
 	};
 };
 
+/**
+ * @param {string} requestNewCodeView
+ * @returns {import('express').RequestHandler}
+ */
 const getRequestNewCodeLPA = (requestNewCodeView) => {
 	return async (_, res) => {
-		res.render(requestNewCodeView.REQUEST_NEW_CODE);
+		res.render(requestNewCodeView);
 	};
 };
 
+/**
+ * @param {string} enterCodeView
+ * @returns {import('express').RequestHandler}
+ */
 const postRequestNewCode = (enterCodeView) => {
 	return async (req, res) => {
-		const id = req.session.enterCodeId;
-		delete req.session.enterCodeId;
+		setSessionNewCode(req.session);
 
-		req.session.enterCode = req.session.enterCode || {};
-		req.session.enterCode.newCode = true;
+		const email = getSessionEmail(req.session, false) ?? getSessionEmail(req.session, true);
+		const action = getSessionEnterCodeAction(req.session);
 
-		const params = id ? `/${id}` : '';
-		res.redirect(`/${enterCodeView}${params}`);
+		try {
+			await getAuthClientConfig(
+				config.oauth.baseUrl,
+				config.oauth.clientID,
+				config.oauth.clientSecret
+			);
+			await createOTPGrant(email, action);
+		} catch (e) {
+			logger.error(e, 'failed to send token to general login user');
+		}
+
+		res.redirect(`/${enterCodeView}`);
 	};
 };
 
+/**
+ * @param {string} enterCodeView
+ * @returns {import('express').RequestHandler}
+ */
 const postRequestNewCodeLPA = (enterCodeView) => {
 	return async (req, res) => {
-		const {
-			body: { emailAddress, errors = {}, errorSummary = [] }
-		} = req;
-
-		// show error page
-		if (Object.keys(errors).length > 0) {
-			return res.render(enterCodeView.REQUEST_NEW_CODE, {
-				errors,
-				errorSummary
-			});
-		}
-
-		let user;
-
 		try {
-			user = await req.appealsApiClient.getUserByEmailV2(emailAddress);
+			setSessionNewCode(req.session);
+			const email = getSessionEmail(req.session, false);
+			const user = await req.appealsApiClient.getUserByEmailV2(email);
+			if (user?.lpaCode && user.lpaStatus !== STATUS_CONSTANTS.REMOVED) {
+				await getAuthClientConfig(
+					config.oauth.baseUrl,
+					config.oauth.clientID,
+					config.oauth.clientSecret
+				);
+				await createOTPGrant(email, enterCodeConfig.actions.lpaDashboard);
+			}
 		} catch (e) {
-			logger.info(e.message);
+			logger.error(e, 'failed to send token to lpa user');
 		}
 
-		if (!user) {
-			const customErrorSummary = [{ text: 'Enter a correct email address', href: '#' }];
-			return res.render(enterCodeView.REQUEST_NEW_CODE, {
-				errors,
-				errorSummary: customErrorSummary
-			});
-		}
-
-		res.redirect(`/${enterCodeView.ENTER_CODE}/${user.id}`);
+		res.redirect(`/${enterCodeView}`);
 	};
 };
 

--- a/packages/forms-web-app/src/controllers/common/your-email-address.js
+++ b/packages/forms-web-app/src/controllers/common/your-email-address.js
@@ -1,7 +1,12 @@
 const { logoutUser } = require('../../services/user.service');
-const crypto = require('node:crypto');
+const logger = require('../../lib/logger');
+const { enterCodeConfig } = require('@pins/common');
+const config = require('../../config');
+const { getAuthClientConfig, createOTPGrant } = require('@pins/common/src/client/auth-client');
+const { setSessionEnterCodeAction, setSessionEmail } = require('../../lib/session-helper');
+const { STATUS_CONSTANTS } = require('@pins/common/src/constants');
 
-const getYourEmailAddress = (views) => {
+const getYourEmailAddressLPA = (views) => {
 	return (req, res) => {
 		const { email } = req.session;
 		res.render(views.YOUR_EMAIL_ADDRESS, {
@@ -10,7 +15,7 @@ const getYourEmailAddress = (views) => {
 	};
 };
 
-const postYourEmailAddress = (views, emailUUIDcache) => {
+const postYourEmailAddressLPA = (views) => {
 	return async (req, res) => {
 		const { body } = req;
 		const { errors = {}, errorSummary = [], 'email-address': email } = body;
@@ -21,43 +26,45 @@ const postYourEmailAddress = (views, emailUUIDcache) => {
 			}
 		];
 		if (!email) {
-			res.render(views.YOUR_EMAIL_ADDRESS, {
+			return res.render(views.YOUR_EMAIL_ADDRESS, {
 				errors,
 				errorSummary: emailErrorSummary
 			});
-			return;
 		}
 
 		if (Object.keys(errors).length > 0) {
-			console.log('errors', errors);
-			res.render(views.YOUR_EMAIL_ADDRESS, {
+			logger.error('errors', errors);
+			return res.render(views.YOUR_EMAIL_ADDRESS, {
 				email,
 				errors,
 				errorSummary
 			});
-			return;
 		}
 
 		logoutUser(req);
 
+		setSessionEnterCodeAction(req.session, enterCodeConfig.actions.lpaDashboard);
+		setSessionEmail(req.session, email);
+
 		try {
 			const user = await req.appealsApiClient.getUserByEmailV2(email);
-			if (!user) {
-				throw new Error('User does not exist');
+			if (user?.lpaCode && user.lpaStatus !== STATUS_CONSTANTS.REMOVED) {
+				await getAuthClientConfig(
+					config.oauth.baseUrl,
+					config.oauth.clientID,
+					config.oauth.clientSecret
+				);
+				await createOTPGrant(email, enterCodeConfig.actions.lpaDashboard);
 			}
-			res.redirect(`/${views.ENTER_CODE}/${user.id}`);
-		} catch (error) {
-			let id = emailUUIDcache.get(email);
-			if (!id) {
-				id = crypto.randomUUID();
-				emailUUIDcache.set(email, id);
-			}
-			res.redirect(`/${views.ENTER_CODE}/${id}`);
+		} catch (e) {
+			logger.error(e, 'failed to send token to lpa user');
 		}
+
+		res.redirect(`/${views.ENTER_CODE}`);
 	};
 };
 
 module.exports = {
-	getYourEmailAddress,
-	postYourEmailAddress
+	getYourEmailAddressLPA,
+	postYourEmailAddressLPA
 };

--- a/packages/forms-web-app/src/controllers/rule-6/email-address.js
+++ b/packages/forms-web-app/src/controllers/rule-6/email-address.js
@@ -1,20 +1,32 @@
 const {
 	setSessionEmail,
-	setSessionEnterCode,
+	getSessionEmail,
 	setSessionEnterCodeAction
 } = require('../../lib/session-helper');
 const { enterCodeConfig } = require('@pins/common');
 const { logoutUser } = require('../../services/user.service');
+const logger = require('../../lib/logger');
+const config = require('../../config');
+const { getAuthClientConfig, createOTPGrant } = require('@pins/common/src/client/auth-client');
+const { isRule6UserByEmail } = require('../../services/user.service');
 
+/**
+ * @param {{EMAIL_ADDRESS: string}} views
+ * @returns {import('express').RequestHandler}
+ */
 const getR6EmailAddress = (views) => {
 	return (req, res) => {
-		const { email } = req.session;
+		const email = getSessionEmail(req.session, false);
 		res.render(views.EMAIL_ADDRESS, {
-			email: email
+			email
 		});
 	};
 };
 
+/**
+ * @param {{EMAIL_ADDRESS: string, ENTER_CODE: string}} views
+ * @returns {import('express').RequestHandler}
+ */
 const postR6EmailAddress = (views) => {
 	return async (req, res) => {
 		const { body } = req;
@@ -38,7 +50,6 @@ const postR6EmailAddress = (views) => {
 		}
 
 		if (Object.keys(errors).length > 0) {
-			console.log('errors', errors);
 			res.render(views.EMAIL_ADDRESS, {
 				email,
 				errors,
@@ -48,31 +59,22 @@ const postR6EmailAddress = (views) => {
 		}
 
 		try {
-			const user = await req.appealsApiClient.getUserByEmailV2(email);
-			if (!user) {
-				throw new Error('user not found');
+			logoutUser(req);
+			setSessionEnterCodeAction(req.session, enterCodeConfig.actions.rule6Dashboard);
+			const isRule6User = await isRule6UserByEmail(req, email);
+			if (isRule6User) {
+				await getAuthClientConfig(
+					config.oauth.baseUrl,
+					config.oauth.clientID,
+					config.oauth.clientSecret
+				);
+				await createOTPGrant(email, enterCodeConfig.actions.rule6Dashboard);
 			}
-			const id = user.id;
-			setSession();
-			res.redirect(`/${views.ENTER_CODE}/${id}`);
 		} catch (e) {
-			res.render(views.EMAIL_ADDRESS, {
-				email,
-				errors: {
-					'email-address': {
-						msg: 'Enter your email address'
-					}
-				},
-				errorSummary: emailErrorSummary
-			});
-			return;
+			logger.error(e, 'failed to send token to rule 6 user');
 		}
 
-		function setSession() {
-			logoutUser(req);
-			setSessionEnterCode(req.session, {}, true);
-			setSessionEnterCodeAction(req.session, enterCodeConfig.actions.confirmEmail);
-		}
+		res.redirect(`/${views.ENTER_CODE}`);
 	};
 };
 

--- a/packages/forms-web-app/src/controllers/rule-6/enter-code.js
+++ b/packages/forms-web-app/src/controllers/rule-6/enter-code.js
@@ -3,9 +3,13 @@ const { isTokenValid } = require('../../lib/is-token-valid');
 const { enterCodeConfig } = require('@pins/common');
 const logger = require('../../lib/logger');
 
-const { getSessionEmail } = require('#lib/session-helper');
-const { getAuthClientConfig, createOTPGrant } = require('@pins/common/src/client/auth-client');
-const config = require('../../config');
+const {
+	getSessionEmail,
+	getSessionEnterCodeAction,
+	deleteSessionEnterCodeAction,
+	getSessionNewCode,
+	deleteSessionNewCode
+} = require('#lib/session-helper');
 const { handleCustomRedirect } = require('#lib/handle-custom-redirect');
 
 /**
@@ -34,38 +38,15 @@ const getEnterCodeR6 = (views) => {
 			return renderEnterCodePage(`/${views.EMAIL_ADDRESS}`);
 		}
 
-		/** @type {string|undefined} */
-		const enterCodeId = req.params.enterCodeId;
-		if (enterCodeId) {
-			req.session.enterCodeId = enterCodeId;
-		}
-
-		const action = req.session?.enterCode?.action ?? enterCodeConfig.actions.confirmEmail;
+		const action = getSessionEnterCodeAction(req.session) ?? enterCodeConfig.actions.confirmEmail;
 
 		// show new code success message only once
-		const newCode = req.session?.enterCode?.newCode;
+		const newCode = getSessionNewCode(req.session);
 		if (newCode) {
-			delete req.session?.enterCode?.newCode;
+			deleteSessionNewCode(req.session);
 		}
 
 		logger.info({ action }, `getEnterCode`);
-
-		const email = getSessionEmail(req.session, false);
-
-		const isRule6User = await isRule6UserByEmail(req, email);
-
-		if (isRule6User) {
-			try {
-				await getAuthClientConfig(
-					config.oauth.baseUrl,
-					config.oauth.clientID,
-					config.oauth.clientSecret
-				);
-				await createOTPGrant(email, action);
-			} catch (e) {
-				logger.error(e, 'failed to send token to general login user');
-			}
-		}
 
 		return renderEnterCodePage(`/${views.EMAIL_ADDRESS}`);
 
@@ -105,13 +86,15 @@ const postEnterCodeR6 = (views) => {
 			return renderError(errorSummary, errors);
 		}
 
-		const action = req.session?.enterCode?.action ?? enterCodeConfig.actions.confirmEmail;
-
 		const isLoginRedirect = Boolean(req.session?.loginRedirect);
 
 		const sessionEmail = getSessionEmail(req.session, false);
 
-		const tokenValid = await isTokenValid(token, sessionEmail, action);
+		const tokenValid = await isTokenValid(
+			token,
+			sessionEmail,
+			enterCodeConfig.actions.rule6Dashboard
+		);
 
 		if (tokenValid.tooManyAttempts) {
 			return res.redirect(`/${views.NEED_NEW_CODE}`);
@@ -136,25 +119,13 @@ const postEnterCodeR6 = (views) => {
 			sessionEmail
 		);
 
-		logger.info(
-			{
-				action
-			},
-			`postEnterCode`
-		);
-
 		if (isLoginRedirect) {
-			deleteTempSessionValues();
+			deleteSessionEnterCodeAction(req.session);
 			return handleCustomRedirect(req, res);
 		}
 
-		deleteTempSessionValues();
+		deleteSessionEnterCodeAction(req.session);
 		return res.redirect(`/${views.DASHBOARD}`);
-
-		function deleteTempSessionValues() {
-			delete req.session.enterCodeId;
-			delete req.session?.enterCode?.action;
-		}
 
 		/**
 		 * @param {Array<Object>|string} errorSummary - if just a string will add single error to form and summary

--- a/packages/forms-web-app/src/lib/is-token-valid.js
+++ b/packages/forms-web-app/src/lib/is-token-valid.js
@@ -62,6 +62,9 @@ const getAuthToken = async (token, emailAddress, action, additionalScopes) => {
 		if (err?.error === 'code_expired') {
 			return codeExpired;
 		}
+		if (err?.error === 'unknown_user_id') {
+			return invalidCode;
+		}
 		throw err;
 	}
 };

--- a/packages/forms-web-app/src/lib/session-helper.js
+++ b/packages/forms-web-app/src/lib/session-helper.js
@@ -4,6 +4,7 @@ const APPEAL_SQL_ID = 'appealSqlId';
 const EMAIL_KEY = 'email';
 const ENTER_CODE_KEY = 'enterCode';
 const ID = 'id';
+const NEW_CODE = 'newCode';
 
 const getSessionAppeal = (session) => session[APPEAL_KEY];
 
@@ -36,16 +37,34 @@ const setSessionEmail = (session, email, appealInSession) => {
 	}
 };
 
-const setSessionEnterCode = (session, code, useExistingValue) => {
-	if (useExistingValue) {
-		session[ENTER_CODE_KEY] = session[ENTER_CODE_KEY] || code;
-	} else {
-		session[ENTER_CODE_KEY] = code;
-	}
+const createSessionEnterCode = (session) => {
+	session[ENTER_CODE_KEY] = session[ENTER_CODE_KEY] || {};
 };
 
 const setSessionEnterCodeAction = (session, action) => {
+	createSessionEnterCode(session);
 	session[ENTER_CODE_KEY][ACTION_KEY] = action;
+};
+
+const getSessionEnterCodeAction = (session) => {
+	return session[ENTER_CODE_KEY][ACTION_KEY];
+};
+
+const deleteSessionEnterCodeAction = (session) => {
+	delete session?.[ENTER_CODE_KEY]?.[ACTION_KEY];
+};
+
+const setSessionNewCode = (session) => {
+	createSessionEnterCode(session);
+	session[ENTER_CODE_KEY][NEW_CODE] = true;
+};
+
+const getSessionNewCode = (session) => {
+	return session?.[ENTER_CODE_KEY]?.[NEW_CODE];
+};
+
+const deleteSessionNewCode = (session) => {
+	delete session?.[ENTER_CODE_KEY]?.[NEW_CODE];
 };
 
 module.exports = {
@@ -55,6 +74,10 @@ module.exports = {
 	getSessionEmail,
 	setSessionAppeal,
 	setSessionEmail,
-	setSessionEnterCode,
-	setSessionEnterCodeAction
+	setSessionEnterCodeAction,
+	getSessionEnterCodeAction,
+	deleteSessionEnterCodeAction,
+	setSessionNewCode,
+	getSessionNewCode,
+	deleteSessionNewCode
 };

--- a/packages/forms-web-app/src/routes/adverts/login/enter-code.js
+++ b/packages/forms-web-app/src/routes/adverts/login/enter-code.js
@@ -1,7 +1,6 @@
 const express = require('express');
 
 const { rules: ruleEnterCode } = require('../../../validators/common/enter-code');
-const { rules: idValidationRules } = require('../../../validators/common/check-id-is-uuid');
 const { validationErrorHandler } = require('../../../validators/validation-error-handler');
 const { getEnterCode, postEnterCode } = require('../../../controllers/common/enter-code');
 
@@ -23,15 +22,10 @@ const views = {
 
 const router = express.Router();
 
-router.get(
-	'/enter-code/:enterCodeId',
-	idValidationRules('enterCodeId'),
-	validationErrorHandler,
-	getEnterCode(views, { isGeneralLogin: false })
-);
+router.get('/enter-code', validationErrorHandler, getEnterCode(views));
 
 router.post(
-	'/enter-code/:enterCodeId',
+	'/enter-code',
 	ruleEnterCode(),
 	validationErrorHandler,
 	postEnterCode(views, { isGeneralLogin: false })

--- a/packages/forms-web-app/src/routes/appeal-householder-decision/login/code-expired.js
+++ b/packages/forms-web-app/src/routes/appeal-householder-decision/login/code-expired.js
@@ -1,9 +1,6 @@
 const express = require('express');
 
-const {
-	getRequestNewCode,
-	postRequestNewCode
-} = require('../../../controllers/common/request-new-code');
+const { getNeedNewCode, postNeedNewCode } = require('../../../controllers/common/need-new-code');
 
 const {
 	VIEW: {
@@ -13,7 +10,7 @@ const {
 
 const router = express.Router();
 
-router.get('/code-expired', getRequestNewCode(CODE_EXPIRED));
-router.post('/code-expired', postRequestNewCode(ENTER_CODE));
+router.get('/code-expired', getNeedNewCode(CODE_EXPIRED));
+router.post('/code-expired', postNeedNewCode(ENTER_CODE));
 
 module.exports = router;

--- a/packages/forms-web-app/src/routes/appeal-householder-decision/login/enter-code.js
+++ b/packages/forms-web-app/src/routes/appeal-householder-decision/login/enter-code.js
@@ -1,7 +1,6 @@
 const express = require('express');
 
 const { rules: ruleEnterCode } = require('../../../validators/common/enter-code');
-const { rules: idValidationRules } = require('../../../validators/common/check-id-is-uuid');
 const { validationErrorHandler } = require('../../../validators/validation-error-handler');
 const { getEnterCode, postEnterCode } = require('../../../controllers/common/enter-code');
 
@@ -39,12 +38,15 @@ const router = express.Router();
 
 router.get(
 	'/enter-code/:enterCodeId',
-	idValidationRules('enterCodeId'),
-	validationErrorHandler,
-	getEnterCode(views, { isGeneralLogin: false })
+	/** @type {import('express').RequestHandler} */
+	(_, res) => {
+		return res.redirect(`/${views.YOUR_APPEALS}`);
+	}
 );
+
+router.get('/enter-code', getEnterCode(views));
 router.post(
-	'/enter-code/:enterCodeId',
+	'/enter-code',
 	ruleEnterCode(),
 	validationErrorHandler,
 	postEnterCode(views, { isGeneralLogin: false })

--- a/packages/forms-web-app/src/routes/cas-planning/login/enter-code.js
+++ b/packages/forms-web-app/src/routes/cas-planning/login/enter-code.js
@@ -1,7 +1,6 @@
 const express = require('express');
 
 const { rules: ruleEnterCode } = require('../../../validators/common/enter-code');
-const { rules: idValidationRules } = require('../../../validators/common/check-id-is-uuid');
 const { validationErrorHandler } = require('../../../validators/validation-error-handler');
 const { getEnterCode, postEnterCode } = require('../../../controllers/common/enter-code');
 
@@ -23,15 +22,10 @@ const views = {
 
 const router = express.Router();
 
-router.get(
-	'/enter-code/:enterCodeId',
-	idValidationRules('enterCodeId'),
-	validationErrorHandler,
-	getEnterCode(views, { isGeneralLogin: false })
-);
+router.get('/enter-code', validationErrorHandler, getEnterCode(views));
 
 router.post(
-	'/enter-code/:enterCodeId',
+	'/enter-code',
 	ruleEnterCode(),
 	validationErrorHandler,
 	postEnterCode(views, { isGeneralLogin: false })

--- a/packages/forms-web-app/src/routes/enforcement-listed-building/login/enter-code.js
+++ b/packages/forms-web-app/src/routes/enforcement-listed-building/login/enter-code.js
@@ -1,7 +1,6 @@
 const express = require('express');
 
 const { rules: ruleEnterCode } = require('../../../validators/common/enter-code');
-const { rules: idValidationRules } = require('../../../validators/common/check-id-is-uuid');
 const { validationErrorHandler } = require('../../../validators/validation-error-handler');
 const { getEnterCode, postEnterCode } = require('../../../controllers/common/enter-code');
 
@@ -29,15 +28,10 @@ const views = {
 
 const router = express.Router();
 
-router.get(
-	'/enter-code/:enterCodeId',
-	idValidationRules('enterCodeId'),
-	validationErrorHandler,
-	getEnterCode(views, { isGeneralLogin: false })
-);
+router.get('/enter-code', validationErrorHandler, getEnterCode(views));
 
 router.post(
-	'/enter-code/:enterCodeId',
+	'/enter-code',
 	ruleEnterCode(),
 	validationErrorHandler,
 	postEnterCode(views, { isGeneralLogin: false })

--- a/packages/forms-web-app/src/routes/enforcement/login/enter-code.js
+++ b/packages/forms-web-app/src/routes/enforcement/login/enter-code.js
@@ -1,7 +1,6 @@
 const express = require('express');
 
 const { rules: ruleEnterCode } = require('../../../validators/common/enter-code');
-const { rules: idValidationRules } = require('../../../validators/common/check-id-is-uuid');
 const { validationErrorHandler } = require('../../../validators/validation-error-handler');
 const { getEnterCode, postEnterCode } = require('../../../controllers/common/enter-code');
 
@@ -23,15 +22,10 @@ const views = {
 
 const router = express.Router();
 
-router.get(
-	'/enter-code/:enterCodeId',
-	idValidationRules('enterCodeId'),
-	validationErrorHandler,
-	getEnterCode(views, { isGeneralLogin: false })
-);
+router.get('/enter-code', validationErrorHandler, getEnterCode(views));
 
 router.post(
-	'/enter-code/:enterCodeId',
+	'/enter-code',
 	ruleEnterCode(),
 	validationErrorHandler,
 	postEnterCode(views, { isGeneralLogin: false })

--- a/packages/forms-web-app/src/routes/full-appeal/login/enter-code.js
+++ b/packages/forms-web-app/src/routes/full-appeal/login/enter-code.js
@@ -1,7 +1,6 @@
 const express = require('express');
 
 const { rules: ruleEnterCode } = require('../../../validators/common/enter-code');
-const { rules: idValidationRules } = require('../../../validators/common/check-id-is-uuid');
 const { validationErrorHandler } = require('../../../validators/validation-error-handler');
 const { getEnterCode, postEnterCode } = require('../../../controllers/common/enter-code');
 
@@ -39,13 +38,16 @@ const router = express.Router();
 
 router.get(
 	'/submit-appeal/enter-code/:enterCodeId',
-	idValidationRules('enterCodeId'),
-	validationErrorHandler,
-	getEnterCode(views, { isGeneralLogin: false })
+	/** @type {import('express').RequestHandler} */
+	(_, res) => {
+		return res.redirect(`/${views.YOUR_APPEALS}`);
+	}
 );
 
+router.get('/submit-appeal/enter-code', validationErrorHandler, getEnterCode(views));
+
 router.post(
-	'/submit-appeal/enter-code/:enterCodeId',
+	'/submit-appeal/enter-code',
 	ruleEnterCode(),
 	validationErrorHandler,
 	postEnterCode(views, { isGeneralLogin: false })

--- a/packages/forms-web-app/src/routes/ldc/login/enter-code.js
+++ b/packages/forms-web-app/src/routes/ldc/login/enter-code.js
@@ -1,7 +1,6 @@
 const express = require('express');
 
 const { rules: ruleEnterCode } = require('../../../validators/common/enter-code');
-const { rules: idValidationRules } = require('../../../validators/common/check-id-is-uuid');
 const { validationErrorHandler } = require('../../../validators/validation-error-handler');
 const { getEnterCode, postEnterCode } = require('../../../controllers/common/enter-code');
 
@@ -29,15 +28,10 @@ const views = {
 
 const router = express.Router();
 
-router.get(
-	'/enter-code/:enterCodeId',
-	idValidationRules('enterCodeId'),
-	validationErrorHandler,
-	getEnterCode(views, { isGeneralLogin: false })
-);
+router.get('/enter-code', validationErrorHandler, getEnterCode(views));
 
 router.post(
-	'/enter-code/:enterCodeId',
+	'/enter-code',
 	ruleEnterCode(),
 	validationErrorHandler,
 	postEnterCode(views, { isGeneralLogin: false })

--- a/packages/forms-web-app/src/routes/listed-building/login/enter-code.js
+++ b/packages/forms-web-app/src/routes/listed-building/login/enter-code.js
@@ -1,7 +1,6 @@
 const express = require('express');
 
 const { rules: ruleEnterCode } = require('../../../validators/common/enter-code');
-const { rules: idValidationRules } = require('../../../validators/common/check-id-is-uuid');
 const { validationErrorHandler } = require('../../../validators/validation-error-handler');
 const { getEnterCode, postEnterCode } = require('../../../controllers/common/enter-code');
 
@@ -29,15 +28,10 @@ const views = {
 
 const router = express.Router();
 
-router.get(
-	'/enter-code/:enterCodeId',
-	idValidationRules('enterCodeId'),
-	validationErrorHandler,
-	getEnterCode(views, { isGeneralLogin: false })
-);
+router.get('/enter-code', validationErrorHandler, getEnterCode(views));
 
 router.post(
-	'/enter-code/:enterCodeId',
+	'/enter-code',
 	ruleEnterCode(),
 	validationErrorHandler,
 	postEnterCode(views, { isGeneralLogin: false })

--- a/packages/forms-web-app/src/routes/lpa-dashboard/code-expired.js
+++ b/packages/forms-web-app/src/routes/lpa-dashboard/code-expired.js
@@ -1,8 +1,8 @@
 const express = require('express');
 
 const {
-	getRequestNewCode,
-	postRequestNewCode
+	getRequestNewCodeLPA,
+	postRequestNewCodeLPA
 } = require('../../controllers/common/request-new-code');
 
 const {
@@ -13,7 +13,7 @@ const {
 
 const router = express.Router();
 
-router.get('/code-expired', getRequestNewCode(CODE_EXPIRED));
-router.post('/code-expired', postRequestNewCode(ENTER_CODE));
+router.get('/code-expired', getRequestNewCodeLPA(CODE_EXPIRED));
+router.post('/code-expired', postRequestNewCodeLPA(ENTER_CODE));
 
 module.exports = router;

--- a/packages/forms-web-app/src/routes/lpa-dashboard/enter-code.js
+++ b/packages/forms-web-app/src/routes/lpa-dashboard/enter-code.js
@@ -26,7 +26,7 @@ const views = {
 	DASHBOARD
 };
 
-router.get('/enter-code/:id', validationErrorHandler, getEnterCodeLPA(views));
-router.post('/enter-code/:id', ruleEnterCode(), validationErrorHandler, postEnterCodeLPA(views));
+router.get('/enter-code', validationErrorHandler, getEnterCodeLPA(views));
+router.post('/enter-code', ruleEnterCode(), validationErrorHandler, postEnterCodeLPA(views));
 
 module.exports = router;

--- a/packages/forms-web-app/src/routes/lpa-dashboard/need-new-code.js
+++ b/packages/forms-web-app/src/routes/lpa-dashboard/need-new-code.js
@@ -1,5 +1,5 @@
 const express = require('express');
-const { getNeedNewCode, postNeedNewCode } = require('../../controllers/common/need-new-code');
+const { getNeedNewCode, postNeedNewCodeLPA } = require('../../controllers/common/need-new-code');
 
 const router = express.Router();
 
@@ -11,7 +11,7 @@ const {
 
 const needViews = { NEED_NEW_CODE, ENTER_CODE };
 
-router.get('/need-new-code/:id', getNeedNewCode(needViews));
-router.post('/need-new-code/:id', postNeedNewCode(needViews));
+router.get('/need-new-code', getNeedNewCode(needViews));
+router.post('/need-new-code', postNeedNewCodeLPA(needViews));
 
 module.exports = router;

--- a/packages/forms-web-app/src/routes/lpa-dashboard/request-new-code.js
+++ b/packages/forms-web-app/src/routes/lpa-dashboard/request-new-code.js
@@ -8,13 +8,11 @@ const router = express.Router();
 
 const {
 	VIEW: {
-		LPA_DASHBOARD: { REQUEST_NEW_CODE, ENTER_CODE }
+		LPA_DASHBOARD: { ENTER_CODE, REQUEST_NEW_CODE }
 	}
 } = require('../../lib/views');
 
-const requestViews = { REQUEST_NEW_CODE, ENTER_CODE };
-
-router.get('/request-new-code', getRequestNewCodeLPA(requestViews));
-router.post('/request-new-code', postRequestNewCodeLPA(requestViews));
+router.get('/request-new-code', getRequestNewCodeLPA(REQUEST_NEW_CODE));
+router.post('/request-new-code', postRequestNewCodeLPA(ENTER_CODE));
 
 module.exports = router;

--- a/packages/forms-web-app/src/routes/lpa-dashboard/your-email-address.js
+++ b/packages/forms-web-app/src/routes/lpa-dashboard/your-email-address.js
@@ -1,14 +1,13 @@
 const express = require('express');
 
 const router = express.Router();
-const MapCache = require('../../lib/map-cache');
 
 const { rules: emailAddressValidationRules } = require('../../validators/common/email-address');
 const { validationErrorHandler } = require('../../validators/validation-error-handler');
 
 const {
-	getYourEmailAddress,
-	postYourEmailAddress
+	getYourEmailAddressLPA,
+	postYourEmailAddressLPA
 } = require('../../controllers/common/your-email-address');
 
 const {
@@ -17,16 +16,14 @@ const {
 	}
 } = require('../../lib/views');
 
-const emailUUIDcache = new MapCache(5);
-
 const views = { YOUR_EMAIL_ADDRESS, ENTER_CODE };
 
-router.get('/your-email-address', getYourEmailAddress(views));
+router.get('/your-email-address', getYourEmailAddressLPA(views));
 router.post(
 	'/your-email-address',
 	emailAddressValidationRules('email-address'),
 	validationErrorHandler,
-	postYourEmailAddress(views, emailUUIDcache)
+	postYourEmailAddressLPA(views)
 );
 
 module.exports = router;

--- a/packages/forms-web-app/src/routes/rule-6/enter-code.js
+++ b/packages/forms-web-app/src/routes/rule-6/enter-code.js
@@ -19,9 +19,7 @@ const views = {
 	DASHBOARD
 };
 
-router.get('/enter-code/:id', validationErrorHandler, getEnterCodeR6(views));
 router.get('/enter-code', validationErrorHandler, getEnterCodeR6(views));
-router.post('/enter-code/:id', ruleEnterCode(), validationErrorHandler, postEnterCodeR6(views));
 router.post('/enter-code', ruleEnterCode(), validationErrorHandler, postEnterCodeR6(views));
 
 module.exports = router;

--- a/packages/forms-web-app/src/routes/rule-6/need-new-code.js
+++ b/packages/forms-web-app/src/routes/rule-6/need-new-code.js
@@ -1,5 +1,5 @@
 const express = require('express');
-const { getNeedNewCode, postNeedNewCode } = require('../../controllers/common/need-new-code');
+const { getNeedNewCode, postNeedNewCodeRule6 } = require('../../controllers/common/need-new-code');
 
 const router = express.Router();
 
@@ -12,6 +12,6 @@ const {
 const needViews = { NEED_NEW_CODE, ENTER_CODE };
 
 router.get('/need-new-code', getNeedNewCode(needViews));
-router.post('/need-new-code', postNeedNewCode(needViews));
+router.post('/need-new-code', postNeedNewCodeRule6(needViews));
 
 module.exports = router;

--- a/packages/forms-web-app/src/services/user.service.js
+++ b/packages/forms-web-app/src/services/user.service.js
@@ -1,5 +1,5 @@
-const { getLPA } = require('../lib/appeals-api-wrapper');
 const { STATUS_CONSTANTS } = require('@pins/common/src/constants');
+const { getLPA } = require('../lib/appeals-api-wrapper');
 
 /**
  * @typedef {Object} AppealUserSession

--- a/packages/forms-web-app/src/views/manage-appeals/enter-code.njk
+++ b/packages/forms-web-app/src/views/manage-appeals/enter-code.njk
@@ -1,28 +1,23 @@
 {% extends "layouts/lpa-dashboard/main-no-back-link.njk" %}
-
 {% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "govuk/components/input/macro.njk" import govukInput %}
 {% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
 {% from "govuk/components/fieldset/macro.njk" import govukFieldset %}
 {% from "govuk/components/notification-banner/macro.njk" import govukNotificationBanner %}
-
 {% set title="Enter the code we sent to your email address - Manage appeals - GOV.UK" %}
-
 {% if errors %}
   {% set title = "Error: " + title %}
 {% endif %}
-
-{% block pageTitle %}{{ title }}{% endblock %}
-
+{% block pageTitle %}
+  {{ title }}
+{% endblock %}
 {% block content %}
-
   {% if errors %}
     {{ govukErrorSummary({
       titleText: "There is a problem",
       errorList: errorSummary
     }) }}
   {% endif %}
-
   {% if showNewCode %}
     {{ govukNotificationBanner({
       text: 'We’ve sent a code to your email address.',
@@ -30,14 +25,11 @@
 			classes: 'govuk-grid-row govuk-grid-column-two-thirds govuk-notification-banner__heading'
     }) }}
   {% endif %}
-
   <div class="govuk-grid-row">
-
     <div class="govuk-grid-column-two-thirds">
-      <form action={{ lpaUserId }} method="POST" novalidate>
-<input type="hidden" name="_csrf" value="{{_csrf}}">
-
-        {{ govukInput({
+      <form action="{{ currentRoute }}" method="POST" novalidate>
+        <input type="hidden" name="_csrf" value="{{ _csrf }}">
+          {{ govukInput({
             label: {
               text: "Enter the code we sent to your email address",
               classes: "govuk-label--l",
@@ -52,18 +44,15 @@
             }
 
           }) }}
-
-        <p class="govuk-body">
-        <a href="{{requestNewCodeLink}}" class="govuk-link">Not received the code?</a>
-        </p>
-
-        {{ govukButton({
+          <p class="govuk-body">
+            <a href="{{ requestNewCodeLink }}" class="govuk-link">Not received the code?</a>
+          </p>
+          {{ govukButton({
           text: "Continue",
           type: "submit",
           attributes: { "data-cy":"button-save-and-continue"}
         }) }}
-      </form>
-
+        </form>
+      </div>
     </div>
-  </div>
-{% endblock %}
+  {% endblock %}

--- a/packages/forms-web-app/src/views/manage-appeals/request-new-code.njk
+++ b/packages/forms-web-app/src/views/manage-appeals/request-new-code.njk
@@ -1,17 +1,13 @@
 {% extends "layouts/lpa-dashboard/main-no-back-link.njk" %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
-{% from "govuk/components/input/macro.njk" import govukInput %}
 {% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
-{% from "govuk/components/fieldset/macro.njk" import govukFieldset %}
 {% set title="Request a new code - Manage appeals - GOV.UK" %}
-
 {% block pageTitle %}
   {% if errors %}
     {% set title = "Error: " + title %}
   {% endif %}
   {{ title }}
 {% endblock %}
-
 {% block content %}
   {% if errors %}
     {{ govukErrorSummary({
@@ -22,36 +18,16 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       <h1 class="govuk-heading-l">Request a new code</h1>
-      <p class="govuk-body">Emails sometimes take a few minutes to arrive. If you do not receive the code, you can request a new one.</p>
+      <p class="govuk-body">Emails sometimes take a few minutes to arrive. If you do not receive the code, you can request a
+        new one.</p>
       <form action="{{ currentRoute }}" method="post" novalidate>
-<input type="hidden" name="_csrf" value="{{_csrf}}">
-         {% call govukFieldset({
-          legend: {
-            text: "Enter your email address",
-            classes: "govuk-fieldset__legend--l",
-            isPageHeading: true
-          }
-        }) %}
-
-        {{ govukInput({
-            classes: "govuk-input govuk-input--width-20",
-            id: "emailAddress",
-            name: "emailAddress",
-            spellcheck: false,
-            value: email-address,
-            errorMessage: errors['email-address'] and {
-              text: errors['email-address'].msg
-            }
-          }) 
-        }}
-
-        {% endcall %}
-        {{ govukButton({
+        <input type="hidden" name="_csrf" value="{{ _csrf }}">
+          {{ govukButton({
           text: "Request a new code",
           type: "submit",
           attributes: { "data-cy":"button-save-and-continue"}
         }) }}
-      </form>
+        </form>
+      </div>
     </div>
-  </div>
-{% endblock %}
+  {% endblock %}


### PR DESCRIPTION
### Description of change

Moves generation of login code away from enter-code page load to the user action (entering email, requesting a new code etc)

V1 save and return link now just redirects to dashboard

Ticket: https://pins-ds.atlassian.net/browse/A2-4696

### Checklist

- [x] Feature complete and ready for users, or behind feature-flag
- [x] Commit history is linear with no merge commits
- [ ] Requires infrastructure changes

### Important

Please do not merge from `main` (please only [rebase](https://github.com/Planning-Inspectorate/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
