### PR TITLE
chore(deps): bump data model to 2.49.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
 				"@azure/service-bus": "^7.9.1",
 				"@azure/storage-blob": "^12.29.1",
 				"@ministryofjustice/frontend": "^1.6.4",
-				"@planning-inspectorate/data-model": "^2.48.0",
+				"@planning-inspectorate/data-model": "^2.49.0",
 				"@prisma/adapter-mssql": "^7.9.1",
 				"@prisma/client": "^7.9.1",
 				"accessible-autocomplete": "^3.0.1",
@@ -7010,9 +7010,9 @@
 			}
 		},
 		"node_modules/@planning-inspectorate/data-model": {
-			"version": "2.48.0",
-			"resolved": "https://registry.npmjs.org/@planning-inspectorate/data-model/-/data-model-2.48.0.tgz",
-			"integrity": "sha512-hpsNrf1hLMDqbyYx7wsjXAg0QTpBsUVG7pSyOYqydNJizj6MZSfGTsCsZSaTRK79fSk+4s4mTPNd0qy4XeTshQ==",
+			"version": "2.50.0",
+			"resolved": "https://registry.npmjs.org/@planning-inspectorate/data-model/-/data-model-2.50.0.tgz",
+			"integrity": "sha512-pIhteKGKsXBBOo5iEjcOBsBmpopyHoPjguGnlZfkxo0sEWfosMHwwjNjD09r8JHEuVImi2w7Ao8dNhvJhRfCCQ==",
 			"license": "MIT",
 			"dependencies": {
 				"jsonc-parser": "^3.3.1"
@@ -14144,6 +14144,7 @@
 			"version": "2.3.3",
 			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
 			"integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+			"dev": true,
 			"hasInstallScript": true,
 			"license": "MIT",
 			"optional": true,

--- a/package.json
+++ b/package.json
@@ -108,7 +108,7 @@
 		"@azure/service-bus": "^7.9.1",
 		"@azure/storage-blob": "^12.29.1",
 		"@ministryofjustice/frontend": "^1.6.4",
-		"@planning-inspectorate/data-model": "^2.48.0",
+		"@planning-inspectorate/data-model": "^2.49.0",
 		"@prisma/adapter-mssql": "^7.9.1",
 		"@prisma/client": "^7.9.1",
 		"accessible-autocomplete": "^3.0.1",


### PR DESCRIPTION
### Description of change

Manual bump of data model to 2.49.0


### Checklist

- [x] Feature complete and ready for users, or behind feature-flag
- [x] Commit history is linear with no merge commits
- [ ] Requires infrastructure changes

### Important

Please do not merge from `main` (please only [rebase](https://github.com/Planning-Inspectorate/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
