### PR TITLE
fix(A2-9116): add display condition for total site area row in LPAQ s…

### DIFF
--- a/packages/forms-web-app/src/controllers/selected-appeal/questionnaire-details/constraints-details-rows.js
+++ b/packages/forms-web-app/src/controllers/selected-appeal/questionnaire-details/constraints-details-rows.js
@@ -14,6 +14,12 @@ const {
 const { APPEAL_DOCUMENT_TYPE } = require('@planning-inspectorate/data-model');
 const { isNotUndefinedOrNull } = require('#lib/is-not-undefined-or-null');
 const {
+	isEnforcementNotice,
+	isEnforcementListed,
+	isLDC,
+	isAnyEnforcement
+} = require('@pins/common/src/lib/appeal-type-checks');
+const {
 	mapAppealTypeToDisplayTextWithAnOrA
 } = require('@pins/common/src/appeal-type-to-display-text');
 
@@ -24,19 +30,20 @@ const {
 exports.constraintsRows = (caseData) => {
 	const documents = caseData.Documents || [];
 
-	const caseType = caseTypeLookup(caseData.appealTypeCode, 'processCode');
+	const { appealTypeCode } = caseData;
+
+	const caseType = caseTypeLookup(appealTypeCode, 'processCode');
 
 	const isExpeditedAppealType = caseType?.expedited === true;
 	const isS20orS78 =
-		caseData.appealTypeCode === CASE_TYPES.S20.processCode ||
-		caseData.appealTypeCode === CASE_TYPES.S78.processCode;
+		appealTypeCode === CASE_TYPES.S20.processCode || appealTypeCode === CASE_TYPES.S78.processCode;
 	const isAdvertAppeal =
-		caseData.appealTypeCode === CASE_TYPES.CAS_ADVERTS.processCode ||
-		caseData.appealTypeCode === CASE_TYPES.ADVERTS.processCode;
-	const isEnforcementAppeal = caseData.appealTypeCode === CASE_TYPES.ENFORCEMENT.processCode;
-	const isEnforcementListedAppeal =
-		caseData.appealTypeCode === CASE_TYPES.ENFORCEMENT_LISTED.processCode;
-	const isLDCAppeal = caseData.appealTypeCode === CASE_TYPES.LDC.processCode;
+		appealTypeCode === CASE_TYPES.CAS_ADVERTS.processCode ||
+		appealTypeCode === CASE_TYPES.ADVERTS.processCode;
+	const isEnforcementAppeal = isEnforcementNotice(appealTypeCode);
+	const isEnforcementListedAppeal = isEnforcementListed(appealTypeCode);
+	const isAnyEnforcementAppeal = isAnyEnforcement(appealTypeCode);
+	const isLDCAppeal = isLDC(appealTypeCode);
 
 	const affectedListedBuildings = caseData.ListedBuildings?.filter(
 		(x) => x.type === LISTED_RELATION_TYPES.affected
@@ -183,7 +190,7 @@ exports.constraintsRows = (caseData) => {
 		{
 			keyText: 'Total site area',
 			valueText: `${caseData.siteAreaSquareMetres} m\u00B2`,
-			condition: () => isNotUndefinedOrNull(caseData.siteAreaSquareMetres)
+			condition: () => isAnyEnforcementAppeal && isNotUndefinedOrNull(caseData.siteAreaSquareMetres)
 		},
 		{
 			keyText: 'Has alleged breach area',

--- a/packages/forms-web-app/src/controllers/selected-appeal/questionnaire-details/constraints-details-rows.test.js
+++ b/packages/forms-web-app/src/controllers/selected-appeal/questionnaire-details/constraints-details-rows.test.js
@@ -440,7 +440,7 @@ describe('constraintsRows', () => {
 		);
 		expect(rows[NOTICE_RELATES_TO_BUILDING_ENGINEERING_ROW].valueText).toEqual('No');
 
-		expect(rows[TOTAL_SITE_AREA_ROW].condition()).toEqual(true);
+		expect(rows[TOTAL_SITE_AREA_ROW].condition()).toEqual(false);
 		expect(rows[TOTAL_SITE_AREA_ROW].keyText).toEqual('Total site area');
 		expect(rows[TOTAL_SITE_AREA_ROW].valueText).toEqual('23 m\u00B2');
 


### PR DESCRIPTION
…ummary page

### Description of change

The 'Total site area' questions is only asked at LPAQ stage for enforcement notice and ELB appeals (otherwise it is just in the appeal form).

This update adds an appeal type check to the display condition for that row on the LPAQ row generators.

Some very minor refactoring to use some appeal type check functions.

Ticket: https://pins-ds.atlassian.net/browse/A2-9116

### Checklist

- [X] Feature complete and ready for users, or behind feature-flag
- [X] Commit history is linear with no merge commits
- [ ] Requires infrastructure changes

### Important

Please do not merge from `main` (please only [rebase](https://github.com/Planning-Inspectorate/appeal-planning-decision/wiki/An-intro-to-Git-Rebase)). This keeps the history linear and easier to debug.
