### PR TITLE
chore(tooling): updating db migrate checkout to use build commit id version

### DIFF
--- a/azure-pipelines-deploy.yml
+++ b/azure-pipelines-deploy.yml
@@ -161,8 +161,9 @@ extends:
           - name: Migrate
             condition: ${{ or(eq(parameters.schemaMigration, true), eq(parameters.seedData, true)) }}
             steps:
-              - checkout: self
-                fetchDepth: 1
+              - bash: |
+                  git clone --depth=1 --no-tags --revision="$(resources.pipeline.build.sourceCommit)" $(Build.Repository.Uri) .
+                displayName: Checkout Build-Commit
               - bash: |
                   if [[ $ENVIRONMENT == "staging"  || $ENVIRONMENT == "training" ]]; then
                     echo "Name: pinskvcommon$(ENVIRONMENT)ukw (env: $(ENVIRONMENT))"


### PR DESCRIPTION
### Description of change

Updating the checkout to use the commit version used by the build pipeline for Prisma migration step

<!-- Please describe the change -->

Ticket: https://pins-ds.atlassian.net/browse/DEV-714

### Checklist

- [ ] Feature complete and ready for users, or behind feature-flag
- [ ] Commit history is linear with no merge commits
- [ ] Requires infrastructure changes

### Important

Please do not merge from `main` (please only [rebase](https://github.com/Planning-Inspectorate/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
