### PR TITLE
fix(api): making event start date null rather than defaulting to 1970…

### DIFF
--- a/packages/appeals-service-api/src/routes/v2/events/repo.js
+++ b/packages/appeals-service-api/src/routes/v2/events/repo.js
@@ -60,7 +60,7 @@ const mapDataModelToFODBEvent = (dataModelEvent) => ({
 	name: dataModelEvent.eventName,
 	status: dataModelEvent.eventStatus,
 	published: !!dataModelEvent.eventPublished,
-	startDate: new Date(dataModelEvent.eventStartDateTime),
+	startDate: dataModelEvent.eventStartDateTime ? new Date(dataModelEvent.eventStartDateTime) : null,
 	endDate: dataModelEvent.eventEndDateTime ? new Date(dataModelEvent.eventEndDateTime) : null,
 	isUrgent: dataModelEvent.isUrgent,
 	notificationOfSiteVisit: dataModelEvent.notificationOfSiteVisit


### PR DESCRIPTION
… (A2-9111)

### Description of change

Adding my change from https://github.com/Planning-Inspectorate/appeal-planning-decision/pull/5650 to the release branch. I have tested it on dev and it works as expected and solves the bug

Adding a check for whether `eventStartDateTime` is null so that it doesn't get set to the default for Date (`new Date(null) = '1970-01-01T00:00:00.000Z'`)

Ticket: https://pins-ds.atlassian.net/browse/A2-9111

### Checklist

- [x] Feature complete and ready for users, or behind feature-flag
- [x] Commit history is linear with no merge commits
- [ ] Requires infrastructure changes

### Important

Please do not merge from `main` (please only [rebase](https://github.com/Planning-Inspectorate/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
