### PR TITLE
fix(api): hiding appeals from comment service with status = ready to …

### DIFF
--- a/packages/appeals-service-api/src/routes/v2/appeal-cases/appeal-cases.spec.js
+++ b/packages/appeals-service-api/src/routes/v2/appeal-cases/appeal-cases.spec.js
@@ -35,7 +35,7 @@ const {
 const {
 	exampleEnforcementListedDataModel
 } = require('../../../../__tests__/developer/fixtures/appeals-enforcement-listed-data-model');
-const { SERVICE_USER_TYPE } = require('@planning-inspectorate/data-model');
+const { APPEAL_CASE_STATUS, SERVICE_USER_TYPE } = require('@planning-inspectorate/data-model');
 const { APPEAL_USER_ROLES } = require('@pins/common/src/constants');
 
 const { appendLinkedCasesForMultipleAppeals } = require('./service');
@@ -301,6 +301,44 @@ module.exports = ({ getSqlClient, setCurrentSub, setCurrentLpa, mockNotifyClient
 								firstName: 'Post',
 								lastName: 'Code'
 							})
+						])
+					);
+				});
+
+				it("doesn't return started cases in validation or ready_to_start", async () => {
+					const validationCase = appealCase('LPA1', 'BS1 6AA', true, true);
+					validationCase.CaseStatus = {
+						connect: { key: APPEAL_CASE_STATUS.VALIDATION }
+					};
+
+					const readyToStartCase = appealCase('LPA1', 'BS1 6AA', true, true);
+					readyToStartCase.CaseStatus = {
+						connect: { key: APPEAL_CASE_STATUS.READY_TO_START }
+					};
+
+					await _createSqlAppealCase(validationCase);
+					await _createSqlAppealCase(readyToStartCase);
+
+					const response = await appealsApi
+						.get(
+							`/api/v2/appeal-cases` +
+								buildQueryString({
+									postcode: 'BS1 6AA',
+									'decided-only': 'false',
+									isStarted: 'true'
+								})
+						)
+						.send();
+
+					expect(response.status).toBe(200);
+					expect(response.body).not.toEqual(
+						expect.arrayContaining([
+							expect.objectContaining({ caseReference: validationCase.caseReference })
+						])
+					);
+					expect(response.body).not.toEqual(
+						expect.arrayContaining([
+							expect.objectContaining({ caseReference: readyToStartCase.caseReference })
 						])
 					);
 				});

--- a/packages/appeals-service-api/src/routes/v2/appeal-cases/repo.js
+++ b/packages/appeals-service-api/src/routes/v2/appeal-cases/repo.js
@@ -9,6 +9,7 @@ const { subYears } = require('date-fns');
 const logger = require('#lib/logger');
 const ApiError = require('#errors/apiError');
 const sanitizePostcode = require('#lib/sanitize-postcode');
+const { APPEAL_CASE_STATUS } = require('@planning-inspectorate/data-model');
 
 /**
  * @typedef {import('@pins/database/src/client/client').Appeal} Appeal
@@ -694,6 +695,8 @@ class AppealCaseRepository {
 		];
 		if (isStarted) {
 			AND.push({ caseStartedDate: { not: null } });
+			AND.push({ caseStatus: { not: APPEAL_CASE_STATUS.READY_TO_START } });
+			AND.push({ caseStatus: { not: APPEAL_CASE_STATUS.VALIDATION } });
 		}
 		addDecidedClauseToQuery(AND, decidedOnly);
 		/** @type {AppealCaseFindManyArgs}	*/


### PR DESCRIPTION
…start/validation (A2-8985)

### Description of change

- Adding checks for the status not being `'validation'` or `'ready_to_start'`
- Adding a test that appeals with those statuses but a `caseStartedDate` don't show up

Note that this situation should not be possible to get into based on 'usual' usage of the system, e.g. an appeal shouldn't be at 'validation' or 'ready to start' but have a caseStartedDate. However due to the production support interventions (and for robustness), it isn't completely implausible that an appeal could end up in this scenario in prod

Ticket: https://pins-ds.atlassian.net/browse/A2-8985

Tested locally

### Checklist

- [x] Feature complete and ready for users, or behind feature-flag
- [x] Commit history is linear with no merge commits
- [ ] Requires infrastructure changes

### Important

Please do not merge from `main` (please only [rebase](https://github.com/Planning-Inspectorate/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
