### PR TITLE
fix(A2-9057): update condition for planning obligation display for en…

### DIFF
--- a/packages/forms-web-app/src/controllers/selected-appeal/appeal-details/appeal-documents-rows.js
+++ b/packages/forms-web-app/src/controllers/selected-appeal/appeal-details/appeal-documents-rows.js
@@ -229,10 +229,9 @@ const enforcementDocumentsRows = (caseData) => {
 		{
 			keyText: 'Planning obligation',
 			valueText: formatDocumentDetails(documents, APPEAL_DOCUMENT_TYPE.PLANNING_OBLIGATION),
-			condition: () =>
-				!!caseData.applicationMadeAndFeePaid ||
-				!!caseData.retrospectiveApplication ||
-				caseData.appealTypeCode === CASE_TYPES.ENFORCEMENT_LISTED.processCode,
+			condition: (caseData) =>
+				caseData.appealTypeCode === CASE_TYPES.ENFORCEMENT_LISTED.processCode ||
+				isNotUndefinedOrNull(caseData.statusPlanningObligation),
 			isEscaped: true
 		},
 		{

--- a/packages/forms-web-app/src/controllers/selected-appeal/appeal-details/appeal-documents-rows.test.js
+++ b/packages/forms-web-app/src/controllers/selected-appeal/appeal-details/appeal-documents-rows.test.js
@@ -273,7 +273,6 @@ describe('appeal-documents-rows - enforcement and enforcement listed', () => {
 		['Application form', 3],
 		['Evidence of agreement to change description of development', 4],
 		['Decision letter', 5],
-		['Planning obligation', 7],
 		['Costs application', 8],
 		['New supporting documents', 9]
 	])('%s', (rowName, rowNumber) => {
@@ -313,6 +312,41 @@ describe('appeal-documents-rows - enforcement and enforcement listed', () => {
 				expect(rows[6].condition(caseData)).toEqual(true);
 			}
 		);
+	});
+
+	// whether is displayed depends on appeal type and conditions
+	// always displays for ELB, for EN only if there is a statusPlanningObligation
+	describe('Planning obligation document', () => {
+		test('row should always display for ENFORCEMENT LISTED', () => {
+			const caseData = {
+				appealTypeCode: CASE_TYPES.ENFORCEMENT_LISTED.processCode
+			};
+			const rows = documentsRows(caseData);
+			expect(rows[7].keyText).toEqual('Planning obligation');
+			expect(rows[7].valueText).toEqual('No');
+			expect(rows[7].condition(caseData)).toEqual(true);
+		});
+
+		test('row should display for ENFORCEMENT if statusPlanningObligation', () => {
+			const caseData = {
+				appealTypeCode: CASE_TYPES.ENFORCEMENT.processCode,
+				statusPlanningObligation: 'finalised'
+			};
+			const rows = documentsRows(caseData);
+			expect(rows[7].keyText).toEqual('Planning obligation');
+			expect(rows[7].valueText).toEqual('No');
+			expect(rows[7].condition(caseData)).toEqual(true);
+		});
+
+		test('row should not display for ENFORCEMENT if no statusPlanningObligation', () => {
+			const caseData = {
+				appealTypeCode: CASE_TYPES.ENFORCEMENT.processCode
+			};
+			const rows = documentsRows(caseData);
+			expect(rows[7].keyText).toEqual('Planning obligation');
+			expect(rows[7].valueText).toEqual('No');
+			expect(rows[7].condition(caseData)).toEqual(false);
+		});
 	});
 });
 


### PR DESCRIPTION
…forcement cases

### Description of change

Updates display condition for appeal details document row in enforcement cases:
- Planning Obligation doc always shows for ELB< shows for EN if statusPlanningObligation present.

Ticket: https://pins-ds.atlassian.net/browse/A2-9057

### Checklist

- [X] Feature complete and ready for users, or behind feature-flag
- [X] Commit history is linear with no merge commits
- [ ] Requires infrastructure changes

### Important

Please do not merge from `main` (please only [rebase](https://github.com/Planning-Inspectorate/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
