### PR TITLE
fix(A2-9063): fix anySignificantChanges not displaying

### DIFF
--- a/packages/forms-web-app/src/controllers/selected-appeal/appeal-details/appeal-details-rows.js
+++ b/packages/forms-web-app/src/controllers/selected-appeal/appeal-details/appeal-details-rows.js
@@ -339,7 +339,18 @@ const getStandardDetailsRows = (caseData, context) => {
 		{
 			keyText: 'Significant changes since application',
 			valueText: formatSignificantChanges(caseData),
-			condition: (caseData) => isNotUndefinedOrNull(caseData.anySignificantChanges),
+			condition: (caseData) =>
+				isNotUndefinedOrNull(caseData.anySignificantChanges) ||
+				isExpeditedPart1Eligible({
+					...caseData,
+					eligibility: { applicationDecision: caseData.applicationDecision }
+				}) ||
+				([
+					CASE_TYPES.HAS.processCode,
+					CASE_TYPES.CAS_ADVERTS.processCode,
+					CASE_TYPES.CAS_PLANNING.processCode
+				].includes(caseData.appealTypeCode) &&
+					isExpeditedAppealDate(caseData.applicationDate)),
 			isEscaped: true
 		},
 		{
@@ -883,7 +894,18 @@ const getExpeditedDetailsRows = (caseData, context) => {
 		{
 			keyText: 'Significant changes since application',
 			valueText: formatSignificantChanges(caseData),
-			condition: (caseData) => isNotUndefinedOrNull(caseData.anySignificantChanges),
+			condition: (caseData) =>
+				isNotUndefinedOrNull(caseData.anySignificantChanges) ||
+				isExpeditedPart1Eligible({
+					...caseData,
+					eligibility: { applicationDecision: caseData.applicationDecision }
+				}) ||
+				([
+					CASE_TYPES.HAS.processCode,
+					CASE_TYPES.CAS_ADVERTS.processCode,
+					CASE_TYPES.CAS_PLANNING.processCode
+				].includes(caseData.appealTypeCode) &&
+					isExpeditedAppealDate(caseData.applicationDate)),
 			isEscaped: true
 		},
 		{
@@ -925,8 +947,6 @@ const getExpeditedDetailsRows = (caseData, context) => {
 
 const formatSignificantChanges = (caseData) => {
 	const changes = caseData.anySignificantChanges?.split(',').map((s) => s.trim()) || [];
-	if (changes.length === 0) return '';
-
 	const mapping = [
 		{
 			key: 'adopted-a-new-local-plan',
@@ -950,9 +970,11 @@ const formatSignificantChanges = (caseData) => {
 		}
 	];
 
+	const matching = mapping.filter((m) => changes.includes(m.key));
+	if (matching.length === 0) return 'No';
+
 	return nl2br(
-		mapping
-			.filter((m) => changes.includes(m.key))
+		matching
 			.map((m) => {
 				const details = m.details ? `\n${m.details}` : '';
 				return `${m.label}:${details}`;

--- a/packages/forms-web-app/src/controllers/selected-appeal/appeal-details/appeal-details-rows.test.js
+++ b/packages/forms-web-app/src/controllers/selected-appeal/appeal-details/appeal-details-rows.test.js
@@ -1646,28 +1646,51 @@ describe('appeal-details-rows - enforcement and enforcement listed', () => {
 			expect(row.condition(expeditedCaseData)).toBe(true);
 		});
 
-		it('should handle empty significant changes', () => {
-			const caseData = { ...expeditedCaseData, anySignificantChanges: null };
+		it('should display "No" for expedited appeal when anySignificantChanges is "no" or empty string', () => {
+			const caseData = { ...expeditedCaseData, anySignificantChanges: 'no' };
+			const rows = detailsRows(caseData, APPEAL_USER_ROLES.APPELLANT);
+			const row = rows.find((r) => r.keyText === 'Significant changes since application');
+			expect(row.condition(caseData)).toBe(true);
+			expect(row.valueText).toBe('No');
+		});
+
+		it('should display formatted changes when specific options are selected', () => {
+			const caseData = {
+				...expeditedCaseData,
+				anySignificantChanges: 'adopted-a-new-local-plan,national-policy-change',
+				anySignificantChanges_localPlanSignificantChanges: 'Plan details',
+				anySignificantChanges_nationalPolicySignificantChanges: 'Policy details'
+			};
+			const rows = detailsRows(caseData, APPEAL_USER_ROLES.APPELLANT);
+			const row = rows.find((r) => r.keyText === 'Significant changes since application');
+			expect(row.condition(caseData)).toBe(true);
+			expect(row.valueText).toContain('Adopted a new local plan:<br>Plan details');
+			expect(row.valueText).toContain('National policy changes:<br>Policy details');
+		});
+
+		it('should display "No" for HAS appeal with application date after 1st April 2026 even if anySignificantChanges is null', () => {
+			const caseData = {
+				...nonExpeditedCaseData,
+				appealTypeCode: 'HAS',
+				applicationDate: '2026-04-02',
+				anySignificantChanges: null
+			};
+			const rows = detailsRows(caseData, APPEAL_USER_ROLES.APPELLANT);
+			const row = rows.find((r) => r.keyText === 'Significant changes since application');
+			expect(row.condition(caseData)).toBe(true);
+			expect(row.valueText).toBe('No');
+		});
+
+		it('should not display row for non-expedited non-S78 appeal with application date before 1st April 2026 when anySignificantChanges is null', () => {
+			const caseData = {
+				...nonExpeditedCaseData,
+				appealTypeCode: 'HAS',
+				applicationDate: '2026-03-01',
+				anySignificantChanges: null
+			};
 			const rows = detailsRows(caseData, APPEAL_USER_ROLES.APPELLANT);
 			const row = rows.find((r) => r.keyText === 'Significant changes since application');
 			expect(row.condition(caseData)).toBe(false);
-		});
-
-		it('should not display the appellant Expected procedure duration if not expedited', () => {
-			const caseData = {
-				...nonExpeditedCaseData
-			};
-			const rows = detailsRows(caseData, APPEAL_USER_ROLES.APPELLANT);
-			const row = rows.find((r) => r.keyText === 'Expected procedure duration');
-			expect(row.condition(caseData)).toBe(true);
-		});
-		it('should not display the appellant Expected witness count if not expedited', () => {
-			const caseData = {
-				...nonExpeditedCaseData
-			};
-			const rows = detailsRows(caseData, APPEAL_USER_ROLES.APPELLANT);
-			const row = rows.find((r) => r.keyText === 'Expected witness count');
-			expect(row.condition(caseData)).toBe(true);
 		});
 	});
 });

--- a/packages/forms-web-app/src/controllers/selected-appeal/questionnaire-details/appeal-process-details-rows.js
+++ b/packages/forms-web-app/src/controllers/selected-appeal/questionnaire-details/appeal-process-details-rows.js
@@ -26,7 +26,6 @@ exports.appealProcessRows = (caseData) => {
 
 	const formatSignificantChanges = (caseData) => {
 		const changes = caseData.anySignificantChangesLpa?.split(',').map((s) => s.trim()) || [];
-		if (changes.length === 0) return '';
 		const mapping = [
 			{
 				key: 'adopted-a-new-local-plan',
@@ -50,9 +49,11 @@ exports.appealProcessRows = (caseData) => {
 			}
 		];
 
+		const matching = mapping.filter((m) => changes.includes(m.key));
+		if (matching.length === 0) return 'No';
+
 		return nl2br(
-			mapping
-				.filter((m) => changes.includes(m.key))
+			matching
 				.map((m) => {
 					const details = m.details ? `\n${m.details}` : '';
 					return `${m.label}:${details}`;

--- a/packages/forms-web-app/src/controllers/selected-appeal/questionnaire-details/appeal-process-details.test.js
+++ b/packages/forms-web-app/src/controllers/selected-appeal/questionnaire-details/appeal-process-details.test.js
@@ -39,7 +39,7 @@ const expectedRowsHas = [
 ];
 const expectedRowsHasExpedited = [
 	...expectedRowsHas,
-	{ title: 'Significant changes since application', value: '' }
+	{ title: 'Significant changes since application', value: 'No' }
 ];
 const expectedRowsS78 = [
 	{ title: 'Appeal procedure', value: 'Inquiry\ninquiry preference\nExpected duration: 6 days' },
@@ -49,7 +49,7 @@ const expectedRowsS78 = [
 ];
 const expectedRowsS78Expedited = [
 	...expectedRowsS78,
-	{ title: 'Significant changes since application', value: '' }
+	{ title: 'Significant changes since application', value: 'No' }
 ];
 const expectedRowsLDC = [{ title: 'Appeals near the site', value: 'No' }];
 
@@ -107,5 +107,46 @@ describe('appealProcessRows', () => {
 		expect(rows[1].valueText).toEqual('No');
 		expect(rows[2].condition()).toEqual(false);
 		expect(rows[3].condition()).toEqual(false);
+	});
+
+	describe('Significant changes row for LPA Questionnaire', () => {
+		it('should display "No" for HAS expedited questionnaire when anySignificantChangesLpa is "no"', () => {
+			const caseData = {
+				...hasExpeditedLPAQData,
+				anySignificantChangesLpa: 'no'
+			};
+			const rows = appealProcessRows(caseData);
+			const row = rows.find((r) => r.keyText === 'Significant changes since application');
+			expect(row).toBeDefined();
+			expect(row.condition(caseData)).toBe(true);
+			expect(row.valueText).toBe('No');
+		});
+
+		it('should format selected LPA significant changes correctly', () => {
+			const caseData = {
+				...hasExpeditedLPAQData,
+				anySignificantChangesLpa: 'adopted-a-new-local-plan,other',
+				anySignificantChangesLpa_localPlanSignificantChanges: 'New Local Plan 2026',
+				anySignificantChangesLpa_otherSignificantChanges: 'Other changes description'
+			};
+			const rows = appealProcessRows(caseData);
+			const row = rows.find((r) => r.keyText === 'Significant changes since application');
+			expect(row).toBeDefined();
+			expect(row.condition(caseData)).toBe(true);
+			expect(row.valueText).toContain('Adopted a new local plan:<br>New Local Plan 2026');
+			expect(row.valueText).toContain('Other:<br>Other changes description');
+		});
+
+		it('should display "No" for S78 expedited LPA questionnaire when no significant changes option is chosen', () => {
+			const caseData = {
+				...s78ExpeditedLPAQData,
+				anySignificantChangesLpa: 'none'
+			};
+			const rows = appealProcessRows(caseData);
+			const row = rows.find((r) => r.keyText === 'Significant changes since application');
+			expect(row).toBeDefined();
+			expect(row.condition(caseData)).toBe(true);
+			expect(row.valueText).toBe('No');
+		});
 	});
 });


### PR DESCRIPTION
### Description of change

Fix Significant changes display on FO dashboards

Updates: 

- Return "No" instead of an empty string when no significant changes are selected.
- Enforce displaying the row for expedited appeal types (S78 expedited, or HAS/CAS Adverts/CAS Planning with application date $\ge$ 1 April 2026).


### Testing
Added unit tests covering display conditions and output formatting for appeal and questionnaire details.

Ticket: https://pins-ds.atlassian.net/browse/A2-9083

### Checklist

- [x] Feature complete and ready for users, or behind feature-flag
- [x] Commit history is linear with no merge commits
- [ ] Requires infrastructure changes

### Important

Please do not merge from `main` (please only [rebase](https://github.com/Planning-Inspectorate/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
