### PR TITLE
fix(A2-9024): fix why are you appealing display in appeal details form and pdf

### DIFF
--- a/packages/forms-web-app/src/controllers/selected-appeal/appeal-details/appeal-details-rows.js
+++ b/packages/forms-web-app/src/controllers/selected-appeal/appeal-details/appeal-details-rows.js
@@ -333,7 +333,16 @@ const getStandardDetailsRows = (caseData, context) => {
 			valueText: caseData.reasonForAppealAppellant ?? '',
 			condition: (caseData) =>
 				isNotUndefinedOrNull(caseData.reasonForAppealAppellant) ||
-				isExpeditedAppealDate(caseData.applicationDate),
+				isExpeditedPart1Eligible({
+					...caseData,
+					eligibility: { applicationDecision: caseData.applicationDecision }
+				}) ||
+				([
+					CASE_TYPES.HAS.processCode,
+					CASE_TYPES.CAS_ADVERTS.processCode,
+					CASE_TYPES.CAS_PLANNING.processCode
+				].includes(caseData.appealTypeCode) &&
+					isExpeditedAppealDate(caseData.applicationDate)),
 			isEscaped: true
 		},
 		{
@@ -888,7 +897,16 @@ const getExpeditedDetailsRows = (caseData, context) => {
 			valueText: caseData.reasonForAppealAppellant ?? '',
 			condition: (caseData) =>
 				isNotUndefinedOrNull(caseData.reasonForAppealAppellant) ||
-				isExpeditedAppealDate(caseData.applicationDate),
+				isExpeditedPart1Eligible({
+					...caseData,
+					eligibility: { applicationDecision: caseData.applicationDecision }
+				}) ||
+				([
+					CASE_TYPES.HAS.processCode,
+					CASE_TYPES.CAS_ADVERTS.processCode,
+					CASE_TYPES.CAS_PLANNING.processCode
+				].includes(caseData.appealTypeCode) &&
+					isExpeditedAppealDate(caseData.applicationDate)),
 			isEscaped: true
 		},
 		{

--- a/packages/forms-web-app/src/controllers/selected-appeal/appeal-details/appeal-details-rows.js
+++ b/packages/forms-web-app/src/controllers/selected-appeal/appeal-details/appeal-details-rows.js
@@ -32,7 +32,7 @@ const {
 const { isNotUndefinedOrNull } = require('#lib/is-not-undefined-or-null');
 const {
 	isExpeditedPart1Eligible,
-	isExpeditedAppealDate
+	isS78ExpeditedPart1Eligible
 } = require('#lib/is-expedited-part1-eligible');
 const { nl2br } = require('@pins/common/src/utils');
 
@@ -57,11 +57,24 @@ const { nl2br } = require('@pins/common/src/utils');
  */
 
 /**
- * @param {AppealCaseDetailed } caseData
+ * @param {AppealCaseDetailed} caseData
+ * @returns {boolean}
+ */
+const shouldDisplayReasonForAppeal = (caseData) =>
+	isNotUndefinedOrNull(caseData.reasonForAppealAppellant) || isExpeditedPart1Eligible(caseData);
+
+/**
+ * @param {AppealCaseDetailed} caseData
+ * @returns {boolean}
+ */
+const shouldDisplaySignificantChanges = (caseData) =>
+	isNotUndefinedOrNull(caseData.anySignificantChanges) || isExpeditedPart1Eligible(caseData);
+
+/**
+ * @param {AppealCaseDetailed} caseData
  * @param {string} userType
  * @returns {Rows}
  */
-
 exports.detailsRows = (caseData, userType) => {
 	if (
 		caseData.appealTypeCode === CASE_TYPES.ENFORCEMENT.processCode ||
@@ -122,7 +135,7 @@ exports.detailsRows = (caseData, userType) => {
 	};
 
 	if (
-		isExpeditedPart1Eligible({
+		isS78ExpeditedPart1Eligible({
 			...caseData,
 			eligibility: { applicationDecision: caseData.applicationDecision }
 		})
@@ -331,35 +344,13 @@ const getStandardDetailsRows = (caseData, context) => {
 		{
 			keyText: 'Why are you appealing?',
 			valueText: caseData.reasonForAppealAppellant ?? '',
-			condition: (caseData) =>
-				isNotUndefinedOrNull(caseData.reasonForAppealAppellant) ||
-				isExpeditedPart1Eligible({
-					...caseData,
-					eligibility: { applicationDecision: caseData.applicationDecision }
-				}) ||
-				([
-					CASE_TYPES.HAS.processCode,
-					CASE_TYPES.CAS_ADVERTS.processCode,
-					CASE_TYPES.CAS_PLANNING.processCode
-				].includes(caseData.appealTypeCode) &&
-					isExpeditedAppealDate(caseData.applicationDate)),
+			condition: shouldDisplayReasonForAppeal,
 			isEscaped: true
 		},
 		{
 			keyText: 'Significant changes since application',
 			valueText: formatSignificantChanges(caseData),
-			condition: (caseData) =>
-				isNotUndefinedOrNull(caseData.anySignificantChanges) ||
-				isExpeditedPart1Eligible({
-					...caseData,
-					eligibility: { applicationDecision: caseData.applicationDecision }
-				}) ||
-				([
-					CASE_TYPES.HAS.processCode,
-					CASE_TYPES.CAS_ADVERTS.processCode,
-					CASE_TYPES.CAS_PLANNING.processCode
-				].includes(caseData.appealTypeCode) &&
-					isExpeditedAppealDate(caseData.applicationDate)),
+			condition: shouldDisplaySignificantChanges,
 			isEscaped: true
 		},
 		{
@@ -895,35 +886,13 @@ const getExpeditedDetailsRows = (caseData, context) => {
 		{
 			keyText: 'Why are you appealing?',
 			valueText: caseData.reasonForAppealAppellant ?? '',
-			condition: (caseData) =>
-				isNotUndefinedOrNull(caseData.reasonForAppealAppellant) ||
-				isExpeditedPart1Eligible({
-					...caseData,
-					eligibility: { applicationDecision: caseData.applicationDecision }
-				}) ||
-				([
-					CASE_TYPES.HAS.processCode,
-					CASE_TYPES.CAS_ADVERTS.processCode,
-					CASE_TYPES.CAS_PLANNING.processCode
-				].includes(caseData.appealTypeCode) &&
-					isExpeditedAppealDate(caseData.applicationDate)),
+			condition: shouldDisplayReasonForAppeal,
 			isEscaped: true
 		},
 		{
 			keyText: 'Significant changes since application',
 			valueText: formatSignificantChanges(caseData),
-			condition: (caseData) =>
-				isNotUndefinedOrNull(caseData.anySignificantChanges) ||
-				isExpeditedPart1Eligible({
-					...caseData,
-					eligibility: { applicationDecision: caseData.applicationDecision }
-				}) ||
-				([
-					CASE_TYPES.HAS.processCode,
-					CASE_TYPES.CAS_ADVERTS.processCode,
-					CASE_TYPES.CAS_PLANNING.processCode
-				].includes(caseData.appealTypeCode) &&
-					isExpeditedAppealDate(caseData.applicationDate)),
+			condition: shouldDisplaySignificantChanges,
 			isEscaped: true
 		},
 		{

--- a/packages/forms-web-app/src/controllers/selected-appeal/appeal-details/appeal-details-rows.test.js
+++ b/packages/forms-web-app/src/controllers/selected-appeal/appeal-details/appeal-details-rows.test.js
@@ -863,7 +863,7 @@ describe('appeal-details-rows', () => {
 	describe('Why are you appealing?', () => {
 		const reasonForAppealIndex = 30;
 
-		it('should display the reason for appeal if set', () => {
+		it('should display the reason for appeal if explicitly set on caseData', () => {
 			const testCase = structuredClone(caseWithAppellant);
 			testCase.reasonForAppealAppellant = 'Some reason';
 			const rows = detailsRows(testCase, APPEAL_USER_ROLES.APPELLANT);
@@ -872,20 +872,71 @@ describe('appeal-details-rows', () => {
 			expect(rows[reasonForAppealIndex].valueText).toEqual('Some reason');
 		});
 
-		it('should display the reason for appeal if application date is after April 1 even if not set', () => {
-			const testCase = structuredClone(caseWithAppellant);
-			testCase.applicationDate = '2026-04-02';
-			testCase.reasonForAppealAppellant = null;
-			const rows = detailsRows(testCase, APPEAL_USER_ROLES.APPELLANT);
-			expect(rows[reasonForAppealIndex].condition(testCase)).toBeTruthy();
-		});
+		it.each([
+			{ type: 'HAS', appealTypeCode: CASE_TYPES.HAS.processCode },
+			{ type: 'CAS Adverts', appealTypeCode: CASE_TYPES.CAS_ADVERTS.processCode },
+			{ type: 'CAS Planning', appealTypeCode: CASE_TYPES.CAS_PLANNING.processCode }
+		])(
+			'should display the reason for appeal if application date is after April 1 even if not set for $type',
+			({ appealTypeCode }) => {
+				const testCase = structuredClone(caseWithAppellant);
+				testCase.appealTypeCode = appealTypeCode;
+				testCase.applicationDate = '2026-04-02';
+				testCase.reasonForAppealAppellant = null;
+				const rows = detailsRows(testCase, APPEAL_USER_ROLES.APPELLANT);
+				expect(rows[reasonForAppealIndex].condition(testCase)).toBeTruthy();
+			}
+		);
 
-		it('should not display the reason for appeal if not set and application date is before April 1', () => {
+		it.each([
+			{ type: 'HAS', appealTypeCode: CASE_TYPES.HAS.processCode },
+			{ type: 'CAS Adverts', appealTypeCode: CASE_TYPES.CAS_ADVERTS.processCode },
+			{ type: 'CAS Planning', appealTypeCode: CASE_TYPES.CAS_PLANNING.processCode }
+		])(
+			'should not display the reason for appeal if not set and application date is before April 1 for $type',
+			({ appealTypeCode }) => {
+				const testCase = structuredClone(caseWithAppellant);
+				testCase.appealTypeCode = appealTypeCode;
+				testCase.applicationDate = '2026-03-01';
+				testCase.reasonForAppealAppellant = null;
+				const rows = detailsRows(testCase, APPEAL_USER_ROLES.APPELLANT);
+				expect(rows[reasonForAppealIndex].condition(testCase)).toBeFalsy();
+			}
+		);
+
+		it('should not display the reason for appeal for non-expedited S78 appeal submitted before April 1 without reason', () => {
 			const testCase = structuredClone(caseWithAppellant);
+			testCase.appealTypeCode = CASE_TYPES.S78.processCode;
+			testCase.typeOfPlanningApplication = 'full-appeal';
+			testCase.applicationDecision = 'refused';
 			testCase.applicationDate = '2026-03-01';
 			testCase.reasonForAppealAppellant = null;
 			const rows = detailsRows(testCase, APPEAL_USER_ROLES.APPELLANT);
 			expect(rows[reasonForAppealIndex].condition(testCase)).toBeFalsy();
+		});
+
+		it('should not display the reason for appeal for non-expedited S78 appeal with post-April 1 application date if not Part 1 eligible', () => {
+			const testCase = structuredClone(caseWithAppellant);
+			testCase.appealTypeCode = CASE_TYPES.S78.processCode;
+			testCase.typeOfPlanningApplication = 'other-ineligible-type';
+			testCase.applicationDecision = 'refused';
+			testCase.applicationDate = '2026-04-02';
+			testCase.reasonForAppealAppellant = null;
+			const rows = detailsRows(testCase, APPEAL_USER_ROLES.APPELLANT);
+			expect(rows[reasonForAppealIndex].condition(testCase)).toBeFalsy();
+		});
+
+		it('should display the reason for appeal for expedited S78 Part 1 eligible appeal with post-April 1 application date', () => {
+			const testCase = structuredClone(caseWithAppellant);
+			testCase.appealTypeCode = CASE_TYPES.S78.processCode;
+			testCase.typeOfPlanningApplication = 'full-appeal';
+			testCase.applicationDecision = 'refused';
+			testCase.applicationDate = '2026-04-02';
+			testCase.reasonForAppealAppellant = null;
+			const rows = detailsRows(testCase, APPEAL_USER_ROLES.APPELLANT);
+			const row = rows.find((r) => r.keyText === 'Why are you appealing?');
+			expect(row).toBeDefined();
+			expect(row.condition(testCase)).toBeTruthy();
 		});
 	});
 

--- a/packages/forms-web-app/src/controllers/selected-appeal/appeal-details/appeal-details-rows.test.js
+++ b/packages/forms-web-app/src/controllers/selected-appeal/appeal-details/appeal-details-rows.test.js
@@ -877,11 +877,11 @@ describe('appeal-details-rows', () => {
 			{ type: 'CAS Adverts', appealTypeCode: CASE_TYPES.CAS_ADVERTS.processCode },
 			{ type: 'CAS Planning', appealTypeCode: CASE_TYPES.CAS_PLANNING.processCode }
 		])(
-			'should display the reason for appeal if application date is after April 1 even if not set for $type',
+			'should display the reason for appeal if application date is on or after 1 April even if not set for $type',
 			({ appealTypeCode }) => {
 				const testCase = structuredClone(caseWithAppellant);
 				testCase.appealTypeCode = appealTypeCode;
-				testCase.applicationDate = '2026-04-02';
+				testCase.applicationDate = '2026-04-01';
 				testCase.reasonForAppealAppellant = null;
 				const rows = detailsRows(testCase, APPEAL_USER_ROLES.APPELLANT);
 				expect(rows[reasonForAppealIndex].condition(testCase)).toBeTruthy();
@@ -915,23 +915,23 @@ describe('appeal-details-rows', () => {
 			expect(rows[reasonForAppealIndex].condition(testCase)).toBeFalsy();
 		});
 
-		it('should not display the reason for appeal for non-expedited S78 appeal with post-April 1 application date if not Part 1 eligible', () => {
+		it('should not display the reason for appeal for non-expedited S78 appeal on or after April 1 application date if not Part 1 eligible', () => {
 			const testCase = structuredClone(caseWithAppellant);
 			testCase.appealTypeCode = CASE_TYPES.S78.processCode;
 			testCase.typeOfPlanningApplication = 'other-ineligible-type';
 			testCase.applicationDecision = 'refused';
-			testCase.applicationDate = '2026-04-02';
+			testCase.applicationDate = '2026-04-01';
 			testCase.reasonForAppealAppellant = null;
 			const rows = detailsRows(testCase, APPEAL_USER_ROLES.APPELLANT);
 			expect(rows[reasonForAppealIndex].condition(testCase)).toBeFalsy();
 		});
 
-		it('should display the reason for appeal for expedited S78 Part 1 eligible appeal with post-April 1 application date', () => {
+		it('should display the reason for appeal for expedited S78 Part 1 eligible appeal on or after April 1 application date', () => {
 			const testCase = structuredClone(caseWithAppellant);
 			testCase.appealTypeCode = CASE_TYPES.S78.processCode;
 			testCase.typeOfPlanningApplication = 'full-appeal';
 			testCase.applicationDecision = 'refused';
-			testCase.applicationDate = '2026-04-02';
+			testCase.applicationDate = '2026-04-01';
 			testCase.reasonForAppealAppellant = null;
 			const rows = detailsRows(testCase, APPEAL_USER_ROLES.APPELLANT);
 			const row = rows.find((r) => r.keyText === 'Why are you appealing?');

--- a/packages/forms-web-app/src/controllers/selected-appeal/appeal-details/appeal-documents-rows.js
+++ b/packages/forms-web-app/src/controllers/selected-appeal/appeal-details/appeal-documents-rows.js
@@ -12,8 +12,9 @@ const {
 } = require('@planning-inspectorate/data-model');
 const { isNotUndefinedOrNull } = require('#lib/is-not-undefined-or-null');
 const {
-	isExpeditedPart1Eligible,
-	isExpeditedAppealDate
+	isS78ExpeditedPart1Eligible,
+	isExpeditedAppealDate,
+	isNonS78ExpeditedPart1Eligible
 } = require('#lib/is-expedited-part1-eligible');
 /**
  * @typedef {import('appeals-service-api').Api.AppealCaseDetailed} AppealCaseDetailed
@@ -38,7 +39,7 @@ exports.documentsRows = (caseData) => {
 		caseData.appealTypeCode === CASE_TYPES.S78.processCode;
 
 	if (
-		isExpeditedPart1Eligible({
+		isS78ExpeditedPart1Eligible({
 			...caseData,
 			eligibility: { applicationDecision: caseData.applicationDecision }
 		})
@@ -99,17 +100,8 @@ exports.documentsRows = (caseData) => {
 		{
 			keyText: 'Appeal statement',
 			valueText: formatDocumentDetails(documents, APPEAL_DOCUMENT_TYPE.APPELLANT_STATEMENT),
-			condition: () => {
-				if (
-					(caseData &&
-						(caseData.appealTypeCode === CASE_TYPES.HAS.processCode ||
-							caseData.appealTypeCode === CASE_TYPES.CAS_PLANNING.processCode)) ||
-					caseData.appealTypeCode === CASE_TYPES.CAS_ADVERTS.processCode
-				) {
-					return !isExpeditedAppealDate(caseData.applicationDate);
-				}
-				return true;
-			},
+			condition: () =>
+				!isNonS78ExpeditedPart1Eligible(caseData?.appealTypeCode, caseData?.applicationDate),
 			isEscaped: true
 		},
 		{
@@ -141,7 +133,7 @@ exports.documentsRows = (caseData) => {
 			condition: () =>
 				(isS20orS78 || isLDC) &&
 				caseData.appellantProcedurePreference !== APPEAL_APPELLANT_PROCEDURE_PREFERENCE.WRITTEN &&
-				!isExpeditedPart1Eligible(caseData),
+				!isS78ExpeditedPart1Eligible(caseData),
 			isEscaped: true
 		},
 		{

--- a/packages/forms-web-app/src/controllers/selected-appeal/questionnaire-details/appeal-process-details-rows.js
+++ b/packages/forms-web-app/src/controllers/selected-appeal/questionnaire-details/appeal-process-details-rows.js
@@ -6,11 +6,8 @@ const {
 } = require('@pins/common');
 const { fieldNames } = require('@pins/common/src/dynamic-forms/field-names');
 const { isNotUndefinedOrNull } = require('#lib/is-not-undefined-or-null');
-const {
-	isExpeditedPart1Eligible,
-	isExpeditedAppealDate
-} = require('#lib/is-expedited-part1-eligible');
-const { CASE_TYPES } = require('@pins/common/src/database/data-static');
+const { isExpeditedPart1Eligible } = require('#lib/is-expedited-part1-eligible');
+
 const { nl2br } = require('@pins/common/src/utils');
 
 /**
@@ -101,19 +98,7 @@ exports.appealProcessRows = (caseData) => {
 		}
 	];
 
-	const isExpeditedS78 = isExpeditedPart1Eligible({
-		...caseData,
-		eligibility: { applicationDecision: caseData.applicationDecision }
-	});
-
-	const isExpedited =
-		[
-			CASE_TYPES.HAS.processCode,
-			CASE_TYPES.CAS_ADVERTS.processCode,
-			CASE_TYPES.CAS_PLANNING.processCode
-		].includes(caseData.appealTypeCode) && isExpeditedAppealDate(caseData.applicationDate);
-
-	if (isExpeditedS78 || isExpedited) {
+	if (isExpeditedPart1Eligible(caseData)) {
 		rows.push(...getExpeditedDetailsRows(caseData));
 	}
 	return rows;

--- a/packages/forms-web-app/src/controllers/selected-appeal/questionnaire-details/index.js
+++ b/packages/forms-web-app/src/controllers/selected-appeal/questionnaire-details/index.js
@@ -22,11 +22,7 @@ const { getDepartmentFromCode } = require('../../../services/department.service'
 const { addCSStoHtml } = require('#lib/add-css-to-html');
 const { generatePDF } = require('#lib/pdf-api-wrapper');
 const { APPEAL_CASE_STAGE } = require('@planning-inspectorate/data-model');
-const {
-	isExpeditedPart1Eligible,
-	isExpeditedAppealDate
-} = require('#lib/is-expedited-part1-eligible');
-const { CASE_TYPES } = require('@pins/common/src/database/data-static');
+const { isExpeditedPart1Eligible } = require('#lib/is-expedited-part1-eligible');
 
 /**
  * Shared controller for /appeals/:caseRef/appeal-details, manage-appeals/:caseRef/appeal-details rule-6-appeals/:caseRef/appeal-details
@@ -101,19 +97,7 @@ exports.get = (layoutTemplate = 'layouts/no-banner-link/main.njk') => {
 		// appeal process rows
 		const appealProcessDetailsRows = appealProcessRows(caseData);
 		const appealProcessDetails = formatQuestionnaireRows(appealProcessDetailsRows, caseData);
-		// original evidence rows
-		const isExpeditedPart1 = isExpeditedPart1Eligible({
-			...caseData,
-			eligibility: { applicationDecision: caseData.applicationDecision }
-		});
-		const isExpedited =
-			[
-				CASE_TYPES.HAS.processCode,
-				CASE_TYPES.CAS_ADVERTS.processCode,
-				CASE_TYPES.CAS_PLANNING.processCode
-			].includes(caseData.appealTypeCode) && isExpeditedAppealDate(caseData.applicationDate);
-
-		const showOriginalEvidence = isExpeditedPart1 || isExpedited;
+		const showOriginalEvidence = isExpeditedPart1Eligible(caseData);
 
 		const originalEvidenceDetailsRows = showOriginalEvidence
 			? originalEvidenceRows({ caseData, userType })

--- a/packages/forms-web-app/src/dynamic-forms/middleware/get-journey-response-for-appellant.js
+++ b/packages/forms-web-app/src/dynamic-forms/middleware/get-journey-response-for-appellant.js
@@ -6,7 +6,7 @@ const { mapDBResponseToJourneyResponseFormat } = require('./utils');
 const { ApiClientError } = require('@pins/common/src/client/api-client-error.js');
 const { isFeatureActive } = require('../../featureFlag');
 const { FLAG } = require('@pins/common/src/feature-flags');
-const { isExpeditedPart1Eligible } = require('#lib/is-expedited-part1-eligible');
+const { isS78ExpeditedPart1Eligible } = require('#lib/is-expedited-part1-eligible');
 const { isLpaInFeatureFlag } = require('#lib/is-lpa-in-feature-flag');
 
 /**
@@ -59,7 +59,7 @@ module.exports = async (request, response, next) => {
 	if (
 		journeyType === JOURNEY_TYPES.S78_APPEAL_FORM.id &&
 		expeditedAppealsEnabled &&
-		isExpeditedPart1Eligible({
+		isS78ExpeditedPart1Eligible({
 			typeOfPlanningApplication: convertedResponse?.typeOfPlanningApplication,
 			applicationDate: convertedResponse?.onApplicationDate,
 			eligibility: {

--- a/packages/forms-web-app/src/dynamic-forms/middleware/get-journey-response-for-appellant.test.js
+++ b/packages/forms-web-app/src/dynamic-forms/middleware/get-journey-response-for-appellant.test.js
@@ -5,7 +5,7 @@ const { ApiClientError } = require('@pins/common/src/client/api-client-error.js'
 const { mapDBResponseToJourneyResponseFormat } = require('./utils');
 const { CASE_TYPES } = require('@pins/common/src/database/data-static');
 const { FLAG } = require('@pins/common/src/feature-flags');
-const { isExpeditedPart1Eligible } = require('#lib/is-expedited-part1-eligible');
+const { isS78ExpeditedPart1Eligible } = require('#lib/is-expedited-part1-eligible');
 
 jest.mock('./utils');
 jest.mock('#lib/is-expedited-part1-eligible');
@@ -40,7 +40,7 @@ describe('getJourneyResponseForAppellant', () => {
 		next = jest.fn();
 		mapDBResponseToJourneyResponseFormat.mockReturnValue(convertedResponse);
 		require('../../lib/is-lpa-in-feature-flag').isLpaInFeatureFlag.mockResolvedValue(true);
-		isExpeditedPart1Eligible.mockReturnValue(false);
+		isS78ExpeditedPart1Eligible.mockReturnValue(false);
 	});
 
 	it('should 404 if submissionId is invalid', async () => {
@@ -119,14 +119,14 @@ describe('getJourneyResponseForAppellant', () => {
 		require('../../lib/is-lpa-in-feature-flag').isLpaInFeatureFlag.mockImplementation(async () => {
 			return true;
 		});
-		isExpeditedPart1Eligible.mockReturnValue(true);
+		isS78ExpeditedPart1Eligible.mockReturnValue(true);
 
 		await getJourneyResponseForAppellant(req, res, next);
 
 		const expectedType = JOURNEY_TYPES.S78_PART_1_APPEAL_FORM.id;
 
 		expect(res.locals.journeyResponse.journeyId).toBe(expectedType);
-		expect(isExpeditedPart1Eligible).toHaveBeenCalledWith({
+		expect(isS78ExpeditedPart1Eligible).toHaveBeenCalledWith({
 			typeOfPlanningApplication: convertedResponse?.typeOfPlanningApplication,
 			applicationDate: convertedResponse?.onApplicationDate,
 			eligibility: {
@@ -147,14 +147,14 @@ describe('getJourneyResponseForAppellant', () => {
 		require('../../lib/is-lpa-in-feature-flag').isLpaInFeatureFlag.mockImplementation(async () => {
 			return true;
 		});
-		isExpeditedPart1Eligible.mockReturnValue(true);
+		isS78ExpeditedPart1Eligible.mockReturnValue(true);
 
 		await getJourneyResponseForAppellant(req, res, next);
 
 		const expectedType = JOURNEY_TYPES.S78_PART_1_APPEAL_FORM.id;
 
 		expect(res.locals.journeyResponse.journeyId).toBe(expectedType);
-		expect(isExpeditedPart1Eligible).toHaveBeenCalledWith({
+		expect(isS78ExpeditedPart1Eligible).toHaveBeenCalledWith({
 			typeOfPlanningApplication: convertedResponse?.typeOfPlanningApplication,
 			applicationDate: convertedResponse?.onApplicationDate,
 			eligibility: {
@@ -175,14 +175,14 @@ describe('getJourneyResponseForAppellant', () => {
 		require('../../lib/is-lpa-in-feature-flag').isLpaInFeatureFlag.mockImplementation(async () => {
 			return true;
 		});
-		isExpeditedPart1Eligible.mockReturnValue(true);
+		isS78ExpeditedPart1Eligible.mockReturnValue(true);
 
 		await getJourneyResponseForAppellant(req, res, next);
 
 		const expectedType = JOURNEY_TYPES.S78_PART_1_APPEAL_FORM.id;
 
 		expect(res.locals.journeyResponse.journeyId).toBe(expectedType);
-		expect(isExpeditedPart1Eligible).toHaveBeenCalledWith({
+		expect(isS78ExpeditedPart1Eligible).toHaveBeenCalledWith({
 			typeOfPlanningApplication: convertedResponse?.typeOfPlanningApplication,
 			applicationDate: convertedResponse?.onApplicationDate,
 			eligibility: {
@@ -203,14 +203,14 @@ describe('getJourneyResponseForAppellant', () => {
 		require('../../lib/is-lpa-in-feature-flag').isLpaInFeatureFlag.mockImplementation(async () => {
 			return true;
 		});
-		isExpeditedPart1Eligible.mockReturnValue(false);
+		isS78ExpeditedPart1Eligible.mockReturnValue(false);
 
 		await getJourneyResponseForAppellant(req, res, next);
 
 		const expectedType = JOURNEY_TYPES.S78_APPEAL_FORM.id;
 
 		expect(res.locals.journeyResponse.journeyId).toBe(expectedType);
-		expect(isExpeditedPart1Eligible).toHaveBeenCalledWith({
+		expect(isS78ExpeditedPart1Eligible).toHaveBeenCalledWith({
 			typeOfPlanningApplication: convertedResponse?.typeOfPlanningApplication,
 			applicationDate: convertedResponse?.onApplicationDate,
 			eligibility: {
@@ -232,14 +232,14 @@ describe('getJourneyResponseForAppellant', () => {
 		require('../../lib/is-lpa-in-feature-flag').isLpaInFeatureFlag.mockImplementation(async () => {
 			return true;
 		});
-		isExpeditedPart1Eligible.mockReturnValue(false);
+		isS78ExpeditedPart1Eligible.mockReturnValue(false);
 
 		await getJourneyResponseForAppellant(req, res, next);
 
 		const expectedType = JOURNEY_TYPES.S78_APPEAL_FORM.id;
 
 		expect(res.locals.journeyResponse.journeyId).toBe(expectedType);
-		expect(isExpeditedPart1Eligible).toHaveBeenCalledWith({
+		expect(isS78ExpeditedPart1Eligible).toHaveBeenCalledWith({
 			typeOfPlanningApplication: convertedResponse?.typeOfPlanningApplication,
 			applicationDate: convertedResponse?.onApplicationDate,
 			eligibility: {

--- a/packages/forms-web-app/src/dynamic-forms/middleware/get-journey-response-for-lpa.js
+++ b/packages/forms-web-app/src/dynamic-forms/middleware/get-journey-response-for-lpa.js
@@ -14,7 +14,7 @@ const {
 	}
 } = require('../../lib/views');
 const {
-	isExpeditedPart1Eligible,
+	isS78ExpeditedPart1Eligible,
 	isExpeditedAppealDate
 } = require('#lib/is-expedited-part1-eligible');
 const { FLAG } = require('@pins/common/src/feature-flags');
@@ -55,7 +55,7 @@ module.exports =
 			FLAG.EXPEDITED_APPEALS_FO_V2
 		);
 
-		const expeditedEligible = isExpeditedPart1Eligible({
+		const expeditedEligible = isS78ExpeditedPart1Eligible({
 			typeOfPlanningApplication: appeal?.typeOfPlanningApplication,
 			applicationDate: appeal?.applicationDate,
 			eligibility: {

--- a/packages/forms-web-app/src/dynamic-forms/middleware/get-journey-response-for-lpa.test.js
+++ b/packages/forms-web-app/src/dynamic-forms/middleware/get-journey-response-for-lpa.test.js
@@ -1,5 +1,5 @@
 const {
-	isExpeditedPart1Eligible,
+	isS78ExpeditedPart1Eligible,
 	isExpeditedAppealDate
 } = require('#lib/is-expedited-part1-eligible');
 jest.mock('#lib/is-expedited-part1-eligible');
@@ -76,7 +76,7 @@ describe('getJourneyResponse', () => {
 		next = jest.fn();
 		mapDBResponseToJourneyResponseFormat.mockReturnValue(convertedResponse);
 		require('../../lib/is-lpa-in-feature-flag').isLpaInFeatureFlag.mockResolvedValue(true);
-		isExpeditedPart1Eligible.mockReturnValue(false);
+		isS78ExpeditedPart1Eligible.mockReturnValue(false);
 		jest.clearAllMocks();
 	});
 
@@ -206,12 +206,12 @@ describe('getJourneyResponse', () => {
 		require('../../lib/is-lpa-in-feature-flag').isLpaInFeatureFlag.mockImplementation(async () => {
 			return true;
 		});
-		isExpeditedPart1Eligible.mockReturnValue(true);
+		isS78ExpeditedPart1Eligible.mockReturnValue(true);
 
 		await getJourneyResponse()(req, res, next);
 
 		expect(res.locals.journeyResponse.journeyId).toBe(JOURNEY_TYPES.S78_QUESTIONNAIRE_PART_1.id);
-		expect(isExpeditedPart1Eligible).toHaveBeenCalledWith({
+		expect(isS78ExpeditedPart1Eligible).toHaveBeenCalledWith({
 			typeOfPlanningApplication: s78Appeal.typeOfPlanningApplication,
 			applicationDate: s78Appeal.applicationDate,
 			eligibility: {
@@ -237,12 +237,12 @@ describe('getJourneyResponse', () => {
 		require('../../lib/is-lpa-in-feature-flag').isLpaInFeatureFlag.mockImplementation(async () => {
 			return true;
 		});
-		isExpeditedPart1Eligible.mockReturnValue(true);
+		isS78ExpeditedPart1Eligible.mockReturnValue(true);
 
 		await getJourneyResponse()(req, res, next);
 
 		expect(res.locals.journeyResponse.journeyId).toBe(JOURNEY_TYPES.S78_QUESTIONNAIRE_PART_1.id);
-		expect(isExpeditedPart1Eligible).toHaveBeenCalledWith({
+		expect(isS78ExpeditedPart1Eligible).toHaveBeenCalledWith({
 			typeOfPlanningApplication: s78Appeal.typeOfPlanningApplication,
 			applicationDate: s78Appeal.applicationDate,
 			eligibility: {
@@ -268,12 +268,12 @@ describe('getJourneyResponse', () => {
 		require('../../lib/is-lpa-in-feature-flag').isLpaInFeatureFlag.mockImplementation(async () => {
 			return true;
 		});
-		isExpeditedPart1Eligible.mockReturnValue(true);
+		isS78ExpeditedPart1Eligible.mockReturnValue(true);
 
 		await getJourneyResponse()(req, res, next);
 
 		expect(res.locals.journeyResponse.journeyId).toBe(JOURNEY_TYPES.S78_QUESTIONNAIRE_PART_1.id);
-		expect(isExpeditedPart1Eligible).toHaveBeenCalledWith({
+		expect(isS78ExpeditedPart1Eligible).toHaveBeenCalledWith({
 			typeOfPlanningApplication: s78Appeal.typeOfPlanningApplication,
 			applicationDate: s78Appeal.applicationDate,
 			eligibility: {
@@ -299,12 +299,12 @@ describe('getJourneyResponse', () => {
 		require('../../lib/is-lpa-in-feature-flag').isLpaInFeatureFlag.mockImplementation(async () => {
 			return true;
 		});
-		isExpeditedPart1Eligible.mockReturnValue(false);
+		isS78ExpeditedPart1Eligible.mockReturnValue(false);
 
 		await getJourneyResponse()(req, res, next);
 
 		expect(res.locals.journeyResponse.journeyId).toBe(JOURNEY_TYPES.S78_QUESTIONNAIRE.id);
-		expect(isExpeditedPart1Eligible).toHaveBeenCalledWith({
+		expect(isS78ExpeditedPart1Eligible).toHaveBeenCalledWith({
 			typeOfPlanningApplication: s78Appeal.typeOfPlanningApplication,
 			applicationDate: s78Appeal.applicationDate,
 			eligibility: {
@@ -330,12 +330,12 @@ describe('getJourneyResponse', () => {
 		require('../../lib/is-lpa-in-feature-flag').isLpaInFeatureFlag.mockImplementation(async () => {
 			return true;
 		});
-		isExpeditedPart1Eligible.mockReturnValue(false);
+		isS78ExpeditedPart1Eligible.mockReturnValue(false);
 
 		await getJourneyResponse()(req, res, next);
 
 		expect(res.locals.journeyResponse.journeyId).toBe(JOURNEY_TYPES.S78_QUESTIONNAIRE.id);
-		expect(isExpeditedPart1Eligible).toHaveBeenCalledWith({
+		expect(isS78ExpeditedPart1Eligible).toHaveBeenCalledWith({
 			typeOfPlanningApplication: s78Appeal.typeOfPlanningApplication,
 			applicationDate: s78Appeal.applicationDate,
 			eligibility: {

--- a/packages/forms-web-app/src/lib/is-expedited-part1-eligible.js
+++ b/packages/forms-web-app/src/lib/is-expedited-part1-eligible.js
@@ -42,7 +42,7 @@ const parseApplicationDate = (value) => {
  * @param {{ applicationDate?: string|Date|null, typeOfPlanningApplication?: string|null, eligibility?: { applicationDecision?: string|null }, appealTypeCode?: string |null, typeDevelopment?: string|null, developmentType?: string|null } | undefined | null} appeal
  * @returns {boolean}
  */
-const isExpeditedPart1Eligible = (appeal) => {
+const isS78ExpeditedPart1Eligible = (appeal) => {
 	if (!eligibleAppealTypesForPart1.has(appeal?.appealTypeCode || '')) {
 		return false;
 	}
@@ -89,8 +89,47 @@ const isExpeditedAppealDate = (value) => {
 	);
 };
 
+/** @type {Set<string>} */
+const expeditedNonS78AppealTypeCodes = new Set([
+	CASE_TYPES.HAS.processCode,
+	CASE_TYPES.CAS_ADVERTS.processCode,
+	CASE_TYPES.CAS_PLANNING.processCode
+]);
+
+/**
+ * @param {string|null|undefined} appealTypeCode
+ * @param {string|Date|null|undefined} applicationDate
+ * @returns {boolean}
+ */
+const isNonS78ExpeditedPart1Eligible = (appealTypeCode, applicationDate) => {
+	if (!appealTypeCode || !expeditedNonS78AppealTypeCodes.has(appealTypeCode)) {
+		return false;
+	}
+
+	return isExpeditedAppealDate(applicationDate);
+};
+
+/**
+ * @param {Object} [caseData]
+ * @returns {boolean}
+ */
+const isExpeditedPart1Eligible = (caseData) => {
+	if (!caseData) {
+		return false;
+	}
+
+	return (
+		isS78ExpeditedPart1Eligible({
+			...caseData,
+			eligibility: { applicationDecision: caseData.applicationDecision }
+		}) || isNonS78ExpeditedPart1Eligible(caseData.appealTypeCode, caseData.applicationDate)
+	);
+};
+
 module.exports = {
 	EXPEDITED_PART_1_CUTOFF_DATE,
-	isExpeditedPart1Eligible,
-	isExpeditedAppealDate
+	isS78ExpeditedPart1Eligible,
+	isExpeditedAppealDate,
+	isNonS78ExpeditedPart1Eligible,
+	isExpeditedPart1Eligible
 };

--- a/packages/forms-web-app/src/lib/is-expedited-part1-eligible.test.js
+++ b/packages/forms-web-app/src/lib/is-expedited-part1-eligible.test.js
@@ -1,12 +1,15 @@
 const { APPLICATION_DECISION, TYPE_OF_PLANNING_APPLICATION } =
 	require('@pins/business-rules').constants;
+const { CASE_TYPES } = require('@pins/common/src/database/data-static');
 const {
 	EXPEDITED_PART_1_CUTOFF_DATE,
-	isExpeditedPart1Eligible,
-	isExpeditedAppealDate
+	isS78ExpeditedPart1Eligible,
+	isExpeditedAppealDate,
+	isNonS78ExpeditedPart1Eligible,
+	isExpeditedPart1Eligible
 } = require('./is-expedited-part1-eligible');
 
-describe('isExpeditedPart1Eligible', () => {
+describe('isS78ExpeditedPart1Eligible', () => {
 	it.each([
 		TYPE_OF_PLANNING_APPLICATION.FULL_APPEAL,
 		TYPE_OF_PLANNING_APPLICATION.OUTLINE_PLANNING,
@@ -14,7 +17,7 @@ describe('isExpeditedPart1Eligible', () => {
 		TYPE_OF_PLANNING_APPLICATION.PERMISSION_IN_PRINCIPLE
 	])('returns true for %s when the date is on the cutoff and the decision is granted', (type) => {
 		expect(
-			isExpeditedPart1Eligible({
+			isS78ExpeditedPart1Eligible({
 				typeOfPlanningApplication: type,
 				applicationDate: `${EXPEDITED_PART_1_CUTOFF_DATE}T00:00:00.000Z`,
 				eligibility: {
@@ -27,7 +30,7 @@ describe('isExpeditedPart1Eligible', () => {
 
 	it('returns true when the date is after the cutoff and the decision is refused', () => {
 		expect(
-			isExpeditedPart1Eligible({
+			isS78ExpeditedPart1Eligible({
 				typeOfPlanningApplication: TYPE_OF_PLANNING_APPLICATION.FULL_APPEAL,
 				applicationDate: '2026-04-02T10:30:00.000Z',
 				eligibility: {
@@ -40,7 +43,7 @@ describe('isExpeditedPart1Eligible', () => {
 
 	it('returns false when the date is before the cutoff', () => {
 		expect(
-			isExpeditedPart1Eligible({
+			isS78ExpeditedPart1Eligible({
 				typeOfPlanningApplication: TYPE_OF_PLANNING_APPLICATION.FULL_APPEAL,
 				applicationDate: '2026-03-31T22:59:59.000Z',
 				eligibility: {
@@ -52,7 +55,7 @@ describe('isExpeditedPart1Eligible', () => {
 
 	it('returns false when the decision is not received', () => {
 		expect(
-			isExpeditedPart1Eligible({
+			isS78ExpeditedPart1Eligible({
 				typeOfPlanningApplication: TYPE_OF_PLANNING_APPLICATION.FULL_APPEAL,
 				applicationDate: '2026-04-01T00:00:00.000Z',
 				eligibility: {
@@ -64,7 +67,7 @@ describe('isExpeditedPart1Eligible', () => {
 
 	it('returns false for unsupported planning application types', () => {
 		expect(
-			isExpeditedPart1Eligible({
+			isS78ExpeditedPart1Eligible({
 				typeOfPlanningApplication: TYPE_OF_PLANNING_APPLICATION.PRIOR_APPROVAL,
 				applicationDate: '2026-04-01T00:00:00.000Z',
 				eligibility: {
@@ -77,7 +80,7 @@ describe('isExpeditedPart1Eligible', () => {
 	describe('minor-commercial-development', () => {
 		it('returns true when decision is GRANTED and date is on/after cutoff', () => {
 			expect(
-				isExpeditedPart1Eligible({
+				isS78ExpeditedPart1Eligible({
 					typeOfPlanningApplication: TYPE_OF_PLANNING_APPLICATION.MINOR_COMMERCIAL_DEVELOPMENT,
 					applicationDate: `${EXPEDITED_PART_1_CUTOFF_DATE}T00:00:00.000Z`,
 					eligibility: {
@@ -90,7 +93,7 @@ describe('isExpeditedPart1Eligible', () => {
 
 		it('returns false when decision is REFUSED', () => {
 			expect(
-				isExpeditedPart1Eligible({
+				isS78ExpeditedPart1Eligible({
 					typeOfPlanningApplication: TYPE_OF_PLANNING_APPLICATION.MINOR_COMMERCIAL_DEVELOPMENT,
 					applicationDate: `${EXPEDITED_PART_1_CUTOFF_DATE}T00:00:00.000Z`,
 					eligibility: {
@@ -103,7 +106,7 @@ describe('isExpeditedPart1Eligible', () => {
 
 		it('returns false when decision is GRANTED but date is before cutoff', () => {
 			expect(
-				isExpeditedPart1Eligible({
+				isS78ExpeditedPart1Eligible({
 					typeOfPlanningApplication: TYPE_OF_PLANNING_APPLICATION.MINOR_COMMERCIAL_DEVELOPMENT,
 					applicationDate: '2026-03-31T22:59:59.000Z',
 					eligibility: {
@@ -118,7 +121,7 @@ describe('isExpeditedPart1Eligible', () => {
 	describe('householder-planning', () => {
 		it('returns true when decision is GRANTED and date is on/after cutoff', () => {
 			expect(
-				isExpeditedPart1Eligible({
+				isS78ExpeditedPart1Eligible({
 					typeOfPlanningApplication: TYPE_OF_PLANNING_APPLICATION.HOUSEHOLDER_PLANNING,
 					applicationDate: `${EXPEDITED_PART_1_CUTOFF_DATE}T00:00:00.000Z`,
 					eligibility: {
@@ -131,7 +134,7 @@ describe('isExpeditedPart1Eligible', () => {
 
 		it('returns false when decision is REFUSED', () => {
 			expect(
-				isExpeditedPart1Eligible({
+				isS78ExpeditedPart1Eligible({
 					typeOfPlanningApplication: TYPE_OF_PLANNING_APPLICATION.HOUSEHOLDER_PLANNING,
 					applicationDate: `${EXPEDITED_PART_1_CUTOFF_DATE}T00:00:00.000Z`,
 					eligibility: {
@@ -144,7 +147,7 @@ describe('isExpeditedPart1Eligible', () => {
 
 		it('returns false when decision is GRANTED but date is before cutoff', () => {
 			expect(
-				isExpeditedPart1Eligible({
+				isS78ExpeditedPart1Eligible({
 					typeOfPlanningApplication: TYPE_OF_PLANNING_APPLICATION.HOUSEHOLDER_PLANNING,
 					applicationDate: '2026-03-31T22:59:59.000Z',
 					eligibility: {
@@ -176,4 +179,103 @@ describe('isExpeditedAppealDate', () => {
 			expect(isExpeditedAppealDate(applicationDate)).toBe(false);
 		}
 	);
+});
+
+describe('isNonS78ExpeditedPart1Eligible', () => {
+	it.each([
+		CASE_TYPES.HAS.processCode,
+		CASE_TYPES.CAS_ADVERTS.processCode,
+		CASE_TYPES.CAS_PLANNING.processCode
+	])('returns true for %s on or after cutoff date', (appealTypeCode) => {
+		expect(
+			isNonS78ExpeditedPart1Eligible(
+				appealTypeCode,
+				`${EXPEDITED_PART_1_CUTOFF_DATE}T00:00:00.000Z`
+			)
+		).toBe(true);
+		expect(isNonS78ExpeditedPart1Eligible(appealTypeCode, '2026-04-01T10:00:00.000Z')).toBe(true);
+	});
+
+	it.each([
+		CASE_TYPES.HAS.processCode,
+		CASE_TYPES.CAS_ADVERTS.processCode,
+		CASE_TYPES.CAS_PLANNING.processCode
+	])('returns false for %s before cutoff date', (appealTypeCode) => {
+		expect(isNonS78ExpeditedPart1Eligible(appealTypeCode, '2026-03-31T22:59:59.000Z')).toBe(false);
+	});
+
+	it.each([
+		CASE_TYPES.S78.processCode,
+		CASE_TYPES.S20.processCode,
+		CASE_TYPES.ADVERTS.processCode,
+		CASE_TYPES.LDC.processCode,
+		CASE_TYPES.ENFORCEMENT.processCode,
+		CASE_TYPES.ENFORCEMENT_LISTED.processCode
+	])(
+		'returns false for unsupported appeal type %s even when date is after cutoff',
+		(appealTypeCode) => {
+			expect(isNonS78ExpeditedPart1Eligible(appealTypeCode, '2026-04-01T10:00:00.000Z')).toBe(
+				false
+			);
+		}
+	);
+
+	it.each([undefined, null, ''])('returns false when appealTypeCode is %p', (appealTypeCode) => {
+		expect(isNonS78ExpeditedPart1Eligible(appealTypeCode, '2026-04-01T10:00:00.000Z')).toBe(false);
+	});
+
+	it.each([undefined, null, 'not-a-date'])(
+		'returns false when applicationDate is %p',
+		(applicationDate) => {
+			expect(isNonS78ExpeditedPart1Eligible(CASE_TYPES.HAS.processCode, applicationDate)).toBe(
+				false
+			);
+		}
+	);
+});
+
+describe('isExpeditedPart1Eligible', () => {
+	it('returns true for eligible S78 appeal', () => {
+		expect(
+			isExpeditedPart1Eligible({
+				appealTypeCode: CASE_TYPES.S78.processCode,
+				typeOfPlanningApplication: TYPE_OF_PLANNING_APPLICATION.FULL_APPEAL,
+				applicationDate: '2026-04-01T10:00:00.000Z',
+				applicationDecision: APPLICATION_DECISION.GRANTED
+			})
+		).toBe(true);
+	});
+
+	it('returns true for eligible non-S78 appeal (e.g. HAS)', () => {
+		expect(
+			isExpeditedPart1Eligible({
+				appealTypeCode: CASE_TYPES.HAS.processCode,
+				applicationDate: '2026-04-01T10:00:00.000Z'
+			})
+		).toBe(true);
+	});
+
+	it('returns false for S78 appeal with application date before cutoff', () => {
+		expect(
+			isExpeditedPart1Eligible({
+				appealTypeCode: CASE_TYPES.S78.processCode,
+				typeOfPlanningApplication: TYPE_OF_PLANNING_APPLICATION.FULL_APPEAL,
+				applicationDate: '2026-03-31T10:00:00.000Z',
+				applicationDecision: APPLICATION_DECISION.GRANTED
+			})
+		).toBe(false);
+	});
+
+	it('returns false for non-S78 appeal with application date before cutoff', () => {
+		expect(
+			isExpeditedPart1Eligible({
+				appealTypeCode: CASE_TYPES.HAS.processCode,
+				applicationDate: '2026-03-31T10:00:00.000Z'
+			})
+		).toBe(false);
+	});
+
+	it.each([undefined, null])('returns false when caseData is %p', (caseData) => {
+		expect(isExpeditedPart1Eligible(caseData)).toBe(false);
+	});
 });


### PR DESCRIPTION
### Description of change

### Description
Fixes an issue where non-expedited appeals (S78, HAS, CAS Planning, CAS Advert) submitted prior to the cut-off date were showing empty Why are you appealing and Significant changes rows in appellant and LPA dashboards.

### Cause
The row conditions in appeal-details-rows.js previously evaluated isExpeditedAppealDate(caseData.applicationDate across all appeal types. Non-expedited S78 cases submitted after the date cut-off or cases without proper type checks triggered row display even when reasonForAppealAppellant or anySignificantChanges was null/empty.

### Changes
Renamed and clarified isS78ExpeditedPart1Eligible for S78 eligibility checks.
Extracted isExpeditedNonS7Part1Eligible for checking 
Created unified isExpeditedAppeal helper consolidating S78 and non-S78 expedited appeal logic.
Extracted reusable row checks (shouldDisplayReasonForAppeal, shouldDisplaySignificantChanges) across standard and expedited detail rows.
Replaced inline expedited checks with isExpeditedPart1Eligible across appeal-details-rows.js, appeal-process-details-rows.js, and questionnaire-details/index.js.
Tests
Added unit tests for isExpeditedNonS7Part1Eligible and isExpeditedPart1Eligible in is-expedited-part1-eligible.test.js.
Added unit tests verifying row visibility logic across HAS, CAS Adverts, CAS Planning, and S78 (pre/post April 1 cut-off, Part 1 eligible and ineligible) in appeal-details-rows.test.js.

Ticket: https://pins-ds.atlassian.net/browse/A2-9024

### Checklist

- [x] Feature complete and ready for users, or behind feature-flag
- [x] Commit history is linear with no merge commits
- [ ] Requires infrastructure changes

### Important

Please do not merge from `main` (please only [rebase](https://github.com/Planning-Inspectorate/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
