### PR TITLE
feat(api): receive broadcasted site visit type without date and time(A2-8970)

### DIFF
--- a/packages/common/src/view-model-maps/events.js
+++ b/packages/common/src/view-model-maps/events.js
@@ -26,7 +26,7 @@ const formatSiteVisits = (events, role, appealType) => {
 					role === APPEAL_USER_ROLES.AGENT ||
 					role === LPA_USER_ROLE)
 			) {
-				if (siteVisit.subtype === EVENT_SUB_TYPES.UNACCOMPANIED) {
+				if (siteVisit.subtype === EVENT_SUB_TYPES.UNACCOMPANIED && siteVisit.status !== 'pending') {
 					return isAnyEnforcementOrLDC(appealType)
 						? null
 						: 'Our inspector will visit the site. You do not need to attend.';

--- a/packages/common/src/view-model-maps/events.test.js
+++ b/packages/common/src/view-model-maps/events.test.js
@@ -70,14 +70,28 @@ describe('view-model-maps/events', () => {
 			const events = [
 				{
 					...siteVisitEvent,
-					startDate: null,
-					endDate: null,
 					subtype: EVENT_SUB_TYPES.UNACCOMPANIED
 				}
 			];
 			const role = APPEAL_USER_ROLES.AGENT;
 
 			expect(formatSiteVisits(events, role, nonEnforcementOrLDCAppealType)).toEqual([
+				'Our inspector will visit the site. You do not need to attend.'
+			]);
+		});
+		it('returns correct array if valid user, nonEnforcementOrLDCAppeal and unaccompanied subtype and no date and time', () => {
+			const events = [
+				{
+					...siteVisitEvent,
+					startDate: null,
+					endDate: null,
+					status: 'pending',
+					subtype: EVENT_SUB_TYPES.UNACCOMPANIED
+				}
+			];
+			const role = APPEAL_USER_ROLES.AGENT;
+
+			expect(formatSiteVisits(events, role, nonEnforcementOrLDCAppealType)).not.toEqual([
 				'Our inspector will visit the site. You do not need to attend.'
 			]);
 		});


### PR DESCRIPTION
### Description of change

- Added additional conditional to not show text if no date and time and USV and status is pending
- Updated unit tests

Ticket: https://pins-ds.atlassian.net/browse/A2-8970

### Checklist

- [ ] Feature complete and ready for users, or behind feature-flag
- [ ] Commit history is linear with no merge commits
- [ ] Requires infrastructure changes

### Important

Please do not merge from `main` (please only [rebase](https://github.com/Planning-Inspectorate/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
