### PR TITLE
feat(A2-8527): display hearing docs

### DIFF
--- a/packages/appeals-service-api/src/routes/v2/appeal-cases/_caseReference/representations/repo.js
+++ b/packages/appeals-service-api/src/routes/v2/appeal-cases/_caseReference/representations/repo.js
@@ -114,7 +114,9 @@ class RepresentationsRepository {
 
 								// Inquiry
 								APPEAL_DOCUMENT_TYPE.INQUIRY_CORE,
-								APPEAL_DOCUMENT_TYPE.INQUIRY_POST_EVENT
+								APPEAL_DOCUMENT_TYPE.INQUIRY_POST_EVENT,
+								// Hearing
+								APPEAL_DOCUMENT_TYPE.HEARING_PROCESS
 							]
 						}
 					}

--- a/packages/common/src/document-types.js
+++ b/packages/common/src/document-types.js
@@ -1240,6 +1240,17 @@ const documentTypes = {
 		publiclyAccessible: false,
 		horizonDocumentType: '',
 		horizonDocumentGroupType: ''
+	},
+	hearingProcess: {
+		name: 'hearingProcess',
+		dataModelName: APPEAL_DOCUMENT_TYPE.HEARING_PROCESS,
+		multiple: true,
+		displayName: '',
+		involvement: '',
+		owner: (_appealTypeCode) => pinsOwner,
+		publiclyAccessible: false,
+		horizonDocumentType: '',
+		horizonDocumentGroupType: ''
 	}
 };
 

--- a/packages/database/src/seed/appeal-documents-dev.js
+++ b/packages/database/src/seed/appeal-documents-dev.js
@@ -865,6 +865,23 @@ const appealDocuments = [
 		origin: 'pins',
 		stage: 'decision',
 		AppealCase: {}
+	},
+	{
+		id: 'd4290e68-bfbb-3bc8-b621-5a9590aa29aa',
+		filename: 'test-hearing-document.pdf',
+		originalFilename: 'test-hearing-document.pdf',
+		size: 16,
+		mime: 'text/plain',
+		documentURI: '',
+		dateCreated: new Date(),
+		published: true,
+		redacted: true,
+		virusCheckStatus: APPEAL_VIRUS_CHECK_STATUS.SCANNED,
+		documentType: APPEAL_DOCUMENT_TYPE.HEARING_PROCESS,
+		sourceSystem: 'appeals',
+		origin: 'pins',
+		stage: 'decision',
+		AppealCase: {}
 	}
 ];
 

--- a/packages/forms-web-app/src/controllers/selected-appeal/appellant-sections.js
+++ b/packages/forms-web-app/src/controllers/selected-appeal/appellant-sections.js
@@ -230,6 +230,20 @@ exports.sections = [
 		]
 	},
 	{
+		heading: 'Hearing Documents',
+		links: [
+			{
+				url: '/hearing-documents',
+				text: 'View hearing documents',
+				condition: (appealCase) =>
+					appealCase.Documents.some(
+						/** @type {DocumentExistsCondition} */
+						(doc) => doc.documentType === APPEAL_DOCUMENT_TYPE.HEARING_PROCESS
+					)
+			}
+		]
+	},
+	{
 		heading: 'Costs',
 		links: [
 			{

--- a/packages/forms-web-app/src/controllers/selected-appeal/lpa-user-sections.js
+++ b/packages/forms-web-app/src/controllers/selected-appeal/lpa-user-sections.js
@@ -254,6 +254,20 @@ exports.sections = [
 		]
 	},
 	{
+		heading: 'Hearing Documents',
+		links: [
+			{
+				url: '/hearing-documents',
+				text: 'View hearing documents',
+				condition: (appealCase) =>
+					appealCase.Documents.some(
+						/** @type {DocumentExistsCondition} */
+						(doc) => doc.documentType === APPEAL_DOCUMENT_TYPE.HEARING_PROCESS
+					)
+			}
+		]
+	},
+	{
 		heading: 'Costs',
 		links: [
 			{

--- a/packages/forms-web-app/src/controllers/selected-appeal/user-sections.test.js
+++ b/packages/forms-web-app/src/controllers/selected-appeal/user-sections.test.js
@@ -500,6 +500,21 @@ describe('LPA and Appellant Sections', () => {
 		});
 	});
 
+	describe('Hearing documents', () => {
+		it('should show hearing documents when docs are present', () => {
+			appealCase.Documents = [
+				{
+					documentType: APPEAL_DOCUMENT_TYPE.HEARING_PROCESS,
+					published: true
+				}
+			];
+			const section = findSectionByHeading(lpaSections, 'Hearing Documents');
+			const link = findLinkByUrl(section, '/hearing-documents');
+			expect(link?.condition(appealCase)).toBe(true);
+			expect(link?.text).toBe('View hearing documents');
+		});
+	});
+
 	describe('Appellant Sections', () => {
 		describe('Appeal details', () => {
 			it('should show "View your appeal details" when caseValidDate is present (is always true)', () => {

--- a/packages/forms-web-app/src/routes/appeals/selected-appeal/selected-appeal.js
+++ b/packages/forms-web-app/src/routes/appeals/selected-appeal/selected-appeal.js
@@ -155,6 +155,15 @@ router.get(
 );
 
 router.get(
+	'/:appealNumber/hearing-documents',
+	documentsController.get({
+		userType,
+		displayName: 'Hearing documents',
+		documentTypes: [APPEAL_DOCUMENT_TYPE.HEARING_PROCESS]
+	})
+);
+
+router.get(
 	`/:appealNumber/download/:documentsLocation/documents/:appealCaseStage`,
 	downloadDocumentsController.get()
 );

--- a/packages/forms-web-app/src/routes/lpa-dashboard/selected-appeal.js
+++ b/packages/forms-web-app/src/routes/lpa-dashboard/selected-appeal.js
@@ -194,4 +194,13 @@ router.get(
 	})
 );
 
+router.get(
+	'/:appealNumber/hearing-documents',
+	documentsController.get({
+		userType,
+		displayName: 'Hearing documents',
+		documentTypes: [APPEAL_DOCUMENT_TYPE.HEARING_PROCESS]
+	})
+);
+
 module.exports = router;


### PR DESCRIPTION
### Description of change

Add display hearing docs  to LPA and appellant dashboards

Ticket: https://pins-ds.atlassian.net/browse/A2-8527

### Checklist

- [x] Feature complete and ready for users, or behind feature-flag
- [x] Commit history is linear with no merge commits
- [ ] Requires infrastructure changes

### Important

Please do not merge from `main` (please only [rebase](https://github.com/Planning-Inspectorate/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
