### PR TITLE
fix(a2-8993): fail silently on missing document for delete

### DIFF
--- a/packages/appeals-service-api/src/routes/v2/documents/index.spec.js
+++ b/packages/appeals-service-api/src/routes/v2/documents/index.spec.js
@@ -295,6 +295,22 @@ module.exports = ({ getSqlClient, appealsApi }) => {
 				expect(notDoc).toBe(0);
 				expect(notRepDoc).toBe(0);
 			});
+
+			it('fails silently if document does not exist', async () => {
+				const caseRef = 'deleteDocument_ref_003';
+				await sqlClient.appealCase.create({
+					data: {
+						Appeal: { create: {} },
+						...createTestAppealCase(caseRef, 'HAS', 'lpa_001')
+					}
+				});
+
+				const docId = crypto.randomUUID();
+
+				const response = await appealsApi.delete(`/api/v2/documents/${docId}`);
+
+				expect(response.status).toBe(200);
+			});
 		});
 
 		describe('get document', () => {

--- a/packages/appeals-service-api/src/routes/v2/documents/repo.js
+++ b/packages/appeals-service-api/src/routes/v2/documents/repo.js
@@ -100,10 +100,12 @@ module.exports = class Repo {
 			}
 		});
 
-		await this.dbClient.document.delete({
-			where: {
-				id
-			}
-		});
+		try {
+			await this.dbClient.document.delete({
+				where: { id }
+			});
+		} catch (error) {
+			if (error?.code !== 'P2025') throw error;
+		}
 	}
 };


### PR DESCRIPTION
### Description of change

Avoid failing if delete message comes through for a document that does not exist

Ticket: https://pins-ds.atlassian.net/browse/A2-8993

### Checklist

- [x] Feature complete and ready for users, or behind feature-flag
- [x] Commit history is linear with no merge commits
- [ ] Requires infrastructure changes

### Important

Please do not merge from `main` (please only [rebase](https://github.com/Planning-Inspectorate/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
