### PR TITLE
fix(a2-8335): error if uploaded file ends up with 0 bytes

### DIFF
--- a/packages/forms-web-app/src/journeys/question-overrides/multi-file-upload.js
+++ b/packages/forms-web-app/src/journeys/question-overrides/multi-file-upload.js
@@ -97,6 +97,23 @@ async function getDataToSave(req, journeyResponse, previouslyUploadedFiles) {
 
 	// save valid files to blob storage
 	const uploadedFiles = await saveFilesToBlobStorage.call(this, validFiles, journeyResponse);
+	const successfulUploadedFiles = [];
+
+	for (const uploadedFile of uploadedFiles) {
+		if (Number(uploadedFile.size) === 0) {
+			const errorMsg = `Failed to upload file: ${uploadedFile.originalFileName}`;
+			errors[uploadedFile.id || uploadedFile.originalFileName] = {
+				value: { name: uploadedFile.originalFileName },
+				msg: errorMsg
+			};
+			errorSummary.push({
+				text: errorMsg
+			});
+			continue;
+		}
+
+		successfulUploadedFiles.push(uploadedFile);
+	}
 
 	const journeyFiles = {
 		answers: {
@@ -113,8 +130,8 @@ async function getDataToSave(req, journeyResponse, previouslyUploadedFiles) {
 		journeyFiles.answers[this.fieldName].uploadedFiles.push(...answer.uploadedFiles);
 	}
 
-	if (uploadedFiles) {
-		journeyFiles.answers[this.fieldName].uploadedFiles.push(...uploadedFiles);
+	if (successfulUploadedFiles) {
+		journeyFiles.answers[this.fieldName].uploadedFiles.push(...successfulUploadedFiles);
 	}
 
 	journeyResponse.answers[this.fieldName] = journeyFiles.answers[this.fieldName];

--- a/packages/forms-web-app/src/journeys/question-overrides/multi-file-upload.test.js
+++ b/packages/forms-web-app/src/journeys/question-overrides/multi-file-upload.test.js
@@ -95,6 +95,34 @@ describe('multi-file-upload', () => {
 			expect(createDocument).toHaveBeenCalled();
 		});
 
+		it('adds an error for zero-byte uploads and keeps valid uploads', async () => {
+			req.files = {
+				TestUpload: [makeTestFile('empty.pdf'), makeTestFile('file2.pdf')]
+			};
+			createDocument.mockImplementation((_, file) =>
+				Promise.resolve({
+					id: file.name,
+					name: file.name,
+					originalFileName: file.name,
+					location: `/docs/${file.name}`,
+					size: file.name === 'empty.pdf' ? '0' : '456'
+				})
+			);
+
+			const result = await questionInstance.getDataToSave(req, journeyResponse, []);
+
+			expect(result.uploadedFiles).toHaveLength(1);
+			expect(result.uploadedFiles[0].originalFileName).toBe('file2.pdf');
+			expect(req.body.errors['empty.pdf']).toBeDefined();
+			expect(Object.values(req.body.errors)[0].msg).toBe('Failed to upload file: empty.pdf');
+			expect(req.body.errorSummary).toEqual([
+				{
+					text: 'Failed to upload file: empty.pdf',
+					href: '#TestUpload'
+				}
+			]);
+		});
+
 		it('returns new files but does not remove existing files', async () => {
 			journeyResponse.answers.SubmissionDocumentUpload = [
 				{ name: 'existing.pdf', originalFileName: 'existing.pdf', type: 'test' }


### PR DESCRIPTION
### Description of change

Ticket: https://pins-ds.atlassian.net/browse/A2-8335

### Checklist

- [x] Feature complete and ready for users, or behind feature-flag
- [x] Commit history is linear with no merge commits
- [ ] Requires infrastructure changes

### Important

Please do not merge from `main` (please only [rebase](https://github.com/Planning-Inspectorate/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
