### PR TITLE
feat(web): added doc fields for s78 expedite (A2-8948)

### DIFF
--- a/packages/forms-web-app/src/controllers/selected-appeal/appeal-details/appeal-documents-rows.js
+++ b/packages/forms-web-app/src/controllers/selected-appeal/appeal-details/appeal-documents-rows.js
@@ -1,4 +1,8 @@
-const { formatDocumentDetails, formatPlanningObligationStatus } = require('@pins/common');
+const {
+	formatDocumentDetails,
+	formatPlanningObligationStatus,
+	documentExists
+} = require('@pins/common');
 const { CASE_TYPES } = require('@pins/common/src/database/data-static');
 
 const {
@@ -252,6 +256,7 @@ const enforcementDocumentsRows = (caseData) => {
  */
 const getExpeditedDocumentsRows = (caseData) => {
 	const documents = caseData.Documents || [];
+	const isS78 = caseData.appealTypeCode === CASE_TYPES.S78.processCode;
 
 	return [
 		{
@@ -292,6 +297,44 @@ const getExpeditedDocumentsRows = (caseData) => {
 			keyText: 'Costs application',
 			valueText: formatDocumentDetails(documents, APPEAL_DOCUMENT_TYPE.APPELLANT_COSTS_APPLICATION),
 			condition: (caseData) => caseData.appellantCostsAppliedFor,
+			isEscaped: true
+		},
+		{
+			keyText: 'Appeal statement',
+			valueText: formatDocumentDetails(documents, APPEAL_DOCUMENT_TYPE.APPELLANT_STATEMENT),
+			condition: () => isS78 && documentExists(documents, APPEAL_DOCUMENT_TYPE.APPELLANT_STATEMENT),
+			isEscaped: true
+		},
+		{
+			keyText: 'Draft statement of common ground',
+			valueText: formatDocumentDetails(documents, APPEAL_DOCUMENT_TYPE.STATEMENT_COMMON_GROUND),
+			condition: () =>
+				isS78 && documentExists(documents, APPEAL_DOCUMENT_TYPE.STATEMENT_COMMON_GROUND),
+			isEscaped: true
+		},
+		{
+			keyText: 'Design and access statement in application',
+			valueText: formatDocumentDetails(documents, APPEAL_DOCUMENT_TYPE.DESIGN_ACCESS_STATEMENT),
+			condition: () =>
+				isS78 && documentExists(documents, APPEAL_DOCUMENT_TYPE.DESIGN_ACCESS_STATEMENT),
+			isEscaped: true
+		},
+		{
+			keyText: 'Plans, drawings and supporting documents',
+			valueText: formatDocumentDetails(documents, APPEAL_DOCUMENT_TYPE.PLANS_DRAWINGS),
+			condition: () => isS78 && documentExists(documents, APPEAL_DOCUMENT_TYPE.PLANS_DRAWINGS),
+			isEscaped: true
+		},
+		{
+			keyText: 'New plans or drawings',
+			valueText: formatDocumentDetails(documents, APPEAL_DOCUMENT_TYPE.NEW_PLANS_DRAWINGS),
+			condition: () => isS78 && documentExists(documents, APPEAL_DOCUMENT_TYPE.NEW_PLANS_DRAWINGS),
+			isEscaped: true
+		},
+		{
+			keyText: 'New supporting documents',
+			valueText: formatDocumentDetails(documents, APPEAL_DOCUMENT_TYPE.OTHER_NEW_DOCUMENTS),
+			condition: () => isS78 && documentExists(documents, APPEAL_DOCUMENT_TYPE.OTHER_NEW_DOCUMENTS),
 			isEscaped: true
 		}
 	];

--- a/packages/forms-web-app/src/controllers/selected-appeal/appeal-details/appeal-documents-rows.test.js
+++ b/packages/forms-web-app/src/controllers/selected-appeal/appeal-details/appeal-documents-rows.test.js
@@ -328,13 +328,69 @@ describe('appeal-documents-rows - expedited part 1', () => {
 		Documents: []
 	};
 
+	const expeditedCaseDataWithOptionalExpeditedDocs = {
+		appealTypeCode: CASE_TYPES.S78.processCode,
+		typeOfPlanningApplication: 'full-appeal',
+		applicationDecision: 'refused',
+		applicationDate: '2026-04-10',
+		changedDevelopmentDescription: true,
+		appellantCostsAppliedFor: true,
+		statusPlanningObligation: 'finalised',
+		Documents: [
+			{
+				id: 1,
+				documentType: APPEAL_DOCUMENT_TYPE.APPELLANT_STATEMENT,
+				filename: 'appeal-statement.pdf',
+				redacted: false
+			},
+			{
+				id: 2,
+				documentType: APPEAL_DOCUMENT_TYPE.STATEMENT_COMMON_GROUND,
+				filename: 'statement-common-ground.pdf',
+				redacted: false
+			},
+			{
+				id: 3,
+				documentType: APPEAL_DOCUMENT_TYPE.DESIGN_ACCESS_STATEMENT,
+				filename: 'design-access-statement.pdf',
+				redacted: false
+			},
+			{
+				id: 4,
+				documentType: APPEAL_DOCUMENT_TYPE.PLANS_DRAWINGS,
+				filename: 'plans-drawings.pdf',
+				redacted: false
+			},
+			{
+				id: 5,
+				documentType: APPEAL_DOCUMENT_TYPE.NEW_PLANS_DRAWINGS,
+				filename: 'new-plans-drawings.pdf',
+				redacted: false
+			},
+			{
+				id: 6,
+				documentType: APPEAL_DOCUMENT_TYPE.OTHER_NEW_DOCUMENTS,
+				filename: 'new-supporting-documents.pdf',
+				redacted: false
+			}
+		]
+	};
+
 	it('should create rows for an expedited part 1 appeal', () => {
 		const rows = documentsRows(expeditedCaseData);
-		expect(rows.length).toEqual(6);
+		expect(rows.length).toEqual(12);
 	});
 
-	it('should have the correct rows in the correct order', () => {
+	it('should have the correct rows in the correct order without optional docs', () => {
 		const rows = documentsRows(expeditedCaseData);
+		const expeditedExpectedRows = [
+			'Appeal statement',
+			'Draft statement of common ground',
+			'Design and access statement in application',
+			'Plans, drawings and supporting documents',
+			'New plans or drawings',
+			'New supporting documents'
+		];
 		const expectedRows = [
 			'Application form',
 			'Decision letter',
@@ -343,10 +399,37 @@ describe('appeal-documents-rows - expedited part 1', () => {
 			'Environmental statement',
 			'Costs application'
 		];
+		const allExpectedRows = [...expectedRows, ...expeditedExpectedRows];
 
 		rows.forEach((row, index) => {
-			expect(row.keyText).toEqual(expectedRows[index]);
-			expect(row.condition(expeditedCaseData)).toEqual(true);
+			expect(row.keyText).toEqual(allExpectedRows[index]);
+			expect(row.condition(expeditedCaseData)).toEqual(index < expectedRows.length ? true : false);
+		});
+	});
+
+	it('should have the correct rows in the correct order with optional docs', () => {
+		const rows = documentsRows(expeditedCaseDataWithOptionalExpeditedDocs);
+		const expeditedExpectedRows = [
+			'Appeal statement',
+			'Draft statement of common ground',
+			'Design and access statement in application',
+			'Plans, drawings and supporting documents',
+			'New plans or drawings',
+			'New supporting documents'
+		];
+		const expectedRows = [
+			'Application form',
+			'Decision letter',
+			'Separate ownership certificate in application',
+			'Evidence of agreement to change description of development',
+			'Environmental statement',
+			'Costs application'
+		];
+		const allExpectedRows = [...expectedRows, ...expeditedExpectedRows];
+
+		rows.forEach((row, index) => {
+			expect(row.keyText).toEqual(allExpectedRows[index]);
+			expect(row.condition(expeditedCaseDataWithOptionalExpeditedDocs)).toEqual(true);
 		});
 	});
 


### PR DESCRIPTION
### Description of change

-Added back s78 expedite document fields that will only show row if s78 expedite and document itself exists
-Updated unit tests

Ticket: https://pins-ds.atlassian.net/browse/A2-8949

### Checklist

- [ ] Feature complete and ready for users, or behind feature-flag
- [ ] Commit history is linear with no merge commits
- [ ] Requires infrastructure changes

### Important

Please do not merge from `main` (please only [rebase](https://github.com/Planning-Inspectorate/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
