### PR TITLE
feat(A2-8880): hide usv banner for enforcement and ldc appeals

### DIFF
--- a/packages/common/src/lib/appeal-type-checks.js
+++ b/packages/common/src/lib/appeal-type-checks.js
@@ -1,0 +1,43 @@
+const { CASE_TYPES } = require('../database/data-static');
+
+/**
+ * @param {string | undefined} appealTypeCode
+ * @returns {boolean}
+ */
+const isEnforcementNotice = (appealTypeCode) =>
+	appealTypeCode === CASE_TYPES.ENFORCEMENT.processCode;
+
+/**
+ * @param {string | undefined} appealTypeCode
+ * @returns {boolean}
+ */
+const isEnforcementListed = (appealTypeCode) =>
+	appealTypeCode === CASE_TYPES.ENFORCEMENT_LISTED.processCode;
+
+/**
+ * @param {string | undefined} appealTypeCode
+ * @returns {boolean}
+ */
+const isAnyEnforcement = (appealTypeCode) =>
+	isEnforcementNotice(appealTypeCode) || isEnforcementListed(appealTypeCode);
+
+/**
+ * @param {string | undefined} appealTypeCode
+ * @returns {boolean}
+ */
+const isLDC = (appealTypeCode) => appealTypeCode === CASE_TYPES.LDC.processCode;
+
+/**
+ * @param {string | undefined} appealTypeCode
+ * @returns {boolean}
+ */
+const isAnyEnforcementOrLDC = (appealTypeCode) =>
+	isLDC(appealTypeCode) || isAnyEnforcement(appealTypeCode);
+
+module.exports = {
+	isEnforcementNotice,
+	isEnforcementListed,
+	isAnyEnforcement,
+	isLDC,
+	isAnyEnforcementOrLDC
+};

--- a/packages/common/src/lib/appeal-type-checks.test.js
+++ b/packages/common/src/lib/appeal-type-checks.test.js
@@ -1,0 +1,44 @@
+const { CASE_TYPES } = require('../database/data-static');
+const { isAnyEnforcement, isAnyEnforcementOrLDC } = require('./appeal-type-checks');
+
+describe(isAnyEnforcement, () => {
+	it.each([CASE_TYPES.ENFORCEMENT.processCode, CASE_TYPES.ENFORCEMENT_LISTED.processCode])(
+		'returns true for %s',
+		(appealType) => {
+			expect(isAnyEnforcement(appealType)).toBe(true);
+		}
+	);
+
+	it.each([
+		CASE_TYPES.HAS.processCode,
+		CASE_TYPES.S78.processCode,
+		CASE_TYPES.S20.processCode,
+		CASE_TYPES.ADVERTS.processCode,
+		CASE_TYPES.CAS_ADVERTS.processCode,
+		CASE_TYPES.CAS_PLANNING.processCode,
+		CASE_TYPES.LDC.processCode
+	])('returns false for %s', (appealType) => {
+		expect(isAnyEnforcement(appealType)).toBe(false);
+	});
+});
+
+describe(isAnyEnforcementOrLDC, () => {
+	it.each([
+		CASE_TYPES.ENFORCEMENT.processCode,
+		CASE_TYPES.ENFORCEMENT_LISTED.processCode,
+		CASE_TYPES.LDC.processCode
+	])('returns true for %s', (appealType) => {
+		expect(isAnyEnforcementOrLDC(appealType)).toBe(true);
+	});
+
+	it.each([
+		CASE_TYPES.HAS.processCode,
+		CASE_TYPES.S78.processCode,
+		CASE_TYPES.S20.processCode,
+		CASE_TYPES.ADVERTS.processCode,
+		CASE_TYPES.CAS_ADVERTS.processCode,
+		CASE_TYPES.CAS_PLANNING.processCode
+	])('returns false for %s', (appealType) => {
+		expect(isAnyEnforcementOrLDC(appealType)).toBe(false);
+	});
+});

--- a/packages/common/src/view-model-maps/events.js
+++ b/packages/common/src/view-model-maps/events.js
@@ -2,6 +2,7 @@ const { APPEAL_USER_ROLES, EVENT_TYPES, EVENT_SUB_TYPES, LPA_USER_ROLE } = requi
 const { format: formatDate } = require('date-fns');
 const { utcToZonedTime } = require('date-fns-tz');
 const { formatEventAddress } = require('../lib/format-address');
+const { isAnyEnforcementOrLDC } = require('../lib/appeal-type-checks');
 const targetTimezone = 'Europe/London';
 
 /**
@@ -11,9 +12,10 @@ const targetTimezone = 'Europe/London';
 /**
  * @param {Array<Event>} events
  * @param {string} role
+ * @param {string | undefined} appealType
  * @returns {Array<string|null>}
  */
-const formatSiteVisits = (events, role) => {
+const formatSiteVisits = (events, role, appealType) => {
 	let siteVisits = events.filter((item) => item.type === EVENT_TYPES.SITE_VISIT);
 
 	return siteVisits
@@ -25,7 +27,9 @@ const formatSiteVisits = (events, role) => {
 					role === LPA_USER_ROLE)
 			) {
 				if (siteVisit.subtype === EVENT_SUB_TYPES.UNACCOMPANIED) {
-					return 'Our inspector will visit the site. You do not need to attend.';
+					return isAnyEnforcementOrLDC(appealType)
+						? null
+						: 'Our inspector will visit the site. You do not need to attend.';
 				}
 
 				const formattedStart = getFormattedTimeAndDate(siteVisit.startDate);

--- a/packages/common/src/view-model-maps/events.test.js
+++ b/packages/common/src/view-model-maps/events.test.js
@@ -1,4 +1,5 @@
 const { LPA_USER_ROLE, APPEAL_USER_ROLES, EVENT_SUB_TYPES } = require('../constants');
+const { CASE_TYPES } = require('../database/data-static');
 const { formatInquiries, formatSiteVisits, formatHearings } = require('./events');
 
 describe('view-model-maps/events', () => {
@@ -41,29 +42,31 @@ describe('view-model-maps/events', () => {
 		addressPostcode: 'AB1 2CD'
 	};
 
+	const nonEnforcementOrLDCAppealType = CASE_TYPES.S78.processCode;
+
 	describe('formatSiteVisits', () => {
 		it('returns empty array if not a valid user', () => {
 			const events = [siteVisitEvent];
 			const role = 'not a valid user';
 
-			expect(formatSiteVisits(events, role)).toHaveLength(0);
+			expect(formatSiteVisits(events, role, nonEnforcementOrLDCAppealType)).toHaveLength(0);
 		});
 
 		it('returns empty array if valid user and no site visit in events array', () => {
 			const events = [inquiryEvent, inquiryEvent, hearingEvent];
 			const role = APPEAL_USER_ROLES.APPELLANT;
 
-			expect(formatSiteVisits(events, role)).toHaveLength(0);
+			expect(formatSiteVisits(events, role, nonEnforcementOrLDCAppealType)).toHaveLength(0);
 		});
 
 		it('returns empty array if valid user but no subtype specified', () => {
 			const events = [siteVisitEvent];
 			const role = APPEAL_USER_ROLES.APPELLANT;
 
-			expect(formatSiteVisits(events, role)).toHaveLength(0);
+			expect(formatSiteVisits(events, role, nonEnforcementOrLDCAppealType)).toHaveLength(0);
 		});
 
-		it('returns correct array if valid user and unaccompanied subtype', () => {
+		it('returns correct array if valid user, nonEnforcementOrLDCAppeal and unaccompanied subtype', () => {
 			const events = [
 				{
 					...siteVisitEvent,
@@ -74,9 +77,27 @@ describe('view-model-maps/events', () => {
 			];
 			const role = APPEAL_USER_ROLES.AGENT;
 
-			expect(formatSiteVisits(events, role)).toEqual([
+			expect(formatSiteVisits(events, role, nonEnforcementOrLDCAppealType)).toEqual([
 				'Our inspector will visit the site. You do not need to attend.'
 			]);
+		});
+
+		it.each([
+			CASE_TYPES.ENFORCEMENT.processCode,
+			CASE_TYPES.ENFORCEMENT_LISTED.processCode,
+			CASE_TYPES.LDC.processCode
+		])('returns empty array if valid user, %s and unaccompanied subtype', (appealType) => {
+			const events = [
+				{
+					...siteVisitEvent,
+					startDate: null,
+					endDate: null,
+					subtype: EVENT_SUB_TYPES.UNACCOMPANIED
+				}
+			];
+			const role = APPEAL_USER_ROLES.AGENT;
+
+			expect(formatSiteVisits(events, role, appealType)).toHaveLength(0);
 		});
 
 		it('returns only siteVisit data not inquiry when user is valid', () => {
@@ -91,7 +112,7 @@ describe('view-model-maps/events', () => {
 			];
 			const role = APPEAL_USER_ROLES.AGENT;
 
-			expect(formatSiteVisits(events, role)).toEqual([
+			expect(formatSiteVisits(events, role, nonEnforcementOrLDCAppealType)).toEqual([
 				'Our inspector will visit the site. You do not need to attend.'
 			]);
 		});
@@ -102,7 +123,7 @@ describe('view-model-maps/events', () => {
 			];
 			const role = LPA_USER_ROLE;
 
-			expect(formatSiteVisits(events, role)).toEqual([
+			expect(formatSiteVisits(events, role, nonEnforcementOrLDCAppealType)).toEqual([
 				'Our inspector will visit the site between 9am and 11am on 29 December 2024. Someone must be at the site to give our inspector access.'
 			]);
 		});
@@ -111,7 +132,7 @@ describe('view-model-maps/events', () => {
 			const events = [{ ...siteVisitEvent, subtype: EVENT_SUB_TYPES.ACCESS }];
 			const role = APPEAL_USER_ROLES.APPELLANT;
 
-			expect(formatSiteVisits(events, role)).toEqual([
+			expect(formatSiteVisits(events, role, nonEnforcementOrLDCAppealType)).toEqual([
 				'Our inspector will visit the site between 9am on 29 December 2024 and 9am on 30 December 2024. Someone must be at the site to give our inspector access.'
 			]);
 		});
@@ -120,7 +141,7 @@ describe('view-model-maps/events', () => {
 			const events = [{ ...siteVisitEvent, endDate: null, subtype: EVENT_SUB_TYPES.ACCESS }];
 			const role = LPA_USER_ROLE;
 
-			expect(formatSiteVisits(events, role)).toEqual([
+			expect(formatSiteVisits(events, role, nonEnforcementOrLDCAppealType)).toEqual([
 				'Our inspector will visit the site at 9am on 29 December 2024. Someone must be at the site to give our inspector access.'
 			]);
 		});
@@ -129,7 +150,7 @@ describe('view-model-maps/events', () => {
 			const events = [{ ...siteVisitEvent, subtype: EVENT_SUB_TYPES.ACCOMPANIED }];
 			const role = APPEAL_USER_ROLES.APPELLANT;
 
-			expect(formatSiteVisits(events, role)).toEqual([
+			expect(formatSiteVisits(events, role, nonEnforcementOrLDCAppealType)).toEqual([
 				'Our inspector will visit the site at 9am on 29 December 2024. You and the other main party must attend the site visit.'
 			]);
 		});

--- a/packages/forms-web-app/jsconfig.json
+++ b/packages/forms-web-app/jsconfig.json
@@ -3,7 +3,8 @@
 	"include": [
 		"**/*.js",
 		"../common/src/lib/linked-appeals.js",
-		"../common/src/lib/linked-appeals.test.js"
+		"../common/src/lib/linked-appeals.test.js",
+		"../common/src/lib/appeal-type-checks.js"
 	],
 	"compilerOptions": {
 		"baseUrl": ".",

--- a/packages/forms-web-app/src/controllers/selected-appeal/index.js
+++ b/packages/forms-web-app/src/controllers/selected-appeal/index.js
@@ -41,9 +41,9 @@ const {
 	formatDashboardLinkedCaseDetails,
 	isChildLinkedAppeal
 } = require('@pins/common/src/lib/linked-appeals');
-const { CASE_TYPES } = require('@pins/common/src/database/data-static');
 const { FLAG } = require('@pins/common/src/feature-flags');
 const { isFeatureActive } = require('../../featureFlag');
+const { isEnforcementNotice } = require('@pins/common/src/lib/appeal-type-checks');
 
 /** @type {Partial<import('@pins/common/src/view-model-maps/sections/def').UserSectionsDict>} */
 const userSectionsDict = {
@@ -101,9 +101,11 @@ exports.get = (layoutTemplate = 'layouts/no-banner-link/main.njk') => {
 				)
 			: caseData.Documents;
 
-		const isEnforcement = caseData.appealTypeCode === CASE_TYPES.ENFORCEMENT.processCode;
+		const { appealTypeCode } = caseData;
 
-		const siteVisits = isChildLinkedAppeal(caseData) ? [] : formatSiteVisits(events, userType);
+		const siteVisits = isChildLinkedAppeal(caseData)
+			? []
+			: formatSiteVisits(events, userType, appealTypeCode);
 
 		const linkedCaseDetails = formatDashboardLinkedCaseDetails(caseData);
 
@@ -114,9 +116,7 @@ exports.get = (layoutTemplate = 'layouts/no-banner-link/main.njk') => {
 		if (!isLPA) {
 			bannerHtmlOverride =
 				config.betaBannerText +
-				config.generateBetaBannerFeedbackLink(
-					config.getAppealTypeFeedbackUrl(caseData.appealTypeCode)
-				);
+				config.generateBetaBannerFeedbackLink(config.getAppealTypeFeedbackUrl(appealTypeCode));
 		}
 
 		const flags = {
@@ -153,7 +153,7 @@ exports.get = (layoutTemplate = 'layouts/no-banner-link/main.njk') => {
 				hearings: formatHearings(events, userType),
 				sections: formatSections({ caseData, sections }),
 				baseUrl: userRouteUrl,
-				decision: mapDecisionTag(caseData.caseDecisionOutcome, isEnforcement),
+				decision: mapDecisionTag(caseData.caseDecisionOutcome, isEnforcementNotice(appealTypeCode)),
 				decisionDate: formatDateForDisplay(caseData.caseDecisionOutcomeDate, {
 					format: 'd MMMM yyyy'
 				}),


### PR DESCRIPTION
### Description of change

Hides the unaccompanied site visit banner for enforcement notice, elb and ldc appeals.

Adds some common appeal type check functions.

Ticket: https://pins-ds.atlassian.net/browse/A2-8880

### Checklist

- [X] Feature complete and ready for users, or behind feature-flag
- [X] Commit history is linear with no merge commits
- [ ] Requires infrastructure changes

### Important

Please do not merge from `main` (please only [rebase](https://github.com/Planning-Inspectorate/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
