### PR TITLE
fix(tooling): updating staging resource group in purge pipeline

### DIFF
--- a/azure-pipelines-purge-container-registry.yml
+++ b/azure-pipelines-purge-container-registry.yml
@@ -49,7 +49,7 @@ jobs:
           resourceGroupsBySub: >
             {
               "dev": ["pins-rg-appeals-service-dev-uks-001", "pins-rg-appeals-service-dev-ukw-001"],
-              "test": ["pins-rg-appeals-service-test-uks-001", "pins-rg-appeals-service-test-ukw-001", pins-rg-appeals-service-staging-ukw-001],
+              "test": ["pins-rg-appeals-service-test-uks-001", "pins-rg-appeals-service-test-ukw-001", "pins-rg-appeals-service-staging-ukw-001"],
               "training": ["pins-rg-appeals-service-training-uks-001", "pins-rg-appeals-service-training-ukw-001"],
               "prod": ["pins-rg-appeals-service-prod-uks-001", "pins-rg-appeals-service-prod-ukw-001"]
             }


### PR DESCRIPTION
### Description of change

Adding quotes to staging resource group name in purge pipeline to fix below error in pipeline run

```
Line |
  62 |  … resourceGroupsBySubRaw= $env:RESOURCE_GROUP_BY_SUB | ConvertFrom-Json
     |                                                         ~~~~~~~~~~~~~~~~
     | Conversion from JSON failed with error: Unexpected character encountered
     | while parsing value: p. Path 'test[1]', line 3, position 91.
```
<!-- Please describe the change -->
