### PR TITLE
fix: ignore casing on user ownership checks

### DIFF
--- a/packages/appeals-service-api/src/routes/v2/appeals/appeals.spec.js
+++ b/packages/appeals-service-api/src/routes/v2/appeals/appeals.spec.js
@@ -203,7 +203,7 @@ module.exports = ({ getSqlClient, setCurrentSub, appealsApi }) => {
 				let serviceUserId;
 
 				beforeAll(async () => {
-					const email = crypto.randomUUID() + '@example.com';
+					const email = 'a' + crypto.randomUUID() + '@example.com';
 					serviceUserId = 'su-' + crypto.randomUUID().slice(0, 8);
 					user = await sqlClient.appealUser.create({ data: { email } });
 					caseRef = 'reps-' + crypto.randomUUID().slice(0, 8);
@@ -214,7 +214,7 @@ module.exports = ({ getSqlClient, setCurrentSub, appealsApi }) => {
 							id: serviceUserId,
 							serviceUserType: SERVICE_USER_TYPE.RULE_6_PARTY,
 							caseReference: caseRef,
-							emailAddress: email
+							emailAddress: email.toUpperCase() // different casing from user email
 						}
 					});
 					await sqlClient.representation.create({
@@ -223,6 +223,26 @@ module.exports = ({ getSqlClient, setCurrentSub, appealsApi }) => {
 							caseReference: caseRef,
 							source: APPEAL_SOURCE.CITIZEN,
 							serviceUserId,
+							representationType: 'comment'
+						}
+					});
+
+					const otheremail = 'b' + crypto.randomUUID() + '@example.com';
+					const otherServiceUserId = 'su-' + crypto.randomUUID().slice(0, 8);
+					await sqlClient.serviceUser.create({
+						data: {
+							id: otherServiceUserId,
+							serviceUserType: SERVICE_USER_TYPE.RULE_6_PARTY,
+							caseReference: caseRef,
+							emailAddress: otheremail
+						}
+					});
+					await sqlClient.representation.create({
+						data: {
+							representationId: crypto.randomUUID(),
+							caseReference: caseRef,
+							source: APPEAL_SOURCE.CITIZEN,
+							serviceUserId: otherServiceUserId,
 							representationType: 'comment'
 						}
 					});

--- a/packages/common/src/access/representation-ownership.js
+++ b/packages/common/src/access/representation-ownership.js
@@ -37,7 +37,7 @@ exports.addOwnershipAndSubmissionDetailsToRepresentations = (
 	// find the service user ids that have matching email with logged in user
 	const loggedInUserIds = new Set(
 		serviceUsersWithEmails
-			.filter((serviceUser) => serviceUser.emailAddress == email)
+			.filter((serviceUser) => serviceUser.emailAddress?.toLowerCase() === email?.toLowerCase())
 			.map((serviceUser) => serviceUser.id)
 	);
 


### PR DESCRIPTION
### Description of change

Ownership checks were case sensitive
Added tests for this and ensuring another user's appeals aren't returned for rule 6 on the same case

### Checklist

- [x] Feature complete and ready for users, or behind feature-flag
- [x] Commit history is linear with no merge commits
- [ ] Requires infrastructure changes

### Important

Please do not merge from `main` (please only [rebase](https://github.com/Planning-Inspectorate/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
