### PR TITLE
feat(A2-8528): display inquiry docs

### DIFF
--- a/packages/appeals-service-api/src/routes/v2/appeal-cases/_caseReference/representations/repo.js
+++ b/packages/appeals-service-api/src/routes/v2/appeal-cases/_caseReference/representations/repo.js
@@ -110,7 +110,10 @@ class RepresentationsRepository {
 								// APPEAL_DOCUMENT_TYPE.APPELLANT_COSTS_WITHDRAWAL,
 
 								// General Supporting
-								APPEAL_DOCUMENT_TYPE.GENERAL_SUPPORTING
+								APPEAL_DOCUMENT_TYPE.GENERAL_SUPPORTING,
+
+								// Inquiry
+								APPEAL_DOCUMENT_TYPE.INQUIRY_CORE
 							]
 						}
 					}

--- a/packages/common/src/client/appeals-api-client.js
+++ b/packages/common/src/client/appeals-api-client.js
@@ -1282,7 +1282,7 @@ class AppealsApiClient {
 	 * @returns {Promise<boolean>}
 	 */
 	async confirmUserHasAccessToAppealCase(id) {
-		const endpoint = `${v2}/appeal-case/${id}/confirm-access`;
+		const endpoint = `${v2}/appeal-cases/${id}/confirm-access`;
 		const response = await this.#makeGetRequest(endpoint);
 		return response.status === 200;
 	}

--- a/packages/common/src/document-types.js
+++ b/packages/common/src/document-types.js
@@ -1218,6 +1218,17 @@ const documentTypes = {
 		publiclyAccessible: false,
 		horizonDocumentType: '',
 		horizonDocumentGroupType: ''
+	},
+	inquiryCore: {
+		name: 'inquiryCore',
+		dataModelName: APPEAL_DOCUMENT_TYPE.INQUIRY_CORE,
+		multiple: true,
+		displayName: '',
+		involvement: '',
+		owner: (_appealTypeCode) => pinsOwner,
+		publiclyAccessible: false,
+		horizonDocumentType: '',
+		horizonDocumentGroupType: ''
 	}
 };
 

--- a/packages/database/src/seed/appeal-documents-dev.js
+++ b/packages/database/src/seed/appeal-documents-dev.js
@@ -831,6 +831,23 @@ const appealDocuments = [
 		origin: 'pins',
 		stage: 'decision',
 		AppealCase: {}
+	},
+	{
+		id: 'd4290e68-bfbb-3bc8-b621-5a9590aa29aa',
+		filename: 'test-inquiry-document.pdf',
+		originalFilename: 'test-inquiry-document.pdf',
+		size: 16,
+		mime: 'text/plain',
+		documentURI: '',
+		dateCreated: new Date(),
+		published: true,
+		redacted: true,
+		virusCheckStatus: APPEAL_VIRUS_CHECK_STATUS.SCANNED,
+		documentType: APPEAL_DOCUMENT_TYPE.INQUIRY_CORE,
+		sourceSystem: 'appeals',
+		origin: 'pins',
+		stage: 'decision',
+		AppealCase: {}
 	}
 ];
 

--- a/packages/forms-web-app/src/controllers/selected-appeal/appellant-sections.js
+++ b/packages/forms-web-app/src/controllers/selected-appeal/appellant-sections.js
@@ -202,6 +202,20 @@ exports.sections = [
 		]
 	},
 	{
+		heading: 'Inquiry Documents',
+		links: [
+			{
+				url: '/inquiry-documents',
+				text: 'View inquiry documents',
+				condition: (appealCase) =>
+					appealCase.Documents.some(
+						/** @type {DocumentExistsCondition} */
+						(doc) => doc.documentType === APPEAL_DOCUMENT_TYPE.INQUIRY_CORE
+					)
+			}
+		]
+	},
+	{
 		heading: 'Costs',
 		links: [
 			{

--- a/packages/forms-web-app/src/controllers/selected-appeal/lpa-user-sections.js
+++ b/packages/forms-web-app/src/controllers/selected-appeal/lpa-user-sections.js
@@ -226,6 +226,20 @@ exports.sections = [
 		]
 	},
 	{
+		heading: 'Inquiry Documents',
+		links: [
+			{
+				url: '/inquiry-documents',
+				text: 'View inquiry documents',
+				condition: (appealCase) =>
+					appealCase.Documents.some(
+						/** @type {DocumentExistsCondition} */
+						(doc) => doc.documentType === APPEAL_DOCUMENT_TYPE.INQUIRY_CORE
+					)
+			}
+		]
+	},
+	{
 		heading: 'Costs',
 		links: [
 			{

--- a/packages/forms-web-app/src/controllers/selected-appeal/user-sections.test.js
+++ b/packages/forms-web-app/src/controllers/selected-appeal/user-sections.test.js
@@ -470,6 +470,21 @@ describe('LPA and Appellant Sections', () => {
 		});
 	});
 
+	describe('Inquiry documents', () => {
+		it('should show supporting documents when docs are present', () => {
+			appealCase.Documents = [
+				{
+					documentType: APPEAL_DOCUMENT_TYPE.INQUIRY_CORE,
+					published: true
+				}
+			];
+			const section = findSectionByHeading(lpaSections, 'Inquiry Documents');
+			const link = findLinkByUrl(section, '/inquiry-documents');
+			expect(link?.condition(appealCase)).toBe(true);
+			expect(link?.text).toBe('View inquiry documents');
+		});
+	});
+
 	describe('Appellant Sections', () => {
 		describe('Appeal details', () => {
 			it('should show "View your appeal details" when caseValidDate is present (is always true)', () => {

--- a/packages/forms-web-app/src/routes/appeals/selected-appeal/selected-appeal.js
+++ b/packages/forms-web-app/src/routes/appeals/selected-appeal/selected-appeal.js
@@ -137,6 +137,15 @@ router.get(
 );
 
 router.get(
+	'/:appealNumber/inquiry-documents',
+	documentsController.get({
+		userType,
+		displayName: 'Inquiry documents',
+		documentTypes: [APPEAL_DOCUMENT_TYPE.INQUIRY_CORE]
+	})
+);
+
+router.get(
 	`/:appealNumber/download/:documentsLocation/documents/:appealCaseStage`,
 	downloadDocumentsController.get()
 );

--- a/packages/forms-web-app/src/routes/lpa-dashboard/selected-appeal.js
+++ b/packages/forms-web-app/src/routes/lpa-dashboard/selected-appeal.js
@@ -176,4 +176,13 @@ router.get(
 	})
 );
 
+router.get(
+	'/:appealNumber/inquiry-documents',
+	documentsController.get({
+		userType,
+		displayName: 'Inquiry documents',
+		documentTypes: [APPEAL_DOCUMENT_TYPE.INQUIRY_CORE]
+	})
+);
+
 module.exports = router;


### PR DESCRIPTION
### Description of change

This PR displays published inquiry documents on the appellant and lpa dashboards

Ticket: https://pins-ds.atlassian.net/browse/A2-8528

### Checklist

- [x] Feature complete and ready for users, or behind feature-flag
- [x] Commit history is linear with no merge commits
- [ ] Requires infrastructure changes

### Important

Please do not merge from `main` (please only [rebase](https://github.com/Planning-Inspectorate/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
