### PR TITLE
fix(A2-8132): remove duplicate application date question

### DIFF
--- a/packages/forms-web-app/src/dynamic-forms/display-questions.js
+++ b/packages/forms-web-app/src/dynamic-forms/display-questions.js
@@ -10,6 +10,7 @@ const { isExpeditedAppealDate } = require('#lib/is-expedited-part1-eligible');
 /**
  * @typedef {import('@pins/dynamic-forms/src/journey-response').JourneyResponse} JourneyResponse
  * @typedef {import('@pins/dynamic-forms/src/question')} Question
+ * @typedef {import('@pins/business-rules/src/constants').TYPE_OF_PLANNING_APPLICATION} TYPE_OF_PLANNING_APPLICATION
  */
 
 /**
@@ -209,6 +210,16 @@ exports.shouldDisplayPreviousApplicationQuestions = (response, questions) => {
  */
 exports.shouldDisplayPriorCorrespondenceUpload = (response) =>
 	!!response.answers.hasContactedPlanningInspectorate;
+
+// A display util which returns true if an appeal response has a typeOfPlanningApplication
+// which is in a specified array
+/**
+ * @param {JourneyResponse} response
+ * @param {TYPE_OF_PLANNING_APPLICATION[]} applicationTypes
+ * @returns {boolean}
+ */
+exports.shouldDisplayBasedOnTypeOfApplication = (response, applicationTypes) =>
+	applicationTypes.includes(response.answers.typeOfPlanningApplication);
 
 /**
  * @param {JourneyResponse} response

--- a/packages/forms-web-app/src/dynamic-forms/docs/s78-appeal-form-journey.md
+++ b/packages/forms-web-app/src/dynamic-forms/docs/s78-appeal-form-journey.md
@@ -104,6 +104,11 @@ condition: () => shouldDisplayTellingTenants(response, questions);
 - radio `/health-safety-issues/` Health and safety issues
 - single-line-input `/reference-number/` What is the application reference number?
 - date `/application-date/` What date did you submit your application?
+
+```js
+condition: () => !shouldDisplayBasedOnTypeOfApplication(response, bysApplicationDateTypes);
+```
+
 - radio `/major-minor-development/` Was your application for a major or minor development?
 - radio `/application-about/` Was your application about any of the following?
 - text-entry `/enter-description-of-development/` Enter the description of development that you submitted in your application

--- a/packages/forms-web-app/src/dynamic-forms/s78-appeal-form/journey.js
+++ b/packages/forms-web-app/src/dynamic-forms/s78-appeal-form/journey.js
@@ -17,9 +17,20 @@ const {
 	shouldDisplayIdentifyingLandowners,
 	shouldDisplayTellingLandowners,
 	shouldDisplayTellingTenants,
-	shouldDisplayUploadDecisionLetter
+	shouldDisplayUploadDecisionLetter,
+	shouldDisplayBasedOnTypeOfApplication
 } = require('../display-questions');
 const { QUESTION_VARIABLES } = require('@pins/common/src/dynamic-forms/question-variables');
+const { TYPE_OF_PLANNING_APPLICATION } = require('@pins/business-rules/src/constants');
+
+// An array of typeOfPlanningApplications where the 'date of application'
+// question is asked during the BYS journey
+const bysApplicationDateTypes = [
+	TYPE_OF_PLANNING_APPLICATION.FULL_APPEAL,
+	TYPE_OF_PLANNING_APPLICATION.OUTLINE_PLANNING,
+	TYPE_OF_PLANNING_APPLICATION.RESERVED_MATTERS,
+	TYPE_OF_PLANNING_APPLICATION.PERMISSION_IN_PRINCIPLE
+];
 
 /**
  * @typedef {import('@pins/dynamic-forms/src/journey-response').JourneyResponse} JourneyResponse
@@ -105,6 +116,9 @@ const makeSections = (response) => {
 			.addQuestion(questions.healthAndSafety)
 			.addQuestion(questions.enterApplicationReference)
 			.addQuestion(questions.planningApplicationDate)
+			.withCondition(
+				() => !shouldDisplayBasedOnTypeOfApplication(response, bysApplicationDateTypes)
+			)
 			.addQuestion(questions.majorMinorDevelopment)
 			.withVariables({
 				[QUESTION_VARIABLES.MAJOR_MINOR_CONTENT]: 'resources/major-minor-development/content.html'

--- a/test-packages/platform-feature-tests/cypress/e2e/appellant-aapd/submit-full-appeal/full-appeal-validation.cy.js
+++ b/test-packages/platform-feature-tests/cypress/e2e/appellant-aapd/submit-full-appeal/full-appeal-validation.cy.js
@@ -189,7 +189,7 @@ describe('Full Appeal Validations', { tags: '@S78-appeal-validation-2' }, () => 
             if (!context?.applicationForm?.isOwnsAllLand) {
                 //Do you own some of the land involved in the appeal?
                 ownSomeLandPage.addOwnSomeLandData(context?.applicationForm?.isOwnsSomeLand, context);
-                //cy.advanceToNextPage();			
+                //cy.advanceToNextPage();
             }
             agriculturalHoldingPage.addAgriculturalHoldingData(context?.applicationForm?.isAgriculturalHolding, context);
 
@@ -199,15 +199,6 @@ describe('Full Appeal Validations', { tags: '@S78-appeal-validation-2' }, () => 
             //What is the application reference number?
             const applicationNumber = `TEST-${Date.now()}`;
             cy.get(prepareAppealSelector?._selectors?.applicationReference).type(applicationNumber);
-            cy.advanceToNextPage();
-            //What date did you submit your application?
-
-            cy.get(prepareAppealSelector?._selectors?.onApplicationDateDay).clear();
-            cy.get(prepareAppealSelector?._selectors?.onApplicationDateDay).type(date.today());
-            cy.get(prepareAppealSelector?._selectors?.onApplicationDateMonth).clear();
-            cy.get(prepareAppealSelector?._selectors?.onApplicationDateMonth).type(date.currentMonth() - 3);
-            cy.get(prepareAppealSelector?._selectors?.onApplicationDateYear).clear();
-            cy.get(prepareAppealSelector?._selectors?.onApplicationDateYear).type(date.currentYear());
             cy.advanceToNextPage();
             //Was your application for a major or minor development?
             majorMinorDevelopmentPage.addMajorMionorDevelopmentData(context?.applicationForm?.majorMionorDevelopmentData);
@@ -227,7 +218,7 @@ describe('Full Appeal Validations', { tags: '@S78-appeal-validation-2' }, () => 
                 cy.advanceToNextPage();
             }
 
-            //How would you prefer us to decide your appeal?		
+            //How would you prefer us to decide your appeal?
             decideAppealsPage.addDecideAppealsData(context?.applicationForm?.appellantProcedurePreference);
             otherAppealsPage.addOtherAppealsData(context?.applicationForm?.anyOtherAppeals, context);
             cy.containsMessage(basePage._selectors?.govukSummaryListKey, 'Was the application made in your name?').next('.govuk-summary-list__value').contains(`${context.applicationForm?.isAppellant === true ? 'Yes' : 'No'}`);


### PR DESCRIPTION
### Description of change

For full planning appeals (s78) which are not following the expedited route, we currently ask the 'when did you submit your planning application' question twice - during the BYS stage and during the Prepare Appeal section of the appeal form.  This PR removes the question from the Appeal Form.

Note, we do ask the question in some appeal forms, where we do not ask it during BYS.

Ticket: https://pins-ds.atlassian.net/browse/A2-8132

### Checklist

- [X] Feature complete and ready for users, or behind feature-flag
- [X] Commit history is linear with no merge commits
- [ ] Requires infrastructure changes

### Important

Please do not merge from `main` (please only [rebase](https://github.com/Planning-Inspectorate/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
