### PR TITLE
test: extra condition order change fixed in lpaq

### DIFF
--- a/test-packages/platform-feature-tests/cypress/support/flows/sections/lpaManageAppeals/houseHolderQuestionnaire.js
+++ b/test-packages/platform-feature-tests/cypress/support/flows/sections/lpaManageAppeals/houseHolderQuestionnaire.js
@@ -125,13 +125,8 @@ export const householderQuestionnaire = (context, lpaManageAppealsData, lpaAppea
 
 		// Appeals process
 		appealProcess.selectNearbyAppeals(context, lpaManageAppealsData, lpaManageAppealsData?.hasAppealType);
-		if (lpaAppealType === lpaManageAppealsData?.hasAppealType) {
-			appealProcess.selectNewConditions(context, lpaManageAppealsData);
-		}
+		appealProcess.selectNewConditions(context, lpaManageAppealsData);
 		appealProcess.selectSignificantChanges(context, lpaManageAppealsData);
-		if (lpaAppealType != lpaManageAppealsData?.hasAppealType) {
-			appealProcess.selectNewConditions(context, lpaManageAppealsData);
-		}
 
 		// Original Evidence
 		originalEvidence.selectDesignAccessStatement(context, lpaManageAppealsData);

--- a/test-packages/platform-feature-tests/cypress/support/flows/sections/lpaManageAppeals/questionnaire.js
+++ b/test-packages/platform-feature-tests/cypress/support/flows/sections/lpaManageAppeals/questionnaire.js
@@ -189,13 +189,8 @@ export const questionnaire = (context, lpaManageAppealsData, lpaAppealType, case
 		appealProcess.selectProcedureType(context, lpaManageAppealsData);
 		appealProcess.selectOngoingAppealsNextToSite(context, lpaManageAppealsData, lpaManageAppealsData?.s78AppealType);
 		if (lpaAppealType != lpaManageAppealsData?.ldcAppealType) {
-			if (lpaAppealType === lpaManageAppealsData?.s78AppealType) {
-				appealProcess.selectNewConditions(context, lpaManageAppealsData);
-			}
+			appealProcess.selectNewConditions(context, lpaManageAppealsData);
 			appealProcess.selectSignificantChanges(context, lpaManageAppealsData);
-			if (lpaAppealType != lpaManageAppealsData?.s78AppealType) {
-				appealProcess.selectNewConditions(context, lpaManageAppealsData);
-			}
 			// Original Evidence
 			originalEvidence.selectDesignAccessStatement(context, lpaManageAppealsData);
 			originalEvidence.selectPlansAndDrawingsSubmitted(context, lpaManageAppealsData);


### PR DESCRIPTION
### Description of change

extra condition row order update test to make it consistent across all expedited lpa questionnaires.

Ticket: https://pins-ds.atlassian.net/browse/A2-8943

### Checklist

- [ ] Feature complete and ready for users, or behind feature-flag
- [ ] Commit history is linear with no merge commits
- [ ] Requires infrastructure changes

### Important

Please do not merge from `main` (please only [rebase](https://github.com/Planning-Inspectorate/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
